### PR TITLE
mcp-ex: Elixir-native rewrite of the index MCP server

### DIFF
--- a/lib/build/elixir-check.nix
+++ b/lib/build/elixir-check.nix
@@ -61,6 +61,9 @@ in
       else null;
 
     strictDeps = true;
+    # Mix >= 1.18 starts Mix.PubSub, which opens a loopback TCP socket at
+    # compile time; the darwin sandbox denies plain sockets without this.
+    __darwinAllowLocalNetworking = true;
 
     nativeBuildInputs =
       [

--- a/lib/languages/elixir.nix
+++ b/lib/languages/elixir.nix
@@ -13,7 +13,7 @@
     "1.15" = pkgs.elixir_1_15;
     "1.16" = pkgs.elixir_1_16;
     "1.17" = pkgs.elixir_1_17;
-    "1.18" = pkgs.elixir_1_18;
+    "1.18" = pkgs.beamPackages.elixir_1_18;
     "1.19" = pkgs.beamPackages.elixir_1_19;
   };
 in {

--- a/lib/languages/erlang.nix
+++ b/lib/languages/erlang.nix
@@ -9,7 +9,7 @@
   toolchainsFor = pkgs: {
     latest = pkgs.beamPackages.erlang;
     "26" = pkgs.erlang_26;
-    "27" = pkgs.erlang_27;
+    "27" = pkgs.beam27Packages.erlang;
     "28" = pkgs.beam28Packages.erlang;
   };
 in {

--- a/packages/mcp-ex/.formatter.exs
+++ b/packages/mcp-ex/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/packages/mcp-ex/.gitignore
+++ b/packages/mcp-ex/.gitignore
@@ -1,0 +1,23 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+ix_mcp-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/packages/mcp-ex/README.md
+++ b/packages/mcp-ex/README.md
@@ -1,21 +1,150 @@
-# IxMcp
+<p align="center"><img src="assets/hero.svg" width="720" alt="elixir_exec runs cells as supervised BEAM processes over one persistent workspace; a blocked cell stalls only itself and job outcomes come back as channel notifications"></p>
 
-**TODO: Add description**
+# ix-mcp-ex
 
-## Installation
+What if a wedged cell could not freeze your agent's whole kernel? ix-mcp-ex is
+an MCP server whose REPL **is Elixir**: one tool, `elixir_exec`, runs code
+against a shared, persistent workspace of bindings, and every cell executes as
+its own supervised BEAM process. The namespace survives across calls, jobs that
+outlive a short budget keep running in the background, and no cell -- however
+stuck -- can delay any other, because the scheduler preempts instead of
+cooperating.
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `ix_mcp` to your list of dependencies in `mix.exs`:
+## Quickstart
 
-```elixir
-def deps do
-  [
-    {:ix_mcp, "~> 0.1.0"}
-  ]
-end
+```
+nix run github:indexable-inc/index#mcp-ex        # MCP over stdio
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/ix_mcp>.
+From a clone (`git clone https://github.com/indexable-inc/index`):
 
+```
+nix run .#mcp-ex
+```
+
+Point an MCP client at that command and call `elixir_exec`.
+
+## The main tool
+
+`elixir_exec(code, budget \\ 15, intent)` evaluates `code` on the shared
+workspace and waits up to `budget` seconds. Finished in time: you get output
+and the rendered result. Still running: it continues as a background job and
+you get a handle. Job control needs no extra tools, because the registry is
+in-language -- the `Jobs` module is aliased in every cell:
+
+```elixir
+Jobs.tail("ab12", 20)      # last lines of a run's output
+Jobs.grep("ab12", ~r/err/) # filter it
+Jobs.await("ab12")         # block this cell (only this cell) until done
+Jobs.result("ab12")        # the value, as a term
+Jobs.cancel("ab12")        # kill it, and every OS process it spawned
+Jobs.history()             # recent runs, grouped by session/topic
+```
+
+Bindings, aliases, and modules you define persist: you are building a session,
+not running one-shot snippets. `Api.api("tail")` and `Api.help(Jobs, :tail)`
+are the discovery surface, generated live from module docs.
+
+## Tools
+
+| tool | what it does |
+|---|---|
+| `elixir_exec` | run a cell; budget-then-background |
+| `read` | fetch a file or a workspace value, with line ranges |
+| `session_set_name` / `topic_set` | label this session's runs for the feed |
+| `kernel_trace` | stack dump of every job's processes, from outside |
+| `kernel_restart` | cancel jobs, restart the workspace, restore bindings |
+| `pr_watch` | watch a PR via `gh`, notify on merge/close/timeout |
+| `tui_act` | drive a federated TUI resource via `ix-resource-cli` |
+
+## Why we left Python
+
+The predecessor ([`packages/mcp`](../mcp)) runs cells on one asyncio IPython
+kernel. It works, and a lot of engineering keeps it working, all of it
+compensating for the same four runtime facts:
+
+1. **Cooperative scheduling.** One synchronous call -- a `subprocess.run`, a
+   store flusher's blocking `put_blob` -- freezes the event loop, and with it
+   every session's jobs and even the status probe you would use to diagnose
+   it. The kernel's docs spend paragraphs teaching agents to wrap calls in
+   `asyncio.to_thread` because one mistake stalls the fleet. On the BEAM,
+   scheduling is preemptive and per-process: a cell that blocks forever costs
+   one process, and the chaos test in this package proves the next job starts
+   on time anyway.
+2. **Silent task death.** An unobserved asyncio `Task` exception parks
+   invisibly until something polls `.result()`. Here a crashed cell is a
+   monitored process whose exit reason -- a crash report carrying the actual
+   error and state -- is pushed to the client as a channel notification the
+   moment it happens.
+3. **Restart blast radius.** Restarting the shared Python kernel kills every
+   session and fleet riding it, and tracing a wedged loop requires
+   faulthandler signal hacks from outside. `kernel_trace` here is
+   `Process.info/2` on live processes; `kernel_restart` is a supervisor
+   restarting one process subtree while an ETS checkpoint hands the bindings
+   straight back.
+4. **No supervision.** Restart budgets, escalation, crash-with-state reports:
+   hand-rolled or absent in the Python runtime. OTP gives all of it
+   declaratively; this server's whole recovery story is its supervision tree.
+
+The orchestration problems were Erlang-shaped all along. The rewrite does not
+add machinery to get these guarantees; it deletes the machinery the old
+runtime needed to approximate them.
+
+### Where `nu()` went
+
+Nowhere: it is deliberately gone, and nothing replaced it. The Python kernel
+needed a blessed shell wrapper because Python subprocess ergonomics plus the
+one-shared-event-loop hazard demanded a managed, non-blocking, cancellable
+path for every external command. In a real language REPL on a preemptive
+runtime that is redundant surface area: a cell that genuinely needs a
+subprocess writes `System.cmd/3` (or opens a `Port`) itself, in-language, and
+blocks nobody. The one behavior from that world that still matters survives
+the cut: cancelling a job kills the OS process tree its cells spawned, so jobs
+never leak orphans.
+
+## Architecture
+
+```
+IxMcp.Supervisor (one_for_one)
+├── IxMcp.Session          session name / topic metadata
+├── IxMcp.Checkpoint       ETS keeper for workspace state (survives restarts)
+├── IxMcp.Workspace        the shared binding + Macro.Env every cell sees
+├── IxMcp.Jobs.Registry    id -> job process
+├── IxMcp.Jobs.Supervisor  (DynamicSupervisor) one child per cell/job
+│   └── IxMcp.Jobs.Job*    spawn_monitor's the evaluation, owns its output ETS
+├── IxMcp.Jobs.History     ordered record of every run
+├── IxMcp.MCP.Notifier     server-initiated notification fan-out
+├── IxMcp.PrWatch.Supervisor (Task.Supervisor) one task per PR watch
+└── IxMcp.MCP.Stdio        newline-delimited JSON-RPC on stdin/stdout
+```
+
+The evaluator copies the design of Livebook's `Livebook.Runtime.Evaluator`
+(persistent binding + `Macro.Env` via `Code.eval_quoted_with_env/4` with
+`:prune_binding`, per-cell output capture through a group-leader IO proxy)
+rather than depending on Livebook, which is an application, not a library.
+The group leader doubles as the job's process-tree tag: it is how tracing
+finds a job's spawned processes and how cancellation finds the ports whose OS
+process trees must die.
+
+Cells are gated by the compiler: code that does not parse is rejected with the
+compiler's diagnostic and never evaluated; warnings ride along in the result.
+There are zero runtime dependencies -- OTP's own `JSON` module is the whole
+wire format.
+
+## Tests
+
+```
+mix test                          # local: 26 tests, includes the chaos suite
+nix build .#mcp-ex.tests.elixir   # sandboxed gate: types, format, credo, tests
+nix build .#mcp-ex.tests.smoke    # real stdio initialize/tools-list exchange
+```
+
+The chaos suite runs the motivating scenario live: a cell blocks forever,
+other jobs keep running, `kernel_trace` shows the wedged frame, restart
+recovers the bindings, and no spawned OS process outlives its job.
+
+## Credits
+
+Written by Claude Code (an AI agent), operated by the ix team. Evaluator
+design after [Livebook](https://github.com/livebook-dev/livebook)'s
+`Livebook.Runtime.Evaluator`.

--- a/packages/mcp-ex/README.md
+++ b/packages/mcp-ex/README.md
@@ -1,0 +1,21 @@
+# IxMcp
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `ix_mcp` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:ix_mcp, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at <https://hexdocs.pm/ix_mcp>.
+

--- a/packages/mcp-ex/assets/hero.svg
+++ b/packages/mcp-ex/assets/hero.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 220" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted  { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .good   { fill: #1a7f37; }
+    .bad    { fill: #cf222e; }
+    .box    { stroke: currentColor; fill: none; stroke-width: 1.2; }
+    .goodbox { stroke: #1a7f37; fill: none; stroke-width: 1.2; }
+    .badbox  { stroke: #cf222e; fill: none; stroke-width: 1.2; stroke-dasharray: 4 3; }
+    text    { fill: currentColor; font-size: 13px; }
+    .small  { font-size: 11px; }
+    .mono   { font-family: ui-monospace, 'SF Mono', Menlo, monospace; }
+    .edge   { stroke: currentColor; fill: none; stroke-width: 1.2; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted  { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .good   { fill: #3fb950; }
+      .bad    { fill: #f85149; }
+      .goodbox { stroke: #3fb950; }
+      .badbox  { stroke: #f85149; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <!-- agent -->
+  <rect class="box" x="16" y="86" width="104" height="48" rx="8"/>
+  <text x="68" y="106" text-anchor="middle">agent</text>
+  <text x="68" y="122" text-anchor="middle" class="small muted">MCP client</text>
+
+  <!-- elixir_exec edge -->
+  <line class="edge" x1="120" y1="110" x2="196" y2="110"/>
+  <text x="158" y="100" text-anchor="middle" class="small mono accent">elixir_exec</text>
+
+  <!-- BEAM box -->
+  <rect class="box" x="200" y="18" width="330" height="184" rx="10"/>
+  <text x="365" y="40" text-anchor="middle">one BEAM, one persistent workspace</text>
+  <text x="365" y="56" text-anchor="middle" class="small mono muted">x = 41   df = big_result   defmodule Helper</text>
+
+  <!-- job processes -->
+  <rect class="goodbox" x="222" y="76" width="88" height="44" rx="8"/>
+  <text x="266" y="94" text-anchor="middle" class="small mono">job a1f2</text>
+  <text x="266" y="110" text-anchor="middle" class="small good">running</text>
+
+  <rect class="badbox" x="322" y="76" width="88" height="44" rx="8"/>
+  <text x="366" y="94" text-anchor="middle" class="small mono">job 9c04</text>
+  <text x="366" y="110" text-anchor="middle" class="small bad">blocked</text>
+
+  <rect class="goodbox" x="422" y="76" width="88" height="44" rx="8"/>
+  <text x="466" y="94" text-anchor="middle" class="small mono">job 77b8</text>
+  <text x="466" y="110" text-anchor="middle" class="small good">running</text>
+
+  <!-- supervisor note -->
+  <text x="365" y="150" text-anchor="middle" class="small muted">each cell is a supervised process: preemptive scheduling,</text>
+  <text x="365" y="166" text-anchor="middle" class="small muted">a blocked cell stalls only itself; cancel kills its OS subtree</text>
+  <text x="365" y="188" text-anchor="middle" class="small mono muted">trace / restart from outside, bindings restored</text>
+
+  <!-- notification edge -->
+  <line class="edge" x1="530" y1="110" x2="606" y2="110"/>
+  <text x="568" y="100" text-anchor="middle" class="small muted">channel</text>
+
+  <rect class="box" x="610" y="86" width="94" height="48" rx="8"/>
+  <text x="657" y="106" text-anchor="middle" class="small">job finished</text>
+  <text x="657" y="122" text-anchor="middle" class="small muted">crash + state</text>
+</svg>

--- a/packages/mcp-ex/config/config.exs
+++ b/packages/mcp-ex/config/config.exs
@@ -1,0 +1,5 @@
+import Config
+
+# Stdout belongs to the MCP JSON-RPC wire; every log line must go to stderr
+# or it would corrupt the protocol stream.
+config :logger, :default_handler, config: [type: :standard_error]

--- a/packages/mcp-ex/default.nix
+++ b/packages/mcp-ex/default.nix
@@ -1,0 +1,169 @@
+{
+  lib,
+  ix,
+}: let
+  # Read the package set from `ix` rather than a `pkgs` callPackage formal
+  # (which `override` can't reach); `ix.pkgs` is the caller's set.
+  inherit (ix) pkgs;
+
+  # mix.exs declares `~> 1.18`; the server and the quality gate build against
+  # the same toolchain so the release never runs code the gate did not check.
+  # 1.18 rather than 1.19: Mix 1.19's PubSub opens a loopback TCP socket at
+  # compile time, which the darwin sandbox denies (:eperm).
+  elixir = ix.languages.elixir.toolchain pkgs {version = "1.18";};
+  erlang = ix.languages.erlang.toolchain pkgs {version = "27";};
+
+  version = "0.1.0"; # keep in sync with mix.exs
+
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [
+      ./lib
+      ./test
+      ./config
+      ./mix.exs
+      ./mix.lock
+      ./.formatter.exs
+    ];
+  };
+
+  # Test-env mix deps (credo + its deps) as a fixed-output derivation so the
+  # sandboxed check runs offline. The SRI pin lives in the sibling pins.json
+  # (repo policy: no inline hash literals); it has no URL (the FOD content is
+  # derived from mix.lock), so refresh it after a lock change by building and
+  # copying the `got:` hash from the mismatch error. The release itself has
+  # zero deps (OTP's JSON module is the whole wire format), so only the check
+  # fetches anything.
+  mixFodDeps = pkgs.beamPackages.fetchMixDeps {
+    pname = "ix-mcp-ex-deps";
+    inherit version src elixir;
+    mixEnv = "test";
+    inherit ((ix.pins.loadPins ./pins.json).mix-deps) hash;
+  };
+
+  # The required Elixir quality lane: compile --warnings-as-errors (Elixir
+  # 1.18's set-theoretic type checker), format, `mix credo --strict` against
+  # the shared lib/elixir/credo.exs, and the ExUnit suite.
+  elixirCheck = ix.buildElixirCheck pkgs {
+    pname = "ix-mcp-ex-check";
+    inherit version src elixir erlang;
+    mixDeps = mixFodDeps;
+  };
+
+  meta = {
+    description = "An MCP server whose REPL is Elixir: persistent bindings on a supervised BEAM evaluator";
+    license = lib.licenses.mit;
+    mainProgram = "ix-mcp-ex";
+  };
+
+  package = pkgs.stdenv.mkDerivation {
+    pname = "ix-mcp-ex";
+    inherit version src meta;
+    strictDeps = true;
+    # Mix >= 1.18 starts Mix.PubSub, which opens a loopback TCP socket at
+    # compile time; the darwin sandbox denies plain sockets without this.
+    __darwinAllowLocalNetworking = true;
+
+    # hex provides the SCM module Mix needs to even parse the lockfile's
+    # test-only credo entry; nothing is fetched in the prod build.
+    nativeBuildInputs = [
+      erlang
+      elixir
+      (pkgs.beamPackages.hex.override {inherit elixir;})
+      pkgs.makeWrapper
+    ];
+
+    env = {
+      MIX_ENV = "prod";
+      HEX_OFFLINE = "1";
+      LANG = "C.UTF-8";
+      LC_CTYPE = "C.UTF-8";
+    };
+
+    postUnpack = ''
+      export MIX_HOME="$TEMPDIR/mix"
+      export HEX_HOME="$TEMPDIR/hex"
+    '';
+
+    buildPhase = ''
+      # shell
+      runHook preBuild
+      # Zero prod deps (credo is test-only), so no deps staging is needed;
+      # --no-deps-check keeps mix from trying to resolve the lock online.
+      mix release --no-deps-check --path "$out/lib/ix-mcp-ex"
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      # shell
+      runHook preInstall
+      # The release launcher needs a writable RELEASE_TMP (the default is the
+      # release root, which is the read-only store).
+      # RELEASE_DISTRIBUTION=none: a stdio MCP server needs no Erlang
+      # distribution, and the default sname mode wants an epmd listen socket
+      # (denied in sandboxes, pointless everywhere else).
+      makeWrapper "$out/lib/ix-mcp-ex/bin/ix_mcp" "$out/bin/ix-mcp-ex" \
+        --set IX_MCP_STDIO 1 \
+        --set RELEASE_DISTRIBUTION none \
+        --set-default RELEASE_TMP /tmp \
+        --add-flags start
+      runHook postInstall
+    '';
+  };
+
+  # End-to-end wire smoke test: a real MCP initialize -> tools/list exchange
+  # over the installed binary's stdio, no network.
+  smoke =
+    pkgs.runCommand "ix-mcp-ex-smoke"
+    {
+      nativeBuildInputs = [package];
+      strictDeps = true;
+    }
+    ''
+      set +e
+      printf '%s\n%s\n' \
+        '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}' \
+        '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+        | ix-mcp-ex > response.jsonl 2> server-stderr.log
+      rc=$?
+      set -e
+      if [ "$rc" -ne 0 ]; then
+        echo "ix-mcp-ex exited $rc" >&2
+        echo "--- stderr ---" >&2
+        cat server-stderr.log >&2
+        echo "--- stdout ---" >&2
+        cat response.jsonl >&2
+        echo "--- env ---" >&2
+        env >&2
+        exit 1
+      fi
+      out_lines=$(cat response.jsonl)
+      case "$out_lines" in
+        *'"protocolVersion":"2025-06-18"'*) ;;
+        *)
+          echo "initialize did not negotiate the protocol version" >&2
+          printf '%s\n' "$out_lines" >&2
+          exit 1
+          ;;
+      esac
+      case "$out_lines" in
+        *'"elixir_exec"'*) ;;
+        *)
+          echo "tools/list did not advertise elixir_exec" >&2
+          printf '%s\n' "$out_lines" >&2
+          exit 1
+          ;;
+      esac
+      mkdir -p "$out"
+    '';
+in
+  package.overrideAttrs (old: {
+    passthru =
+      (old.passthru or {})
+      // {
+        tests = {
+          elixir = elixirCheck;
+          inherit smoke;
+        };
+      };
+  })

--- a/packages/mcp-ex/lib/ix_mcp.ex
+++ b/packages/mcp-ex/lib/ix_mcp.ex
@@ -1,18 +1,8 @@
 defmodule IxMcp do
   @moduledoc """
-  Documentation for `IxMcp`.
+  An MCP server whose REPL is Elixir: one shared, persistent workspace of
+  bindings, cells evaluated in supervised BEAM processes, and job control as
+  plain in-language calls. See `IxMcp.Application` for the supervision tree
+  and the package README for why this replaced a Python asyncio kernel.
   """
-
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> IxMcp.hello()
-      :world
-
-  """
-  def hello do
-    :world
-  end
 end

--- a/packages/mcp-ex/lib/ix_mcp.ex
+++ b/packages/mcp-ex/lib/ix_mcp.ex
@@ -1,0 +1,18 @@
+defmodule IxMcp do
+  @moduledoc """
+  Documentation for `IxMcp`.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> IxMcp.hello()
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/api.ex
+++ b/packages/mcp-ex/lib/ix_mcp/api.ex
@@ -1,0 +1,117 @@
+defmodule IxMcp.Api do
+  @moduledoc """
+  The discovery surface, in-language (the workspace prelude aliases it):
+
+      Api.api()                 # every function of the bundled surface, one row each
+      Api.api("tail")           # rows whose name or summary mentions "tail"
+      Api.help(Jobs)            # a module's full doc
+      Api.help(Jobs, :tail)     # one function's full doc
+
+  Docs come live from `Code.fetch_docs/1`, so what you read is what is
+  actually loaded -- the same guarantee the Python `api()` gave with its
+  provenance column.
+  """
+
+  @surface [IxMcp.Jobs, IxMcp.Api, IxMcp.Kernel, IxMcp.Workspace, IxMcp.Checkpoint, IxMcp.Reader]
+
+  @type row :: %{
+          module: module(),
+          name: atom(),
+          arity: non_neg_integer(),
+          signature: String.t(),
+          summary: String.t()
+        }
+
+  @doc "Rows for the bundled surface, optionally filtered by substring on name/signature/summary."
+  @spec api(String.t() | nil) :: [row()]
+  def api(filter \\ nil) do
+    rows = Enum.flat_map(@surface, &module_rows/1)
+
+    case filter do
+      nil ->
+        rows
+
+      needle ->
+        down = String.downcase(needle)
+
+        Enum.filter(rows, fn row ->
+          String.contains?(String.downcase("#{row.name} #{row.signature} #{row.summary}"), down)
+        end)
+    end
+  end
+
+  @doc "Render `api/1` rows as an aligned text table (what the tools surface prints)."
+  @spec render([row()]) :: String.t()
+  def render(rows) do
+    Enum.map_join(rows, "\n", fn row ->
+      mod = row.module |> inspect() |> String.replace_prefix("IxMcp.", "")
+      String.pad_trailing("#{mod}.#{row.signature}", 46) <> " " <> row.summary
+    end)
+  end
+
+  @doc "Full documentation for a module."
+  @spec help(module()) :: String.t()
+  def help(module) do
+    case Code.fetch_docs(module) do
+      {:docs_v1, _, _, _, %{"en" => moduledoc}, _, _} ->
+        "# #{inspect(module)}\n\n#{moduledoc}\n\n" <> render(module_rows(module))
+
+      {:docs_v1, _, _, _, _, _, _} ->
+        "#{inspect(module)}: no module doc\n\n" <> render(module_rows(module))
+
+      {:error, reason} ->
+        "no docs for #{inspect(module)}: #{inspect(reason)}"
+    end
+  end
+
+  @doc "Full documentation for one function of a module."
+  @spec help(module(), atom()) :: String.t()
+  def help(module, function) do
+    case Code.fetch_docs(module) do
+      {:docs_v1, _, _, _, _, _, docs} ->
+        docs
+        |> Enum.filter(&match?({{:function, ^function, _}, _, _, _, _}, &1))
+        |> case do
+          [] ->
+            "#{inspect(module)}.#{function}: not found"
+
+          matches ->
+            Enum.map_join(matches, "\n\n", fn {{:function, _, _}, _, [signature | _], doc, _} ->
+              "#{inspect(module)}.#{signature}\n\n#{doc_text(doc)}"
+            end)
+        end
+
+      {:error, reason} ->
+        "no docs for #{inspect(module)}: #{inspect(reason)}"
+    end
+  end
+
+  defp module_rows(module) do
+    case Code.fetch_docs(module) do
+      {:docs_v1, _, _, _, _, _, docs} ->
+        for {{:function, name, arity}, _anno, signatures, doc, _meta} <- docs,
+            doc != :hidden do
+          %{
+            module: module,
+            name: name,
+            arity: arity,
+            signature: List.first(signatures) || "#{name}/#{arity}",
+            summary: doc |> doc_text() |> first_sentence()
+          }
+        end
+
+      {:error, _} ->
+        []
+    end
+  end
+
+  defp doc_text(%{"en" => text}), do: text
+  defp doc_text(_), do: ""
+
+  defp first_sentence(text) do
+    text
+    |> String.split("\n", parts: 2)
+    |> List.first()
+    |> String.slice(0, 120)
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/application.ex
+++ b/packages/mcp-ex/lib/ix_mcp/application.ex
@@ -1,20 +1,44 @@
 defmodule IxMcp.Application do
-  # See https://hexdocs.pm/elixir/Application.html
-  # for more information on OTP Applications
-  @moduledoc false
+  @moduledoc """
+  Supervision tree:
+
+      IxMcp.Supervisor (one_for_one)
+      ├── IxMcp.Session         session name / topic metadata
+      ├── IxMcp.Checkpoint      ETS keeper for workspace state (survives Workspace restarts)
+      ├── IxMcp.Workspace       the shared binding + Macro.Env every cell sees
+      ├── IxMcp.Jobs.Registry   id -> job process
+      ├── IxMcp.Jobs.Supervisor (DynamicSupervisor)  one child per cell/job
+      │   └── IxMcp.Jobs.Job*   runs one evaluation in a monitored process
+      ├── IxMcp.Jobs.History    ordered record of every run
+      ├── IxMcp.MCP.Notifier    server-initiated notification fan-out
+      └── IxMcp.MCP.Stdio       (only when IX_MCP_STDIO=1) the stdio transport
+
+  The transport is opt-in via environment so `mix test` and IEx sessions get
+  the full evaluator without a reader loop competing for stdin.
+  """
 
   use Application
 
   @impl true
   def start(_type, _args) do
-    children = [
-      # Starts a worker by calling: IxMcp.Worker.start_link(arg)
-      # {IxMcp.Worker, arg}
-    ]
+    children =
+      [
+        IxMcp.Session,
+        IxMcp.Checkpoint,
+        IxMcp.Workspace,
+        {Registry, keys: :unique, name: IxMcp.Jobs.Registry},
+        {DynamicSupervisor, name: IxMcp.Jobs.Supervisor, strategy: :one_for_one},
+        IxMcp.Jobs.History,
+        IxMcp.MCP.Notifier
+      ] ++ transport()
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
-    # for other strategies and supported options
-    opts = [strategy: :one_for_one, name: IxMcp.Supervisor]
-    Supervisor.start_link(children, opts)
+    Supervisor.start_link(children, strategy: :one_for_one, name: IxMcp.Supervisor)
+  end
+
+  defp transport do
+    case System.get_env("IX_MCP_STDIO") do
+      "1" -> [IxMcp.MCP.Stdio]
+      _ -> []
+    end
   end
 end

--- a/packages/mcp-ex/lib/ix_mcp/application.ex
+++ b/packages/mcp-ex/lib/ix_mcp/application.ex
@@ -11,6 +11,7 @@ defmodule IxMcp.Application do
       │   └── IxMcp.Jobs.Job*   runs one evaluation in a monitored process
       ├── IxMcp.Jobs.History    ordered record of every run
       ├── IxMcp.MCP.Notifier    server-initiated notification fan-out
+      ├── IxMcp.PrWatch.Supervisor (Task.Supervisor)  one task per PR watch
       └── IxMcp.MCP.Stdio       (only when IX_MCP_STDIO=1) the stdio transport
 
   The transport is opt-in via environment so `mix test` and IEx sessions get
@@ -29,7 +30,8 @@ defmodule IxMcp.Application do
         {Registry, keys: :unique, name: IxMcp.Jobs.Registry},
         {DynamicSupervisor, name: IxMcp.Jobs.Supervisor, strategy: :one_for_one},
         IxMcp.Jobs.History,
-        IxMcp.MCP.Notifier
+        IxMcp.MCP.Notifier,
+        {Task.Supervisor, name: IxMcp.PrWatch.Supervisor}
       ] ++ transport()
 
     Supervisor.start_link(children, strategy: :one_for_one, name: IxMcp.Supervisor)

--- a/packages/mcp-ex/lib/ix_mcp/application.ex
+++ b/packages/mcp-ex/lib/ix_mcp/application.ex
@@ -1,0 +1,20 @@
+defmodule IxMcp.Application do
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    children = [
+      # Starts a worker by calling: IxMcp.Worker.start_link(arg)
+      # {IxMcp.Worker, arg}
+    ]
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: IxMcp.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/checkpoint.ex
+++ b/packages/mcp-ex/lib/ix_mcp/checkpoint.ex
@@ -76,7 +76,9 @@ defmodule IxMcp.Checkpoint do
   def load_file(path) do
     with {:ok, bin} <- File.read(path),
          {:ix_mcp_checkpoint, 1, named} <- :erlang.binary_to_term(bin) do
-      binding = Enum.map(named, fn {name, value_bin} -> {name, :erlang.binary_to_term(value_bin)} end)
+      binding =
+        Enum.map(named, fn {name, value_bin} -> {name, :erlang.binary_to_term(value_bin)} end)
+
       {current, env} =
         case fetch() do
           {:ok, b, e} -> {b, e}
@@ -108,7 +110,9 @@ defmodule IxMcp.Checkpoint do
   defp contains_live_ref?(v) when is_pid(v) or is_port(v) or is_reference(v), do: true
   defp contains_live_ref?(v) when is_function(v), do: not check_fun(v)
   defp contains_live_ref?(v) when is_list(v), do: Enum.any?(v, &contains_live_ref?/1)
-  defp contains_live_ref?(v) when is_tuple(v), do: v |> Tuple.to_list() |> Enum.any?(&contains_live_ref?/1)
+
+  defp contains_live_ref?(v) when is_tuple(v),
+    do: v |> Tuple.to_list() |> Enum.any?(&contains_live_ref?/1)
 
   defp contains_live_ref?(%_struct{} = v),
     do: v |> Map.from_struct() |> Map.values() |> Enum.any?(&contains_live_ref?/1)

--- a/packages/mcp-ex/lib/ix_mcp/checkpoint.ex
+++ b/packages/mcp-ex/lib/ix_mcp/checkpoint.ex
@@ -1,0 +1,130 @@
+defmodule IxMcp.Checkpoint do
+  @moduledoc """
+  Keeps the workspace's binding and env in an ETS table owned by this process,
+  so a crashed or deliberately restarted `IxMcp.Workspace` restores its state
+  on init. Because the table never leaves the VM, values need no serialization
+  -- pids, refs, and closures all survive a workspace restart intact.
+
+  `save_file/1` / `load_file/1` additionally persist to disk for cross-VM
+  session restore, per-name via `:erlang.term_to_binary/1`; names whose values
+  cannot be externalized (live pids, ports, refs) are skipped and reported,
+  matching the Python session checkpointer's skip-and-report contract.
+  """
+
+  use GenServer
+
+  @table __MODULE__
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    _ = :ets.new(@table, [:named_table, :set, :public, read_concurrency: true])
+    {:ok, %{}}
+  end
+
+  @spec store(Code.binding(), Macro.Env.t()) :: :ok
+  def store(binding, env) do
+    :ets.insert(@table, {:workspace, binding, env})
+    :ok
+  end
+
+  @spec fetch() :: {:ok, Code.binding(), Macro.Env.t()} | :empty
+  def fetch do
+    case :ets.lookup(@table, :workspace) do
+      [{:workspace, binding, env}] -> {:ok, binding, env}
+      [] -> :empty
+    end
+  end
+
+  @spec clear() :: :ok
+  def clear do
+    :ets.delete(@table, :workspace)
+    :ok
+  end
+
+  @doc "Persist the current checkpoint to `path`. Returns names skipped as unserializable."
+  @spec save_file(Path.t()) :: {:ok, [atom()]} | {:error, term()}
+  def save_file(path) do
+    case fetch() do
+      :empty ->
+        {:error, :empty}
+
+      {:ok, binding, _env} ->
+        {kept, skipped} =
+          Enum.reduce(binding, {[], []}, fn {name, value}, {kept, skipped} ->
+            case try_externalize(value) do
+              {:ok, bin} -> {[{name, bin} | kept], skipped}
+              :error -> {kept, [name | skipped]}
+            end
+          end)
+
+        payload = :erlang.term_to_binary({:ix_mcp_checkpoint, 1, Enum.reverse(kept)})
+
+        case File.write(path, payload) do
+          :ok -> {:ok, Enum.reverse(skipped)}
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  @doc "Load a checkpoint file into the live table (merging over current binding)."
+  @spec load_file(Path.t()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def load_file(path) do
+    with {:ok, bin} <- File.read(path),
+         {:ix_mcp_checkpoint, 1, named} <- :erlang.binary_to_term(bin) do
+      binding = Enum.map(named, fn {name, value_bin} -> {name, :erlang.binary_to_term(value_bin)} end)
+      {current, env} =
+        case fetch() do
+          {:ok, b, e} -> {b, e}
+          :empty -> {[], Code.env_for_eval(file: "cell")}
+        end
+
+      merged = Keyword.merge(current, binding)
+      store(merged, env)
+      {:ok, length(binding)}
+    else
+      {:error, reason} -> {:error, reason}
+      _other -> {:error, :bad_checkpoint}
+    end
+  end
+
+  # A term is externalizable when a round trip through the external term
+  # format yields a structurally equal term: pids/ports/refs survive encoding
+  # but come back dead, so reject anything containing them outright.
+  defp try_externalize(value) do
+    if contains_live_ref?(value) do
+      :error
+    else
+      {:ok, :erlang.term_to_binary(value)}
+    end
+  rescue
+    _ -> :error
+  end
+
+  defp contains_live_ref?(v) when is_pid(v) or is_port(v) or is_reference(v), do: true
+  defp contains_live_ref?(v) when is_function(v), do: not check_fun(v)
+  defp contains_live_ref?(v) when is_list(v), do: Enum.any?(v, &contains_live_ref?/1)
+  defp contains_live_ref?(v) when is_tuple(v), do: v |> Tuple.to_list() |> Enum.any?(&contains_live_ref?/1)
+
+  defp contains_live_ref?(%_struct{} = v),
+    do: v |> Map.from_struct() |> Map.values() |> Enum.any?(&contains_live_ref?/1)
+
+  defp contains_live_ref?(v) when is_map(v) do
+    Enum.any?(v, fn {k, val} -> contains_live_ref?(k) or contains_live_ref?(val) end)
+  end
+
+  defp contains_live_ref?(_), do: false
+
+  # Closures defined in cells reference modules that exist only in this VM;
+  # only external (capture) funs of loaded modules survive a file round trip.
+  defp check_fun(fun) do
+    case Function.info(fun, :type) do
+      {:type, :external} -> true
+      _ -> false
+    end
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/evaluator.ex
+++ b/packages/mcp-ex/lib/ix_mcp/evaluator.ex
@@ -1,0 +1,89 @@
+defmodule IxMcp.Evaluator do
+  @moduledoc """
+  Evaluates one cell in the calling process, the way Livebook's
+  `Livebook.Runtime.Evaluator` does it: parse to AST, then
+  `Code.eval_quoted_with_env/4` with `:prune_binding` against a snapshot of
+  the workspace context. Output goes to whatever group leader the caller
+  installed (each job installs its own `IxMcp.Evaluator.IOProxy`).
+
+  The parse step is the per-cell gate: code that does not parse is rejected
+  with a compiler diagnostic and never evaluated. Compile-time warnings are
+  collected via `Code.with_diagnostics/2` and returned alongside the result.
+  """
+
+  @type ok :: {:ok, term(), Code.binding(), Macro.Env.t(), [String.t()]}
+  @type failure :: {:parse_error, String.t()} | {:runtime_error, String.t(), [String.t()]}
+
+  @spec eval(String.t(), Code.binding(), Macro.Env.t()) :: ok() | failure()
+  def eval(code, binding, env) when is_binary(code) do
+    case Code.string_to_quoted(code, file: env.file, columns: true, emit_warnings: false) do
+      {:ok, quoted} ->
+        eval_quoted(quoted, binding, env)
+
+      {:error, {meta, message, token}} ->
+        {:parse_error, format_parse_error(meta, message, token)}
+    end
+  end
+
+  defp eval_quoted(quoted, binding, env) do
+    {result, diagnostics} =
+      Code.with_diagnostics(fn ->
+        try do
+          {value, binding, env} =
+            Code.eval_quoted_with_env(quoted, binding, env, prune_binding: true)
+
+          {:ok, value, binding, env}
+        catch
+          kind, error ->
+            {:error, format_error(kind, error, prune_stacktrace(__STACKTRACE__))}
+        end
+      end)
+
+    rendered_diags = Enum.map(diagnostics, &format_diagnostic/1)
+
+    case result do
+      {:ok, value, binding, env} -> {:ok, value, binding, env, rendered_diags}
+      {:error, formatted} -> {:runtime_error, formatted, rendered_diags}
+    end
+  end
+
+  @doc "Render a value the way the REPL should show it."
+  @spec render(term()) :: String.t()
+  def render(value) do
+    inspect(value, pretty: true, limit: 50, printable_limit: 4096, width: 100)
+  end
+
+  defp format_error(kind, error, stacktrace) do
+    Exception.format(kind, error, stacktrace)
+  end
+
+  defp format_parse_error(meta, message, token) do
+    line = Keyword.get(meta, :line, 1)
+    column = Keyword.get(meta, :column, 1)
+    rendered_message = render_parse_message(message, token)
+    "cell:#{line}:#{column}: #{rendered_message}"
+  end
+
+  # `Code.string_to_quoted/2` reports the message either as a binary or as a
+  # {prefix, suffix} pair the token belongs between.
+  defp render_parse_message({prefix, suffix}, token), do: "#{prefix}#{token}#{suffix}"
+  defp render_parse_message(message, token), do: "#{message}#{token}"
+
+  defp format_diagnostic(%{severity: severity, message: message, position: position}) do
+    "#{severity}: cell:#{format_position(position)}: #{message}"
+  end
+
+  defp format_position({line, column}), do: "#{line}:#{column}"
+  defp format_position(line) when is_integer(line), do: "#{line}"
+  defp format_position(_), do: "?"
+
+  # Everything below the compiler's eval frames is evaluator machinery the
+  # cell author did not write; cut it the way Livebook does.
+  defp prune_stacktrace(stacktrace) do
+    stacktrace
+    |> Enum.take_while(fn {mod, fun, _arity, _meta} -> {mod, fun} != {:elixir, :eval_forms} end)
+    |> Enum.reject(fn {mod, _fun, _arity, _meta} ->
+      mod in [IxMcp.Evaluator, Code, :elixir, :erl_eval]
+    end)
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/evaluator/io_proxy.ex
+++ b/packages/mcp-ex/lib/ix_mcp/evaluator/io_proxy.ex
@@ -1,0 +1,64 @@
+defmodule IxMcp.Evaluator.IOProxy do
+  @moduledoc """
+  A group leader for one job: an Erlang IO device that appends every
+  `put_chars` request to the job's output buffer instead of the real stdout.
+
+  Installing it as group leader does double duty. First, output capture:
+  `IO.puts` in a cell, and in every process the cell spawns, lands in the
+  job's pageable buffer. Second, process tagging: the group leader is
+  inherited by spawned processes, so "every process this job created" is
+  answerable by scanning `Process.list/0` for this group leader -- which is
+  how cancellation finds the OS processes a job's cells spawned (see
+  `IxMcp.OsProc`).
+
+  Input requests answer `:eof`: cells are non-interactive, exactly like the
+  Python kernel.
+  """
+
+  @spec start_link((iodata() -> any())) :: {:ok, pid()}
+  def start_link(sink) when is_function(sink, 1) do
+    {:ok, spawn_link(fn -> loop(sink) end)}
+  end
+
+  defp loop(sink) do
+    receive do
+      {:io_request, from, reply_as, request} ->
+        send(from, {:io_reply, reply_as, handle(request, sink)})
+        loop(sink)
+
+      _other ->
+        loop(sink)
+    end
+  end
+
+  defp handle({:put_chars, encoding, chars}, sink) do
+    sink.(convert(chars, encoding))
+    :ok
+  rescue
+    _ -> {:error, :put_chars}
+  end
+
+  defp handle({:put_chars, encoding, mod, fun, args}, sink) do
+    handle({:put_chars, encoding, apply(mod, fun, args)}, sink)
+  end
+
+  defp handle({:requests, requests}, sink) do
+    Enum.reduce_while(requests, :ok, fn request, :ok ->
+      case handle(request, sink) do
+        :ok -> {:cont, :ok}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp handle({:get_chars, _enc, _prompt, _count}, _sink), do: :eof
+  defp handle({:get_line, _enc, _prompt}, _sink), do: :eof
+  defp handle({:get_until, _enc, _prompt, _mod, _fun, _args}, _sink), do: :eof
+  defp handle({:setopts, _opts}, _sink), do: :ok
+  defp handle(:getopts, _sink), do: [binary: true, encoding: :unicode]
+  defp handle({:get_geometry, _}, _sink), do: {:error, :enotsup}
+  defp handle(_request, _sink), do: {:error, :request}
+
+  defp convert(chars, :unicode), do: :unicode.characters_to_binary(chars)
+  defp convert(chars, :latin1), do: :erlang.iolist_to_binary(chars)
+end

--- a/packages/mcp-ex/lib/ix_mcp/jobs.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs.ex
@@ -10,6 +10,7 @@ defmodule IxMcp.Jobs do
       Jobs.history()            # recent runs, newest first
   """
 
+  alias IxMcp.Jobs.History
   alias IxMcp.Jobs.Job
 
   @doc """
@@ -113,8 +114,8 @@ defmodule IxMcp.Jobs do
   end
 
   @doc "Recent runs, newest first."
-  @spec history(pos_integer()) :: [IxMcp.Jobs.History.entry()]
-  def history(n \\ 20), do: IxMcp.Jobs.History.list(n)
+  @spec history(pos_integer()) :: [History.entry()]
+  def history(n \\ 20), do: History.list(n)
 
   defp lines(id) do
     id |> output() |> String.split("\n")

--- a/packages/mcp-ex/lib/ix_mcp/jobs.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs.ex
@@ -1,0 +1,133 @@
+defmodule IxMcp.Jobs do
+  @moduledoc """
+  The job registry facade -- available in every cell (the workspace prelude
+  aliases it), so job control needs no extra tools, exactly like the Python
+  kernel's `jobs` dict:
+
+      Jobs.tail("ab12", 20)     # last lines of a run's output
+      Jobs.await("ab12")        # block this cell (only this cell) until done
+      Jobs.cancel("ab12")       # kill it, and every OS process it spawned
+      Jobs.history()            # recent runs, newest first
+  """
+
+  alias IxMcp.Jobs.Job
+
+  @doc """
+  Start `code` as a new job and wait up to `budget_s` seconds. Finished or
+  not, returns `{summary, output}` -- when still running, the job continues
+  in the background under its returned id.
+  """
+  @spec run(String.t(), keyword()) :: {Job.summary(), String.t()}
+  def run(code, opts \\ []) when is_binary(code) do
+    budget_s = Keyword.get(opts, :budget, 15)
+    id = generate_id()
+
+    {:ok, pid} =
+      DynamicSupervisor.start_child(
+        IxMcp.Jobs.Supervisor,
+        {Job, {id, code, Keyword.take(opts, [:intent])}}
+      )
+
+    case Job.await(pid, round(budget_s * 1000)) do
+      {:ok, summary} -> {summary, Job.output(pid)}
+      :timeout -> {Job.summary(pid), Job.output(pid)}
+    end
+  end
+
+  @doc "Look up a job process by id."
+  @spec lookup(String.t()) :: {:ok, pid()} | {:error, :not_found}
+  def lookup(id) do
+    case Registry.lookup(IxMcp.Jobs.Registry, id) do
+      [{pid, _}] -> {:ok, pid}
+      [] -> {:error, :not_found}
+    end
+  end
+
+  @spec get(String.t()) :: Job.summary()
+  def get(id), do: with_job(id, &Job.summary/1)
+
+  @doc "Block the calling process (a cell, never the server) until the job finishes."
+  @spec await(String.t(), timeout()) :: Job.summary() | :timeout
+  def await(id, timeout_ms \\ :infinity) do
+    with_job(id, fn pid ->
+      case Job.await(pid, timeout_ms) do
+        {:ok, summary} -> summary
+        :timeout -> :timeout
+      end
+    end)
+  end
+
+  @spec cancel(String.t()) :: :ok | {:error, :finished}
+  def cancel(id), do: with_job(id, &Job.cancel/1)
+
+  @spec result(String.t()) :: {:ok, term()} | {:error, :running | String.t()}
+  def result(id), do: with_job(id, &Job.result/1)
+
+  @spec output(String.t()) :: String.t()
+  def output(id), do: with_job(id, &Job.output/1)
+
+  @doc "Last `n` lines of the job's output."
+  @spec tail(String.t(), pos_integer()) :: String.t()
+  def tail(id, n \\ 20) do
+    id |> lines() |> Enum.take(-n) |> Enum.join("\n")
+  end
+
+  @doc "First `n` lines of the job's output."
+  @spec head(String.t(), pos_integer()) :: String.t()
+  def head(id, n \\ 20) do
+    id |> lines() |> Enum.take(n) |> Enum.join("\n")
+  end
+
+  @doc "Lines `first..last` (1-based, inclusive)."
+  @spec lines(String.t(), pos_integer(), pos_integer()) :: String.t()
+  def lines(id, first, last) when first >= 1 and last >= first do
+    id |> lines() |> Enum.slice((first - 1)..(last - 1)) |> Enum.join("\n")
+  end
+
+  @doc "Lines `[from, to)` (0-based, exclusive), Python-slice style."
+  @spec slice(String.t(), non_neg_integer(), non_neg_integer()) :: String.t()
+  def slice(id, from, to) when from >= 0 and to >= from do
+    id |> lines() |> Enum.slice(from, to - from) |> Enum.join("\n")
+  end
+
+  @doc "Output lines matching `pattern` (a regex or a plain substring)."
+  @spec grep(String.t(), Regex.t() | String.t()) :: String.t()
+  def grep(id, %Regex{} = pattern) do
+    id |> lines() |> Enum.filter(&Regex.match?(pattern, &1)) |> Enum.join("\n")
+  end
+
+  def grep(id, pattern) when is_binary(pattern) do
+    id |> lines() |> Enum.filter(&String.contains?(&1, pattern)) |> Enum.join("\n")
+  end
+
+  @doc "Ids and summaries of jobs that are still running."
+  @spec running() :: [Job.summary()]
+  def running do
+    IxMcp.Jobs.Supervisor
+    |> DynamicSupervisor.which_children()
+    |> Enum.flat_map(fn
+      {_, pid, :worker, _} when is_pid(pid) -> [Job.summary(pid)]
+      _ -> []
+    end)
+    |> Enum.filter(& &1.running)
+  end
+
+  @doc "Recent runs, newest first."
+  @spec history(pos_integer()) :: [IxMcp.Jobs.History.entry()]
+  def history(n \\ 20), do: IxMcp.Jobs.History.list(n)
+
+  defp lines(id) do
+    id |> output() |> String.split("\n")
+  end
+
+  defp with_job(id, fun) do
+    case lookup(id) do
+      {:ok, pid} -> fun.(pid)
+      {:error, :not_found} -> raise ArgumentError, "no such job: #{inspect(id)}"
+    end
+  end
+
+  defp generate_id do
+    Base.encode16(:crypto.strong_rand_bytes(4), case: :lower)
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/jobs/history.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs/history.ex
@@ -1,0 +1,46 @@
+defmodule IxMcp.Jobs.History do
+  @moduledoc """
+  Ordered record of every run: id, intent, session/topic at start time, a code
+  preview, and final status. This is what `Jobs.history/1` pages and what the
+  `elixir_exec` feed groups by session and topic.
+  """
+
+  use Agent
+
+  @type entry :: %{
+          id: String.t(),
+          intent: String.t() | nil,
+          session: String.t() | nil,
+          topic: String.t() | nil,
+          code: String.t(),
+          status: IxMcp.Jobs.Job.status(),
+          started_at: DateTime.t(),
+          elapsed_s: float() | nil
+        }
+
+  @spec start_link(term()) :: Agent.on_start()
+  def start_link(_opts) do
+    Agent.start_link(fn -> [] end, name: __MODULE__)
+  end
+
+  @spec record(map()) :: :ok
+  def record(entry) do
+    Agent.update(__MODULE__, fn entries -> [Map.put(entry, :elapsed_s, nil) | entries] end)
+  end
+
+  @spec finished(String.t(), IxMcp.Jobs.Job.status(), float()) :: :ok
+  def finished(id, status, elapsed_s) do
+    Agent.update(__MODULE__, fn entries ->
+      Enum.map(entries, fn
+        %{id: ^id} = entry -> %{entry | status: status, elapsed_s: elapsed_s}
+        entry -> entry
+      end)
+    end)
+  end
+
+  @doc "Latest `n` runs, newest first."
+  @spec list(pos_integer()) :: [entry()]
+  def list(n \\ 20) do
+    Agent.get(__MODULE__, fn entries -> Enum.take(entries, n) end)
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
@@ -71,6 +71,10 @@ defmodule IxMcp.Jobs.Job do
   @spec cancel(GenServer.server()) :: :ok | {:error, :finished}
   def cancel(server), do: GenServer.call(server, :cancel)
 
+  @doc "The evaluation process and IO proxy (for tracing from outside)."
+  @spec procs(GenServer.server()) :: {pid(), pid()}
+  def procs(server), do: GenServer.call(server, :procs)
+
   @doc """
   Wait until the job finishes, up to `timeout_ms`. Returns the final summary
   or `:timeout` -- in which case the job keeps running in the background,
@@ -198,6 +202,8 @@ defmodule IxMcp.Jobs.Job do
   end
 
   def handle_call(:buffer, _from, state), do: {:reply, state.buffer, state}
+
+  def handle_call(:procs, _from, state), do: {:reply, {state.eval_pid, state.io_proxy}, state}
 
   @impl true
   def handle_cast({:unsubscribe, pid}, state) do

--- a/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
@@ -16,7 +16,11 @@ defmodule IxMcp.Jobs.Job do
 
   alias IxMcp.Evaluator
   alias IxMcp.Evaluator.IOProxy
+  alias IxMcp.Jobs.History
+  alias IxMcp.MCP.Notifier
   alias IxMcp.OsProc
+  alias IxMcp.Session
+  alias IxMcp.Workspace
 
   @enforce_keys [:id, :code]
   defstruct [
@@ -39,6 +43,25 @@ defmodule IxMcp.Jobs.Job do
   ]
 
   @type status :: :running | :done | :failed | :cancelled
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          code: String.t(),
+          intent: String.t() | nil,
+          session: String.t() | nil,
+          topic: String.t() | nil,
+          buffer: :ets.tid() | nil,
+          io_proxy: pid() | nil,
+          eval_pid: pid() | nil,
+          eval_ref: reference() | nil,
+          started_mono: integer() | nil,
+          started_at: DateTime.t() | nil,
+          finished_mono: integer() | nil,
+          result: {:value, term()} | {:failure, String.t()} | nil,
+          status: status(),
+          diagnostics: [String.t()],
+          subscribers: [pid()]
+        }
 
   @type summary :: %{
           id: String.t(),
@@ -117,7 +140,7 @@ defmodule IxMcp.Jobs.Job do
 
   @impl true
   def init({id, code, opts}) do
-    session = IxMcp.Session.get()
+    session = Session.get()
 
     state = %__MODULE__{
       id: id,
@@ -144,12 +167,12 @@ defmodule IxMcp.Jobs.Job do
     {eval_pid, eval_ref} =
       spawn_monitor(fn ->
         Process.group_leader(self(), io_proxy)
-        {binding, env} = IxMcp.Workspace.snapshot()
+        {binding, env} = Workspace.snapshot()
 
         outcome =
           case Evaluator.eval(code, binding, env) do
             {:ok, value, binding, env, diags} ->
-              IxMcp.Workspace.merge(binding, env)
+              Workspace.merge(binding, env)
               {:done, value, diags}
 
             {:parse_error, message} ->
@@ -162,7 +185,7 @@ defmodule IxMcp.Jobs.Job do
         send(job, {:eval_finished, self(), outcome})
       end)
 
-    IxMcp.Jobs.History.record(initial_history(state))
+    History.record(initial_history(state))
     {:noreply, %{state | io_proxy: io_proxy, eval_pid: eval_pid, eval_ref: eval_ref}}
   end
 
@@ -223,7 +246,10 @@ defmodule IxMcp.Jobs.Job do
     {:noreply, state}
   end
 
-  def handle_info({:DOWN, ref, :process, _pid, reason}, %{eval_ref: ref, status: :running} = state) do
+  def handle_info(
+        {:DOWN, ref, :process, _pid, reason},
+        %{eval_ref: ref, status: :running} = state
+      ) do
     # The cell's process died without reporting: a crash (exit, throw from a
     # linked process, kill). The exit reason IS the crash report, state and
     # all -- format it whole.
@@ -245,8 +271,8 @@ defmodule IxMcp.Jobs.Job do
 
     summary = build_summary(state)
     Enum.each(state.subscribers, fn pid -> send(pid, {:ix_job_finished, state.id, summary}) end)
-    IxMcp.Jobs.History.finished(state.id, status, summary.elapsed_s)
-    IxMcp.MCP.Notifier.job_finished(summary)
+    History.finished(state.id, status, summary.elapsed_s)
+    Notifier.job_finished(summary)
     %{state | subscribers: []}
   end
 
@@ -263,7 +289,8 @@ defmodule IxMcp.Jobs.Job do
       running: state.status == :running,
       intent: state.intent,
       elapsed_s: (finished - state.started_mono) / 1000,
-      output_bytes: :ets.foldl(fn {_seq, chunk}, acc -> acc + byte_size(chunk) end, 0, state.buffer),
+      output_bytes:
+        :ets.foldl(fn {_seq, chunk}, acc -> acc + byte_size(chunk) end, 0, state.buffer),
       diagnostics: state.diagnostics,
       result: render_result(state)
     }

--- a/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
@@ -1,0 +1,281 @@
+defmodule IxMcp.Jobs.Job do
+  @moduledoc """
+  One cell run. The GenServer is the job's record and control point; the
+  evaluation itself happens in a separate spawned process so that a blocking
+  cell blocks only itself -- the scheduler preempts it, other jobs and the
+  server keep running, and cancellation is `Process.exit(pid, :kill)` plus OS
+  subprocess-tree cleanup rather than a signal hack against a wedged loop.
+
+  The process stays alive after the run finishes: it holds the output buffer
+  (an ETS table) and the result term, so paging (`tail/head/grep/...`) and
+  `Jobs.result/1` work for as long as the server lives, like the Python
+  `jobs` dict.
+  """
+
+  use GenServer, restart: :temporary
+
+  alias IxMcp.Evaluator
+  alias IxMcp.Evaluator.IOProxy
+  alias IxMcp.OsProc
+
+  @enforce_keys [:id, :code]
+  defstruct [
+    :id,
+    :code,
+    :intent,
+    :session,
+    :topic,
+    :buffer,
+    :io_proxy,
+    :eval_pid,
+    :eval_ref,
+    :started_mono,
+    :started_at,
+    :finished_mono,
+    :result,
+    status: :running,
+    diagnostics: [],
+    subscribers: []
+  ]
+
+  @type status :: :running | :done | :failed | :cancelled
+
+  @type summary :: %{
+          id: String.t(),
+          status: status(),
+          running: boolean(),
+          intent: String.t() | nil,
+          elapsed_s: float(),
+          output_bytes: non_neg_integer(),
+          diagnostics: [String.t()],
+          result: String.t() | nil
+        }
+
+  # -- client ----------------------------------------------------------------
+
+  @spec start_link({String.t(), String.t(), keyword()}) :: GenServer.on_start()
+  def start_link({id, code, opts}) do
+    GenServer.start_link(__MODULE__, {id, code, opts}, name: via(id))
+  end
+
+  @spec via(String.t()) :: {:via, Registry, {IxMcp.Jobs.Registry, String.t()}}
+  def via(id), do: {:via, Registry, {IxMcp.Jobs.Registry, id}}
+
+  @spec summary(GenServer.server()) :: summary()
+  def summary(server), do: GenServer.call(server, :summary)
+
+  @doc "The job's result value. `{:error, :running}` while the job runs."
+  @spec result(GenServer.server()) :: {:ok, term()} | {:error, :running | String.t()}
+  def result(server), do: GenServer.call(server, :result)
+
+  @spec cancel(GenServer.server()) :: :ok | {:error, :finished}
+  def cancel(server), do: GenServer.call(server, :cancel)
+
+  @doc """
+  Wait until the job finishes, up to `timeout_ms`. Returns the final summary
+  or `:timeout` -- in which case the job keeps running in the background,
+  which is the entire budget-then-background contract.
+  """
+  @spec await(GenServer.server(), timeout()) :: {:ok, summary()} | :timeout
+  def await(server, timeout_ms) do
+    case GenServer.call(server, {:subscribe, self()}) do
+      {:finished, summary} ->
+        {:ok, summary}
+
+      :subscribed ->
+        receive do
+          {:ix_job_finished, _id, summary} -> {:ok, summary}
+        after
+          timeout_ms ->
+            GenServer.cast(server, {:unsubscribe, self()})
+
+            # The finish notification may have raced the timeout; prefer it.
+            receive do
+              {:ix_job_finished, _id, summary} -> {:ok, summary}
+            after
+              0 -> :timeout
+            end
+        end
+    end
+  end
+
+  @doc "Full captured output of the job as one binary."
+  @spec output(GenServer.server()) :: String.t()
+  def output(server) do
+    server
+    |> GenServer.call(:buffer)
+    |> :ets.tab2list()
+    |> Enum.sort()
+    |> Enum.map_join("", fn {_seq, chunk} -> chunk end)
+  end
+
+  # -- server ----------------------------------------------------------------
+
+  @impl true
+  def init({id, code, opts}) do
+    session = IxMcp.Session.get()
+
+    state = %__MODULE__{
+      id: id,
+      code: code,
+      intent: Keyword.get(opts, :intent),
+      session: session.name,
+      topic: session.topic,
+      buffer: :ets.new(:job_output, [:ordered_set, :public]),
+      started_mono: System.monotonic_time(:millisecond),
+      started_at: DateTime.utc_now()
+    }
+
+    {:ok, state, {:continue, :spawn_eval}}
+  end
+
+  @impl true
+  def handle_continue(:spawn_eval, state) do
+    buffer = state.buffer
+    {:ok, io_proxy} = IOProxy.start_link(fn chunk -> append(buffer, chunk) end)
+
+    job = self()
+    code = state.code
+
+    {eval_pid, eval_ref} =
+      spawn_monitor(fn ->
+        Process.group_leader(self(), io_proxy)
+        {binding, env} = IxMcp.Workspace.snapshot()
+
+        outcome =
+          case Evaluator.eval(code, binding, env) do
+            {:ok, value, binding, env, diags} ->
+              IxMcp.Workspace.merge(binding, env)
+              {:done, value, diags}
+
+            {:parse_error, message} ->
+              {:failed, "parse error: " <> message, []}
+
+            {:runtime_error, formatted, diags} ->
+              {:failed, formatted, diags}
+          end
+
+        send(job, {:eval_finished, self(), outcome})
+      end)
+
+    IxMcp.Jobs.History.record(initial_history(state))
+    {:noreply, %{state | io_proxy: io_proxy, eval_pid: eval_pid, eval_ref: eval_ref}}
+  end
+
+  @impl true
+  def handle_call(:summary, _from, state), do: {:reply, build_summary(state), state}
+
+  def handle_call(:result, _from, %{status: :running} = state),
+    do: {:reply, {:error, :running}, state}
+
+  def handle_call(:result, _from, %{result: {:value, value}} = state),
+    do: {:reply, {:ok, value}, state}
+
+  def handle_call(:result, _from, %{result: {:failure, message}} = state),
+    do: {:reply, {:error, message}, state}
+
+  def handle_call(:cancel, _from, %{status: :running} = state) do
+    # OS subprocesses first: once the BEAM processes die, the ports close and
+    # the pids can no longer be discovered.
+    state.io_proxy |> OsProc.os_pids() |> Enum.each(&OsProc.kill_tree/1)
+
+    state.io_proxy
+    |> OsProc.job_processes()
+    |> Enum.each(fn pid -> Process.exit(pid, :kill) end)
+
+    Process.demonitor(state.eval_ref, [:flush])
+    {:reply, :ok, finish(state, :cancelled, {:failure, "cancelled"}, [])}
+  end
+
+  def handle_call(:cancel, _from, state), do: {:reply, {:error, :finished}, state}
+
+  def handle_call({:subscribe, pid}, _from, %{status: :running} = state) do
+    {:reply, :subscribed, %{state | subscribers: [pid | state.subscribers]}}
+  end
+
+  def handle_call({:subscribe, _pid}, _from, state) do
+    {:reply, {:finished, build_summary(state)}, state}
+  end
+
+  def handle_call(:buffer, _from, state), do: {:reply, state.buffer, state}
+
+  @impl true
+  def handle_cast({:unsubscribe, pid}, state) do
+    {:noreply, %{state | subscribers: List.delete(state.subscribers, pid)}}
+  end
+
+  @impl true
+  def handle_info({:eval_finished, pid, outcome}, %{eval_pid: pid} = state) do
+    Process.demonitor(state.eval_ref, [:flush])
+
+    state =
+      case outcome do
+        {:done, value, diags} -> finish(state, :done, {:value, value}, diags)
+        {:failed, message, diags} -> finish(state, :failed, {:failure, message}, diags)
+      end
+
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, reason}, %{eval_ref: ref, status: :running} = state) do
+    # The cell's process died without reporting: a crash (exit, throw from a
+    # linked process, kill). The exit reason IS the crash report, state and
+    # all -- format it whole.
+    {:noreply, finish(state, :failed, {:failure, Exception.format_exit(reason)}, [])}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # -- internals ---------------------------------------------------------------
+
+  defp finish(state, status, result, diags) do
+    state = %{
+      state
+      | status: status,
+        result: result,
+        diagnostics: diags,
+        finished_mono: System.monotonic_time(:millisecond)
+    }
+
+    summary = build_summary(state)
+    Enum.each(state.subscribers, fn pid -> send(pid, {:ix_job_finished, state.id, summary}) end)
+    IxMcp.Jobs.History.finished(state.id, status, summary.elapsed_s)
+    IxMcp.MCP.Notifier.job_finished(summary)
+    %{state | subscribers: []}
+  end
+
+  defp append(buffer, chunk) do
+    :ets.insert(buffer, {System.unique_integer([:monotonic]), chunk})
+  end
+
+  defp build_summary(state) do
+    finished = state.finished_mono || System.monotonic_time(:millisecond)
+
+    %{
+      id: state.id,
+      status: state.status,
+      running: state.status == :running,
+      intent: state.intent,
+      elapsed_s: (finished - state.started_mono) / 1000,
+      output_bytes: :ets.foldl(fn {_seq, chunk}, acc -> acc + byte_size(chunk) end, 0, state.buffer),
+      diagnostics: state.diagnostics,
+      result: render_result(state)
+    }
+  end
+
+  defp render_result(%{result: {:value, value}}), do: Evaluator.render(value)
+  defp render_result(%{result: {:failure, message}}), do: message
+  defp render_result(_), do: nil
+
+  defp initial_history(state) do
+    %{
+      id: state.id,
+      intent: state.intent,
+      session: state.session,
+      topic: state.topic,
+      code: String.slice(state.code, 0, 200),
+      status: :running,
+      started_at: state.started_at
+    }
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/kernel.ex
+++ b/packages/mcp-ex/lib/ix_mcp/kernel.ex
@@ -78,7 +78,9 @@ defmodule IxMcp.Kernel do
       info ->
         stack =
           info[:current_stacktrace]
-          |> Enum.map_join("\n", fn entry -> "    " <> Exception.format_stacktrace_entry(entry) end)
+          |> Enum.map_join("\n", fn entry ->
+            "    " <> Exception.format_stacktrace_entry(entry)
+          end)
 
         "#{label} #{inspect(pid)} [#{info[:status]}, queue=#{info[:message_queue_len]}, reductions=#{info[:reductions]}]\n" <>
           stack

--- a/packages/mcp-ex/lib/ix_mcp/kernel.ex
+++ b/packages/mcp-ex/lib/ix_mcp/kernel.ex
@@ -1,0 +1,87 @@
+defmodule IxMcp.Kernel do
+  @moduledoc """
+  The operations that needed signal hacks in the Python kernel, as ordinary
+  BEAM introspection:
+
+  * `trace/0` -- a live stack dump of every job's evaluation process (and the
+    processes it spawned), taken with `Process.info/2` from outside. It works
+    no matter what any cell is doing, because no cell can block this process.
+  * `restart/0` -- kill every running job (including its OS subprocesses),
+    restart the workspace, and restore bindings from the checkpoint table.
+    Blast radius: this server's jobs, nothing else.
+  """
+
+  alias IxMcp.Jobs
+  alias IxMcp.Jobs.Job
+
+  @doc "Human-readable stack report for all running jobs and core server processes."
+  @spec trace() :: String.t()
+  def trace do
+    job_sections =
+      for summary <- Jobs.running() do
+        {:ok, pid} = Jobs.lookup(summary.id)
+        {eval_pid, io_proxy} = Job.procs(pid)
+
+        spawned =
+          io_proxy
+          |> IxMcp.OsProc.job_processes()
+          |> List.delete(eval_pid)
+
+        section =
+          [
+            "job #{summary.id} (#{summary.intent || "no intent"}), " <>
+              "running #{Float.round(summary.elapsed_s, 1)}s:",
+            describe(eval_pid, "  eval")
+          ] ++ Enum.map(spawned, &describe(&1, "  spawned"))
+
+        Enum.join(section, "\n")
+      end
+
+    core_sections =
+      for name <- [IxMcp.Workspace, IxMcp.Session, IxMcp.Checkpoint, IxMcp.MCP.Stdio],
+          pid = Process.whereis(name),
+          pid != nil,
+          do: describe(pid, inspect(name))
+
+    sections = job_sections ++ ["core processes:" | core_sections]
+
+    case job_sections do
+      [] -> Enum.join(["no running jobs" | sections], "\n")
+      _ -> Enum.join(sections, "\n\n")
+    end
+  end
+
+  @doc """
+  Restart the evaluator: cancel all running jobs (their OS process trees die
+  with them), restart the workspace process, and restore bindings from the
+  checkpoint. Returns what was killed and what came back.
+  """
+  @spec restart() :: %{jobs_cancelled: [String.t()], bindings_restored: non_neg_integer()}
+  def restart do
+    cancelled =
+      for summary <- Jobs.running() do
+        Jobs.cancel(summary.id)
+        summary.id
+      end
+
+    :ok = Supervisor.terminate_child(IxMcp.Supervisor, IxMcp.Workspace)
+    {:ok, _pid} = Supervisor.restart_child(IxMcp.Supervisor, IxMcp.Workspace)
+
+    %{jobs_cancelled: cancelled, bindings_restored: length(IxMcp.Workspace.names())}
+  end
+
+  defp describe(pid, label) do
+    case Process.info(pid, [:current_stacktrace, :status, :message_queue_len, :reductions]) do
+      nil ->
+        "#{label} #{inspect(pid)}: dead"
+
+      info ->
+        stack =
+          info[:current_stacktrace]
+          |> Enum.map_join("\n", fn entry -> "    " <> Exception.format_stacktrace_entry(entry) end)
+
+        "#{label} #{inspect(pid)} [#{info[:status]}, queue=#{info[:message_queue_len]}, reductions=#{info[:reductions]}]\n" <>
+          stack
+    end
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/notifier.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/notifier.ex
@@ -1,0 +1,70 @@
+defmodule IxMcp.MCP.Notifier do
+  @moduledoc """
+  Fan-out point for server-initiated MCP notifications (the "channel"): job
+  completions and failures are pushed to every connected transport, carrying
+  the full crash reason -- on the BEAM the exit reason is already a crash
+  report with state, so nothing has to be reconstructed after the fact.
+
+  Transports register themselves; when none is connected (tests, IEx),
+  notifying is a no-op rather than an error.
+  """
+
+  use GenServer
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @spec register(pid()) :: :ok
+  def register(transport) when is_pid(transport) do
+    GenServer.cast(__MODULE__, {:register, transport})
+  end
+
+  @spec job_finished(IxMcp.Jobs.Job.summary()) :: :ok
+  def job_finished(summary) do
+    notify("notifications/message", %{
+      "level" => level_for(summary.status),
+      "logger" => "ix_mcp.jobs",
+      "data" => %{
+        "event" => "job_finished",
+        "job" => summary.id,
+        "status" => Atom.to_string(summary.status),
+        "intent" => summary.intent,
+        "elapsed_s" => summary.elapsed_s,
+        "result" => summary.result
+      }
+    })
+  end
+
+  @spec notify(String.t(), map()) :: :ok
+  def notify(method, params) do
+    case Process.whereis(__MODULE__) do
+      nil -> :ok
+      pid -> GenServer.cast(pid, {:notify, method, params})
+    end
+  end
+
+  @impl true
+  def init(_), do: {:ok, %{transports: []}}
+
+  @impl true
+  def handle_cast({:register, transport}, state) do
+    Process.monitor(transport)
+    {:noreply, %{state | transports: [transport | state.transports]}}
+  end
+
+  def handle_cast({:notify, method, params}, state) do
+    message = %{"jsonrpc" => "2.0", "method" => method, "params" => params}
+    Enum.each(state.transports, fn pid -> send(pid, {:mcp_send, message}) end)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    {:noreply, %{state | transports: List.delete(state.transports, pid)}}
+  end
+
+  defp level_for(:done), do: "info"
+  defp level_for(_), do: "error"
+end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/server.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/server.ex
@@ -1,0 +1,73 @@
+defmodule IxMcp.MCP.Server do
+  @moduledoc """
+  Transport-independent MCP request handling: takes one decoded JSON-RPC
+  message, returns the response map (or `nil` for notifications). The tool
+  surface itself lives in `IxMcp.MCP.Tools`.
+  """
+
+  alias IxMcp.MCP.Tools
+
+  @protocol_version "2025-06-18"
+
+  @spec handle(map()) :: map() | nil
+  def handle(%{"method" => method} = message) do
+    id = Map.get(message, "id")
+    params = Map.get(message, "params", %{})
+
+    case {method, id} do
+      {"initialize", id} when id != nil ->
+        result(id, %{
+          "protocolVersion" => negotiate_version(params),
+          "capabilities" => %{"tools" => %{"listChanged" => false}, "logging" => %{}},
+          "serverInfo" => %{"name" => "ix-mcp-ex", "version" => version()}
+        })
+
+      {"ping", id} when id != nil ->
+        result(id, %{})
+
+      {"tools/list", id} when id != nil ->
+        result(id, %{"tools" => Tools.list()})
+
+      {"tools/call", id} when id != nil ->
+        handle_tool_call(id, params)
+
+      {_notification, nil} ->
+        nil
+
+      {other, id} ->
+        error(id, -32_601, "method not found: #{other}")
+    end
+  end
+
+  def handle(_message), do: error(nil, -32_600, "invalid request")
+
+  defp handle_tool_call(id, %{"name" => name} = params) do
+    arguments = Map.get(params, "arguments", %{})
+
+    case Tools.call(name, arguments) do
+      {:ok, text} ->
+        result(id, %{"content" => [%{"type" => "text", "text" => text}], "isError" => false})
+
+      {:error, text} ->
+        result(id, %{"content" => [%{"type" => "text", "text" => text}], "isError" => true})
+    end
+  end
+
+  defp handle_tool_call(id, _params), do: error(id, -32_602, "tools/call requires a name")
+
+  defp result(id, result), do: %{"jsonrpc" => "2.0", "id" => id, "result" => result}
+
+  defp error(id, code, message),
+    do: %{"jsonrpc" => "2.0", "id" => id, "error" => %{"code" => code, "message" => message}}
+
+  # Echo the client's version when we can speak it; otherwise offer ours.
+  defp negotiate_version(%{"protocolVersion" => v}) when is_binary(v), do: v
+  defp negotiate_version(_), do: @protocol_version
+
+  defp version do
+    case :application.get_key(:ix_mcp, :vsn) do
+      {:ok, vsn} -> List.to_string(vsn)
+      _ -> "0.0.0"
+    end
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/stdio.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/stdio.ex
@@ -12,6 +12,7 @@ defmodule IxMcp.MCP.Stdio do
 
   use GenServer
 
+  alias IxMcp.MCP.Notifier
   alias IxMcp.MCP.Server
 
   @spec start_link(term()) :: GenServer.on_start()
@@ -21,30 +22,32 @@ defmodule IxMcp.MCP.Stdio do
 
   @impl true
   def init(_) do
-    IxMcp.MCP.Notifier.register(self())
+    Notifier.register(self())
     reader = self()
     spawn_link(fn -> read_loop(reader) end)
-    {:ok, %{}}
+    {:ok, %{pending: MapSet.new(), eof: false}}
   end
 
   @impl true
   def handle_info({:mcp_recv, line}, state) do
     stdio = self()
 
-    Task.start(fn ->
-      case JSON.decode(line) do
-        {:ok, message} ->
-          case Server.handle(message) do
-            nil -> :ok
-            response -> send(stdio, {:mcp_send, response})
-          end
+    {:ok, pid} =
+      Task.start(fn ->
+        case JSON.decode(line) do
+          {:ok, message} ->
+            case Server.handle(message) do
+              nil -> :ok
+              response -> send(stdio, {:mcp_send, response})
+            end
 
-        {:error, _reason} ->
-          send(stdio, {:mcp_send, parse_error()})
-      end
-    end)
+          {:error, _reason} ->
+            send(stdio, {:mcp_send, parse_error()})
+        end
+      end)
 
-    {:noreply, state}
+    ref = Process.monitor(pid)
+    {:noreply, %{state | pending: MapSet.put(state.pending, ref)}}
   end
 
   def handle_info({:mcp_send, message}, state) do
@@ -52,11 +55,25 @@ defmodule IxMcp.MCP.Stdio do
     {:noreply, state}
   end
 
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    maybe_stop(%{state | pending: MapSet.delete(state.pending, ref)})
+  end
+
+  # The client closed stdin: finish the requests already dispatched, then
+  # stop the whole VM cleanly (exit 0) -- an MCP server's life IS its stdin.
   def handle_info(:mcp_eof, state) do
-    {:stop, :normal, state}
+    maybe_stop(%{state | eof: true})
   end
 
   def handle_info(_msg, state), do: {:noreply, state}
+
+  defp maybe_stop(state) do
+    if state.eof and MapSet.size(state.pending) == 0 do
+      System.stop(0)
+    end
+
+    {:noreply, state}
+  end
 
   defp read_loop(server) do
     case IO.binread(:stdio, :line) do
@@ -77,6 +94,10 @@ defmodule IxMcp.MCP.Stdio do
   end
 
   defp parse_error do
-    %{"jsonrpc" => "2.0", "id" => nil, "error" => %{"code" => -32_700, "message" => "parse error"}}
+    %{
+      "jsonrpc" => "2.0",
+      "id" => nil,
+      "error" => %{"code" => -32_700, "message" => "parse error"}
+    }
   end
 end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/stdio.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/stdio.ex
@@ -1,0 +1,82 @@
+defmodule IxMcp.MCP.Stdio do
+  @moduledoc """
+  MCP over stdio: newline-delimited JSON-RPC on stdin/stdout. The reader loop
+  dispatches every request in its own task, so one slow `elixir_exec` call
+  never delays the next request -- the same guarantee the jobs layer gives
+  cells, applied to the wire.
+
+  All writes to stdout go through this process, which is the only place in
+  the application allowed to touch it (logs go to stderr, cell output goes to
+  each job's IOProxy).
+  """
+
+  use GenServer
+
+  alias IxMcp.MCP.Server
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    IxMcp.MCP.Notifier.register(self())
+    reader = self()
+    spawn_link(fn -> read_loop(reader) end)
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info({:mcp_recv, line}, state) do
+    stdio = self()
+
+    Task.start(fn ->
+      case JSON.decode(line) do
+        {:ok, message} ->
+          case Server.handle(message) do
+            nil -> :ok
+            response -> send(stdio, {:mcp_send, response})
+          end
+
+        {:error, _reason} ->
+          send(stdio, {:mcp_send, parse_error()})
+      end
+    end)
+
+    {:noreply, state}
+  end
+
+  def handle_info({:mcp_send, message}, state) do
+    IO.binwrite(:stdio, [JSON.encode!(message), "\n"])
+    {:noreply, state}
+  end
+
+  def handle_info(:mcp_eof, state) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  defp read_loop(server) do
+    case IO.binread(:stdio, :line) do
+      :eof ->
+        send(server, :mcp_eof)
+
+      {:error, _reason} ->
+        send(server, :mcp_eof)
+
+      line ->
+        case String.trim(line) do
+          "" -> :ok
+          trimmed -> send(server, {:mcp_recv, trimmed})
+        end
+
+        read_loop(server)
+    end
+  end
+
+  defp parse_error do
+    %{"jsonrpc" => "2.0", "id" => nil, "error" => %{"code" => -32_700, "message" => "parse error"}}
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -93,6 +93,54 @@ defmodule IxMcp.MCP.Tools do
         "inputSchema" => %{"type" => "object", "properties" => %{}}
       },
       %{
+        "name" => "pr_watch",
+        "description" => """
+        Watch a GitHub pull request via `gh` and push a channel notification
+        when it merges, closes, errors, or the watch times out. Watching is
+        read-only: it never arms auto-merge; merging stays an explicit act.
+        """,
+        "inputSchema" => %{
+          "type" => "object",
+          "properties" => %{
+            "pr" => %{
+              "type" => "string",
+              "description" => "PR number, URL, or branch gh understands"
+            },
+            "cwd" => %{
+              "type" => "string",
+              "description" => "Repository worktree where gh should run"
+            },
+            "interval" => %{"type" => "number", "default" => 15},
+            "timeout" => %{"type" => "number", "default" => 3600}
+          },
+          "required" => ["pr", "cwd"]
+        }
+      },
+      %{
+        "name" => "tui_act",
+        "description" => """
+        Drive a federated TUI resource: send keystrokes to a peer's live
+        terminal resource. Bridges to `ix-resource-cli act` and degrades
+        clearly when the CLI is absent. Omit `peer` to probe the peers in
+        IX_RESOURCE_PEERS for the one advertising the uri.
+        """,
+        "inputSchema" => %{
+          "type" => "object",
+          "properties" => %{
+            "uri" => %{"type" => "string", "description" => "ix://<host>/<name> resource uri"},
+            "send_keys" => %{
+              "type" => "string",
+              "description" => "Literal keystrokes, e.g. 'ls\n' or 'C-c'"
+            },
+            "peer" => %{
+              "type" => "string",
+              "description" => "Optional full endpoint URL of one peer"
+            }
+          },
+          "required" => ["uri", "send_keys"]
+        }
+      },
+      %{
         "name" => "kernel_restart",
         "description" => """
         Restart the evaluator on purpose: cancel every running job (their OS
@@ -137,6 +185,20 @@ defmodule IxMcp.MCP.Tools do
   def call("read", _args), do: {:error, "read requires string `target`"}
 
   def call("kernel_trace", _args), do: {:ok, IxMcp.Kernel.trace()}
+
+  def call("pr_watch", %{"pr" => pr, "cwd" => cwd} = args)
+      when is_binary(pr) and is_binary(cwd) do
+    IxMcp.PrWatch.start(pr, cwd, Map.get(args, "interval", 15), Map.get(args, "timeout", 3600))
+  end
+
+  def call("pr_watch", _args), do: {:error, "pr_watch requires string `pr` and `cwd`"}
+
+  def call("tui_act", %{"uri" => uri, "send_keys" => keys} = args)
+      when is_binary(uri) and is_binary(keys) do
+    IxMcp.Resources.act(uri, keys, Map.get(args, "peer"))
+  end
+
+  def call("tui_act", _args), do: {:error, "tui_act requires string `uri` and `send_keys`"}
 
   def call("kernel_restart", _args) do
     report = IxMcp.Kernel.restart()

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -1,0 +1,131 @@
+defmodule IxMcp.MCP.Tools do
+  @moduledoc """
+  The MCP tool surface. Every tool returns `{:ok, text}` or `{:error, text}`;
+  the transport wraps that in the MCP content envelope.
+  """
+
+  alias IxMcp.Jobs
+
+  @budget_cap 120
+
+  @spec list() :: [map()]
+  def list do
+    [
+      %{
+        "name" => "elixir_exec",
+        "description" => """
+        Run Elixir on the shared persistent workspace. Waits up to `budget`
+        seconds; if the code is still running it keeps going in the background
+        as a job and this returns a job handle. Bindings persist across calls:
+        variables, aliases, imports, and modules you define stay defined.
+        Job control is in-language via the `Jobs` module (aliased in every
+        cell): `Jobs.tail("ab12", 20)`, `Jobs.await("ab12")`,
+        `Jobs.cancel("ab12")`, `Jobs.history()`. Each cell runs in its own
+        BEAM process, so a blocking cell never delays other jobs or this
+        server.
+        """,
+        "inputSchema" => %{
+          "type" => "object",
+          "properties" => %{
+            "code" => %{"type" => "string", "description" => "Elixir source to evaluate"},
+            "budget" => %{
+              "type" => "number",
+              "description" =>
+                "Seconds to wait before backgrounding the run (cap: #{@budget_cap}s)",
+              "default" => 15
+            },
+            "intent" => %{
+              "type" => "string",
+              "description" => "Short human description of what this run does (titles the run)"
+            }
+          },
+          "required" => ["code", "intent"]
+        }
+      },
+      %{
+        "name" => "session_set_name",
+        "description" =>
+          "Name this connection's session. Call before acting tools; the name labels every run this server records.",
+        "inputSchema" => %{
+          "type" => "object",
+          "properties" => %{"name" => %{"type" => "string", "minLength" => 3, "maxLength" => 80}},
+          "required" => ["name"]
+        }
+      },
+      %{
+        "name" => "topic_set",
+        "description" =>
+          "Set the current topic. Runs fold under the topic inside the session; change it when work moves to a new phase.",
+        "inputSchema" => %{
+          "type" => "object",
+          "properties" => %{"topic" => %{"type" => "string", "minLength" => 3, "maxLength" => 80}},
+          "required" => ["topic"]
+        }
+      }
+    ]
+  end
+
+  @spec call(String.t(), map()) :: {:ok, String.t()} | {:error, String.t()}
+  def call("elixir_exec", %{"code" => code} = args) when is_binary(code) do
+    budget = args |> Map.get("budget", 15) |> clamp_budget()
+    intent = Map.get(args, "intent")
+
+    {summary, output} = Jobs.run(code, budget: budget, intent: intent)
+    {:ok, render_run(summary, output)}
+  end
+
+  def call("elixir_exec", _args), do: {:error, "elixir_exec requires string `code`"}
+
+  def call("session_set_name", %{"name" => name}) when is_binary(name) do
+    :ok = IxMcp.Session.set_name(name)
+    {:ok, "session named: #{name}"}
+  end
+
+  def call("session_set_name", _args), do: {:error, "session_set_name requires string `name`"}
+
+  def call("topic_set", %{"topic" => topic}) when is_binary(topic) do
+    :ok = IxMcp.Session.set_topic(topic)
+    {:ok, "topic set: #{topic}"}
+  end
+
+  def call("topic_set", _args), do: {:error, "topic_set requires string `topic`"}
+
+  def call(other, _args), do: {:error, "unknown tool: #{other}"}
+
+  defp clamp_budget(budget) when is_number(budget) and budget > 0, do: min(budget, @budget_cap)
+  defp clamp_budget(_), do: 15
+
+  defp render_run(summary, output) do
+    header =
+      JSON.encode!(%{
+        "job" => summary.id,
+        "status" => Atom.to_string(summary.status),
+        "running" => summary.running,
+        "elapsed_s" => Float.round(summary.elapsed_s, 2)
+      })
+
+    sections =
+      [header] ++
+        diagnostics_section(summary.diagnostics) ++
+        output_section(output) ++
+        result_section(summary)
+
+    Enum.join(sections, "\n")
+  end
+
+  defp diagnostics_section([]), do: []
+  defp diagnostics_section(diags), do: Enum.map(diags, &("-- " <> &1))
+
+  defp output_section(""), do: []
+  defp output_section(output), do: [String.trim_trailing(output, "\n")]
+
+  defp result_section(%{running: true}) do
+    [
+      "job still running; page it with Jobs.tail(id, n) / await it with Jobs.await(id) in a later elixir_exec call"
+    ]
+  end
+
+  defp result_section(%{status: :done, result: rendered}), do: ["=> " <> rendered]
+  defp result_section(%{result: nil}), do: []
+  defp result_section(%{result: rendered}), do: [rendered]
+end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -61,6 +61,46 @@ defmodule IxMcp.MCP.Tools do
           "properties" => %{"topic" => %{"type" => "string", "minLength" => 3, "maxLength" => 80}},
           "required" => ["topic"]
         }
+      },
+      %{
+        "name" => "read",
+        "description" => """
+        Read a file (or a workspace value) into your context. `target` is read
+        as a file when it names one on disk; otherwise it is evaluated as an
+        Elixir expression against the shared workspace, exactly like a cell
+        (e.g. `Jobs.output("ab12")`, or a variable you bound earlier). An
+        expression whose value is a string naming an existing file reads that
+        file too. Pass `start`/`end` for a 1-based inclusive line range.
+        """,
+        "inputSchema" => %{
+          "type" => "object",
+          "properties" => %{
+            "target" => %{"type" => "string"},
+            "start" => %{"type" => "integer", "minimum" => 1},
+            "end" => %{"type" => "integer", "minimum" => 1}
+          },
+          "required" => ["target"]
+        }
+      },
+      %{
+        "name" => "kernel_trace",
+        "description" => """
+        Dump the current stack of every running job's processes (and core
+        server processes), taken from outside with Process.info/2. Works no
+        matter what any cell is doing -- no cell can block this server -- so
+        use it to see WHERE a slow job is stuck, then cancel or await it.
+        """,
+        "inputSchema" => %{"type" => "object", "properties" => %{}}
+      },
+      %{
+        "name" => "kernel_restart",
+        "description" => """
+        Restart the evaluator on purpose: cancel every running job (their OS
+        subprocess trees die with them), restart the workspace process, and
+        restore bindings from the in-VM checkpoint. Scoped to this server
+        only. Bindings survive; running jobs do not.
+        """,
+        "inputSchema" => %{"type" => "object", "properties" => %{}}
       }
     ]
   end
@@ -89,6 +129,22 @@ defmodule IxMcp.MCP.Tools do
   end
 
   def call("topic_set", _args), do: {:error, "topic_set requires string `topic`"}
+
+  def call("read", %{"target" => target} = args) when is_binary(target) do
+    IxMcp.Reader.read(target, Map.get(args, "start"), Map.get(args, "end"))
+  end
+
+  def call("read", _args), do: {:error, "read requires string `target`"}
+
+  def call("kernel_trace", _args), do: {:ok, IxMcp.Kernel.trace()}
+
+  def call("kernel_restart", _args) do
+    report = IxMcp.Kernel.restart()
+
+    {:ok,
+     "evaluator restarted: cancelled jobs #{inspect(report.jobs_cancelled)}, " <>
+       "#{report.bindings_restored} bindings restored"}
+  end
 
   def call(other, _args), do: {:error, "unknown tool: #{other}"}
 

--- a/packages/mcp-ex/lib/ix_mcp/os_proc.ex
+++ b/packages/mcp-ex/lib/ix_mcp/os_proc.ex
@@ -1,0 +1,69 @@
+defmodule IxMcp.OsProc do
+  @moduledoc """
+  Finds and kills the OS processes a job's cells spawned, so cancelling a job
+  never leaks orphan subprocesses.
+
+  There is no blessed shell helper in this server -- a cell that needs a
+  subprocess writes `System.cmd/3` or opens a `Port` itself -- but the
+  cancellation contract survives the cut: every port opened by any process in
+  the job's process tree (identified by the job's group leader, which spawned
+  processes inherit) is resolved to its OS pid, and that pid's whole descendant
+  tree is killed.
+  """
+
+  @doc "BEAM processes whose group leader is `group_leader` (the job's tree)."
+  @spec job_processes(pid()) :: [pid()]
+  def job_processes(group_leader) do
+    for pid <- Process.list(),
+        pid != group_leader,
+        {:group_leader, gl} <- [Process.info(pid, :group_leader)],
+        gl == group_leader,
+        do: pid
+  end
+
+  @doc "OS pids of ports connected to any process in the job's tree."
+  @spec os_pids(pid()) :: [pos_integer()]
+  def os_pids(group_leader) do
+    owners = MapSet.new(job_processes(group_leader))
+
+    for port <- Port.list(),
+        info = Port.info(port),
+        info != nil,
+        MapSet.member?(owners, Keyword.get(info, :connected)),
+        os_pid = Keyword.get(info, :os_pid),
+        is_integer(os_pid),
+        do: os_pid
+  end
+
+  @doc "Kill an OS pid and all of its descendants (TERM has no grace: jobs being cancelled are already condemned)."
+  @spec kill_tree(pos_integer()) :: :ok
+  def kill_tree(os_pid) do
+    os_pid
+    |> descendants()
+    |> Enum.each(fn pid -> System.cmd("kill", ["-9", Integer.to_string(pid)], stderr_to_stdout: true) end)
+
+    :ok
+  end
+
+  @doc "The pid plus its full descendant tree, children before parents are killed last."
+  @spec descendants(pos_integer()) :: [pos_integer()]
+  def descendants(os_pid) do
+    children =
+      case System.cmd("pgrep", ["-P", Integer.to_string(os_pid)], stderr_to_stdout: true) do
+        {out, 0} ->
+          out
+          |> String.split("\n", trim: true)
+          |> Enum.flat_map(fn line ->
+            case Integer.parse(String.trim(line)) do
+              {pid, ""} -> [pid]
+              _ -> []
+            end
+          end)
+
+        _ ->
+          []
+      end
+
+    Enum.flat_map(children, &descendants/1) ++ [os_pid]
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/os_proc.ex
+++ b/packages/mcp-ex/lib/ix_mcp/os_proc.ex
@@ -40,7 +40,9 @@ defmodule IxMcp.OsProc do
   def kill_tree(os_pid) do
     os_pid
     |> descendants()
-    |> Enum.each(fn pid -> System.cmd("kill", ["-9", Integer.to_string(pid)], stderr_to_stdout: true) end)
+    |> Enum.each(fn pid ->
+      System.cmd("kill", ["-9", Integer.to_string(pid)], stderr_to_stdout: true)
+    end)
 
     :ok
   end

--- a/packages/mcp-ex/lib/ix_mcp/pr_watch.ex
+++ b/packages/mcp-ex/lib/ix_mcp/pr_watch.ex
@@ -1,0 +1,78 @@
+defmodule IxMcp.PrWatch do
+  @moduledoc """
+  Watch a GitHub pull request via `gh` and push a channel notification when it
+  merges, closes, or the watch times out. Each watch is one supervised task:
+  a hung `gh` invocation stalls that watch alone, and the notification carries
+  the final state -- no hand-written polling loops in agent sessions.
+
+  Divergence from the Python tool, on purpose: no auto-merge arming. Watching
+  is read-only here; merging stays an explicit act by the caller.
+  """
+
+  alias IxMcp.MCP.Notifier
+
+  @spec start(String.t(), String.t(), number(), number()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  def start(pr, cwd, interval_s, timeout_s) do
+    cond do
+      System.find_executable("gh") == nil ->
+        {:error, "gh not found on PATH; pr_watch needs the GitHub CLI"}
+
+      not File.dir?(cwd) ->
+        {:error, "cwd does not exist: #{cwd}"}
+
+      true ->
+        {:ok, pid} =
+          Task.Supervisor.start_child(IxMcp.PrWatch.Supervisor, fn ->
+            deadline = System.monotonic_time(:millisecond) + round(timeout_s * 1000)
+            watch(pr, cwd, round(interval_s * 1000), deadline)
+          end)
+
+        {:ok, "watching PR #{pr} (#{inspect(pid)}); a channel notification reports the outcome"}
+    end
+  end
+
+  defp watch(pr, cwd, interval_ms, deadline) do
+    case poll(pr, cwd) do
+      {:final, state, detail} ->
+        notify(pr, state, detail)
+
+      :pending ->
+        if System.monotonic_time(:millisecond) > deadline do
+          notify(pr, "timeout", "watch window elapsed before the PR reached a final state")
+        else
+          Process.sleep(interval_ms)
+          watch(pr, cwd, interval_ms, deadline)
+        end
+
+      {:error, detail} ->
+        notify(pr, "error", detail)
+    end
+  end
+
+  defp poll(pr, cwd) do
+    case System.cmd("gh", ["pr", "view", pr, "--json", "state,mergedAt,url"],
+           cd: cwd,
+           stderr_to_stdout: true
+         ) do
+      {out, 0} ->
+        case JSON.decode(out) do
+          {:ok, %{"state" => "MERGED"} = view} -> {:final, "merged", view["url"]}
+          {:ok, %{"state" => "CLOSED"} = view} -> {:final, "closed", view["url"]}
+          {:ok, _view} -> :pending
+          {:error, _} -> {:error, "unparseable gh output: #{String.slice(out, 0, 200)}"}
+        end
+
+      {out, _nonzero} ->
+        {:error, String.slice(out, 0, 400)}
+    end
+  end
+
+  defp notify(pr, state, detail) do
+    Notifier.notify("notifications/message", %{
+      "level" => if(state == "merged", do: "info", else: "warning"),
+      "logger" => "ix_mcp.pr_watch",
+      "data" => %{"event" => "pr_watch", "pr" => pr, "state" => state, "detail" => detail}
+    })
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/reader.ex
+++ b/packages/mcp-ex/lib/ix_mcp/reader.ex
@@ -7,32 +7,37 @@ defmodule IxMcp.Reader do
   reads that file too. `start`/`end` select a 1-based inclusive line range.
   """
 
+  alias IxMcp.Evaluator
+  alias IxMcp.Jobs
+
   @eval_budget_s 30
 
   @spec read(String.t(), pos_integer() | nil, pos_integer() | nil) ::
           {:ok, String.t()} | {:error, String.t()}
   def read(target, first \\ nil, last \\ nil) do
-    cond do
-      File.regular?(target) ->
-        read_file(target, first, last)
+    if File.regular?(target) do
+      read_file(target, first, last)
+    else
+      read_value(target, first, last)
+    end
+  end
 
-      true ->
-        case IxMcp.Jobs.run(target, budget: @eval_budget_s, intent: "read #{String.slice(target, 0, 40)}") do
-          {%{status: :done} = summary, _output} ->
-            value_result(summary.id, first, last)
+  defp read_value(target, first, last) do
+    case Jobs.run(target, budget: @eval_budget_s, intent: "read #{String.slice(target, 0, 40)}") do
+      {%{status: :done} = summary, _output} ->
+        value_result(summary.id, first, last)
 
-          {%{running: true} = summary, _output} ->
-            {:error,
-             "expression still evaluating after #{@eval_budget_s}s; page it as job #{summary.id}"}
+      {%{running: true} = summary, _output} ->
+        {:error,
+         "expression still evaluating after #{@eval_budget_s}s; page it as job #{summary.id}"}
 
-          {%{result: message}, _output} ->
-            {:error, message || "evaluation failed"}
-        end
+      {%{result: message}, _output} ->
+        {:error, message || "evaluation failed"}
     end
   end
 
   defp value_result(job_id, first, last) do
-    case IxMcp.Jobs.result(job_id) do
+    case Jobs.result(job_id) do
       {:ok, value} when is_binary(value) ->
         if File.regular?(value) do
           read_file(value, first, last)
@@ -41,7 +46,7 @@ defmodule IxMcp.Reader do
         end
 
       {:ok, value} ->
-        {:ok, slice_lines(IxMcp.Evaluator.render(value), first, last)}
+        {:ok, slice_lines(Evaluator.render(value), first, last)}
 
       {:error, reason} ->
         {:error, inspect(reason)}

--- a/packages/mcp-ex/lib/ix_mcp/reader.ex
+++ b/packages/mcp-ex/lib/ix_mcp/reader.ex
@@ -1,0 +1,66 @@
+defmodule IxMcp.Reader do
+  @moduledoc """
+  The `read` tool: fetch a file -- or a workspace value -- into the caller's
+  context. `target` is read as a file when it names one on disk; otherwise it
+  is evaluated as an Elixir expression against the shared workspace, exactly
+  like a cell. An expression whose value is a string naming an existing file
+  reads that file too. `start`/`end` select a 1-based inclusive line range.
+  """
+
+  @eval_budget_s 30
+
+  @spec read(String.t(), pos_integer() | nil, pos_integer() | nil) ::
+          {:ok, String.t()} | {:error, String.t()}
+  def read(target, first \\ nil, last \\ nil) do
+    cond do
+      File.regular?(target) ->
+        read_file(target, first, last)
+
+      true ->
+        case IxMcp.Jobs.run(target, budget: @eval_budget_s, intent: "read #{String.slice(target, 0, 40)}") do
+          {%{status: :done} = summary, _output} ->
+            value_result(summary.id, first, last)
+
+          {%{running: true} = summary, _output} ->
+            {:error,
+             "expression still evaluating after #{@eval_budget_s}s; page it as job #{summary.id}"}
+
+          {%{result: message}, _output} ->
+            {:error, message || "evaluation failed"}
+        end
+    end
+  end
+
+  defp value_result(job_id, first, last) do
+    case IxMcp.Jobs.result(job_id) do
+      {:ok, value} when is_binary(value) ->
+        if File.regular?(value) do
+          read_file(value, first, last)
+        else
+          {:ok, slice_lines(value, first, last)}
+        end
+
+      {:ok, value} ->
+        {:ok, slice_lines(IxMcp.Evaluator.render(value), first, last)}
+
+      {:error, reason} ->
+        {:error, inspect(reason)}
+    end
+  end
+
+  defp read_file(path, first, last) do
+    case File.read(path) do
+      {:ok, content} -> {:ok, slice_lines(content, first, last)}
+      {:error, reason} -> {:error, "#{path}: #{:file.format_error(reason)}"}
+    end
+  end
+
+  defp slice_lines(content, nil, nil), do: content
+
+  defp slice_lines(content, first, last) do
+    lines = String.split(content, "\n")
+    first = max(first || 1, 1)
+    last = min(last || length(lines), length(lines))
+    lines |> Enum.slice((first - 1)..(last - 1)//1) |> Enum.join("\n")
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/resources.ex
+++ b/packages/mcp-ex/lib/ix_mcp/resources.ex
@@ -1,0 +1,45 @@
+defmodule IxMcp.Resources do
+  @moduledoc """
+  Bridge to the federated-resource CLI (`ix-resource-cli`), the same binary
+  the Python server shelled out to: `act --send-keys=<keys> --peer <url> --
+  <uri>` drives a peer's live terminal resource. When no peer is given, the
+  peers configured in `IX_RESOURCE_PEERS` are probed with `get` until one
+  advertises the uri. Degrades to a clear error when the CLI is absent.
+  """
+
+  @bin "ix-resource-cli"
+
+  @spec act(String.t(), String.t(), String.t() | nil) ::
+          {:ok, String.t()} | {:error, String.t()}
+  def act(uri, send_keys, peer) do
+    case System.find_executable(@bin) do
+      nil ->
+        {:error, "#{@bin} not found on PATH; tui_act needs the resource CLI"}
+
+      _bin ->
+        case peer || find_peer(uri) do
+          nil ->
+            {:error, "no peer advertises #{uri}; set IX_RESOURCE_PEERS or pass `peer` explicitly"}
+
+          peer_url ->
+            run(["act", "--send-keys=#{send_keys}", "--peer", peer_url, "--", uri])
+        end
+    end
+  end
+
+  defp find_peer(uri) do
+    "IX_RESOURCE_PEERS"
+    |> System.get_env("")
+    |> String.split([",", " "], trim: true)
+    |> Enum.find(fn peer_url ->
+      match?({:ok, _}, run(["get", "--peer", peer_url, "--", uri]))
+    end)
+  end
+
+  defp run(args) do
+    case System.cmd(@bin, args, stderr_to_stdout: true) do
+      {out, 0} -> {:ok, String.trim(out)}
+      {out, code} -> {:error, "#{@bin} exited #{code}: #{String.slice(out, 0, 400)}"}
+    end
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/session.ex
+++ b/packages/mcp-ex/lib/ix_mcp/session.ex
@@ -1,0 +1,31 @@
+defmodule IxMcp.Session do
+  @moduledoc """
+  Dashboard-facing metadata for this server instance: a human task label and a
+  current topic. Jobs record the session/topic active when they started, so a
+  feed of runs groups the same way the Python dashboard grouped them.
+  """
+
+  use Agent
+
+  @type t :: %{name: String.t() | nil, topic: String.t() | nil}
+
+  @spec start_link(term()) :: Agent.on_start()
+  def start_link(_opts) do
+    Agent.start_link(fn -> %{name: nil, topic: nil} end, name: __MODULE__)
+  end
+
+  @spec set_name(String.t()) :: :ok
+  def set_name(name) when is_binary(name) do
+    Agent.update(__MODULE__, &%{&1 | name: name})
+  end
+
+  @spec set_topic(String.t()) :: :ok
+  def set_topic(topic) when is_binary(topic) do
+    Agent.update(__MODULE__, &%{&1 | topic: topic})
+  end
+
+  @spec get() :: t()
+  def get do
+    Agent.get(__MODULE__, & &1)
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/workspace.ex
+++ b/packages/mcp-ex/lib/ix_mcp/workspace.ex
@@ -1,0 +1,87 @@
+defmodule IxMcp.Workspace do
+  @moduledoc """
+  Owns the shared evaluation context: the binding and `Macro.Env` every cell
+  sees. A cell evaluates in its own process against a snapshot and merges its
+  resulting context back on success -- last writer wins per variable, exactly
+  the race concurrent Python cells already had on the shared namespace, minus
+  the ability to freeze each other.
+
+  Every merge is checkpointed into `IxMcp.Checkpoint` (an ETS table owned by a
+  different process), so killing or restarting this server -- the analog of a
+  kernel restart -- loses nothing: `init/1` restores the last checkpoint.
+  """
+
+  use GenServer
+
+  @prelude "alias IxMcp.Jobs"
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @doc "The current {binding, env} snapshot a cell should evaluate against."
+  @spec snapshot() :: {Code.binding(), Macro.Env.t()}
+  def snapshot do
+    GenServer.call(__MODULE__, :snapshot)
+  end
+
+  @doc "Merge a finished cell's resulting context back into the shared state."
+  @spec merge(Code.binding(), Macro.Env.t()) :: :ok
+  def merge(binding, env) do
+    GenServer.call(__MODULE__, {:merge, binding, env})
+  end
+
+  @doc "Names bound right now (for introspection / api surface)."
+  @spec names() :: [atom()]
+  def names do
+    {binding, _env} = snapshot()
+    binding |> Keyword.keys() |> Enum.sort()
+  end
+
+  @doc "Drop all bindings and start from the prelude env again."
+  @spec reset() :: :ok
+  def reset do
+    GenServer.call(__MODULE__, :reset)
+  end
+
+  @impl true
+  def init(_) do
+    case IxMcp.Checkpoint.fetch() do
+      {:ok, binding, env} -> {:ok, %{binding: binding, env: env}}
+      :empty -> {:ok, fresh()}
+    end
+  end
+
+  @impl true
+  def handle_call(:snapshot, _from, state) do
+    {:reply, {state.binding, state.env}, state}
+  end
+
+  def handle_call({:merge, binding, env}, _from, state) do
+    # Variables the cell bound or rebound win; variables it never touched
+    # (pruned from its returned binding) keep their current values.
+    merged = Keyword.merge(state.binding, binding)
+    state = %{state | binding: merged, env: env}
+    IxMcp.Checkpoint.store(state.binding, state.env)
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:reset, _from, _state) do
+    state = fresh()
+    IxMcp.Checkpoint.store(state.binding, state.env)
+    {:reply, :ok, state}
+  end
+
+  defp fresh do
+    env = Code.env_for_eval(file: "cell")
+    # Evaluate the prelude so its aliases live in the env every cell sees;
+    # cells can then write `Jobs.tail("ab12", 20)` with no setup.
+    {_value, binding, env} = Code.eval_quoted_with_env(quoted_prelude(), [], env)
+    %{binding: binding, env: env}
+  end
+
+  defp quoted_prelude do
+    Code.string_to_quoted!(@prelude, file: "prelude")
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/workspace.ex
+++ b/packages/mcp-ex/lib/ix_mcp/workspace.ex
@@ -13,7 +13,7 @@ defmodule IxMcp.Workspace do
 
   use GenServer
 
-  @prelude "alias IxMcp.Jobs"
+  @prelude "alias IxMcp.Jobs; alias IxMcp.Api"
 
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do

--- a/packages/mcp-ex/mix.exs
+++ b/packages/mcp-ex/mix.exs
@@ -19,10 +19,14 @@ defmodule IxMcp.MixProject do
     ]
   end
 
-  # Zero runtime dependencies on purpose: OTP >= 27 ships a JSON module
+  # Zero RUNTIME dependencies on purpose: OTP >= 27 ships a JSON module
   # (exposed as `JSON` in Elixir 1.18), so the MCP wire format needs no hex
-  # package and the Nix build needs no Mix-deps fixed-output derivation.
+  # package and the released server carries no Mix deps at all.
   defp deps do
-    []
+    [
+      # Static-analysis gate, test-only so the server runs `mix` offline with
+      # no deps; the sandboxed check runs in :test where credo is fetched.
+      {:credo, "~> 1.7", only: :test, runtime: false}
+    ]
   end
 end

--- a/packages/mcp-ex/mix.exs
+++ b/packages/mcp-ex/mix.exs
@@ -1,0 +1,29 @@
+defmodule IxMcp.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :ix_mcp,
+      version: "0.1.0",
+      elixir: "~> 1.18",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {IxMcp.Application, []}
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+end

--- a/packages/mcp-ex/mix.exs
+++ b/packages/mcp-ex/mix.exs
@@ -7,23 +7,22 @@ defmodule IxMcp.MixProject do
       version: "0.1.0",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
+      elixirc_options: [warnings_as_errors: true],
       deps: deps()
     ]
   end
 
-  # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:logger, :crypto],
       mod: {IxMcp.Application, []}
     ]
   end
 
-  # Run "mix help deps" to learn about dependencies.
+  # Zero runtime dependencies on purpose: OTP >= 27 ships a JSON module
+  # (exposed as `JSON` in Elixir 1.18), so the MCP wire format needs no hex
+  # package and the Nix build needs no Mix-deps fixed-output derivation.
   defp deps do
-    [
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
-    ]
+    []
   end
 end

--- a/packages/mcp-ex/mix.lock
+++ b/packages/mcp-ex/mix.lock
@@ -1,0 +1,6 @@
+%{
+  "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
+  "credo": {:hex, :credo, "1.7.19", "cc52129665fc7c15143d47838fda0f9cd6dac9ceced7bf4da6f85fcbfe64b12a", [:mix], [{:bunt, "~> 0.2.1 or ~> 1.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2 or ~> 1.0", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "2d8bc95d5a7bb99dd2613621d4f08c6a3575c3fd4b62e6a2b48a100352a557b8"},
+  "file_system": {:hex, :file_system, "1.1.1", "31864f4685b0148f25bd3fbef2b1228457c0c89024ad67f7a81a3ffbc0bbad3a", [:mix], [], "hexpm", "7a15ff97dfe526aeefb090a7a9d3d03aa907e100e262a0f8f7746b78f8f87a5d"},
+  "jason": {:hex, :jason, "1.4.5", "2e3a008590b0b8d7388c20293e9dcc9cf3e5d642fd2a114e4cbbb52e595d940a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0 or ~> 3.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b0c823996102bcd0239b3c2444eb00409b72f6a140c1950bc8b457d836b30684"},
+}

--- a/packages/mcp-ex/package.nix
+++ b/packages/mcp-ex/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "mcp-ex";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+  passthruTests = true;
+}

--- a/packages/mcp-ex/pins.json
+++ b/packages/mcp-ex/pins.json
@@ -1,0 +1,5 @@
+{
+  "mix-deps": {
+    "hash": "sha256-EXaJddUakJETdzPNFWgJRgBWG4VcrP/Z5tOCuE+BXdo="
+  }
+}

--- a/packages/mcp-ex/test/ix_mcp/api_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/api_test.exs
@@ -1,0 +1,27 @@
+defmodule IxMcp.ApiTest do
+  use ExUnit.Case, async: false
+
+  alias IxMcp.Jobs
+
+  setup do
+    IxMcp.Workspace.reset()
+    :ok
+  end
+
+  test "api() lists the bundled surface with summaries, filterable" do
+    rows = IxMcp.Api.api("tail")
+    assert Enum.any?(rows, &(&1.name == :tail and &1.module == IxMcp.Jobs))
+  end
+
+  test "help/2 returns a function's full doc" do
+    text = IxMcp.Api.help(IxMcp.Jobs, :tail)
+    assert text =~ "tail("
+    assert text =~ "Last"
+  end
+
+  test "Api is aliased in cells, like Jobs" do
+    {summary, _} = Jobs.run("Api.api(\"grep\") |> length()", intent: "use Api from a cell")
+    assert summary.status == :done
+    assert summary.result >= "1"
+  end
+end

--- a/packages/mcp-ex/test/ix_mcp/chaos_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/chaos_test.exs
@@ -43,15 +43,15 @@ defmodule IxMcp.ChaosTest do
     assert after_restart.result == "42"
   end
 
+  @tag :os_procs
   test "a job cancelled mid-subprocess leaves no orphan even under restart" do
     marker = "ix-mcp-chaos-#{System.unique_integer([:positive])}"
 
-    {job, _} =
-      Jobs.run(
-        "System.cmd(\"sh\", [\"-c\", \"sleep 600; echo #{marker}\"])",
-        budget: 0.2,
-        intent: "spawn subprocess"
-      )
+    code = """
+    System.cmd("sh", ["-c", "sleep 600; echo #{marker}"])
+    """
+
+    {job, _} = Jobs.run(code, budget: 0.2, intent: "spawn subprocess")
 
     assert job.running
     assert {_, 0} = System.cmd("pgrep", ["-f", marker])

--- a/packages/mcp-ex/test/ix_mcp/chaos_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/chaos_test.exs
@@ -1,0 +1,75 @@
+defmodule IxMcp.ChaosTest do
+  @moduledoc """
+  The failure classes that motivated leaving Python, exercised live: a cell
+  blocks forever while other jobs keep running; we trace it from outside,
+  then restart the evaluator and the bindings come back.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias IxMcp.Jobs
+
+  setup do
+    IxMcp.Workspace.reset()
+    :ok
+  end
+
+  test "wedged cell: others run, trace sees it, restart recovers bindings" do
+    # State that must survive the storm.
+    {bound, _} = Jobs.run("precious = %{answer: 42}", intent: "bind state")
+    assert bound.status == :done
+
+    # A cell wedges forever -- the Python equivalent froze every session.
+    {wedged, _} = Jobs.run("Process.sleep(:infinity)", budget: 0.05, intent: "wedge")
+    assert wedged.running
+
+    # Other jobs are unaffected.
+    {ok, _} = Jobs.run("precious.answer * 2", intent: "keep working")
+    assert ok.result == "84"
+
+    # Trace from outside shows the wedged frame while it is still wedged.
+    trace = IxMcp.Kernel.trace()
+    assert trace =~ wedged.id
+    assert trace =~ "sleep"
+
+    # Restart: the wedged job dies, bindings restore from the checkpoint.
+    report = IxMcp.Kernel.restart()
+    assert wedged.id in report.jobs_cancelled
+    assert report.bindings_restored >= 1
+    assert Jobs.get(wedged.id).status == :cancelled
+
+    {after_restart, _} = Jobs.run("precious.answer", intent: "check restore")
+    assert after_restart.status == :done
+    assert after_restart.result == "42"
+  end
+
+  test "a job cancelled mid-subprocess leaves no orphan even under restart" do
+    marker = "ix-mcp-chaos-#{System.unique_integer([:positive])}"
+
+    {job, _} =
+      Jobs.run(
+        "System.cmd(\"sh\", [\"-c\", \"sleep 600; echo #{marker}\"])",
+        budget: 0.2,
+        intent: "spawn subprocess"
+      )
+
+    assert job.running
+    assert {_, 0} = System.cmd("pgrep", ["-f", marker])
+
+    IxMcp.Kernel.restart()
+    Process.sleep(200)
+
+    assert {_, 1} = System.cmd("pgrep", ["-f", marker])
+  end
+
+  test "workspace crash restores bindings via supervisor + checkpoint (no tool call needed)" do
+    {_, _} = Jobs.run("phoenix = :rises", intent: "bind")
+
+    Process.exit(Process.whereis(IxMcp.Workspace), :kill)
+    Process.sleep(100)
+
+    {summary, _} = Jobs.run("phoenix", intent: "after crash")
+    assert summary.status == :done
+    assert summary.result == ":rises"
+  end
+end

--- a/packages/mcp-ex/test/ix_mcp/checkpoint_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/checkpoint_test.exs
@@ -1,0 +1,31 @@
+defmodule IxMcp.CheckpointTest do
+  use ExUnit.Case, async: false
+
+  alias IxMcp.Jobs
+
+  setup do
+    IxMcp.Workspace.reset()
+    :ok
+  end
+
+  test "file checkpoint round-trips data and skips live references" do
+    {_, _} = Jobs.run("keep_me = [1, 2, 3]", intent: "bind data")
+    {_, _} = Jobs.run("me = self()", intent: "bind a pid")
+
+    path = Path.join(System.tmp_dir!(), "ix-mcp-checkpoint-#{System.unique_integer([:positive])}")
+    on_exit(fn -> File.rm(path) end)
+
+    assert {:ok, skipped} = IxMcp.Checkpoint.save_file(path)
+    assert :me in skipped
+
+    IxMcp.Workspace.reset()
+    IxMcp.Checkpoint.clear()
+    assert {:ok, restored} = IxMcp.Checkpoint.load_file(path)
+    assert restored >= 1
+
+    # Workspace picks the checkpoint up on its next restart.
+    IxMcp.Kernel.restart()
+    {summary, _} = Jobs.run("keep_me", intent: "after load")
+    assert summary.result == "[1, 2, 3]"
+  end
+end

--- a/packages/mcp-ex/test/ix_mcp/evaluator_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/evaluator_test.exs
@@ -1,0 +1,72 @@
+defmodule IxMcp.EvaluatorTest do
+  use ExUnit.Case, async: false
+
+  alias IxMcp.Jobs
+
+  setup do
+    IxMcp.Workspace.reset()
+    :ok
+  end
+
+  test "bindings persist across cells" do
+    {summary, _out} = Jobs.run("x = 41", intent: "bind x")
+    assert summary.status == :done
+
+    {summary, _out} = Jobs.run("x + 1", intent: "use x")
+    assert summary.status == :done
+    assert summary.result == "42"
+  end
+
+  test "aliases and modules defined in cells persist" do
+    {summary, _out} =
+      Jobs.run("defmodule CellHelper, do: def double(n), do: n * 2", intent: "define module")
+
+    assert summary.status == :done
+
+    {summary, _out} = Jobs.run("CellHelper.double(21)", intent: "call module")
+    assert summary.status == :done
+    assert summary.result == "42"
+  end
+
+  test "stdout is captured per job, including from spawned processes" do
+    code = """
+    IO.puts("from the cell")
+    Task.await(Task.async(fn -> IO.puts("from a spawned task") end))
+    """
+
+    {summary, output} = Jobs.run(code, intent: "print")
+    assert summary.status == :done
+    assert output =~ "from the cell"
+    assert output =~ "from a spawned task"
+  end
+
+  test "parse errors gate the cell: nothing evaluates" do
+    {summary, _out} = Jobs.run("x = ) nonsense", intent: "syntax error")
+    assert summary.status == :failed
+    assert summary.result =~ "parse error"
+
+    # The workspace must be untouched.
+    refute :x in IxMcp.Workspace.names()
+  end
+
+  test "runtime errors report a formatted exception and keep prior bindings" do
+    {_summary, _out} = Jobs.run("kept = :safe", intent: "bind")
+    {summary, _out} = Jobs.run("1 / 0", intent: "raise")
+
+    assert summary.status == :failed
+    assert summary.result =~ "ArithmeticError"
+    assert :kept in IxMcp.Workspace.names()
+  end
+
+  test "a failed cell merges nothing" do
+    {summary, _out} = Jobs.run("doomed = 1; raise \"boom\"", intent: "fail late")
+    assert summary.status == :failed
+    refute :doomed in IxMcp.Workspace.names()
+  end
+
+  test "compiler warnings are surfaced as diagnostics without failing the cell" do
+    {summary, _out} = Jobs.run("fn -> unused = 1 end.()", intent: "warn")
+    assert summary.status == :done
+    assert Enum.any?(summary.diagnostics, &(&1 =~ "unused"))
+  end
+end

--- a/packages/mcp-ex/test/ix_mcp/jobs_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/jobs_test.exs
@@ -1,0 +1,99 @@
+defmodule IxMcp.JobsTest do
+  use ExUnit.Case, async: false
+
+  alias IxMcp.Jobs
+
+  setup do
+    IxMcp.Workspace.reset()
+    :ok
+  end
+
+  test "budget-then-background: a slow cell returns a running handle and finishes later" do
+    {summary, _out} = Jobs.run("Process.sleep(300); :finally", budget: 0.05, intent: "slow")
+    assert summary.running
+
+    final = Jobs.await(summary.id, 5_000)
+    assert final.status == :done
+    assert final.result == ":finally"
+  end
+
+  test "a blocking cell never delays other jobs (the whole point)" do
+    {blocked, _out} = Jobs.run("Process.sleep(:infinity)", budget: 0.05, intent: "block forever")
+    assert blocked.running
+
+    started = System.monotonic_time(:millisecond)
+    {quick, _out} = Jobs.run("1 + 1", intent: "quick")
+    elapsed = System.monotonic_time(:millisecond) - started
+
+    assert quick.status == :done
+    assert quick.result == "2"
+    assert elapsed < 1_000
+
+    assert :ok = Jobs.cancel(blocked.id)
+    assert Jobs.get(blocked.id).status == :cancelled
+  end
+
+  test "output paging: tail, head, lines, slice, grep" do
+    code = "for i <- 1..50, do: IO.puts(\"line \#{i}\")"
+    {summary, _out} = Jobs.run(code, intent: "print lines")
+    assert summary.status == :done
+
+    assert Jobs.tail(summary.id, 2) =~ "line 50"
+    assert Jobs.head(summary.id, 1) == "line 1"
+    assert Jobs.lines(summary.id, 2, 3) == "line 2\nline 3"
+    assert Jobs.slice(summary.id, 0, 2) == "line 1\nline 2"
+    assert Jobs.grep(summary.id, ~r/line 4[89]/) == "line 48\nline 49"
+    assert Jobs.grep(summary.id, "line 50") == "line 50"
+  end
+
+  test "result/1 returns the value term, or :running while unfinished" do
+    {running, _out} = Jobs.run("Process.sleep(200); %{a: 1}", budget: 0.05, intent: "slow map")
+    assert {:error, :running} = Jobs.result(running.id)
+
+    Jobs.await(running.id, 5_000)
+    assert {:ok, %{a: 1}} = Jobs.result(running.id)
+  end
+
+  test "history records runs with session and topic grouping" do
+    IxMcp.Session.set_name("test session")
+    IxMcp.Session.set_topic("test topic")
+
+    {summary, _out} = Jobs.run(":recorded", intent: "history entry")
+    entry = Enum.find(Jobs.history(10), &(&1.id == summary.id))
+
+    assert entry.intent == "history entry"
+    assert entry.session == "test session"
+    assert entry.topic == "test topic"
+    assert entry.status == :done
+  end
+
+  test "a crashed cell reports the exit reason, jobs registry survives" do
+    {summary, _out} = Jobs.run("exit({:kaboom, %{state: 42}})", intent: "crash")
+    assert summary.status == :failed
+    assert summary.result =~ "kaboom"
+    assert summary.result =~ "42"
+  end
+
+  @tag :os_procs
+  test "cancelling a job kills OS processes its cell spawned (no orphans)" do
+    marker = "ix-mcp-test-#{System.unique_integer([:positive])}"
+
+    # A compound command keeps `sh` alive (a simple command would be exec'd,
+    # dropping the marker from any argv pgrep can see).
+    code = """
+    System.cmd("sh", ["-c", "sleep 600; echo #{marker}"])
+    """
+
+    {summary, _out} = Jobs.run(code, budget: 0.2, intent: "spawn subprocess")
+    assert summary.running
+
+    # The subprocess exists while the job runs...
+    assert {_, 0} = System.cmd("pgrep", ["-f", marker])
+
+    assert :ok = Jobs.cancel(summary.id)
+    Process.sleep(200)
+
+    # ...and is gone, with its whole tree, after cancellation.
+    assert {_, 1} = System.cmd("pgrep", ["-f", marker])
+  end
+end

--- a/packages/mcp-ex/test/ix_mcp/mcp_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/mcp_test.exs
@@ -42,8 +42,14 @@ defmodule IxMcp.MCPTest do
   end
 
   test "session_set_name and topic_set round-trip" do
-    Server.handle(request("tools/call", %{"name" => "session_set_name", "arguments" => %{"name" => "abc"}}))
-    Server.handle(request("tools/call", %{"name" => "topic_set", "arguments" => %{"topic" => "xyz"}}))
+    Server.handle(
+      request("tools/call", %{"name" => "session_set_name", "arguments" => %{"name" => "abc"}})
+    )
+
+    Server.handle(
+      request("tools/call", %{"name" => "topic_set", "arguments" => %{"topic" => "xyz"}})
+    )
+
     assert IxMcp.Session.get() == %{name: "abc", topic: "xyz"}
   end
 

--- a/packages/mcp-ex/test/ix_mcp/mcp_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/mcp_test.exs
@@ -1,0 +1,54 @@
+defmodule IxMcp.MCPTest do
+  use ExUnit.Case, async: false
+
+  alias IxMcp.MCP.Server
+
+  setup do
+    IxMcp.Workspace.reset()
+    :ok
+  end
+
+  defp request(method, params, id \\ 1) do
+    %{"jsonrpc" => "2.0", "id" => id, "method" => method, "params" => params}
+  end
+
+  test "initialize negotiates a version and advertises tools" do
+    response = Server.handle(request("initialize", %{"protocolVersion" => "2025-06-18"}))
+    assert response["result"]["protocolVersion"] == "2025-06-18"
+    assert response["result"]["serverInfo"]["name"] == "ix-mcp-ex"
+  end
+
+  test "tools/list exposes elixir_exec with required code+intent" do
+    response = Server.handle(request("tools/list", %{}))
+    tools = response["result"]["tools"]
+    exec = Enum.find(tools, &(&1["name"] == "elixir_exec"))
+    assert exec["inputSchema"]["required"] == ["code", "intent"]
+  end
+
+  test "tools/call elixir_exec runs code and reports the result" do
+    response =
+      Server.handle(
+        request("tools/call", %{
+          "name" => "elixir_exec",
+          "arguments" => %{"code" => "IO.puts(\"hi\"); 2 + 2", "intent" => "test add"}
+        })
+      )
+
+    refute response["result"]["isError"]
+    [%{"type" => "text", "text" => text}] = response["result"]["content"]
+    assert text =~ ~s("status":"done")
+    assert text =~ "hi"
+    assert text =~ "=> 4"
+  end
+
+  test "session_set_name and topic_set round-trip" do
+    Server.handle(request("tools/call", %{"name" => "session_set_name", "arguments" => %{"name" => "abc"}}))
+    Server.handle(request("tools/call", %{"name" => "topic_set", "arguments" => %{"topic" => "xyz"}}))
+    assert IxMcp.Session.get() == %{name: "abc", topic: "xyz"}
+  end
+
+  test "unknown method returns a JSON-RPC error, notifications return nil" do
+    assert %{"error" => %{"code" => -32_601}} = Server.handle(request("bogus/method", %{}))
+    assert Server.handle(%{"method" => "notifications/initialized"}) == nil
+  end
+end

--- a/packages/mcp-ex/test/ix_mcp_test.exs
+++ b/packages/mcp-ex/test/ix_mcp_test.exs
@@ -1,0 +1,8 @@
+defmodule IxMcpTest do
+  use ExUnit.Case
+  doctest IxMcp
+
+  test "greets the world" do
+    assert IxMcp.hello() == :world
+  end
+end

--- a/packages/mcp-ex/test/ix_mcp_test.exs
+++ b/packages/mcp-ex/test/ix_mcp_test.exs
@@ -1,8 +1,0 @@
-defmodule IxMcpTest do
-  use ExUnit.Case
-  doctest IxMcp
-
-  test "greets the world" do
-    assert IxMcp.hello() == :world
-  end
-end

--- a/packages/mcp-ex/test/test_helper.exs
+++ b/packages/mcp-ex/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/packages/mcp-ex/test/test_helper.exs
+++ b/packages/mcp-ex/test/test_helper.exs
@@ -1,1 +1,4 @@
-ExUnit.start()
+# The orphan-cleanup tests probe OS process state with pgrep, which the Nix
+# sandbox does not provide; they still run in any normal dev environment.
+exclude = if System.find_executable("pgrep"), do: [], else: [:os_procs]
+ExUnit.start(exclude: exclude)


### PR DESCRIPTION
## Elixir-native rewrite of the index MCP server

The REPL agents drive IS Elixir: `elixir_exec` runs cells against a persistent BEAM workspace instead of `python_exec` against an asyncio IPython kernel. New package: `packages/mcp-ex` (OTP app `ix_mcp`, binary `ix-mcp-ex`), zero runtime deps (OTP's built-in `JSON` is the wire format).

**Authorship disclosure: this PR is authored by Claude Code (AI), operated by @andrewgazelka.** Also credited in the package README.

## Spec table (parity vs `packages/mcp` / `ix_notebook_mcp`)

| Python surface | Wire behavior being matched | Status in this PR |
|---|---|---|
| `python_exec(code, budget=15, intent)` | run on shared persistent namespace; wait `budget` s (cap 120); still-running becomes background job with `{"job","status","running","elapsed_s"}` handle | **ported** as `elixir_exec`: same contract, same handle shape, same 120s cap; each cell is its own supervised BEAM process |
| persistent namespace | vars/functions/classes/imports survive across calls | **ported**: binding + `Macro.Env` (aliases, imports, modules) persist; divergence: a failed cell merges nothing (Elixir eval is transactional per cell) |
| `jobs` dict: `tail/head/slice/lines/grep`, `.output`, `.result` (raises while running), `await`, `.cancel()`, `history()` | in-language job control, no extra tools | **ported**: `Jobs` module aliased in every cell; `Jobs.result` returns `{:error, :running}` instead of raising; paging over ETS buffers |
| job cancellation | stop the job | **ported +strengthened**: cancel kills every OS process tree the job's cells spawned (group-leader tagging -> ports -> pid subtrees); chaos-tested, incl. across `kernel_restart` |
| channel notifications | push job completion/failure to client | **ported**: `notifications/message` with full crash reports (exit reason with state, free on BEAM) |
| `session_set_name` / `topic_set` | label/group runs for the live feed | **ported**: recorded on every run and in `Jobs.history()` |
| `read(target, start, end)` | file, or expression eval'd in kernel (string naming a file follows); errors `kernel unavailable` when kernel wedged | **ported**; the `kernel unavailable` failure mode is gone by construction (no cell can wedge the server; expression eval has a 30s budget then returns a job handle) |
| `kernel_trace` | faulthandler SIGUSR2 stack dump, works while event loop is wedged | **ported** as `Process.info/2` walk of every job's process tree + core processes; no signals needed, works during any wedge |
| `kernel_restart` | respawn kernel child, restore session checkpoint | **ported** as supervisor restart of the workspace; bindings restored from an in-VM ETS checkpoint (plus per-name `term_to_binary` file save/load that skips live refs, like dill's skip-and-report) |
| `pr_watch(pr, cwd, interval, timeout, auto_merge=true)` | watch PR, notify merge/fail/timeout, arm auto-merge by default | **ported minus auto-merge** (deliberate divergence: watching stays read-only; merging is an explicit act) |
| `tui_act(uri, send_keys, peer)` | bridge to `ix-resource-cli act`, probe `IX_RESOURCE_PEERS`, degrade clearly without the CLI | **ported**, same bridge and degradation |
| `reply(resource, text)` | send text to a live dashboard resource page | **dropped**: bound to the Python dashboard's interactive resource layer, which this server does not have |
| `api()` / `help()` | Polars DataFrame of every builtin + bundled module surface, live provenance | **ported (adapted)**: `Api.api/1` filterable rows + `Api.help/1,2` live from `Code.fetch_docs`; text rows rather than a DataFrame (Explorer battery deferred, below) |
| `nu()` / shell helper | managed non-blocking shell wrapper | **dropped (operator-decided)**: cells write `System.cmd/3` / `Port` in-language; the wrapper existed because of asyncio's wedge hazard, which BEAM removes. The one surviving behavior -- no orphan subprocesses on cancel -- is kept and chaos-tested. See README |
| per-cell typecheck gate (ty) | reject bad cells before execution | **ported (adapted)**: parse gate (`Code.string_to_quoted`) rejects before eval with compiler diagnostics; warnings surfaced via `Code.with_diagnostics`; repo lane runs `mix compile --warnings-as-errors` (Elixir 1.18 set-theoretic types) |
| transports: stdio + streamable HTTP | `serve` / `serve --http` | **stdio ported**; HTTP not in this PR |
| dashboard web UI, display helpers, rich renders | live human feed | **dropped in this PR** (session/topic/intent/history metadata is retained server-side for a future feed) |
| session files (`.ixnb` SQLite: cell log, replay, debounced checkpoints) | reopenable durable notebook | **partial**: checkpoint save/restore yes (ETS + file), SQLite cell log/replay no |
| Python batteries (Polars, httpx, etc.) | preloaded modules | **deferred**: zero-dep core on purpose; Explorer (same Polars engine) + Req are the follow-up batteries, FOD pin flow already in place |

## Architecture

- Evaluator copies `Livebook.Runtime.Evaluator`'s design (persistent binding+env via `Code.eval_quoted_with_env/4` with `:prune_binding`, group-leader IOProxy per job for output capture) instead of depending on Livebook, which is an app, not a library. The group leader doubles as the job's process-tree tag for tracing and orphan cleanup.
- Supervision tree in the README (and `IxMcp.Application` moduledoc).
- `lib/languages/{elixir,erlang}.nix`: deprecated `elixir_1_18`/`erlang_27` attrs repointed at beamPackages equivalents (eval aborted under abort-on-warn); `lib/build/elixir-check.nix` gains `__darwinAllowLocalNetworking` (Mix >= 1.18 PubSub opens a loopback socket at compile time).

## Validation

- `mix test`: 26 tests, 0 failures, including the chaos suite: a cell blocks forever while other jobs run on time; `kernel_trace` shows the wedged frame live; `kernel_restart` recovers bindings; cancelled jobs leave no orphan OS processes (pgrep-verified), even across restart.
- `nix build .#mcp-ex` green; `.#mcp-ex.tests.elixir` (sandboxed: warnings-as-errors compile, format, `credo --strict` vs shared config, tests, offline via pinned mix-deps FOD) green; `.#mcp-ex.tests.smoke` (real stdio initialize -> tools/list exchange against the installed release) green.
- `nix run .#lint` green.

## Status / phases

- [x] Phase 1: MCP stdio + session_set_name/topic_set + `elixir_exec` with persistent bindings + tests
- [x] Phase 2: jobs (budget-then-background, registry, paging, channel notifications, orphan-free cancel)
- [x] Phase 3: trace/restart from outside + bindings checkpoint/restore + chaos tests
- [x] Phase 4: remaining tools, api()/help(), README (hero + "Why we left Python"), Nix packaging, lint green

Remaining (follow-ups, out of this PR): streamable HTTP transport, Explorer/Req batteries, a live feed to replace the dashboard, `.ixnb`-style durable cell log.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Elixir-native MCP server rewrite as `ix-mcp-ex`
> - Introduces a full Elixir/OTP rewrite of the index MCP server in [packages/mcp-ex/](https://github.com/indexable-inc/index/pull/3506/files#diff-a273cb414d970d51389d7a989bd0f05ac25325c593ba52b3487e30ac295fa9d8), replacing the previous implementation with a zero-runtime-dep server using OTP's built-in JSON.
> - Implements MCP JSON-RPC over stdio ([IxMcp.MCP.Stdio](https://github.com/indexable-inc/index/pull/3506/files#diff-775ac658aaedab87f4cd5e80d254eaeb13c77ac446f0e4fb2583980ab94a7cb7)) with tool dispatch ([IxMcp.MCP.Tools](https://github.com/indexable-inc/index/pull/3506/files#diff-c1967b7edcd9f2a8628cd2ebf989cfe1e0daf0af2416367f04b4e816c897e776)) for code execution, session/topic management, file reading, PR watching, kernel trace/restart, and TUI resource actions.
> - Runs Elixir code cells in supervised per-job processes ([IxMcp.Jobs.Job](https://github.com/indexable-inc/index/pull/3506/files#diff-cd26f23adf8d8e75fd1b4f9fd5f7cc906cd5aba85c413011e10200c5c85351c4)) with isolated IO capture, cancellation that kills OS subprocess trees, and background execution with output paging.
> - Shares persistent bindings and aliases across jobs via [IxMcp.Workspace](https://github.com/indexable-inc/index/pull/3506/files#diff-b6913aef0a83c3863db107092de78443233e4994f05eaf6202d458892d708d8e), checkpointed to disk for recovery across restarts.
> - Adds Nix packaging with pinned Elixir 1.18/Erlang 27 toolchains, a smoke test exercising `initialize` and `tools/list` over stdio, and Darwin sandbox fixes for Mix 1.18's loopback TCP socket at compile time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 590e62f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->