### PR TITLE
Remove weave-serve launchd agent from darwin profile

### DIFF
--- a/users/andrewgazelka/options.nix
+++ b/users/andrewgazelka/options.nix
@@ -102,12 +102,6 @@
       };
     };
 
-    weave.enable = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = "Run the local Weave fact server.";
-    };
-
     sshSigningPublicKey = lib.mkOption {
       type = lib.types.str;
       default = builtins.head (

--- a/users/andrewgazelka/profiles/darwin-home.nix
+++ b/users/andrewgazelka/profiles/darwin-home.nix
@@ -651,38 +651,6 @@ in {
     };
   };
 
-  # Weave fact server (indexable-inc/weave): the ix-mcp kernel store's
-  # write-behind flusher POSTs facts to 127.0.0.1:7677; with no listener every
-  # kernel cell logs connection-refused retries and drops facts (index#3203).
-  # The agent host (and its --agents flag) was retired outright in
-  # indexable-inc/weave#266 (fabric phase 3, index#3193), which closed the
-  # write-path wedge indexable-inc/weave#240 by construction: the journal
-  # only records facts. Binary + ui are gc-rooted out-links (this
-  # config has no weave input); refresh with
-  #   nix build ~/Projects/indexable-inc/weave#default --out-link ~/.local/share/weave/app
-  #   nix build ~/Projects/indexable-inc/weave#ui --out-link ~/.local/share/weave/ui
-  # Log stays at ~/.local/share/weave/serve.log next to the store: the path
-  # existing tooling and memories already reference.
-  launchd.agents.weave-serve = {
-    enable = cfg.weave.enable;
-    config = {
-      ProgramArguments = lockArgs "weave-serve" [
-        "${config.home.homeDirectory}/.local/share/weave/app/bin/weave"
-        "--store"
-        "${config.home.homeDirectory}/.local/share/weave/store"
-        "serve"
-        "--addr"
-        "127.0.0.1:7677"
-        "--ui"
-        "${config.home.homeDirectory}/.local/share/weave/ui"
-      ];
-      KeepAlive = true;
-      RunAtLoad = true;
-      StandardOutPath = "${config.home.homeDirectory}/.local/share/weave/serve.log";
-      StandardErrorPath = "${config.home.homeDirectory}/.local/share/weave/serve.log";
-    };
-  };
-
   launchd.agents.grayscale-off = {
     enable = false;
     config = {


### PR DESCRIPTION
Weave was pegging 3.5 cores on hydra (26h CPU over 30h wall, busy loop). Removes the `weave-serve` launchd agent and its `weave.enable` option from the andrewgazelka darwin profile.

Kernel store writes to `:7677` spool durably and `fabric` raises `FabricError` loudly when the server is absent, so nothing fails silently.

Requested by Andrew; authored by Claude Code (Opus).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove weave-serve launchd agent from darwin home profile
> Removes the `launchd.agents.weave-serve` agent definition from [darwin-home.nix](https://github.com/indexable-inc/index/pull/3507/files#diff-7b4b5d284711ad1f33b0b8435434d62bae77f9441d69ae1563fb02b61e408671) and the associated `weave.enable` option from [options.nix](https://github.com/indexable-inc/index/pull/3507/files#diff-e2d6dc3bb070a114e9baae9f4b8c329946568b5e444d9ef00ed7e63453e0ab02). The weave server will no longer be started or managed by launchd on darwin.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a598b20.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->