### PR TITLE
prompt: add feasibilityClaims rule (precedent-test impossibility claims)

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -189,6 +189,27 @@
     };
   }
   {
+    feasibilityClaims = {
+      text = ''
+        When judging a claim that something is impossible or infeasible, treat
+        each cited limit as a hypothesis: find the strongest existing system
+        that solved the analogous problem under the same constraint (a
+        fuel-bounded solver, incremental recomputation, cached execution of
+        untrusted build code) and test the objection against it before
+        endorsing it. A received limitation you have not tried to break is
+        folklore, not a verdict.
+      '';
+      reason = ''
+        Asked why an eval-backed home-manager LSP was "impossible", the agent
+        opened with the right verdict but relayed the folk objections
+        (undecidability, no schema without eval, effects) as real limits; the
+        user had to dismantle each one by citing rust-analyzer precedent
+        (fueled trait solver, salsa, proc-macro server). Precedent-testing
+        objections is the load-bearing move and was nowhere in the rules.
+      '';
+    };
+  }
+  {
     machineBuildObservability = {
       tags = ["claude-code"];
       text = ''


### PR DESCRIPTION
Adds a `feasibilityClaims` rule to the house prompt: when judging an impossibility/infeasibility claim, treat each cited limit as a hypothesis and test it against the strongest existing system that solved the analogous problem under the same constraint, before endorsing it.

Provenance: asked why an eval-backed home-manager options LSP was "impossible", the agent relayed the folk objections (undecidability, no schema without eval, effects) as real limits; the user dismantled each via rust-analyzer precedent (fueled trait solver, salsa, proc-macro server). The existing epistemics rules (validate, rootCause) only cover operational facts, so nothing fired on a conceptual claim.

Validated: rendered via `nix eval --raw --impure --expr '(import ./packages/agent/prompt { lib = (import <nixpkgs> {}).lib; }).systemPrompt'` and reread the new paragraph; `nix fmt` clean; pre-commit lint suite green.

Closes #3508

🤖 Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `feasibilityClaims` rule to agent prompt for precedent-testing impossibility claims
> Adds a new `feasibilityClaims` entry to [rules.nix](https://github.com/indexable-inc/index/pull/3509/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) with guidance instructing the agent to treat cited limits as hypotheses and test them against the strongest known precedent systems, rather than accepting impossibility claims at face value. The `reason` field documents a prior failure mode where the agent accepted infeasibility claims without challenge.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f034757.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->