### PR TITLE
workstation: drive agents with mcp-ex instead of the Python kernel

### DIFF
--- a/lib/util/mcp/servers.nix
+++ b/lib/util/mcp/servers.nix
@@ -21,12 +21,18 @@
     "SLACK_USER_TOKEN"
   ];
 
-  defaultServers = {indexCommand ? null}:
+  defaultServers = {
+    indexCommand ? null,
+    # The Python kernel's entrypoint needs its `serve` subcommand; the Elixir
+    # server (packages/mcp-ex) is stdio-serve-only and takes no arguments, so
+    # consumers pointing at it pass `indexArgs = []`.
+    indexArgs ? ["serve"],
+  }:
     lib.optionalAttrs (indexCommand != null) {
       index = {
         transport = "stdio";
         command = indexCommand;
-        args = ["serve"];
+        args = indexArgs;
         envVars = indexApiEnvVars;
       };
     }

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -200,7 +200,11 @@
   # Codex.
   ixMcp = ix.mcp;
   agentMcpServers = ixMcp.defaultServers {
-    indexCommand = lib.getExe indexPkgs.mcp;
+    # The Elixir-native server (packages/mcp-ex) replaces the Python kernel on
+    # this workstation: agents drive `elixir_exec` against a persistent BEAM
+    # workspace. No subcommands; stdio serve is its only mode.
+    indexCommand = lib.getExe indexPkgs.mcp-ex;
+    indexArgs = [];
   };
   codexMcpServers = lib.mapAttrs (_: def:
     if (def.transport or "stdio") == "stdio"


### PR DESCRIPTION
Points the shared `index` MCP server on andrewgazelka's workstation at the just-merged Elixir-native server (`packages/mcp-ex`, #3506) instead of the Python kernel.

- `ix.mcp.defaultServers` gains `indexArgs ? ["serve"]`: the Python entrypoint needs its `serve` subcommand, mcp-ex is stdio-serve-only with no arguments.
- Workstation profile passes `indexCommand = lib.getExe indexPkgs.mcp-ex; indexArgs = [];`.

Validation: `homeConfigurations."andrewgazelka@hydra"` builds with the index input overridden to this branch (workstation profile is not CI-evaluated, per prior art).

Authored by Claude Code (AI), operated by @andrewgazelka.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `mcp` with `mcp-ex` as the agent MCP server binary in the workstation profile
> - Switches [workstation.nix](https://github.com/indexable-inc/index/pull/3511/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962) to invoke `mcp-ex` with no arguments instead of `mcp` with the implicit `serve` argument.
> - Adds an `indexArgs` parameter to the `defaultServers` function in [servers.nix](https://github.com/indexable-inc/index/pull/3511/files#diff-a74190c62a3086f0b0e05489808b80559c743c45cb2f5d09e9734aa712b7604b), allowing callers to override the default `["serve"]` args passed to the index server command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a6e124.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->