### PR TITLE
mcp-ex: add Fleet for remote exec over Erlang distribution

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/api.ex
+++ b/packages/mcp-ex/lib/ix_mcp/api.ex
@@ -12,7 +12,7 @@ defmodule IxMcp.Api do
   provenance column.
   """
 
-  @surface [IxMcp.Jobs, IxMcp.Api, IxMcp.Kernel, IxMcp.Workspace, IxMcp.Checkpoint, IxMcp.Reader]
+  @surface [IxMcp.Jobs, IxMcp.Api, IxMcp.Fleet, IxMcp.Kernel, IxMcp.Workspace, IxMcp.Checkpoint, IxMcp.Reader]
 
   @type row :: %{
           module: module(),

--- a/packages/mcp-ex/lib/ix_mcp/fleet.ex
+++ b/packages/mcp-ex/lib/ix_mcp/fleet.ex
@@ -1,0 +1,215 @@
+defmodule IxMcp.Fleet do
+  @moduledoc """
+  Run Elixir on other BEAM nodes over the tailnet -- one specific node, a
+  random one, or a fan-out across many -- using native Erlang distribution
+  and `:erpc`.
+
+  This module is deliberately **topology-agnostic**: it never hard-codes any
+  hostname. The node list and the shared cookie come from the environment,
+  injected by whatever deploys this server:
+
+    * `IX_BEAM_NODES` -- comma/space/newline separated node names, e.g.
+      `beamd@host-a.tailnet.ts.net beamd@host-b.tailnet.ts.net`. Empty/unset
+      means no fleet is configured and the fan-out helpers return
+      `{:error, :no_nodes}`.
+    * `IX_BEAM_COOKIE` (or `IX_BEAM_COOKIE_FILE` pointing at a file) -- the
+      shared distribution cookie. Every node in the fleet, and this server,
+      must agree on it; it is a root-equivalent credential.
+    * `IX_BEAM_LOCAL_NAME` -- optional. The long name this node registers as
+      when distribution starts. Defaults to `mcp-ex@<hostname>`.
+
+  Distribution is started **lazily** on the first fleet call (see
+  `ensure_dist/0`): the release ships with distribution off so its sandboxed
+  build and tests never try to open an epmd listen socket.
+
+  Code is sent to remote nodes as **source strings** evaluated with
+  `Code.eval_string/1`, not as closures. Closures would serialize as
+  module + hash and only resolve if both sides run byte-identical modules;
+  strings sidestep that entirely and keep ad-hoc cells simple.
+
+      Fleet.exec(:"beamd@host-a.tailnet.ts.net", "System.schedulers_online()")
+      Fleet.exec_any("node() |> to_string()")            # a random node
+      Fleet.multicall(Fleet.nodes(), "node()", timeout: 10_000)
+  """
+
+  @nodes_env "IX_BEAM_NODES"
+  @cookie_env "IX_BEAM_COOKIE"
+  @cookie_file_env "IX_BEAM_COOKIE_FILE"
+  @local_name_env "IX_BEAM_LOCAL_NAME"
+
+  @default_timeout 15_000
+
+  @type exec_result :: {:ok, term()} | {:error, term()}
+
+  @doc """
+  The configured fleet nodes, parsed from `IX_BEAM_NODES`. Returns `[]` when
+  the variable is unset or empty.
+  """
+  @spec nodes() :: [node()]
+  def nodes do
+    (System.get_env(@nodes_env) || "")
+    |> String.split([",", " ", "\n", "\t"], trim: true)
+    |> Enum.map(&String.to_atom/1)
+  end
+
+  @doc """
+  Ensure distributed Erlang is running on this node, starting it (and setting
+  the shared cookie) on first use. Idempotent.
+  """
+  @spec ensure_dist() :: {:ok, node()} | {:error, term()}
+  def ensure_dist do
+    if Node.alive?() do
+      {:ok, node()}
+    else
+      start_distribution()
+    end
+  end
+
+  @doc """
+  Evaluate `code` on `target` and return `{:ok, value}` or `{:error, reason}`.
+  A dead or unreachable node fails only this call. `:timeout` (ms) defaults to
+  #{@default_timeout}.
+  """
+  @spec exec(node(), String.t(), keyword()) :: exec_result()
+  def exec(target, code, opts \\ []) when is_atom(target) and is_binary(code) do
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+
+    with {:ok, _} <- ensure_dist() do
+      try do
+        {value, _binding} = :erpc.call(target, Code, :eval_string, [code], timeout)
+        {:ok, value}
+      catch
+        kind, reason -> {:error, {kind, reason}}
+      end
+    end
+  end
+
+  @doc """
+  Evaluate `code` on one random configured node. `{:error, :no_nodes}` when
+  `IX_BEAM_NODES` is empty.
+  """
+  @spec exec_any(String.t(), keyword()) :: exec_result()
+  def exec_any(code, opts \\ []) when is_binary(code) do
+    case nodes() do
+      [] -> {:error, :no_nodes}
+      ns -> exec(Enum.random(ns), code, opts)
+    end
+  end
+
+  @doc """
+  Evaluate `code` on the least-loaded reachable node (by scheduler run-queue
+  length). `{:error, :no_nodes}` when none are configured.
+  """
+  @spec exec_least_loaded(String.t(), keyword()) :: exec_result()
+  def exec_least_loaded(code, opts \\ []) when is_binary(code) do
+    case nodes() do
+      [] ->
+        {:error, :no_nodes}
+
+      ns ->
+        with {:ok, _} <- ensure_dist(),
+             {:ok, target} <- least_loaded(ns, Keyword.get(opts, :probe_timeout, 5_000)) do
+          exec(target, code, opts)
+        end
+    end
+  end
+
+  @doc """
+  Fan `code` out across `targets`, returning `{node, {:ok, value} | {:error,
+  reason}}` per node. One dead node cannot poison the batch. `:timeout` (ms)
+  is enforced per node.
+  """
+  @spec multicall([node()], String.t(), keyword()) :: [{node(), exec_result()}]
+  def multicall(targets, code, opts \\ []) when is_list(targets) and is_binary(code) do
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+
+    case ensure_dist() do
+      {:ok, _} ->
+        targets
+        |> :erpc.multicall(Code, :eval_string, [code], timeout)
+        |> Enum.zip(targets)
+        |> Enum.map(fn {result, target} -> {target, normalize(result)} end)
+
+      {:error, reason} ->
+        Enum.map(targets, &{&1, {:error, reason}})
+    end
+  end
+
+  # -- internals ------------------------------------------------------------
+
+  @spec least_loaded([node()], timeout()) :: {:ok, node()} | {:error, :no_reachable_nodes}
+  defp least_loaded(targets, timeout) do
+    targets
+    |> :erpc.multicall(:erlang, :statistics, [:run_queue], timeout)
+    |> Enum.zip(targets)
+    |> Enum.flat_map(fn
+      {{:ok, queue}, target} -> [{queue, target}]
+      {_other, _target} -> []
+    end)
+    |> case do
+      [] -> {:error, :no_reachable_nodes}
+      loads -> {:ok, elem(Enum.min_by(loads, &elem(&1, 0)), 1)}
+    end
+  end
+
+  @spec start_distribution() :: {:ok, node()} | {:error, term()}
+  defp start_distribution do
+    case Node.start(local_name(), :longnames) do
+      {:ok, _pid} ->
+        set_cookie()
+        {:ok, node()}
+
+      {:error, {:already_started, _pid}} ->
+        set_cookie()
+        {:ok, node()}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @spec local_name() :: atom()
+  defp local_name do
+    case System.get_env(@local_name_env) do
+      name when is_binary(name) and name != "" ->
+        String.to_atom(name)
+
+      _ ->
+        {:ok, host} = :inet.gethostname()
+        String.to_atom("mcp-ex@" <> to_string(host))
+    end
+  end
+
+  @spec set_cookie() :: :ok
+  defp set_cookie do
+    case cookie() do
+      nil -> :ok
+      value -> Node.set_cookie(String.to_atom(value))
+    end
+
+    :ok
+  end
+
+  @spec cookie() :: String.t() | nil
+  defp cookie do
+    cond do
+      value = System.get_env(@cookie_env) -> value
+      path = System.get_env(@cookie_file_env) -> read_cookie_file(path)
+      true -> nil
+    end
+  end
+
+  @spec read_cookie_file(String.t()) :: String.t() | nil
+  defp read_cookie_file(path) do
+    case File.read(path) do
+      {:ok, contents} -> String.trim(contents)
+      {:error, _} -> nil
+    end
+  end
+
+  @spec normalize(term()) :: exec_result()
+  defp normalize({:ok, {value, _binding}}), do: {:ok, value}
+  defp normalize({:error, reason}), do: {:error, reason}
+  defp normalize({:throw, value}), do: {:error, {:throw, value}}
+  defp normalize({:exit, reason}), do: {:error, {:exit, reason}}
+end

--- a/packages/mcp-ex/lib/ix_mcp/workspace.ex
+++ b/packages/mcp-ex/lib/ix_mcp/workspace.ex
@@ -13,7 +13,7 @@ defmodule IxMcp.Workspace do
 
   use GenServer
 
-  @prelude "alias IxMcp.Jobs; alias IxMcp.Api"
+  @prelude "alias IxMcp.Jobs; alias IxMcp.Api; alias IxMcp.Fleet"
 
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do

--- a/packages/mcp-ex/test/ix_mcp/fleet_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/fleet_test.exs
@@ -1,0 +1,61 @@
+defmodule IxMcp.FleetTest do
+  use ExUnit.Case, async: false
+
+  alias IxMcp.Fleet
+
+  @nodes_env "IX_BEAM_NODES"
+
+  setup do
+    original = System.get_env(@nodes_env)
+
+    on_exit(fn ->
+      case original do
+        nil -> System.delete_env(@nodes_env)
+        value -> System.put_env(@nodes_env, value)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "nodes/0" do
+    test "returns [] when IX_BEAM_NODES is unset" do
+      System.delete_env(@nodes_env)
+      assert Fleet.nodes() == []
+    end
+
+    test "returns [] when IX_BEAM_NODES is empty" do
+      System.put_env(@nodes_env, "")
+      assert Fleet.nodes() == []
+    end
+
+    test "splits on commas, spaces, tabs and newlines" do
+      System.put_env(@nodes_env, "beamd@a.ts.net, beamd@b.ts.net\tbeamd@c.ts.net\nbeamd@d.ts.net")
+
+      assert Fleet.nodes() == [
+               :"beamd@a.ts.net",
+               :"beamd@b.ts.net",
+               :"beamd@c.ts.net",
+               :"beamd@d.ts.net"
+             ]
+    end
+  end
+
+  describe "dispatch with no configured nodes" do
+    setup do
+      System.delete_env(@nodes_env)
+      :ok
+    end
+
+    # These short-circuit on an empty node list *before* touching
+    # distribution, so the suite never opens an epmd socket (which the
+    # sandboxed build forbids).
+    test "exec_any/2 reports :no_nodes" do
+      assert Fleet.exec_any("1 + 1") == {:error, :no_nodes}
+    end
+
+    test "exec_least_loaded/2 reports :no_nodes" do
+      assert Fleet.exec_least_loaded("1 + 1") == {:error, :no_nodes}
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `IxMcp.Fleet` to mcp-ex: run Elixir on other BEAM nodes over the tailnet using native Erlang distribution and `:erpc`.

- `Fleet.exec(node, code, opts)` -- one specific node
- `Fleet.exec_any(code, opts)` -- a random configured node
- `Fleet.exec_least_loaded(code, opts)` -- least-loaded reachable node (run-queue probe)
- `Fleet.multicall(nodes, code, opts)` -- fan-out; per-node `{:ok,_}|{:error,_}`, one dead node can't poison the batch
- `Fleet.nodes/0`, `Fleet.ensure_dist/0`

Aliased into the cell prelude and the `Api` discovery surface next to `Jobs`.

## Topology stays out of this repo

The node list and shared cookie come only from the environment, injected by the deployment: `IX_BEAM_NODES`, `IX_BEAM_COOKIE` / `IX_BEAM_COOKIE_FILE`, `IX_BEAM_LOCAL_NAME`. No fleet hostnames are committed here. Fleet-side install (the `beamd` service + cookie) is a companion PR in the `ix` repo.

## Design notes

- Lazy distribution: `ensure_dist/0` starts distribution on the first fleet call, so the sandboxed build/tests never open an epmd socket.
- Strings, not closures: code is sent as source for `Code.eval_string`, sidestepping the module+hash closure-resolution hazard.
- Tests are offline (only the no-nodes-guarded paths + parsing).

## Validation (local)

`mix compile --warnings-as-errors` clean; `mix test test/ix_mcp/fleet_test.exs` = 5 passed; `mix credo lib/ix_mcp/fleet.ex --strict` = no issues.

## Not yet wired (owner steps)

Pointing this at the fleet needs the companion `ix` PR deployed (beamd + cookie) and `IX_BEAM_NODES`/cookie env set for the mcp-ex process (private config).

Draft pending the `ix` companion and review.

AI-authored (Claude) at @andrewgazelka's direction.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `IxMcp.Fleet` for remote code execution over Erlang distribution
> - Adds [`IxMcp.Fleet`](https://github.com/indexable-inc/index/pull/3514/files#diff-f963afd2cb8ce622b244fbab551e894f946ed3a61480357d3eaa55367c5e05fc) with four execution modes: targeted (`exec/3`), random-node (`exec_any/2`), least-loaded (`exec_least_loaded/2`), and fan-out (`multicall/3`), all evaluating Elixir source strings via `:erpc` on configured BEAM nodes.
> - Node list is configured via `IX_BEAM_NODES` (comma/space/newline separated); cookie via `IX_BEAM_COOKIE` or `IX_BEAM_COOKIE_FILE`; local node name via `IX_BEAM_LOCAL_NAME`.
> - Distribution is started lazily on first fleet operation via `ensure_dist/0`.
> - `IxMcp.Fleet` is aliased as `Fleet` in the workspace `@prelude` so it is available in evaluated code by default.
> - Risk: remote execution evaluates arbitrary Elixir source strings on connected nodes with no sandboxing beyond what `:erpc` provides.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17c746b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->