### PR TITLE
mcp-ex: elixir_exec description -- prefer raw Elixir over shelling out

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -23,6 +23,16 @@ defmodule IxMcp.MCP.Tools do
         `Jobs.cancel("ab12")`, `Jobs.history()`. Each cell runs in its own
         BEAM process, so a blocking cell never delays other jobs or this
         server.
+
+        Write plain Elixir, not shell. For files and data use the standard
+        library directly -- File.read!/1, File.write!/2, Path.wildcard/1,
+        File.ls!/1, File.stat!/1 -- instead of shelling out. Reserve
+        System.cmd/3 for real external programs (git, nix, gh), and always
+        pass its arguments as a list: System.cmd("git", ["-C", dir, "status"]).
+        Never build shell command strings, and never use bash here-docs or
+        nested quoting to pass multi-line text -- they are brittle and can
+        wedge this transport. To hand multi-line text to a program, write it
+        to a file with File.write!/2 and pass the path.
         """,
         "inputSchema" => %{
           "type" => "object",


### PR DESCRIPTION
## What

Extends the `elixir_exec` tool description to steer callers to **raw Elixir instead of shelling out**:

- Use `File`, `Path`, `System` directly (`File.read!/1`, `Path.wildcard/1`, `File.write!/2`) rather than `System.cmd("bash", ...)`.
- Reserve `System.cmd/3` for real external programs (git, nix, gh); pass args as a list.
- Never use bash here-docs / nested quoting for multi-line text.

## Why

Here-docs and nested shell quoting inside cells are brittle and can wedge the stdio transport -- observed live this session (a here-doc in a cell dropped the MCP connection mid-call, twice). Native Elixir file ops are the reliable path.

Description-only change to one tool. `mix compile --warnings-as-errors` clean, `mix credo --strict` clean.

AI-authored (Claude) at @andrewgazelka's direction.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `elixir_exec` tool instructions to prefer plain Elixir over shell commands
> Adds coding guidance to the `IxMcp.MCP.Tools` instruction string in [tools.ex](https://github.com/indexable-inc/index/pull/3516/files#diff-c1967b7edcd9f2a8628cd2ebf989cfe1e0daf0af2416367f04b4e816c897e776). The new guidance directs the tool to use standard library functions for file and data operations, reserve `System.cmd/3` for external programs with args as a list, and avoid building shell command strings or here-docs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52ce7bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->