### PR TITLE
claude-code: stop disabling 1M context by default

### DIFF
--- a/doc/claude-code/overview.md
+++ b/doc/claude-code/overview.md
@@ -56,11 +56,14 @@ agent content from Nix outputs instead of invoking `nix build` interactively.
 ### Soft env defaults (set only when unset)
 
 `env_defaults` are applied only if the user has not set them
-(`default.nix:147-152`, `382`): `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` keeps every
-session on the standard 200K window instead of the silently auto-upgraded 1M
-window (uncached, slower per turn, ~5x the input price; past-the-window work
-belongs in subagents, and the smaller window makes auto-compaction trigger
-sooner). Verified against 2.1.197, the flag gates every 1M path in the CLI:
+(`default.nix:147-152`, `382`). Every feature toggled off in the typed
+`features` arg rides here as its `CLAUDE_CODE_DISABLE_<NAME>=1` var; by
+default that is only `cron` (`CLAUDE_CODE_DISABLE_CRON=1`, dropping the
+scheduling/loop tools). 1M context is NOT disabled by default (#3487):
+native-1M models run their full window. Consumers that want the 1M paths off
+(uncached, slower per turn, ~5x the input price) set
+`features.context1M = false`, which bakes `CLAUDE_CODE_DISABLE_1M_CONTEXT=1`.
+Verified against 2.1.197, that flag gates every 1M path in the CLI:
 the explicit `[1m]` model suffix, the silent auto-upgrade on eligible models,
 honoring a `context-1m` beta header, and the built-in `[1m]` rows in `/model`.
 One cosmetic residual: server-pushed model options
@@ -69,10 +72,11 @@ valued `claude-fable-5[1m]`) can still appear in the picker — selecting one
 still runs at the standard window when the disable flag is active.
 
 The wrapper also bakes the same knobs into the settings render's `env` map
-(`CLAUDE_CODE_DISABLE_1M_CONTEXT=1`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW=300000`)
-so `/context` and autocompact stay on the ~300K working window even if
-launch-time `env_defaults` are missing. Install checks assert both paths.
-Re-enable 1M per machine with `export CLAUDE_CODE_DISABLE_1M_CONTEXT=`.
+(the disabled-feature vars plus `CLAUDE_CODE_AUTO_COMPACT_WINDOW=300000`, so
+`/context` and autocompact keep the ~300K working window even on a native-1M
+model, and even if launch-time `env_defaults` are missing). Install checks
+assert both paths. A caller's own export — even empty — always wins over an
+env_default, so any baked disable can be undone per machine.
 
 ### Prepended flags (`wrapperFlags`, `default.nix:353-361`)
 

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -51,9 +51,9 @@
   # CLAUDE_CODE_AUTO_COMPACT_WINDOW into settings `env` (null bakes nothing).
   # Unknown keys throw, like systemTools. Merged over `defaultFeatures` in the
   # let-block:
-  #  - context1M = false: every 1M path in the CLI (the [1m] model suffix, the
-  #    silent auto-upgrade, the context-1m beta header) is ~5x input price;
-  #    past-the-window work belongs in subagents.
+  #  - context1M = true: stock behavior; native-1M models run their full
+  #    window (#3487). false bakes CLAUDE_CODE_DISABLE_1M_CONTEXT=1, gating
+  #    every 1M path in the CLI ([1m] suffix, auto-upgrade, beta header).
   #  - cron = false: drops the scheduling/loop tools.
   #  - autoCompactWindow = 300000: native-1M models (Fable 5, Sonnet 5,
   #    Opus 4.8) otherwise autocompact near the 1M cliff; 300K matches the
@@ -243,7 +243,7 @@
     cron = "CLAUDE_CODE_DISABLE_CRON";
   };
   defaultFeatures = {
-    context1M = false;
+    context1M = true;
     cron = false;
     autoCompactWindow = 300000;
   };

--- a/packages/agent/claude-code/install-check.nix
+++ b/packages/agent/claude-code/install-check.nix
@@ -98,22 +98,29 @@
       printf 'claude launcher env check failed: disabled-feature vars must be env_defaults, not env\n' >&2
       exit 1
     fi
-    ${lib.optionalString (wrapperEnvDefaults ? CLAUDE_CODE_DISABLE_1M_CONTEXT) ''
-    envstub="$PWD/envstub"
-    printf '%s\n' '#!${runtimeShell}' 'printf "%s\n" "''${CLAUDE_CODE_DISABLE_1M_CONTEXT-unset}"' > "$envstub"
-    chmod +x "$envstub"
-    sed "s|@helper@|$envstub|" ${launchSpec} > "$PWD/env-spec.json"
-    got="$(env -u CLAUDE_CODE_DISABLE_1M_CONTEXT IX_LAUNCH_SPEC="$PWD/env-spec.json" "$launcher")"
-    if [ "$got" != 1 ]; then
-      printf '1M-context guard check failed: unset caller env must get the default, got %s\n' "$got" >&2
-      exit 1
-    fi
-    got="$(env CLAUDE_CODE_DISABLE_1M_CONTEXT= IX_LAUNCH_SPEC="$PWD/env-spec.json" "$launcher")"
-    if [ "$got" != "" ]; then
-      printf '1M-context guard check failed: caller re-enable (empty value) must win, got %s\n' "$got" >&2
-      exit 1
-    fi
-  ''}
+    ${lib.optionalString (wrapperEnvDefaults != {}) (
+    # The soft-default mechanism itself, through one representative disabled
+    # toggle (whichever the build carries): an unset caller env gets the baked
+    # default, and an explicit caller value — even empty — wins.
+    let
+      guardVar = lib.head (builtins.attrNames wrapperEnvDefaults);
+    in ''
+      envstub="$PWD/envstub"
+      printf '%s\n' '#!${runtimeShell}' 'printf "%s\n" "''${${guardVar}-unset}"' > "$envstub"
+      chmod +x "$envstub"
+      sed "s|@helper@|$envstub|" ${launchSpec} > "$PWD/env-spec.json"
+      got="$(env -u ${guardVar} IX_LAUNCH_SPEC="$PWD/env-spec.json" "$launcher")"
+      if [ "$got" != 1 ]; then
+        printf 'env-defaults guard check failed: unset caller env must get the default, got %s\n' "$got" >&2
+        exit 1
+      fi
+      got="$(env ${guardVar}= IX_LAUNCH_SPEC="$PWD/env-spec.json" "$launcher")"
+      if [ "$got" != "" ]; then
+        printf 'env-defaults guard check failed: caller override (empty value) must win, got %s\n' "$got" >&2
+        exit 1
+      fi
+    ''
+  )}
 
     # The typed feature render must land verbatim in the baked settings env
     # (read at CC startup even when the launch env is missing), and the house

--- a/packages/agent/home-manager/claude-code.nix
+++ b/packages/agent/home-manager/claude-code.nix
@@ -111,7 +111,7 @@ in {
       type = lib.types.attrsOf (lib.types.nullOr (lib.types.either lib.types.bool lib.types.int));
       default = {};
       example = {
-        context1M = true;
+        context1M = false;
         autoCompactWindow = null;
       };
       description = ''

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -168,13 +168,12 @@
     # controlled keys; the module materializes the result into the writable
     # ~/.claude/settings.json.
     extraSettings = claudeSettings;
-    # Personal opt-outs from the fleet posture: run the model's native 1M
-    # window (no DISABLE_1M clamp, no AUTO_COMPACT_WINDOW override) and keep
-    # the harness subagent/task tool schemas loaded. Pairs with the
-    # `backgroundSubagents` omit on programs.claude-code below, whose rule
-    # text declares these tools absent.
+    # Personal opt-outs from the fleet posture: autocompact at the model's
+    # native window (no AUTO_COMPACT_WINDOW clamp; the 1M window itself is
+    # the wrapper default since #3487) and keep the harness subagent/task
+    # tool schemas loaded. Pairs with the `backgroundSubagents` omit on
+    # programs.claude-code below, whose rule text declares these tools absent.
     features = {
-      context1M = true;
       autoCompactWindow = null;
     };
     # Matches agentPromptOmitRules `forceMerge` above: without this the baked


### PR DESCRIPTION
## Why

The wrapper baked `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` into every session, clamping native-1M models to the standard window with no declarative way back in short of a per-machine env export. `context1M` now defaults `true` (stock CLI behavior); `features.context1M = false` still bakes the disable var into both the launch `env_defaults` and the settings env for consumers that want the 1M paths off.

Deliberately unchanged: the autocompact posture (`CLAUDE_CODE_AUTO_COMPACT_WINDOW=300000`), so default sessions gain the 1M window but keep compacting at the ~300K working window; opting out of that clamp stays a separate `autoCompactWindow` decision.

## Reviewer notes

- The install check's soft-default round trip was keyed to the 1M var and would have silently stopped rendering once no default build carries it; it is generalized to whichever disabled toggle the build carries (`CLAUDE_CODE_DISABLE_CRON` for the default build).
- The `users/andrewgazelka` workstation `context1M = true` opt-out is dropped as a no-op; its `autoCompactWindow = null` opt-out stays.
- The Home Manager `features` example now shows `context1M = false`, since `true` became the default.
- Verified locally per CONTRIBUTING: `nix run .#lint` clean; `nix build .#claude-code` passes the install check, as does an overridden `features.context1M = false` build (its guard exercises the 1M var; settings env renders `CLAUDE_CODE_DISABLE_1M_CONTEXT=1`).

Fixes #3487

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable 1M context by default in the claude-code wrapper
> - Changes `context1M` in `defaultFeatures` from `false` to `true` in [default.nix](https://github.com/indexable-inc/index/pull/3517/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8), so 1M-context paths (1m suffix, auto-upgrade, beta header) are active out of the box.
> - To disable, set `features.context1M = false`, which bakes `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` into the wrapper env defaults.
> - Generalizes the install check in [install-check.nix](https://github.com/indexable-inc/index/pull/3517/files#diff-1c44d854435c9b28e9ccf7b49e6b2baa8924419492b25c7a1aacf651e518efb7) to validate the soft-default env mechanism against any present default key, rather than only the 1M flag.
> - Removes the now-redundant explicit `features.context1M = true` override from the [workstation profile](https://github.com/indexable-inc/index/pull/3517/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962).
> - Behavioral Change: any build that did not previously override `context1M` will now run with 1M context enabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77073e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->