### PR TITLE
ci-budget: report queue-admission misses as pool saturation with wait and depth

### DIFF
--- a/.github/actions/ci-budget/worker/worker.mjs
+++ b/.github/actions/ci-budget/worker/worker.mjs
@@ -196,6 +196,46 @@ export async function currentWorkerJob({
   return job;
 }
 
+/// Best-effort queue-depth probe for the admission failure message: how many
+/// workflow runs the repository still has queued while this late worker runs
+/// its check. The count is diagnostic context only, so callers must not let a
+/// failure here mask the deadline miss itself.
+export async function queuedRunCount({
+  apiUrl = "https://api.github.com",
+  fetchImpl = fetch,
+  repository,
+  token,
+}) {
+  const url = new URL(apiUrl);
+  const basePath = url.pathname.replace(/\/$/, "");
+  url.pathname = `${basePath}/repos/${repositoryPath(repository)}/actions/runs`;
+  url.searchParams.set("status", "queued");
+  url.searchParams.set("per_page", "1");
+  const response = await fetchImpl(url, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`GitHub queued runs request failed with ${response.status}`);
+  }
+  const payload = JSON.parse(body);
+  if (
+    payload === null ||
+    Array.isArray(payload) ||
+    typeof payload !== "object" ||
+    typeof payload.total_count !== "number" ||
+    !Number.isSafeInteger(payload.total_count) ||
+    payload.total_count < 0
+  ) {
+    throw new Error("GitHub queued runs response is malformed");
+  }
+  return payload.total_count;
+}
+
 function timestamp(value, name) {
   if (typeof value !== "string") {
     throw new Error(`GitHub worker job has no ${name}`);
@@ -219,8 +259,22 @@ export function assertQueueAdmission({ job, policy }) {
   const deadline =
     timing.createdAtMilliseconds + policy.queue_start_seconds * 1000;
   if (timing.startedAtMilliseconds > deadline) {
+    // A late start means no dispatcher slot freed up in time, not that this
+    // runner was slow: the self-hosted pool is one slot per host, shared by
+    // every workflow (PR ci, auto-deploy, prod deploy, cache-warm, publish,
+    // antithesis, ...), so a stacked deploy backlog starves PR admission
+    // (indexable-inc/ix#7625). Say how long the job actually waited so the
+    // failure reads as pool saturation instead of a runner defect.
+    const waitedSeconds = Math.round(
+      (timing.startedAtMilliseconds - timing.createdAtMilliseconds) / 1000,
+    );
     throw new DeadlineExceeded(
-      `worker started after its queue admission deadline (${job.started_at} > ${new Date(deadline).toISOString()})`,
+      `worker waited ${waitedSeconds}s for a runner slot, over the ` +
+        `${policy.queue_start_seconds}s queue admission budget (created ` +
+        `${job.created_at}, started ${job.started_at}, deadline ` +
+        `${new Date(deadline).toISOString()}). Every self-hosted dispatcher ` +
+        `slot stayed busy past the deadline; rerun once the backlog drains ` +
+        `(indexable-inc/ix#7625)`,
     );
   }
   return timing;
@@ -390,7 +444,25 @@ export async function main() {
     runnerName: process.env.RUNNER_NAME,
     token,
   });
-  const timing = assertQueueAdmission({ job, policy });
+  let timing;
+  try {
+    timing = assertQueueAdmission({ job, policy });
+  } catch (error) {
+    if (error instanceof DeadlineExceeded) {
+      try {
+        const depth = await queuedRunCount({
+          apiUrl: process.env.GITHUB_API_URL,
+          repository,
+          token,
+        });
+        error.message += ` ${depth} workflow run(s) were still queued in ${repository} at check time.`;
+      } catch {
+        // Queue depth is best-effort context; a second GitHub API failure
+        // must not mask the deadline miss itself.
+      }
+    }
+    throw error;
+  }
   if (mode === "check") return 0;
   assertSetupAllowance({
     nowMilliseconds: Date.now(),

--- a/.github/actions/ci-budget/worker/worker.test.mjs
+++ b/.github/actions/ci-budget/worker/worker.test.mjs
@@ -15,6 +15,7 @@ import {
   currentWorkerJob,
   loadPolicy,
   parseArguments,
+  queuedRunCount,
   runBudgetedScript,
   validationSeconds,
 } from "./worker.mjs";
@@ -279,6 +280,80 @@ test("queue admission accepts the boundary and rejects one millisecond late", ()
         policy,
       }),
     DeadlineExceeded,
+  );
+});
+
+test("queue admission failure reports the wait, the budget, and saturation", () => {
+  const policy = loadPolicy();
+  // ix#7625: a PR worker created at 13:17:16Z started 33 minutes later while
+  // stacked deploy runs held every dispatcher slot. The failure must read as
+  // pool saturation with the actual wait, not as a bare timestamp comparison.
+  assert.throws(
+    () =>
+      assertQueueAdmission({
+        job: workerJob({
+          createdAt: "2026-07-17T13:17:16Z",
+          startedAt: "2026-07-17T13:50:23Z",
+        }),
+        policy,
+      }),
+    (error) => {
+      assert.ok(error instanceof DeadlineExceeded);
+      assert.match(error.message, /waited 1987s for a runner slot/);
+      assert.match(error.message, /300s queue admission budget/);
+      assert.match(error.message, /deadline 2026-07-17T13:22:16\.000Z/);
+      assert.match(error.message, /dispatcher\s+slot stayed busy/);
+      assert.match(error.message, /ix#7625/);
+      return true;
+    },
+  );
+});
+
+test("queued run count reads total_count and fails closed on malformed bodies", async () => {
+  const requests = [];
+  const depth = await queuedRunCount({
+    fetchImpl: async (url) => {
+      requests.push(new URL(url));
+      return new Response(
+        JSON.stringify({ total_count: 21, workflow_runs: [{}] }),
+        { status: 200 },
+      );
+    },
+    repository: "indexable-inc/ix",
+    token: "secret",
+  });
+
+  assert.equal(depth, 21);
+  assert.equal(requests.length, 1);
+  assert.equal(
+    requests[0].pathname,
+    "/repos/indexable-inc/ix/actions/runs",
+  );
+  assert.equal(requests[0].searchParams.get("status"), "queued");
+
+  for (const body of [
+    JSON.stringify({ workflow_runs: [] }),
+    JSON.stringify({ total_count: "21" }),
+    JSON.stringify({ total_count: -1 }),
+    JSON.stringify([]),
+  ]) {
+    await assert.rejects(
+      queuedRunCount({
+        fetchImpl: async () => new Response(body, { status: 200 }),
+        repository: "indexable-inc/ix",
+        token: "secret",
+      }),
+      /malformed/,
+    );
+  }
+
+  await assert.rejects(
+    queuedRunCount({
+      fetchImpl: async () => new Response("[]", { status: 500 }),
+      repository: "indexable-inc/ix",
+      token: "secret",
+    }),
+    /failed with 500/,
   );
 });
 


### PR DESCRIPTION
## Why

During the ix#7620 CAS-outage recovery, PR CI workers in `indexable-inc/ix` missed the 5-minute queue-admission deadline by ~30 minutes (indexable-inc/ix#7625, runs 29578170215 / 29587004747). The dispatcher was healthy: every host offers exactly one runner slot, all slots were held for 80+ minutes by the outage backlog (stacked auto-deploy runs, an antithesis run, ovh-apply, and a CAS-stalled PR job at 1h23m wall / 6min CPU), and one of five workers (hil-compute-1) was down 03:58-14:32Z behind the root-control start failure.

The admission check only fires after the runner finally starts, and today it fails with a bare timestamp comparison:

    worker started after its queue admission deadline (2026-07-17T13:50:23Z > 2026-07-17T13:22:16Z)

which reads like a runner defect and gives no hint that the fix is "drain the backlog, then rerun".

## What

- `assertQueueAdmission` now reports how long the job actually waited vs the 300s budget, keeps the created/started/deadline timestamps, and says explicitly that every dispatcher slot stayed busy past the deadline (pointer to indexable-inc/ix#7625).
- New `queuedRunCount` probe: on a deadline miss, the check appends how many workflow runs the repository still had queued -- best effort, so a second GitHub API failure can never mask the deadline miss itself.
- Tests: the ix#7625 timestamps pinned as a regression case, plus `queuedRunCount` happy path, malformed-body, and HTTP-failure coverage.

No policy change: the 300s budget and the check/cancel semantics are untouched.

(sent by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report queue depth and wait duration on queue admission deadline violations in ci-budget
> - Adds `queuedRunCount` in [worker.mjs](.github/actions/ci-budget/worker/worker.mjs) that queries the GitHub API for the number of queued workflow runs in a repository, validating the response shape and throwing on errors.
> - When `assertQueueAdmission` detects a deadline violation, the error message now includes how long the job waited, the configured budget, timestamps, the deadline, and a saturation explanation.
> - In the main entrypoint, a `DeadlineExceeded` error triggers a best-effort fetch of the current queued run depth, which is appended to the error message before rethrowing; fetch failures are swallowed to avoid masking the original error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab32dba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->