### PR TITLE
mcp-ex: format api.ex @surface list

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/api.ex
+++ b/packages/mcp-ex/lib/ix_mcp/api.ex
@@ -12,7 +12,15 @@ defmodule IxMcp.Api do
   provenance column.
   """
 
-  @surface [IxMcp.Jobs, IxMcp.Api, IxMcp.Fleet, IxMcp.Kernel, IxMcp.Workspace, IxMcp.Checkpoint, IxMcp.Reader]
+  @surface [
+    IxMcp.Jobs,
+    IxMcp.Api,
+    IxMcp.Fleet,
+    IxMcp.Kernel,
+    IxMcp.Workspace,
+    IxMcp.Checkpoint,
+    IxMcp.Reader
+  ]
 
   @type row :: %{
           module: module(),


### PR DESCRIPTION
`mix format --check-formatted` fails on `packages/mcp-ex/lib/ix_mcp/api.ex` since 06b69685 (#3516), breaking `flake-check` (`ix-mcp-ex-check`) for every PR (seen on #3519, run 29593955260). This applies the formatter's own rewrite of the `@surface` list; verified locally with `mix format --check-formatted lib/ix_mcp/api.ex` (exit 0).

Fixes #3521.

Generated with Claude Code (Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reformat `@surface` list in `IxMcp.Api` to multi-line style
> Reformats the `@surface` module attribute in [`api.ex`](https://github.com/indexable-inc/index/pull/3522/files#diff-a98214b5f223f2b1e5e46e41192f35b5805b27f482077bff25cb3334f063232c) from a single-line list to a multi-line list. No modules are added, removed, or reordered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3dc9b32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->