### PR TITLE
fix: unbreak main flake-check (mix format + stale read-tool assertion)

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/api.ex
+++ b/packages/mcp-ex/lib/ix_mcp/api.ex
@@ -12,7 +12,15 @@ defmodule IxMcp.Api do
   provenance column.
   """
 
-  @surface [IxMcp.Jobs, IxMcp.Api, IxMcp.Fleet, IxMcp.Kernel, IxMcp.Workspace, IxMcp.Checkpoint, IxMcp.Reader]
+  @surface [
+    IxMcp.Jobs,
+    IxMcp.Api,
+    IxMcp.Fleet,
+    IxMcp.Kernel,
+    IxMcp.Workspace,
+    IxMcp.Checkpoint,
+    IxMcp.Reader
+  ]
 
   @type row :: %{
           module: module(),

--- a/packages/mcp/tests/test_mcp_ui.py
+++ b/packages/mcp/tests/test_mcp_ui.py
@@ -275,9 +275,6 @@ def test_tools_declare_ui_resource_in_meta() -> None:
         meta = by_name[name].meta
         assert meta is not None, f"{name} must opt into the UI viewer"
         assert meta["ui"]["resourceUri"] == mcp_ui.VIEWER_URI
-    # `read` deliberately stays plain: its contract is full text to the model
-    # with only a one-line note for the human.
-    assert by_name["read"].meta is None
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
main is red at 06b69685 — flake-check: 308 ok, 2 failures:

- `.#requiredGateRoots.x86_64-linux.rust-mcp-ex.elixir` — `mix format --check-formatted` fails on `packages/mcp-ex/lib/ix_mcp/api.ex`. Root cause: #3516 landed an overlong `@surface` list unformatted.
- `.#requiredGateRoots.x86_64-linux.rust-mcp.mcpUiTests` — `KeyError: 'read'` in `tests/test_mcp_ui.py`. Root cause: #3503 deleted the `read` tool but missed the stale `by_name["read"].meta is None` assertion.

Fix: ran `mix format` on api.ex; dropped the stale assertion (the remaining `python_exec`/`pr_watch` loop matches the intended 8-tool surface — no replacement guard needed).

Validation (local):

- `mix format --check-formatted` — pass
- `mix compile --warnings-as-errors` — pass, zero warnings (Elixir 1.18)
- `mix credo --strict` against the shared gate config `lib/elixir/credo.exs` — pass, no issues
- `tests/test_mcp_ui.py` full file via the local pytest recipe — 17 passed, 0 failed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix failing flake check by reformatting `@surface` attribute and removing stale `read` tool assertion
> - Reformats the `@surface` module attribute in [api.ex](https://github.com/indexable-inc/index/pull/3525/files#diff-a98214b5f223f2b1e5e46e41192f35b5805b27f482077bff25cb3334f063232c) from a single-line list to multi-line to satisfy `mix format`.
> - Removes the stale assertion that the `read` tool has no meta in [test_mcp_ui.py](https://github.com/indexable-inc/index/pull/3525/files#diff-d6abe9d5afa6d6555054f096033bcef43605949d9640a107fed62e3047d5b085), which was failing because the tool now defines meta.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8211e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->