### PR TITLE
mcp-ex: stop treating non-ASCII stdin as EOF (fixes #3523)

### DIFF
--- a/packages/mcp-ex/default.nix
+++ b/packages/mcp-ex/default.nix
@@ -137,10 +137,11 @@
     }
     ''
       set +e
-      printf '%s\n%s\n%s\n' \
+      printf '%s\n%s\n%s\n%s\n' \
         '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}' \
         '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
         '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"session_set_name","arguments":{"name":"smoke"}}}' \
+        '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"elixir_exec","arguments":{"intent":"utf8 wire roundtrip","budget":60,"code":"\"snow ☃\""}}}' \
         | IX_MCP_ACTIONS_DB="$PWD/actions.db" ix-mcp-ex > response.jsonl 2> server-stderr.log
       rc=$?
       set -e
@@ -175,6 +176,17 @@
         *'session named: smoke'*) ;;
         *)
           echo "tools/call session_set_name did not answer" >&2
+          printf '%s\n' "$out_lines" >&2
+          exit 1
+          ;;
+      esac
+      # Multi-byte UTF-8 in an inbound request used to kill the reader --
+      # #3523: the :unicode io device made IO.binread/2 return
+      # {:error, {:no_translation, :unicode, :latin1}}, swallowed as EOF.
+      case "$out_lines" in
+        *'snow ☃'*) ;;
+        *)
+          echo "elixir_exec did not round-trip a multi-byte UTF-8 payload" >&2
           printf '%s\n' "$out_lines" >&2
           exit 1
           ;;

--- a/packages/mcp-ex/lib/ix_mcp/mcp/stdio.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/stdio.ex
@@ -22,6 +22,13 @@ defmodule IxMcp.MCP.Stdio do
 
   @impl true
   def init(_) do
+    # The wire is bytes: JSON-RPC lines arrive and leave as UTF-8, but the
+    # io device defaults to :unicode, where IO.binread/2 fails with
+    # {:error, {:no_translation, :unicode, :latin1}} at the first codepoint
+    # above 255 -- #3523 (https://github.com/indexable-inc/index/issues/3523):
+    # one emoji in a cell payload closed the whole connection. :latin1 +
+    # binary makes stdio a transparent byte pipe in both directions.
+    :ok = :io.setopts(:standard_io, binary: true, encoding: :latin1)
     Notifier.register(self())
     reader = self()
     spawn_link(fn -> read_loop(reader) end)
@@ -80,7 +87,11 @@ defmodule IxMcp.MCP.Stdio do
       :eof ->
         send(server, :mcp_eof)
 
-      {:error, _reason} ->
+      {:error, reason} ->
+        # A read error is not a clean EOF; name it on stderr before shutting
+        # down, or the death is indistinguishable from the client exiting
+        # (how #3523 stayed invisible: no log line, exit 0).
+        IO.puts(:stderr, "ix-mcp-ex: stdin read error: " <> inspect(reason))
         send(server, :mcp_eof)
 
       line ->


### PR DESCRIPTION
Fixes #3523.

**Root cause:** the stdio io device defaults to `:unicode` encoding, so `IO.binread(:stdio, :line)` returns `{:error, {:no_translation, :unicode, :latin1}}` at the first inbound codepoint above 255. `read_loop` swallowed every read error as EOF, and the EOF path calls `System.stop(0)`: the server exits cleanly with no log line and the client reports `MCP error -32000: Connection closed`.

**Repro:** send any `elixir_exec` call whose `code` contains an emoji or other multi-byte character; the whole connection dies. Verified against the release binary over raw stdio (ASCII payloads fine, one emoji kills it, exit 0, empty stderr).

**Fix:**
- `:io.setopts(:standard_io, binary: true, encoding: :latin1)` in `Stdio.init`: stdio becomes a transparent byte pipe in both directions (JSON-RPC lines are UTF-8 bytes).
- Read errors are now named on stderr instead of masquerading as clean EOF.
- The wire smoke test round-trips a multi-byte payload (U+2603), so the exact repro is the regression test.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix non-ASCII stdin being treated as EOF in `IxMcp.MCP.Stdio`
> - Sets `:io.setopts(:standard_io, binary: true, encoding: :latin1)` in [`stdio.ex`](https://github.com/indexable-inc/index/pull/3528/files#diff-775ac658aaedab87f4cd5e80d254eaeb13c77ac446f0e4fb2583980ab94a7cb7) before the read loop starts, making stdin a transparent byte pipe and preventing `IO.binread/2` from returning translation errors on multi-byte UTF-8 input.
> - Read errors now print a diagnostic message to stderr (including the reason) before signaling `:mcp_eof`, rather than silently treating them as EOF.
> - Adds a UTF-8 test case ("snow ☃") to [`default.nix`](https://github.com/indexable-inc/index/pull/3528/files#diff-563967e170d403f754f28e98f423edbb153588ae9111be797d344a115cd85850) that fails the build if multi-byte input is not echoed correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 192b3c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->