### PR TITLE
mcp-ex: live action rows -- log before running, sample the running cell's stacktrace

### DIFF
--- a/packages/mcp-ex/config/config.exs
+++ b/packages/mcp-ex/config/config.exs
@@ -13,4 +13,6 @@ config :elixir_make, :force_build, exqlite: true
 # HOME, and no test should touch the operator's real log file.
 if config_env() == :test do
   config :ix_mcp, actions_db: ":memory:"
+  # Fast stack samples so the live-row tests observe one without real waits.
+  config :ix_mcp, stack_sample_interval_ms: 25
 end

--- a/packages/mcp-ex/lib/ix_mcp/action_log.ex
+++ b/packages/mcp-ex/lib/ix_mcp/action_log.ex
@@ -8,6 +8,18 @@ defmodule IxMcp.ActionLog do
   current session/topic ids live in `IxMcp.Session`. Pure logging for future
   reference; nothing on the hot path reads it.
 
+  Action rows are live (#3536): inserted with `status = 'running'` when the
+  call arrives (`start_action/2`) and finalized to `done`/`failed`/
+  `cancelled` when its work completes (`finish_action/5`) -- for `exec` that
+  is when the eval finishes, which for a backgrounded job is after the wire
+  response shipped. While an exec runs, its job samples the eval process's
+  `current_stacktrace` into `stack`/`stack_at` (`update_stack/3`), so a
+  reader can show the line a hung cell sits on. There is deliberately no
+  startup sweep of leftover `running` rows: several server instances share
+  one database, so a sweep would clobber a live sibling's rows. A row whose
+  kernel died stays `running` with a frozen `stack_at`; readers judge
+  liveness by that freshness (samples land every second).
+
   The database path resolves as app env `:actions_db` (tests pin
   `":memory:"`), then `$IX_MCP_ACTIONS_DB`, then
   `$XDG_STATE_HOME/ix-mcp-ex/actions.db` (state home defaulting to
@@ -36,8 +48,16 @@ defmodule IxMcp.ActionLog do
   """
 
   @create_actions """
-  CREATE TABLE actions (id INTEGER PRIMARY KEY, at TEXT NOT NULL, session_id INTEGER NOT NULL REFERENCES sessions(id), topic_id INTEGER REFERENCES topics(id), tool TEXT NOT NULL, intent TEXT, arguments TEXT NOT NULL, is_error INTEGER NOT NULL, elapsed_ms INTEGER NOT NULL)
+  CREATE TABLE actions (id INTEGER PRIMARY KEY, at TEXT NOT NULL, session_id INTEGER NOT NULL REFERENCES sessions(id), topic_id INTEGER REFERENCES topics(id), tool TEXT NOT NULL, intent TEXT, arguments TEXT NOT NULL, is_error INTEGER NOT NULL, elapsed_ms INTEGER NOT NULL, status TEXT NOT NULL DEFAULT 'done', stack TEXT, stack_at TEXT)
   """
+
+  # A pre-#3536 v2 database lacks the live-row columns; DEFAULT 'done' is
+  # exactly right for its rows, which were all written after the fact.
+  @add_live_columns [
+    "ALTER TABLE actions ADD COLUMN status TEXT NOT NULL DEFAULT 'done'",
+    "ALTER TABLE actions ADD COLUMN stack TEXT",
+    "ALTER TABLE actions ADD COLUMN stack_at TEXT"
+  ]
 
   # The v1 shape kept session/topic as TEXT per action row. The backfill
   # makes one session per distinct v1 session string (NULLs collapse into
@@ -72,12 +92,23 @@ defmodule IxMcp.ActionLog do
   ]
 
   @insert """
-  INSERT INTO actions (at, session_id, topic_id, tool, intent, arguments, is_error, elapsed_ms)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  INSERT INTO actions (at, session_id, topic_id, tool, intent, arguments, is_error, elapsed_ms, status)
+  VALUES (?, ?, ?, ?, ?, ?, 0, 0, 'running')
+  """
+
+  # Both updates guard on status = 'running': a finalize is idempotent and a
+  # stack sample racing the finish can never resurrect a finished row.
+  @finish """
+  UPDATE actions SET status = ?, is_error = ?, elapsed_ms = ?, stack = NULL, stack_at = NULL
+  WHERE id = ? AND status = 'running'
+  """
+
+  @update_stack """
+  UPDATE actions SET stack = ?, stack_at = ? WHERE id = ? AND status = 'running'
   """
 
   @select_recent """
-  SELECT a.at, s.name, t.name, a.tool, a.intent, a.arguments, a.is_error, a.elapsed_ms
+  SELECT a.at, s.name, t.name, a.tool, a.intent, a.arguments, a.is_error, a.elapsed_ms, a.status, a.stack
   FROM actions a
   JOIN sessions s ON s.id = a.session_id
   LEFT JOIN topics t ON t.id = a.topic_id
@@ -92,7 +123,9 @@ defmodule IxMcp.ActionLog do
           intent: String.t() | nil,
           arguments: String.t(),
           is_error: boolean(),
-          elapsed_ms: non_neg_integer()
+          elapsed_ms: non_neg_integer(),
+          status: String.t(),
+          stack: String.t() | nil
         }
 
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -118,10 +151,24 @@ defmodule IxMcp.ActionLog do
     GenServer.call(server, {:create_topic, session_id, name, now()})
   end
 
-  @doc "Record one action; returns once the row is written."
-  @spec record(map(), GenServer.server()) :: :ok
-  def record(action, server \\ __MODULE__) do
-    GenServer.call(server, {:record, Map.put(action, :at, now())})
+  @doc "Insert an action row as `running` before the call executes; returns its id."
+  @spec start_action(map(), GenServer.server()) :: integer()
+  def start_action(action, server \\ __MODULE__) do
+    GenServer.call(server, {:start_action, Map.put(action, :at, now())})
+  end
+
+  @doc "Finalize a running action row; a no-op when it already finished."
+  @spec finish_action(integer(), String.t(), boolean(), non_neg_integer(), GenServer.server()) ::
+          :ok
+  def finish_action(id, status, is_error, elapsed_ms, server \\ __MODULE__)
+      when status in ["done", "failed", "cancelled"] do
+    GenServer.call(server, {:finish_action, id, status, is_error, elapsed_ms})
+  end
+
+  @doc "Refresh a running action row's sampled stack (JSON frames); a no-op once finished."
+  @spec update_stack(integer(), String.t(), GenServer.server()) :: :ok
+  def update_stack(id, stack_json, server \\ __MODULE__) do
+    GenServer.call(server, {:update_stack, id, stack_json, now()})
   end
 
   @doc "Latest `n` recorded actions, newest first, with session/topic names joined in."
@@ -155,6 +202,7 @@ defmodule IxMcp.ActionLog do
 
     case shape(conn) do
       :v2 -> :ok
+      :v2_pre_live -> execute_all(conn, @add_live_columns)
       :empty -> execute_all(conn, [@create_sessions, @create_topics, @create_actions])
       :v1 -> execute_all(conn, ["BEGIN IMMEDIATE"] ++ @migrate_v1 ++ ["COMMIT"])
     end
@@ -186,7 +234,7 @@ defmodule IxMcp.ActionLog do
     {:reply, id, state}
   end
 
-  def handle_call({:record, action}, _from, %{conn: conn, insert: insert} = state) do
+  def handle_call({:start_action, action}, _from, %{conn: conn, insert: insert} = state) do
     :ok =
       Sqlite3.bind(insert, [
         action.at,
@@ -194,12 +242,25 @@ defmodule IxMcp.ActionLog do
         action.topic_id,
         action.tool,
         action.intent,
-        action.arguments,
-        bool_to_int(action.is_error),
-        action.elapsed_ms
+        action.arguments
       ])
 
     :done = Sqlite3.step(conn, insert)
+    {:ok, id} = Sqlite3.last_insert_rowid(conn)
+    {:reply, id, state}
+  end
+
+  def handle_call(
+        {:finish_action, id, status, is_error, elapsed_ms},
+        _from,
+        %{conn: conn} = state
+      ) do
+    run(conn, @finish, [status, bool_to_int(is_error), elapsed_ms, id])
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:update_stack, id, stack_json, at}, _from, %{conn: conn} = state) do
+    run(conn, @update_stack, [stack_json, at, id])
     {:reply, :ok, state}
   end
 
@@ -230,8 +291,15 @@ defmodule IxMcp.ActionLog do
 
   defp shape(conn) do
     case table_columns(conn, "actions") do
-      [] -> :empty
-      columns -> if "session_id" in columns, do: :v2, else: :v1
+      [] ->
+        :empty
+
+      columns ->
+        cond do
+          "session_id" not in columns -> :v1
+          "status" not in columns -> :v2_pre_live
+          true -> :v2
+        end
     end
   end
 
@@ -273,7 +341,18 @@ defmodule IxMcp.ActionLog do
   defp bool_to_int(true), do: 1
   defp bool_to_int(false), do: 0
 
-  defp row_to_entry([at, session, topic, tool, intent, arguments, is_error, elapsed_ms]) do
+  defp row_to_entry([
+         at,
+         session,
+         topic,
+         tool,
+         intent,
+         arguments,
+         is_error,
+         elapsed_ms,
+         status,
+         stack
+       ]) do
     %{
       at: at,
       session: session,
@@ -282,7 +361,9 @@ defmodule IxMcp.ActionLog do
       intent: intent,
       arguments: arguments,
       is_error: is_error == 1,
-      elapsed_ms: elapsed_ms
+      elapsed_ms: elapsed_ms,
+      status: status,
+      stack: stack
     }
   end
 end

--- a/packages/mcp-ex/lib/ix_mcp/jobs.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs.ex
@@ -26,7 +26,7 @@ defmodule IxMcp.Jobs do
     {:ok, pid} =
       DynamicSupervisor.start_child(
         IxMcp.Jobs.Supervisor,
-        {Job, {id, code, Keyword.take(opts, [:intent])}}
+        {Job, {id, code, Keyword.take(opts, [:intent, :action_id])}}
       )
 
     case Job.await(pid, round(budget_s * 1000)) do

--- a/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
@@ -14,6 +14,7 @@ defmodule IxMcp.Jobs.Job do
 
   use GenServer, restart: :temporary
 
+  alias IxMcp.ActionLog
   alias IxMcp.Evaluator
   alias IxMcp.Evaluator.IOProxy
   alias IxMcp.Jobs.History
@@ -22,11 +23,17 @@ defmodule IxMcp.Jobs.Job do
   alias IxMcp.Session
   alias IxMcp.Workspace
 
+  # How often a running exec's eval process is stack-sampled into the action
+  # log (Process.info(pid, :current_stacktrace) -- external, works on a
+  # wedged process). Tests shrink it via app env to keep the suite fast.
+  @stack_sample_interval_ms Application.compile_env(:ix_mcp, :stack_sample_interval_ms, 1000)
+
   @enforce_keys [:id, :code]
   defstruct [
     :id,
     :code,
     :intent,
+    :action_id,
     :session,
     :topic,
     :buffer,
@@ -48,6 +55,7 @@ defmodule IxMcp.Jobs.Job do
           id: String.t(),
           code: String.t(),
           intent: String.t() | nil,
+          action_id: integer() | nil,
           session: String.t() | nil,
           topic: String.t() | nil,
           buffer: :ets.tid() | nil,
@@ -146,6 +154,7 @@ defmodule IxMcp.Jobs.Job do
       id: id,
       code: code,
       intent: Keyword.get(opts, :intent),
+      action_id: Keyword.get(opts, :action_id),
       session: session.name,
       topic: session.topic,
       buffer: :ets.new(:job_output, [:ordered_set, :public]),
@@ -186,6 +195,7 @@ defmodule IxMcp.Jobs.Job do
       end)
 
     History.record(initial_history(state))
+    if state.action_id, do: Process.send_after(self(), :sample_stack, @stack_sample_interval_ms)
     {:noreply, %{state | io_proxy: io_proxy, eval_pid: eval_pid, eval_ref: eval_ref}}
   end
 
@@ -256,6 +266,26 @@ defmodule IxMcp.Jobs.Job do
     {:noreply, finish(state, :failed, {:failure, Exception.format_exit(reason)}, [])}
   end
 
+  # Sampling stops itself once the run finished (no reschedule); the
+  # status='running' guard in the log makes a racing last sample harmless.
+  def handle_info(:sample_stack, %{status: :running} = state) do
+    case Process.info(state.eval_pid, :current_stacktrace) do
+      {:current_stacktrace, frames} ->
+        stack = JSON.encode!(Enum.map(frames, &Exception.format_stacktrace_entry/1))
+        ActionLog.update_stack(state.action_id, stack)
+
+      # The eval exited between the tick and the probe; the finish path owns
+      # the row now.
+      nil ->
+        :ok
+    end
+
+    Process.send_after(self(), :sample_stack, @stack_sample_interval_ms)
+    {:noreply, state}
+  end
+
+  def handle_info(:sample_stack, state), do: {:noreply, state}
+
   def handle_info(_msg, state), do: {:noreply, state}
 
   # -- internals ---------------------------------------------------------------
@@ -268,6 +298,17 @@ defmodule IxMcp.Jobs.Job do
         diagnostics: diags,
         finished_mono: System.monotonic_time(:millisecond)
     }
+
+    # Finalize the action row before waking subscribers: a caller that saw
+    # the run finish must find the row already final, never still running.
+    if state.action_id do
+      ActionLog.finish_action(
+        state.action_id,
+        Atom.to_string(status),
+        status == :failed,
+        state.finished_mono - state.started_mono
+      )
+    end
 
     summary = build_summary(state)
     Enum.each(state.subscribers, fn pid -> send(pid, {:ix_job_finished, state.id, summary}) end)

--- a/packages/mcp-ex/lib/ix_mcp/mcp/server.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/server.ex
@@ -45,8 +45,22 @@ defmodule IxMcp.MCP.Server do
   defp handle_tool_call(id, %{"name" => name} = params) do
     arguments = Map.get(params, "arguments", %{})
     started = System.monotonic_time(:millisecond)
-    outcome = Tools.call(name, arguments)
-    log_action(name, arguments, outcome, System.monotonic_time(:millisecond) - started)
+    action_id = log_start(name, arguments)
+    outcome = Tools.call(name, arguments, action_id)
+
+    # exec rows are finalized by the job they spawn (whose eval may outlive
+    # this response -- the budget-then-background contract) or by exec's own
+    # argument rejection in Tools; every other tool is synchronous, so its
+    # wire outcome is its fate. The status='running' guard in finish_action
+    # makes a duplicate finalize harmless, never wrong.
+    if name != "exec" do
+      IxMcp.ActionLog.finish_action(
+        action_id,
+        finish_status(outcome),
+        match?({:error, _}, outcome),
+        System.monotonic_time(:millisecond) - started
+      )
+    end
 
     case outcome do
       {:ok, text} ->
@@ -59,23 +73,25 @@ defmodule IxMcp.MCP.Server do
 
   defp handle_tool_call(id, _params), do: error(id, -32_602, "tools/call requires a name")
 
-  # Every tools/call lands one metadata row in the action log before its
-  # response ships (see IxMcp.ActionLog for why the write is synchronous).
-  # Asking the session for ids here -- not at connect time -- is what makes
-  # session rows lazy: a connection that never calls a tool leaves no row.
-  defp log_action(tool, arguments, outcome, elapsed_ms) do
+  # Every tools/call lands one `running` row in the action log BEFORE it
+  # executes (#3536), so a reader sees in-flight calls and a crash mid-call
+  # leaves a visible running row rather than nothing. Asking the session for
+  # ids here -- not at connect time -- is what makes session rows lazy: a
+  # connection that never calls a tool leaves no row.
+  defp log_start(tool, arguments) do
     %{session_id: session_id, topic_id: topic_id} = IxMcp.Session.ids()
 
-    IxMcp.ActionLog.record(%{
+    IxMcp.ActionLog.start_action(%{
       session_id: session_id,
       topic_id: topic_id,
       tool: tool,
       intent: intent(arguments),
-      arguments: JSON.encode!(arguments),
-      is_error: match?({:error, _}, outcome),
-      elapsed_ms: elapsed_ms
+      arguments: JSON.encode!(arguments)
     })
   end
+
+  defp finish_status({:ok, _text}), do: "done"
+  defp finish_status({:error, _text}), do: "failed"
 
   # How agents learn the in-language surface (the old read/kernel_trace/
   # kernel_restart/pr_watch/tui_act tools, folded into cells -- #3532):

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -104,32 +104,45 @@ defmodule IxMcp.MCP.Tools do
     ]
   end
 
-  @spec call(String.t(), map()) :: {:ok, String.t()} | {:error, String.t()}
-  def call("exec", %{"code" => code} = args) when is_binary(code) do
+  @doc """
+  Run one tool call. `action_id` is the call's pre-inserted action-log row
+  (#3536): a valid exec hands it to the job it spawns, which finalizes the
+  row when the eval finishes; exec's argument rejection finalizes it right
+  here (no job ever owns it); every other tool leaves it to the transport,
+  which finalizes with the wire outcome.
+  """
+  @spec call(String.t(), map(), integer() | nil) :: {:ok, String.t()} | {:error, String.t()}
+  def call(name, args, action_id \\ nil)
+
+  def call("exec", %{"code" => code} = args, action_id) when is_binary(code) do
     budget = args |> Map.get("budget", 15) |> clamp_budget()
     intent = Map.get(args, "intent")
 
-    {summary, output} = Jobs.run(code, budget: budget, intent: intent)
+    {summary, output} = Jobs.run(code, budget: budget, intent: intent, action_id: action_id)
     {:ok, render_run(summary, output)}
   end
 
-  def call("exec", _args), do: {:error, "exec requires string `code`"}
+  def call("exec", _args, action_id) do
+    if action_id, do: IxMcp.ActionLog.finish_action(action_id, "failed", true, 0)
+    {:error, "exec requires string `code`"}
+  end
 
-  def call("session_set_name", %{"name" => name}) when is_binary(name) do
+  def call("session_set_name", %{"name" => name}, _action_id) when is_binary(name) do
     :ok = IxMcp.Session.set_name(name)
     {:ok, "session named: #{name}"}
   end
 
-  def call("session_set_name", _args), do: {:error, "session_set_name requires string `name`"}
+  def call("session_set_name", _args, _action_id),
+    do: {:error, "session_set_name requires string `name`"}
 
-  def call("topic_set", %{"topic" => topic}) when is_binary(topic) do
+  def call("topic_set", %{"topic" => topic}, _action_id) when is_binary(topic) do
     :ok = IxMcp.Session.set_topic(topic)
     {:ok, "topic set: #{topic}"}
   end
 
-  def call("topic_set", _args), do: {:error, "topic_set requires string `topic`"}
+  def call("topic_set", _args, _action_id), do: {:error, "topic_set requires string `topic`"}
 
-  def call(other, _args), do: {:error, "unknown tool: #{other}"}
+  def call(other, _args, _action_id), do: {:error, "unknown tool: #{other}"}
 
   defp clamp_budget(budget) when is_number(budget) and budget > 0, do: min(budget, @budget_cap)
   defp clamp_budget(_), do: 15

--- a/packages/mcp-ex/test/action_log_test.exs
+++ b/packages/mcp-ex/test/action_log_test.exs
@@ -39,6 +39,8 @@ defmodule IxMcp.ActionLogTest do
     assert entry.topic == "logging"
     assert entry.intent == "log probe"
     refute entry.is_error
+    assert entry.status == "done"
+    assert entry.stack == nil
     assert entry.elapsed_ms >= 0
     assert {:ok, %DateTime{}, 0} = DateTime.from_iso8601(entry.at)
   end
@@ -61,6 +63,99 @@ defmodule IxMcp.ActionLogTest do
     assert entry.tool == "exec"
     assert entry.intent == "not really code"
     assert entry.is_error
+    assert entry.status == "failed"
+  end
+
+  test "an exec row is running before the eval finishes, then finalizes with its true elapsed" do
+    response =
+      Server.handle(%{
+        "jsonrpc" => "2.0",
+        "id" => 5,
+        "method" => "tools/call",
+        "params" => %{
+          "name" => "exec",
+          "arguments" => %{
+            "code" => "Process.sleep(250); :ok",
+            "intent" => "outlive the budget",
+            "budget" => 0.05
+          }
+        }
+      })
+
+    [%{"text" => text}] = response["result"]["content"]
+    %{"job" => job_id, "running" => true} = text |> String.split("\n") |> hd() |> JSON.decode!()
+
+    # The wire response shipped while the eval still runs: the row says so.
+    assert [%{tool: "exec", status: "running", elapsed_ms: 0} | _] = ActionLog.recent(1)
+
+    assert %{status: :done} = IxMcp.Jobs.await(job_id, 5_000)
+
+    # finish_action runs before the awaiting caller wakes, so the row is
+    # already final here -- with the eval's elapsed, not the wire budget's.
+    assert [entry | _] = ActionLog.recent(1)
+    assert entry.status == "done"
+    refute entry.is_error
+    assert entry.elapsed_ms >= 200
+    assert entry.stack == nil
+  end
+
+  test "a running exec's current_stacktrace is sampled into the row; cancel finalizes it" do
+    response =
+      Server.handle(%{
+        "jsonrpc" => "2.0",
+        "id" => 6,
+        "method" => "tools/call",
+        "params" => %{
+          "name" => "exec",
+          "arguments" => %{
+            "code" => "Process.sleep(:infinity)",
+            "intent" => "wedge for sampling",
+            "budget" => 0.05
+          }
+        }
+      })
+
+    [%{"text" => text}] = response["result"]["content"]
+    %{"job" => job_id} = text |> String.split("\n") |> hd() |> JSON.decode!()
+
+    # The sampler ticks every 25ms under test config; give it a few ticks.
+    stack =
+      poll_until(fn ->
+        case ActionLog.recent(1) do
+          [%{status: "running", stack: stack} | _] when is_binary(stack) -> stack
+          _ -> nil
+        end
+      end)
+
+    frames = JSON.decode!(stack)
+    assert Enum.any?(frames, &(&1 =~ "sleep")), "expected a sleep frame in #{inspect(frames)}"
+
+    :ok = IxMcp.Jobs.cancel(job_id)
+
+    assert [entry | _] = ActionLog.recent(1)
+    assert entry.status == "cancelled"
+    refute entry.is_error
+    assert entry.stack == nil, "finalizing clears the sampled stack"
+  end
+
+  defp poll_until(fun, deadline_ms \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + deadline_ms
+    do_poll(fun, deadline)
+  end
+
+  defp do_poll(fun, deadline) do
+    case fun.() do
+      nil ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          flunk("condition not met within #{deadline}ms deadline")
+        else
+          Process.sleep(10)
+          do_poll(fun, deadline)
+        end
+
+      value ->
+        value
+    end
   end
 
   test "one server instance is one session; topic_set is a timeline, not a dictionary" do
@@ -98,21 +193,22 @@ defmodule IxMcp.ActionLogTest do
     session_id = ActionLog.create_session("s", log)
     topic_id = ActionLog.create_topic(session_id, "t", log)
 
-    :ok =
-      ActionLog.record(
+    action_id =
+      ActionLog.start_action(
         %{
           session_id: session_id,
           topic_id: topic_id,
           tool: "exec",
           intent: "persist me",
-          arguments: "{}",
-          is_error: false,
-          elapsed_ms: 7
+          arguments: "{}"
         },
         log
       )
 
-    assert [%{intent: "persist me"}] = ActionLog.recent(20, log)
+    assert [%{intent: "persist me", status: "running"}] = ActionLog.recent(20, log)
+    :ok = ActionLog.finish_action(action_id, "done", false, 7, log)
+
+    assert [%{intent: "persist me", status: "done", elapsed_ms: 7}] = ActionLog.recent(20, log)
     stop_supervised!(:first_open)
 
     reopened =
@@ -120,6 +216,42 @@ defmodule IxMcp.ActionLogTest do
 
     assert [%{intent: "persist me", tool: "exec", session: "s", topic: "t"}] =
              ActionLog.recent(20, reopened)
+  end
+
+  test "a pre-live v2 database gains the status/stack columns; its rows read as done" do
+    path = tmp_db()
+
+    # The #3532 v2 shape, before the live-row columns (#3536).
+    {:ok, conn} = Sqlite3.open(path)
+
+    for statement <- [
+          "CREATE TABLE sessions (id INTEGER PRIMARY KEY, name TEXT, started_at TEXT NOT NULL)",
+          "CREATE TABLE topics (id INTEGER PRIMARY KEY, session_id INTEGER NOT NULL REFERENCES sessions(id), name TEXT NOT NULL, started_at TEXT NOT NULL)",
+          "CREATE TABLE actions (id INTEGER PRIMARY KEY, at TEXT NOT NULL, session_id INTEGER NOT NULL REFERENCES sessions(id), topic_id INTEGER REFERENCES topics(id), tool TEXT NOT NULL, intent TEXT, arguments TEXT NOT NULL, is_error INTEGER NOT NULL, elapsed_ms INTEGER NOT NULL)",
+          "INSERT INTO sessions (id, name, started_at) VALUES (1, 'old', '2026-07-17T10:00:00Z')",
+          "INSERT INTO actions (at, session_id, topic_id, tool, intent, arguments, is_error, elapsed_ms) VALUES ('2026-07-17T10:00:01Z', 1, NULL, 'exec', 'pre-live row', '{}', 0, 5)"
+        ] do
+      :ok = Sqlite3.execute(conn, statement)
+    end
+
+    :ok = Sqlite3.close(conn)
+
+    log = start_supervised!({ActionLog, path: path, name: :action_log_pre_live})
+
+    # Old rows were written after the fact, so 'done' is their true status.
+    assert [%{intent: "pre-live row", status: "done", stack: nil}] = ActionLog.recent(10, log)
+
+    # The migrated table supports the live lifecycle end to end.
+    action_id =
+      ActionLog.start_action(
+        %{session_id: 1, topic_id: nil, tool: "exec", intent: "new row", arguments: "{}"},
+        log
+      )
+
+    :ok = ActionLog.update_stack(action_id, ~s(["frame"]), log)
+    assert [%{status: "running", stack: ~s(["frame"])} | _] = ActionLog.recent(10, log)
+    :ok = ActionLog.finish_action(action_id, "done", false, 3, log)
+    assert [%{status: "done", stack: nil} | _] = ActionLog.recent(10, log)
   end
 
   test "a v1 database migrates losslessly to the normalized schema, once" do
@@ -220,7 +352,10 @@ defmodule IxMcp.ActionLogTest do
              "intent",
              "arguments",
              "is_error",
-             "elapsed_ms"
+             "elapsed_ms",
+             "status",
+             "stack",
+             "stack_at"
            ]
 
     {:ok, statement} =


### PR DESCRIPTION
Closes #3536.

- `Server.handle_tool_call` inserts the actions row (`status='running'`) before `Tools.call`; non-exec tools finalize with the wire outcome, exec rows are finalized by the job's own finish path (covers within-budget, backgrounded, cancelled, and crashed evals with the eval's true elapsed, and now records real exec failures in `is_error`).
- `IxMcp.Jobs.Job` samples `Process.info(eval_pid, :current_stacktrace)` every second (test env: 25ms) into `stack`/`stack_at`, cleared on finish; both UPDATEs guard on `status='running'`.
- Existing v2 dbs migrate via `ALTER TABLE ... ADD COLUMN status TEXT NOT NULL DEFAULT 'done'` + `stack`/`stack_at`; deliberately no sweep of stale `running` rows (multiple instances share the db), readers judge liveness by `stack_at` freshness.
- Behavior note: a `topic_set` action row now files under the topic that was current when the call arrived (the row predates the new topic row), where it previously appeared as the new topic's first row.

Validated locally with the CI-equivalent gates: `mix test` (42 tests), `mix compile --warnings-as-errors --force`, `mix credo --strict --config-file ../../lib/elixir/credo.exs`, `mix format --check-formatted`.

(PR by Claude Code, Claude Opus 4.6)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add live action rows with stack sampling to MCP exec job logging
> - Replaces `record/2` with `start_action/2` and `finish_action/5` in [`IxMcp.ActionLog`](https://github.com/indexable-inc/index/pull/3540/files#diff-3e72adde29b4a1c32aaa66b83a963485a2f67735bd45ed8c1652532de4c4adab), so action rows are created in `'running'` state and finalized with accurate status and elapsed time after execution.
> - Running exec jobs in [`IxMcp.Jobs.Job`](https://github.com/indexable-inc/index/pull/3540/files#diff-cd26f23adf8d8e75fd1b4f9fd5f7cc906cd5aba85c413011e10200c5c85351c4) periodically sample their evaluator process stacktrace (default every 1000ms) and persist it to the action log via `update_stack/3`; sampling stops when the job finishes or is cancelled.
> - [`IxMcp.MCP.Server`](https://github.com/indexable-inc/index/pull/3540/files#diff-af5d28ee1360e147fedaede7a1c272afb886734489007685969e936fe9d11c0a) logs a running action before invoking any tool and finalizes it immediately after for non-exec tools; exec tools are finalized by the job itself.
> - Existing v2 databases missing the `status`/`stack`/`stack_at` columns are migrated automatically on init; prior rows read back as `status='done'`.
> - Risk: `record/2` is removed — any callers outside this PR will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8331e33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->