### PR TITLE
ci-budget: widen queue admission to 30 min while capacity is one slot per host

### DIFF
--- a/.github/actions/ci-budget/catalog/policy.json
+++ b/.github/actions/ci-budget/catalog/policy.json
@@ -1,7 +1,7 @@
 {
   "big_change_label": "ci/big-change",
   "extended_validation_seconds": 10800,
-  "queue_start_seconds": 300,
+  "queue_start_seconds": 1800,
   "repositories": {
     "indexable-inc/index": {
       "costly_paths": [


### PR DESCRIPTION
One-line bridge: queue_start_seconds 300 -> 1800. Under maxActiveJobs=1 per host (ix#7658), placement takes 9-25 min whenever a backlog exists, so the 5-min budget fails every queued run rather than making anything faster (five receipt runs killed today; evidence ix#7623). Revert once typed runner classes land real concurrency. Written by Claude Code (AI). Refs ix#7625, ix#7658.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Widen CI budget queue admission window to 30 minutes
> Increases `queue_start_seconds` from 300 to 1800 in [policy.json](https://github.com/indexable-inc/index/pull/3541/files#diff-8f21aab076c62de6c8ce200f623b760868bc5ffef5b79976e37c13de48af697c) to match the stated capacity of one slot per host. The previous 5-minute window was too narrow relative to available capacity.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f0a574.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->