### PR TITLE
mcp-ex: binary cell output must ride the wire, not kill it (fixes #3538)

### DIFF
--- a/packages/mcp-ex/default.nix
+++ b/packages/mcp-ex/default.nix
@@ -137,11 +137,13 @@
     }
     ''
       set +e
-      printf '%s\n%s\n%s\n%s\n' \
+      printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
         '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}' \
         '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
         '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"session_set_name","arguments":{"name":"smoke"}}}' \
         '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"exec","arguments":{"intent":"utf8 wire roundtrip","budget":60,"code":"\"snow ☃\""}}}' \
+        '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"exec","arguments":{"intent":"binary output rides as escapes","budget":60,"code":"IO.puts(<<255, 97>> <> \"bin-marker\")"}}}' \
+        '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"exec","arguments":{"intent":"connection survives binary output","budget":60,"code":"\"alive-after-binary\""}}}' \
         | IX_MCP_ACTIONS_DB="$PWD/actions.db" ix-mcp-ex > response.jsonl 2> server-stderr.log
       rc=$?
       set -e
@@ -187,6 +189,28 @@
         *'snow ☃'*) ;;
         *)
           echo "exec did not round-trip a multi-byte UTF-8 payload" >&2
+          printf '%s\n' "$out_lines" >&2
+          exit 1
+          ;;
+      esac
+      # Raw binary bytes in cell output used to kill the whole connection --
+      # #3538: the {:error, ...} tuple from :unicode.characters_to_binary/1
+      # poisoned the job record, no reply ever came, and the client hung.
+      # The invalid byte must come back as a visible \xNN escape ("xFF"
+      # rather than the backslash, which JSON escaping doubles) ...
+      case "$out_lines" in
+        *'xFFabin-marker'*) ;;
+        *)
+          echo "exec did not escape invalid bytes in cell output" >&2
+          printf '%s\n' "$out_lines" >&2
+          exit 1
+          ;;
+      esac
+      # ... and the connection must survive to answer the next request.
+      case "$out_lines" in
+        *'alive-after-binary'*) ;;
+        *)
+          echo "connection did not survive binary cell output" >&2
           printf '%s\n' "$out_lines" >&2
           exit 1
           ;;

--- a/packages/mcp-ex/lib/ix_mcp/evaluator/io_proxy.ex
+++ b/packages/mcp-ex/lib/ix_mcp/evaluator/io_proxy.ex
@@ -13,7 +13,13 @@ defmodule IxMcp.Evaluator.IOProxy do
 
   Input requests answer `:eof`: cells are non-interactive, exactly like the
   Python kernel.
+
+  The sink's contract is a valid UTF-8 binary, nothing else: chunks feed
+  `byte_size/1` sums in job summaries and ride tool replies as JSON. See
+  `convert/2` (#3538).
   """
+
+  alias IxMcp.UTF8
 
   @spec start_link((iodata() -> any())) :: {:ok, pid()}
   def start_link(sink) when is_function(sink, 1) do
@@ -59,6 +65,21 @@ defmodule IxMcp.Evaluator.IOProxy do
   defp handle({:get_geometry, _}, _sink), do: {:error, :enotsup}
   defp handle(_request, _sink), do: {:error, :request}
 
-  defp convert(chars, :unicode), do: :unicode.characters_to_binary(chars)
-  defp convert(chars, :latin1), do: :erlang.iolist_to_binary(chars)
+  # `:unicode.characters_to_binary/1` answers invalid UTF-8 with an
+  # {:error, ...} TUPLE, not a binary. Passed through unchecked, that tuple
+  # landed in the job's output buffer as if it were output, `byte_size/1`
+  # crashed the job GenServer mid-finish, and the client hung forever on a
+  # request nothing would ever answer -- #3538, a cell printing a compiled
+  # binary. UTF8.sanitize/1 keeps valid UTF-8 byte-identical and turns
+  # every invalid byte into a visible `\xNN` escape, so the sink invariant
+  # (valid UTF-8 binary, always) holds no matter what a cell prints.
+  defp convert(chars, :unicode), do: UTF8.sanitize(chars)
+
+  # :latin1 put_chars (IO.binwrite and friends) hands over raw bytes. Bytes
+  # that already form valid UTF-8 pass byte-identical -- the same
+  # transparency #3523 gave the wire -- and anything else is escaped rather
+  # than reinterpreted as Latin-1 text: what actually reaches this clause is
+  # binary dumps, and mapping them to accented letters would disguise the
+  # bytes instead of naming them (#3538).
+  defp convert(chars, :latin1), do: chars |> :erlang.iolist_to_binary() |> UTF8.sanitize()
 end

--- a/packages/mcp-ex/lib/ix_mcp/jobs.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs.ex
@@ -58,8 +58,35 @@ defmodule IxMcp.Jobs do
     end)
   end
 
-  @spec cancel(String.t()) :: :ok | {:error, :finished}
-  def cancel(id), do: with_job(id, &Job.cancel/1)
+  @spec cancel(String.t()) :: :ok | {:error, :finished | Job.status()}
+  def cancel(id) do
+    case lookup(id) do
+      {:ok, pid} ->
+        try do
+          Job.cancel(pid)
+        catch
+          # The registry unregisters dead pids asynchronously, so a lookup
+          # can briefly return a process that no longer exists; that
+          # :noproc means the same thing as a missed lookup (#3538).
+          :exit, {:noproc, _call} -> report_dead(id)
+        end
+
+      {:error, :not_found} ->
+        report_dead(id)
+    end
+  end
+
+  # A job whose process is gone cannot be cancelled, but it may still be on
+  # record: #3538 killed job processes out from under their ids, and raising
+  # "no such job" -- about an id `history/1` still listed -- sent the
+  # operator chasing a phantom. Report the recorded state; raise only for
+  # ids this server never ran.
+  defp report_dead(id) do
+    case History.get(id) do
+      %{status: status} -> {:error, status}
+      nil -> raise ArgumentError, "no such job: #{inspect(id)}"
+    end
+  end
 
   @spec result(String.t()) :: {:ok, term()} | {:error, :running | String.t()}
   def result(id), do: with_job(id, &Job.result/1)

--- a/packages/mcp-ex/lib/ix_mcp/jobs/history.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs/history.ex
@@ -3,9 +3,15 @@ defmodule IxMcp.Jobs.History do
   Ordered record of every run: id, intent, session/topic at start time, a code
   preview, and final status. This is what `Jobs.history/1` pages and what the
   `exec` feed groups by session and topic.
+
+  A GenServer rather than an Agent so it can monitor each recording job
+  process: a job that dies without reporting -- a crash, a kill -- still gets
+  its row driven to a terminal status by the DOWN handler below. Before
+  #3538 a crashed job GenServer left its row saying `:running` forever about
+  a process that no longer existed, with nothing left alive to correct it.
   """
 
-  use Agent
+  use GenServer
 
   @type entry :: %{
           id: String.t(),
@@ -18,29 +24,108 @@ defmodule IxMcp.Jobs.History do
           elapsed_s: float() | nil
         }
 
-  @spec start_link(term()) :: Agent.on_start()
+  @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do
-    Agent.start_link(fn -> [] end, name: __MODULE__)
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
+  @doc "Record a new run for the calling job process."
   @spec record(map()) :: :ok
   def record(entry) do
-    Agent.update(__MODULE__, fn entries -> [Map.put(entry, :elapsed_s, nil) | entries] end)
+    GenServer.call(__MODULE__, {:record, entry})
   end
 
   @spec finished(String.t(), IxMcp.Jobs.Job.status(), float()) :: :ok
   def finished(id, status, elapsed_s) do
-    Agent.update(__MODULE__, fn entries ->
-      Enum.map(entries, fn
-        %{id: ^id} = entry -> %{entry | status: status, elapsed_s: elapsed_s}
-        entry -> entry
-      end)
-    end)
+    GenServer.call(__MODULE__, {:finished, id, status, elapsed_s})
   end
 
   @doc "Latest `n` runs, newest first."
   @spec list(pos_integer()) :: [entry()]
   def list(n \\ 20) do
-    Agent.get(__MODULE__, fn entries -> Enum.take(entries, n) end)
+    GenServer.call(__MODULE__, {:list, n})
+  end
+
+  @doc "The recorded run with this id, or nil."
+  @spec get(String.t()) :: entry() | nil
+  def get(id) do
+    GenServer.call(__MODULE__, {:get, id})
+  end
+
+  @impl true
+  def init(_) do
+    {:ok, %{entries: [], monitors: %{}}}
+  end
+
+  @impl true
+  def handle_call({:record, entry}, {job, _tag}, state) do
+    # Monitor the recording job: if its process dies before `finished/3`,
+    # the DOWN clause below is the only thing left that can finalize the
+    # row (#3538 -- a poisoned output buffer crashed the job GenServer
+    # between eval success and finish, orphaning the row at :running).
+    ref = Process.monitor(job)
+    entry = Map.put(entry, :elapsed_s, nil)
+
+    {:reply, :ok,
+     %{
+       state
+       | entries: [entry | state.entries],
+         monitors: Map.put(state.monitors, ref, entry.id)
+     }}
+  end
+
+  def handle_call({:finished, id, status, elapsed_s}, _from, state) do
+    entries =
+      Enum.map(state.entries, fn
+        %{id: ^id} = entry -> %{entry | status: status, elapsed_s: elapsed_s}
+        entry -> entry
+      end)
+
+    {:reply, :ok, %{state | entries: entries, monitors: demonitor(state.monitors, id)}}
+  end
+
+  def handle_call({:list, n}, _from, state) do
+    {:reply, Enum.take(state.entries, n), state}
+  end
+
+  def handle_call({:get, id}, _from, state) do
+    {:reply, Enum.find(state.entries, &(&1.id == id)), state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    {id, monitors} = Map.pop(state.monitors, ref)
+
+    # A dead job that never reported a terminal status failed, whatever the
+    # exit reason: the row must stop claiming :running about a process that
+    # no longer exists (#3538). The :running guard keeps rows that finished
+    # or were cancelled exactly as they reported themselves.
+    entries =
+      Enum.map(state.entries, fn
+        %{id: ^id, status: :running} = entry ->
+          %{
+            entry
+            | status: :failed,
+              elapsed_s: DateTime.diff(DateTime.utc_now(), entry.started_at, :millisecond) / 1000
+          }
+
+        entry ->
+          entry
+      end)
+
+    {:noreply, %{state | entries: entries, monitors: monitors}}
+  end
+
+  # The row is terminal; the monitor has nothing left to guard. Flush it so
+  # the eventual (normal) death of the long-lived job process costs nothing.
+  defp demonitor(monitors, id) do
+    case Enum.find(monitors, fn {_ref, job_id} -> job_id == id end) do
+      {ref, _job_id} ->
+        Process.demonitor(ref, [:flush])
+        Map.delete(monitors, ref)
+
+      nil ->
+        monitors
+    end
   end
 end

--- a/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
@@ -317,7 +317,13 @@ defmodule IxMcp.Jobs.Job do
     %{state | subscribers: []}
   end
 
-  defp append(buffer, chunk) do
+  # Only binaries may enter the buffer (IOProxy's convert/2 guarantees valid
+  # UTF-8): a non-binary chunk resurfaces as a `byte_size/1` crash in
+  # build_summary/1 -- after the eval already succeeded -- which is how
+  # #3538 orphaned history rows at :running. The guard turns any regression
+  # into a failed put_chars at the offending call site instead of a poisoned
+  # job record.
+  defp append(buffer, chunk) when is_binary(chunk) do
     :ets.insert(buffer, {System.unique_integer([:monotonic]), chunk})
   end
 

--- a/packages/mcp-ex/lib/ix_mcp/mcp/stdio.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/stdio.ex
@@ -8,6 +8,11 @@ defmodule IxMcp.MCP.Stdio do
   All writes to stdout go through this process, which is the only place in
   the application allowed to touch it (logs go to stderr, cell output goes to
   each job's IOProxy).
+
+  Invariant: every request that carries an id gets exactly one reply. A
+  handler task that dies is answered with a JSON-RPC error, and a response
+  the encoder rejects degrades to one -- silently dropping either left the
+  client waiting forever on a connection that looked alive (#3538).
   """
 
   use GenServer
@@ -34,38 +39,56 @@ defmodule IxMcp.MCP.Stdio do
     Notifier.register(self())
     reader = self()
     spawn_link(fn -> read_loop(reader) end)
-    {:ok, %{pending: MapSet.new(), eof: false}}
+    {:ok, %{pending: %{}, eof: false}}
   end
 
   @impl true
   def handle_info({:mcp_recv, line}, state) do
     stdio = self()
 
-    {:ok, pid} =
-      Task.start(fn ->
-        case JSON.decode(line) do
-          {:ok, message} ->
+    # Decode here, not in the task: the reply-always invariant needs the
+    # request id BEFORE the handler can die. A crashing task takes
+    # everything it knew with it, and an id-less DOWN can only be dropped --
+    # exactly the silent hang #3538 diagnosed. Decoding is cheap; the slow
+    # part (Server.handle) stays off this process.
+    case JSON.decode(line) do
+      {:ok, message} ->
+        {:ok, pid} =
+          Task.start(fn ->
             case Server.handle(message) do
               nil -> :ok
               response -> send(stdio, {:mcp_send, response})
             end
+          end)
 
-          {:error, _reason} ->
-            send(stdio, {:mcp_send, parse_error()})
-        end
-      end)
+        ref = Process.monitor(pid)
+        {:noreply, %{state | pending: Map.put(state.pending, ref, Map.get(message, "id"))}}
 
-    ref = Process.monitor(pid)
-    {:noreply, %{state | pending: MapSet.put(state.pending, ref)}}
+      {:error, _reason} ->
+        write(parse_error())
+        {:noreply, state}
+    end
   end
 
   def handle_info({:mcp_send, message}, state) do
-    IO.binwrite(:stdio, [JSON.encode!(message), "\n"])
+    write(message)
     {:noreply, state}
   end
 
-  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
-    maybe_stop(%{state | pending: MapSet.delete(state.pending, ref)})
+  def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
+    {id, pending} = Map.pop(state.pending, ref)
+
+    # A handler task that died abnormally never sent its reply (the send is
+    # a finished handler's last act), so this DOWN is the final chance to
+    # answer. Dropping the ref without replying -- the pre-#3538 behavior --
+    # left the client waiting forever on a request the server had already
+    # forgotten. Written before maybe_stop/1 so a shutdown on EOF cannot
+    # outrun the reply.
+    if reason != :normal and id != nil do
+      write(handler_died(id, reason))
+    end
+
+    maybe_stop(%{state | pending: pending})
   end
 
   # The client closed stdin: finish the requests already dispatched, then
@@ -77,11 +100,27 @@ defmodule IxMcp.MCP.Stdio do
   def handle_info(_msg, state), do: {:noreply, state}
 
   defp maybe_stop(state) do
-    if state.eof and MapSet.size(state.pending) == 0 do
+    if state.eof and map_size(state.pending) == 0 do
       System.stop(0)
     end
 
     {:noreply, state}
+  end
+
+  defp write(message) do
+    # Encoding must not be able to kill the transport: JSON.encode! raises
+    # {:invalid_byte, _} on invalid UTF-8, this process owns stdout, and its
+    # linked read_loop dies with it -- one bad byte in one response used to
+    # cost the whole connection (#3538). Degrade to an error reply for the
+    # same id so the client learns the response was unencodable and moves on.
+    line =
+      try do
+        JSON.encode!(message)
+      rescue
+        error -> JSON.encode!(unencodable(message, error))
+      end
+
+    IO.binwrite(:stdio, [line, "\n"])
   end
 
   defp read_loop(server) do
@@ -104,6 +143,31 @@ defmodule IxMcp.MCP.Stdio do
 
         read_loop(server)
     end
+  end
+
+  defp handler_died(id, reason) do
+    %{
+      "jsonrpc" => "2.0",
+      "id" => id,
+      "error" => %{
+        "code" => -32_603,
+        # inspect/2 rather than Exception.format_exit/1: inspect's output is
+        # always valid UTF-8, and the limits bound a reason that could embed
+        # megabytes of crashed-process state.
+        "message" => "request handler died: " <> inspect(reason, limit: 25, printable_limit: 500)
+      }
+    }
+  end
+
+  defp unencodable(message, error) do
+    %{
+      "jsonrpc" => "2.0",
+      "id" => Map.get(message, "id"),
+      "error" => %{
+        "code" => -32_603,
+        "message" => "response could not be encoded as JSON: " <> Exception.message(error)
+      }
+    }
   end
 
   defp parse_error do

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -10,8 +10,17 @@ defmodule IxMcp.MCP.Tools do
   """
 
   alias IxMcp.Jobs
+  alias IxMcp.UTF8
 
   @budget_cap 120
+
+  # One exec reply's output budget. The full output always stays in the
+  # job's buffer for paging (Jobs.tail/lines/grep); only what a single reply
+  # carries is capped. Why cap at all: a cell that printed a multi-megabyte
+  # compiled binary rode whole into one JSON-RPC line (#3538) -- no client
+  # consumes that usefully, and the agent harness's context budget is orders
+  # of magnitude smaller. 64KiB is far above a legitimate reply page.
+  @max_output_bytes 65_536
 
   @surface_guide """
   Everything beyond running code is in-language, pre-aliased in every cell:
@@ -169,7 +178,19 @@ defmodule IxMcp.MCP.Tools do
   defp diagnostics_section(diags), do: Enum.map(diags, &("-- " <> &1))
 
   defp output_section(""), do: []
-  defp output_section(output), do: [String.trim_trailing(output, "\n")]
+
+  defp output_section(output) when byte_size(output) <= @max_output_bytes,
+    do: [String.trim_trailing(output, "\n")]
+
+  defp output_section(output) do
+    kept = UTF8.truncate(output, @max_output_bytes)
+
+    [
+      String.trim_trailing(kept, "\n"),
+      "[output truncated: showing first #{byte_size(kept)} of #{byte_size(output)} bytes; " <>
+        "page the full output with Jobs.lines(id, first, last) or Jobs.tail(id, n)]"
+    ]
+  end
 
   defp result_section(%{running: true}) do
     [

--- a/packages/mcp-ex/lib/ix_mcp/utf8.ex
+++ b/packages/mcp-ex/lib/ix_mcp/utf8.ex
@@ -1,0 +1,81 @@
+defmodule IxMcp.UTF8 do
+  @moduledoc """
+  Lossy-but-loud UTF-8 sanitation for text that rides the JSON-RPC wire.
+
+  #3523 made stdio a transparent byte pipe so valid UTF-8 crosses the wire
+  untouched; this module is the outbound half of that contract (#3538). The
+  OTP JSON encoder raises on invalid UTF-8, and `:unicode.characters_to_binary/1`
+  answers invalid input with an `{:error, ...}` tuple instead of a binary --
+  so one cell printing a compiled binary could poison its job record and
+  kill the whole connection. Here valid UTF-8 passes through byte-identical
+  (the #3523 transparency, extended to output) and every byte that cannot
+  ride becomes a visible `\\xNN` escape: loud enough to see, harmless to
+  encode.
+  """
+
+  @doc """
+  Convert chardata to a valid UTF-8 binary, escaping whatever cannot be
+  converted: invalid bytes as `\\xNN`, invalid codepoints as `\\u{...}`.
+  """
+  @spec sanitize(IO.chardata()) :: String.t()
+  def sanitize(chardata) do
+    case :unicode.characters_to_binary(chardata) do
+      binary when is_binary(binary) -> binary
+      {_error_or_incomplete, converted, rest} -> sanitize_rest(rest, [converted])
+    end
+  end
+
+  # Iterate with an iodata accumulator instead of concatenating around a
+  # recursive call: the #3538 payload was a multi-megabyte compiled binary,
+  # where per-escape stack growth would trade one crash for another.
+  # `:error` stops at the first invalid unit, `:incomplete` at a truncated
+  # trailing multibyte sequence; either way the offending unit is escaped
+  # and conversion resumes right after it.
+  defp sanitize_rest(rest, acc) do
+    {escaped, tail} = escape_head(rest)
+
+    case :unicode.characters_to_binary(tail) do
+      binary when is_binary(binary) ->
+        IO.iodata_to_binary(Enum.reverse([binary, escaped | acc]))
+
+      {_error_or_incomplete, converted, next_rest} ->
+        sanitize_rest(next_rest, [converted, escaped | acc])
+    end
+  end
+
+  # `rest` keeps the shape of the input -- a binary tail, or the unconsumed
+  # elements of a chardata list -- with the offending unit at its head.
+  defp escape_head(<<byte, tail::binary>>), do: {escape_byte(byte), tail}
+  defp escape_head([head | tail]) when is_integer(head), do: {escape_codepoint(head), tail}
+  defp escape_head([]), do: {"", []}
+
+  defp escape_head([head | tail]) do
+    {escaped, inner_tail} = escape_head(head)
+    {escaped, [inner_tail | tail]}
+  end
+
+  defp escape_byte(byte), do: "\\x" <> Base.encode16(<<byte>>)
+
+  defp escape_codepoint(codepoint), do: "\\u{" <> Integer.to_string(codepoint, 16) <> "}"
+
+  @doc """
+  The longest prefix of `binary` at most `max_bytes` long that does not end
+  inside a multibyte codepoint. A byte cap that split a sequence would
+  reintroduce the exact invalid-UTF-8 payload this module exists to keep
+  off the wire (#3538).
+  """
+  @spec truncate(String.t(), non_neg_integer()) :: String.t()
+  def truncate(binary, max_bytes) when byte_size(binary) <= max_bytes, do: binary
+  def truncate(binary, max_bytes), do: cut(binary, max_bytes)
+
+  defp cut(_binary, 0), do: ""
+
+  # A continuation byte (0b10xxxxxx) right after the cut means the cut
+  # falls mid-sequence; back up until the next byte starts a codepoint.
+  defp cut(binary, cut_at) do
+    case binary do
+      <<_::binary-size(cut_at), 0b10::2, _::bitstring>> -> cut(binary, cut_at - 1)
+      <<keep::binary-size(cut_at), _::binary>> -> keep
+    end
+  end
+end

--- a/packages/mcp-ex/test/ix_mcp/jobs_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/jobs_test.exs
@@ -96,4 +96,72 @@ defmodule IxMcp.JobsTest do
     # ...and is gone, with its whole tree, after cancellation.
     assert {_, 1} = System.cmd("pgrep", ["-f", marker])
   end
+
+  # -- #3538: raw binary bytes in cell output ---------------------------------
+
+  test "a cell printing raw binary bytes still finishes, escaped, with a terminal history row" do
+    # The incident shape (IO.puts of a compiled binary): pre-fix,
+    # :unicode.characters_to_binary/1 returned an {:error, ...} tuple that
+    # landed in the output buffer as if it were output, byte_size/1 crashed
+    # the job GenServer mid-finish, the history row sat at :running forever,
+    # and this very call exited :noproc after its budget.
+    {summary, output} = Jobs.run(~S|IO.puts(<<0xFF>> <> "tail")|, budget: 2, intent: "binary out")
+
+    assert summary.status == :done
+    assert output == "\\xFFtail\n"
+
+    entry = Enum.find(Jobs.history(10), &(&1.id == summary.id))
+    assert entry.status == :done
+  end
+
+  test "IO.binwrite: bytes valid as UTF-8 pass byte-identical, invalid bytes are escaped" do
+    {utf8, utf8_out} = Jobs.run(~S|IO.binwrite("snow ☃")|, budget: 2, intent: "binwrite utf8")
+    assert utf8.status == :done
+    assert utf8_out == "snow ☃"
+
+    {bin, bin_out} = Jobs.run(~S|IO.binwrite(<<0xFF>>)|, budget: 2, intent: "binwrite binary")
+    assert bin.status == :done
+    assert bin_out == "\\xFF"
+  end
+
+  test "a job whose process dies mid-run gets a terminal history row, and cancel reports it" do
+    {running, _out} = Jobs.run("Process.sleep(:infinity)", budget: 0.05, intent: "to be killed")
+    assert running.running
+
+    {:ok, pid} = Jobs.lookup(running.id)
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :killed}
+
+    # History finalizes on its own DOWN signal; poll for the flip.
+    entry =
+      eventually(fn ->
+        Enum.find(Jobs.history(10), &(&1.id == running.id && &1.status != :running))
+      end)
+
+    assert entry.status == :failed
+    assert is_float(entry.elapsed_s)
+
+    # The job process is gone but the run is on record: report its state
+    # (pre-fix this raised "no such job" about an id history still listed).
+    assert Jobs.cancel(running.id) == {:error, :failed}
+  end
+
+  test "cancel on an id that never existed still raises" do
+    assert_raise ArgumentError, ~r/no such job/, fn -> Jobs.cancel("00000000") end
+  end
+
+  defp eventually(probe, tries \\ 50) do
+    case probe.() do
+      nil when tries > 0 ->
+        Process.sleep(20)
+        eventually(probe, tries - 1)
+
+      nil ->
+        flunk("condition never became true")
+
+      value ->
+        value
+    end
+  end
 end

--- a/packages/mcp-ex/test/ix_mcp/mcp_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/mcp_test.exs
@@ -66,4 +66,51 @@ defmodule IxMcp.MCPTest do
     assert %{"error" => %{"code" => -32_601}} = Server.handle(request("bogus/method", %{}))
     assert Server.handle(%{"method" => "notifications/initialized"}) == nil
   end
+
+  # -- #3538: binary output must ride the wire, not kill it -------------------
+
+  test "exec of a binary-printing cell replies with escaped output that the wire can encode" do
+    response =
+      Server.handle(
+        request("tools/call", %{
+          "name" => "exec",
+          "arguments" => %{
+            "code" => ~S|IO.puts(<<0xFF>> <> "marker")|,
+            "budget" => 2,
+            "intent" => "binary output"
+          }
+        })
+      )
+
+    refute response["result"]["isError"]
+    [%{"type" => "text", "text" => text}] = response["result"]["content"]
+    assert text =~ "\\xFFmarker"
+
+    # The leg that killed the connection: the stdio transport JSON-encodes
+    # this exact map, and the OTP encoder raises {:invalid_byte, _} on any
+    # invalid UTF-8 anywhere inside it.
+    assert is_binary(JSON.encode!(response))
+  end
+
+  test "exec output above the cap is truncated loudly, naming the original byte count" do
+    total = 300 * 1024
+
+    response =
+      Server.handle(
+        request("tools/call", %{
+          "name" => "exec",
+          "arguments" => %{
+            "code" => "IO.write(String.duplicate(\"x\", #{total}))",
+            "budget" => 5,
+            "intent" => "big output"
+          }
+        })
+      )
+
+    [%{"type" => "text", "text" => text}] = response["result"]["content"]
+    assert text =~ "output truncated"
+    assert text =~ "#{total} bytes"
+    # The reply must stay bounded no matter how much the cell printed.
+    assert byte_size(text) < 100_000
+  end
 end

--- a/packages/mcp-ex/test/ix_mcp/stdio_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/stdio_test.exs
@@ -1,0 +1,55 @@
+defmodule IxMcp.MCP.StdioTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias IxMcp.MCP.Stdio
+
+  # These drive the GenServer callbacks directly in the test process: the
+  # real Stdio owns the actual stdin/stdout (and stops the VM at EOF), so
+  # end-to-end wire coverage lives in the package's nix smoke test. What
+  # these pin is the reply-always invariant (#3538): every request with an
+  # id gets exactly one reply, whatever happens to its handler.
+
+  test "a handler task that dies abnormally still produces an error reply" do
+    ref = make_ref()
+    state = %{pending: %{ref => 7}, eof: false}
+    down = {:DOWN, ref, :process, self(), {:noproc, {GenServer, :call, []}}}
+
+    output =
+      capture_io(fn ->
+        assert {:noreply, %{pending: pending}} = Stdio.handle_info(down, state)
+        assert pending == %{}
+      end)
+
+    assert output =~ ~s("id":7)
+    assert output =~ "-32603"
+    assert output =~ "request handler died"
+  end
+
+  test "a handler task that exits :normal already replied; no synthetic error" do
+    ref = make_ref()
+    state = %{pending: %{ref => 7}, eof: false}
+
+    output =
+      capture_io(fn ->
+        assert {:noreply, _state} =
+                 Stdio.handle_info({:DOWN, ref, :process, self(), :normal}, state)
+      end)
+
+    assert output == ""
+  end
+
+  test "an unencodable response degrades to an error reply instead of killing the transport" do
+    state = %{pending: %{}, eof: false}
+    message = %{"jsonrpc" => "2.0", "id" => 3, "result" => %{"content" => <<0xFF>>}}
+
+    output =
+      capture_io(fn ->
+        assert {:noreply, ^state} = Stdio.handle_info({:mcp_send, message}, state)
+      end)
+
+    assert output =~ ~s("id":3)
+    assert output =~ "could not be encoded"
+  end
+end

--- a/packages/mcp-ex/test/ix_mcp/utf8_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/utf8_test.exs
@@ -1,0 +1,48 @@
+defmodule IxMcp.UTF8Test do
+  use ExUnit.Case, async: true
+
+  alias IxMcp.UTF8
+
+  describe "sanitize/1" do
+    test "valid UTF-8 passes through byte-identical, multibyte included" do
+      # The #3523 transparency contract, extended to output: what can ride
+      # as-is must ride as-is.
+      assert UTF8.sanitize("snow ☃") == "snow ☃"
+      assert UTF8.sanitize([?a, "bc", [~c"de"]]) == "abcde"
+    end
+
+    test "invalid bytes become visible \\xNN escapes" do
+      assert UTF8.sanitize(<<0xFF, "abc">>) == "\\xFFabc"
+      assert UTF8.sanitize(<<"ok", 0xC0, 0x80, "end">>) == "ok\\xC0\\x80end"
+    end
+
+    test "the IO.puts shape: chardata list with an embedded invalid binary" do
+      # IO.puts hands the group leader [data, ?\n]; #3538's repro rode in
+      # exactly like this.
+      assert UTF8.sanitize([<<0xFF, "a">>, ?\n]) == "\\xFFa\n"
+    end
+
+    test "a truncated trailing multibyte sequence is escaped, not dropped" do
+      assert UTF8.sanitize(<<"a", 0xE2, 0x98>>) == "a\\xE2\\x98"
+    end
+
+    test "invalid codepoints escape as \\u{...}" do
+      assert UTF8.sanitize([0x110000]) == "\\u{110000}"
+    end
+  end
+
+  describe "truncate/2" do
+    test "input at or under the cap is untouched" do
+      assert UTF8.truncate("abc", 3) == "abc"
+      assert UTF8.truncate("abc", 10) == "abc"
+    end
+
+    test "never cuts inside a multibyte sequence" do
+      # "☃" is three bytes: budgets landing mid-snowman back up to "a".
+      assert UTF8.truncate("a☃b", 4) == "a☃"
+      assert UTF8.truncate("a☃b", 3) == "a"
+      assert UTF8.truncate("a☃b", 2) == "a"
+      assert UTF8.truncate("☃", 1) == ""
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3538.

A cell printing raw binary (`IO.puts(File.read!(<compiled binary>))`) killed the MCP connection: the harness hung forever and the job's history row was orphaned at `:running` (`Jobs.cancel` then raised "no such job"). Reproduced end-to-end in tests before fixing; the pinned death path:

1. `:unicode.characters_to_binary/1` answers invalid UTF-8 with an `{:error, ...}` **tuple**, which `IOProxy.convert/2` passed to the job's output buffer as if it were output.
2. `byte_size/1` on that tuple crashed the Job GenServer mid-`finish` -- after the eval had already succeeded -- before `History.finished/3` and before subscribers were notified.
3. The awaiting request task then died `:noproc`, and Stdio's `DOWN` handler silently dropped the pending reply: no response, ever, on a connection that looked alive.

The fix, layer by layer:

- **`IxMcp.UTF8` (new)**: valid UTF-8 passes byte-identical (the #3523 wire transparency, extended to output); invalid bytes become visible `\xNN` escapes, invalid codepoints `\u{...}`. `IOProxy` sanitizes both `:unicode` and `:latin1` `put_chars`, so the sink invariant (valid UTF-8 binary, always) holds no matter what a cell prints. `Job.append/2` now guards `is_binary` so any regression fails the offending `put_chars`, not the job record.
- **Stdio reply-always**: the request id is captured before dispatch, a handler task that dies abnormally is answered with a JSON-RPC `-32603` error, and a response the JSON encoder rejects degrades to an error reply instead of crashing the transport (and its linked read loop -- the whole connection).
- **History finalization**: `Jobs.History` is now a GenServer that monitors each recording job and drives its row to a terminal `:failed` if the process dies without reporting. `Jobs.cancel/1` on a dead-but-recorded id reports the recorded state instead of raising (including the async-Registry `:noproc` race the sandboxed suite caught).
- **Output cap**: one exec reply carries at most 64KiB of output, truncated on a codepoint boundary with a marker naming the original byte count; full output stays pageable via `Jobs.tail/lines/grep`.

The nix smoke test now round-trips a binary-printing cell over real stdio and proves the connection survives to answer the next request.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP stdio transport to survive binary and invalid UTF-8 cell output
> - Adds [`IxMcp.UTF8`](https://github.com/indexable-inc/index/pull/3542/files#diff-af0cd410ef5f7c9c8af49a7aeba2052bf322e92eefd4db556e69685417251b14) with `sanitize/1` (escapes invalid bytes as `\xNN`) and `truncate/2` (byte-safe UTF-8 truncation); [`IOProxy.convert/2`](https://github.com/indexable-inc/index/pull/3542/files#diff-5aa2693b587d4194a0408dfff4e54d189e2f5656d509149e7b7246537ab1d670) now uses `sanitize/1` so all cell output is guaranteed valid UTF-8.
> - [`IxMcp.MCP.Stdio`](https://github.com/indexable-inc/index/pull/3542/files#diff-775ac658aaedab87f4cd5e80d254eaeb13c77ac446f0e4fb2583980ab94a7cb7) now tracks `ref -> id` for in-flight tasks; a crashed handler emits a JSON-RPC error reply instead of silently dropping the request, and a response that fails JSON encoding degrades to an error reply rather than killing the transport.
> - [`IxMcp.Jobs.History`](https://github.com/indexable-inc/index/pull/3542/files#diff-3ec5af6bd6a30c316cdf60f2fcbd7a3ef36b358e7e3682a10747c8035f6735e8) is refactored from Agent to GenServer and monitors job processes, automatically marking jobs `:failed` with elapsed time if they die without reporting.
> - [`IxMcp.MCP.Tools`](https://github.com/indexable-inc/index/pull/3542/files#diff-c1967b7edcd9f2a8628cd2ebf989cfe1e0daf0af2416367f04b4e816c897e776) truncates exec output exceeding `@max_output_bytes` using `UTF8.truncate/2` and appends an advisory line with byte counts.
> - Behavioral Change: `cancel/1` in [`IxMcp.Jobs`](https://github.com/indexable-inc/index/pull/3542/files#diff-4b32b41230aeb491b1cb281b931eee2f7be20df1fd5c07374727ce4819007dc7) now returns `{:error, status}` for gone-but-known jobs and raises only for unknown ids.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b45a9bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->