### PR TITLE
mcp-ex: version the action log via PRAGMA user_version; route crash dumps into the state dir

### DIFF
--- a/packages/mcp-ex/default.nix
+++ b/packages/mcp-ex/default.nix
@@ -137,13 +137,14 @@
     }
     ''
       set +e
-      printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
+      printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
         '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}' \
         '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
         '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"session_set_name","arguments":{"name":"smoke"}}}' \
         '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"exec","arguments":{"intent":"utf8 wire roundtrip","budget":60,"code":"\"snow ☃\""}}}' \
         '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"exec","arguments":{"intent":"binary output rides as escapes","budget":60,"code":"IO.puts(<<255, 97>> <> \"bin-marker\")"}}}' \
         '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"exec","arguments":{"intent":"connection survives binary output","budget":60,"code":"\"alive-after-binary\""}}}' \
+        '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"exec","arguments":{"intent":"crash dump routing probe","budget":60,"code":"System.fetch_env!(\"ERL_CRASH_DUMP\")"}}}' \
         | IX_MCP_ACTIONS_DB="$PWD/actions.db" ix-mcp-ex > response.jsonl 2> server-stderr.log
       rc=$?
       set -e
@@ -211,6 +212,18 @@
         *'alive-after-binary'*) ;;
         *)
           echo "connection did not survive binary cell output" >&2
+          printf '%s\n' "$out_lines" >&2
+          exit 1
+          ;;
+      esac
+      # index#3539: the app exports ERL_CRASH_DUMP next to the action log, so
+      # a BEAM crash dump cannot land in (and get committed to) whatever cwd
+      # the MCP client ran the server from; the probe proves the routing
+      # holds in the shipped release, not just under mix.
+      case "$out_lines" in
+        *"$PWD/erl_crash.dump"*) ;;
+        *)
+          echo "ERL_CRASH_DUMP is not routed next to the action log" >&2
           printf '%s\n' "$out_lines" >&2
           exit 1
           ;;

--- a/packages/mcp-ex/lib/ix_mcp/action_log.ex
+++ b/packages/mcp-ex/lib/ix_mcp/action_log.ex
@@ -23,9 +23,12 @@ defmodule IxMcp.ActionLog do
   The database path resolves as app env `:actions_db` (tests pin
   `":memory:"`), then `$IX_MCP_ACTIONS_DB`, then
   `$XDG_STATE_HOME/ix-mcp-ex/actions.db` (state home defaulting to
-  `~/.local/state`). A pre-#3532 database (an `actions` table without a
-  `session_id` column) is migrated losslessly, in one transaction, when the
-  log opens. Writes are synchronous calls on purpose: the BEAM halts as soon
+  `~/.local/state`). The schema carries its version in `PRAGMA
+  user_version` (#3539): an older database migrates forward through the
+  ordered steps (losslessly, one transaction per step) when the log opens,
+  while a database stamped by a newer server is refused -- loudly, but
+  without failing startup: logging disables for this instance, because a
+  tool server must not die over its own log. Writes are synchronous calls on purpose: the BEAM halts as soon
   as stdin closes, so a fire-and-forget cast loses the tail of a short-lived
   session (observed live), while a call makes the row durable before the
   tool response ships; one SQLite insert is negligible against MCP wire
@@ -36,6 +39,8 @@ defmodule IxMcp.ActionLog do
   use GenServer
 
   alias Exqlite.Sqlite3
+
+  require Logger
 
   # The schema is a published contract (#3532): the action-log UI is built
   # against these exact tables, so changes here must be coordinated.
@@ -51,13 +56,25 @@ defmodule IxMcp.ActionLog do
   CREATE TABLE actions (id INTEGER PRIMARY KEY, at TEXT NOT NULL, session_id INTEGER NOT NULL REFERENCES sessions(id), topic_id INTEGER REFERENCES topics(id), tool TEXT NOT NULL, intent TEXT, arguments TEXT NOT NULL, is_error INTEGER NOT NULL, elapsed_ms INTEGER NOT NULL, status TEXT NOT NULL DEFAULT 'done', stack TEXT, stack_at TEXT)
   """
 
-  # A pre-#3536 v2 database lacks the live-row columns; DEFAULT 'done' is
-  # exactly right for its rows, which were all written after the fact.
-  @add_live_columns [
-    "ALTER TABLE actions ADD COLUMN status TEXT NOT NULL DEFAULT 'done'",
-    "ALTER TABLE actions ADD COLUMN stack TEXT",
-    "ALTER TABLE actions ADD COLUMN stack_at TEXT"
-  ]
+  # index#3539: the schema version is stamped into SQLite's `PRAGMA
+  # user_version` header field instead of being re-derived by column
+  # sniffing on every open. Sniffing can only classify shapes this binary
+  # already knows: when the on-disk schema is NEWER than the reader (the
+  # 2026-07-17 incident -- a #3512-era binary starting against the file the
+  # #3532 normalization had already rewritten), every sniff answer is wrong
+  # and the mismatch surfaces as a match-crash deep in a prepare. A stamped
+  # version makes older shapes migratable in order, the current shape a
+  # no-op, and a future shape explicitly detectable. The ladder: 1 = the
+  # flat #3512 log, 2 = the #3532 normalization, 3 = the #3536 live rows.
+  @user_version 3
+
+  # Frozen historical DDL for the 1 -> 2 step: the actions shape exactly as
+  # #3532 shipped it, before the live-row columns. A migration must never
+  # borrow the current @create_actions, or editing today's schema would
+  # silently rewrite the ladder's history.
+  @create_actions_v2 """
+  CREATE TABLE actions (id INTEGER PRIMARY KEY, at TEXT NOT NULL, session_id INTEGER NOT NULL REFERENCES sessions(id), topic_id INTEGER REFERENCES topics(id), tool TEXT NOT NULL, intent TEXT, arguments TEXT NOT NULL, is_error INTEGER NOT NULL, elapsed_ms INTEGER NOT NULL)
+  """
 
   # The v1 shape kept session/topic as TEXT per action row. The backfill
   # makes one session per distinct v1 session string (NULLs collapse into
@@ -65,11 +82,11 @@ defmodule IxMcp.ActionLog do
   # distinct (session, topic) pair -- v1 rows carry no topic boundaries, so
   # per-pair is the finest lossless grain -- and earliest-seen timestamps
   # stand in for the started_at v1 never stored.
-  @migrate_v1 [
+  @migrate_v1_to_v2 [
     "ALTER TABLE actions RENAME TO actions_v1",
     @create_sessions,
     @create_topics,
-    @create_actions,
+    @create_actions_v2,
     """
     INSERT INTO sessions (name, started_at)
     SELECT session, MIN(at) FROM actions_v1 GROUP BY session
@@ -90,6 +107,20 @@ defmodule IxMcp.ActionLog do
     """,
     "DROP TABLE actions_v1"
   ]
+
+  # A v2 database predates the live-row columns (#3536); DEFAULT 'done' is
+  # exactly right for its rows, which were all written after the fact.
+  @migrate_v2_to_v3 [
+    "ALTER TABLE actions ADD COLUMN status TEXT NOT NULL DEFAULT 'done'",
+    "ALTER TABLE actions ADD COLUMN stack TEXT",
+    "ALTER TABLE actions ADD COLUMN stack_at TEXT"
+  ]
+
+  # Ordered migrations keyed by the user_version each upgrades FROM. Every
+  # step runs in one immediate transaction that also stamps the version it
+  # produces, so an interrupted migration leaves the previous consistent,
+  # correctly-stamped version on disk.
+  @migrations [{1, @migrate_v1_to_v2}, {2, @migrate_v2_to_v3}]
 
   @insert """
   INSERT INTO actions (at, session_id, topic_id, tool, intent, arguments, is_error, elapsed_ms, status)
@@ -192,26 +223,62 @@ defmodule IxMcp.ActionLog do
     GenServer.call(server, :topics)
   end
 
+  @doc """
+  The resolved database path: app env `:actions_db` (tests pin `":memory:"`),
+  then `$IX_MCP_ACTIONS_DB`, then `$XDG_STATE_HOME/ix-mcp-ex/actions.db`.
+  Public because crash-dump routing (`IxMcp.Application`) aims
+  `ERL_CRASH_DUMP` at the same directory (#3539).
+  """
+  @spec db_path() :: String.t()
+  def db_path do
+    Application.get_env(:ix_mcp, :actions_db) ||
+      System.get_env("IX_MCP_ACTIONS_DB") ||
+      Path.join([state_home(), "ix-mcp-ex", "actions.db"])
+  end
+
   @impl true
   def init(opts) do
-    path = Keyword.get(opts, :path) || configured_path()
+    path = Keyword.get(opts, :path) || db_path()
 
     if path != ":memory:", do: File.mkdir_p!(Path.dirname(path))
 
     {:ok, conn} = Sqlite3.open(path)
 
-    case shape(conn) do
-      :v2 -> :ok
-      :v2_pre_live -> execute_all(conn, @add_live_columns)
-      :empty -> execute_all(conn, [@create_sessions, @create_topics, @create_actions])
-      :v1 -> execute_all(conn, ["BEGIN IMMEDIATE"] ++ @migrate_v1 ++ ["COMMIT"])
-    end
+    # index#3539: on 2026-07-17 a server binary match-crashed right here
+    # against an action log written under a newer schema, and the failed
+    # child took the whole application down -- every tool call died over a
+    # log nothing on the hot path reads. Older on-disk versions migrate
+    # forward; a future version (a newer server already ran against this
+    # file) refuses loudly but keeps the server up, degraded to not
+    # recording, so the blast radius stays scoped to the log itself.
+    case ensure_version(conn) do
+      :ok ->
+        {:ok, insert} = Sqlite3.prepare(conn, @insert)
+        {:ok, %{conn: conn, insert: insert}}
 
-    {:ok, insert} = Sqlite3.prepare(conn, @insert)
-    {:ok, %{conn: conn, insert: insert}}
+      {:future, found} ->
+        :ok = Sqlite3.close(conn)
+
+        Logger.error(
+          "action log #{path} has schema user_version #{found}, newer than the supported " <>
+            "#{@user_version}: a newer ix-mcp-ex has run against this file. Upgrade this " <>
+            "server or point IX_MCP_ACTIONS_DB at a fresh path; not recording actions for " <>
+            "this instance (index#3539)."
+        )
+
+        {:ok, :disabled}
+    end
   end
 
+  # index#3539 degraded mode: the file belongs to a newer server, so writes
+  # are dropped and reads answer empty rather than crashing every caller.
+  # Ids still come back as integers because IxMcp.Session stores them only
+  # to hand them straight back to this module, where they are ignored.
   @impl true
+  def handle_call(request, _from, :disabled) do
+    {:reply, disabled_reply(request), :disabled}
+  end
+
   def handle_call({:create_session, name, at}, _from, %{conn: conn} = state) do
     run(conn, "INSERT INTO sessions (name, started_at) VALUES (?, ?)", [name, at])
     {:ok, id} = Sqlite3.last_insert_rowid(conn)
@@ -289,19 +356,76 @@ defmodule IxMcp.ActionLog do
     {:reply, rows, state}
   end
 
-  defp shape(conn) do
+  defp ensure_version(conn) do
+    case user_version(conn) do
+      @user_version ->
+        :ok
+
+      found when found > @user_version ->
+        {:future, found}
+
+      0 ->
+        # Every database written before stamping existed reads 0, so a 0 is
+        # classified by inspecting the actual tables -- the one situation
+        # where sniffing is sound, because 0 can only be a fresh file or a
+        # shape older than stamping -- and the file leaves stamped, so every
+        # later open trusts the version alone.
+        case unstamped_version(conn) do
+          :fresh -> create(conn)
+          version -> migrate(conn, version)
+        end
+
+      found ->
+        migrate(conn, found)
+    end
+  end
+
+  defp user_version(conn) do
+    [[version]] = fetch(conn, "PRAGMA user_version", [])
+    version
+  end
+
+  defp unstamped_version(conn) do
     case table_columns(conn, "actions") do
       [] ->
-        :empty
+        :fresh
 
       columns ->
         cond do
-          "session_id" not in columns -> :v1
-          "status" not in columns -> :v2_pre_live
-          true -> :v2
+          "session_id" not in columns -> 1
+          "status" not in columns -> 2
+          true -> @user_version
         end
     end
   end
+
+  defp create(conn) do
+    execute_all(
+      conn,
+      ["BEGIN IMMEDIATE", @create_sessions, @create_topics, @create_actions, stamp(), "COMMIT"]
+    )
+  end
+
+  # An already-current file from before stamping existed: mark it, move on.
+  defp migrate(conn, @user_version), do: execute_all(conn, [stamp()])
+
+  defp migrate(conn, from) do
+    @migrations
+    |> Enum.drop_while(fn {version, _statements} -> version < from end)
+    |> Enum.each(fn {version, statements} ->
+      execute_all(conn, ["BEGIN IMMEDIATE"] ++ statements ++ [stamp(version + 1), "COMMIT"])
+    end)
+  end
+
+  defp stamp(version \\ @user_version), do: "PRAGMA user_version = #{version}"
+
+  defp disabled_reply({:create_session, _name, _at}), do: 0
+  defp disabled_reply({:create_topic, _session_id, _name, _at}), do: 0
+  defp disabled_reply({:start_action, _action}), do: 0
+  defp disabled_reply({:recent, _n}), do: []
+  defp disabled_reply(:sessions), do: []
+  defp disabled_reply(:topics), do: []
+  defp disabled_reply(_request), do: :ok
 
   defp table_columns(conn, table) do
     for [_cid, name | _rest] <- fetch(conn, "PRAGMA table_info(#{table})", []), do: name
@@ -324,12 +448,6 @@ defmodule IxMcp.ActionLog do
     {:ok, rows} = Sqlite3.fetch_all(conn, statement)
     :ok = Sqlite3.release(conn, statement)
     rows
-  end
-
-  defp configured_path do
-    Application.get_env(:ix_mcp, :actions_db) ||
-      System.get_env("IX_MCP_ACTIONS_DB") ||
-      Path.join([state_home(), "ix-mcp-ex", "actions.db"])
   end
 
   defp state_home do

--- a/packages/mcp-ex/lib/ix_mcp/application.ex
+++ b/packages/mcp-ex/lib/ix_mcp/application.ex
@@ -16,13 +16,17 @@ defmodule IxMcp.Application do
       └── IxMcp.MCP.Stdio       (only when IX_MCP_STDIO=1) the stdio transport
 
   The transport is opt-in via environment so `mix test` and IEx sessions get
-  the full evaluator without a reader loop competing for stdin.
+  the full evaluator without a reader loop competing for stdin. Before the
+  tree starts, `ERL_CRASH_DUMP` is pointed into the action log's directory:
+  a BEAM crash dump otherwise lands in the inherited cwd (#3539).
   """
 
   use Application
 
   @impl true
   def start(_type, _args) do
+    route_crash_dumps()
+
     children =
       [
         # ActionLog before Session: Session lazily creates its rows through it.
@@ -38,6 +42,26 @@ defmodule IxMcp.Application do
       ] ++ transport()
 
     Supervisor.start_link(children, strategy: :one_for_one, name: IxMcp.Supervisor)
+  end
+
+  # index#3539: without ERL_CRASH_DUMP the BEAM writes erl_crash.dump into
+  # whatever cwd it inherited from the MCP client -- the 2026-07-17 startup
+  # crash dumped 3.6MB into ~/.config/nix, which then got committed by
+  # accident. The runtime reads the variable at dump time, not at boot, so
+  # exporting it before any child can fail routes every dump from
+  # application start on into the state dir that already holds the action
+  # log. An explicit operator ERL_CRASH_DUMP wins; the in-memory test
+  # database has no directory to aim at, so it opts out.
+  defp route_crash_dumps do
+    db = IxMcp.ActionLog.db_path()
+
+    if is_nil(System.get_env("ERL_CRASH_DUMP")) and db != ":memory:" do
+      dir = Path.dirname(db)
+      File.mkdir_p!(dir)
+      System.put_env("ERL_CRASH_DUMP", Path.join(dir, "erl_crash.dump"))
+    end
+
+    :ok
   end
 
   defp transport do

--- a/packages/mcp-ex/test/action_log_test.exs
+++ b/packages/mcp-ex/test/action_log_test.exs
@@ -1,6 +1,8 @@
 defmodule IxMcp.ActionLogTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
+
   alias Exqlite.Sqlite3
   alias IxMcp.ActionLog
   alias IxMcp.MCP.Server
@@ -14,6 +16,15 @@ defmodule IxMcp.ActionLogTest do
 
     on_exit(fn -> File.rm(path) end)
     path
+  end
+
+  defp user_version(path) do
+    {:ok, conn} = Sqlite3.open(path)
+    {:ok, statement} = Sqlite3.prepare(conn, "PRAGMA user_version")
+    {:ok, [[version]]} = Sqlite3.fetch_all(conn, statement)
+    :ok = Sqlite3.release(conn, statement)
+    :ok = Sqlite3.close(conn)
+    version
   end
 
   test "a tools/call lands one row under the current session and topic" do
@@ -252,6 +263,9 @@ defmodule IxMcp.ActionLogTest do
     assert [%{status: "running", stack: ~s(["frame"])} | _] = ActionLog.recent(10, log)
     :ok = ActionLog.finish_action(action_id, "done", false, 3, log)
     assert [%{status: "done", stack: nil} | _] = ActionLog.recent(10, log)
+
+    # The 2 -> 3 step stamped the file on its way through (index#3539).
+    assert user_version(path) == 3
   end
 
   test "a v1 database migrates losslessly to the normalized schema, once" do
@@ -335,6 +349,9 @@ defmodule IxMcp.ActionLogTest do
 
     stop_supervised!(:migrate)
 
+    # The ladder ran 1 -> 2 -> 3 and left the stamp behind (index#3539).
+    assert user_version(path) == 3
+
     # The migrated file is the v2 shape on disk: normalized columns, no v1
     # leftovers, and a reopen (no-op detection) does not duplicate rows.
     {:ok, conn} = Sqlite3.open(path)
@@ -372,5 +389,80 @@ defmodule IxMcp.ActionLogTest do
     reopened = start_supervised!({ActionLog, path: path, name: :action_log_remigration})
     assert length(ActionLog.sessions(reopened)) == 3
     assert length(ActionLog.recent(10, reopened)) == 6
+  end
+
+  test "a fresh database is created stamped with the current schema version" do
+    path = tmp_db()
+    start_supervised!({ActionLog, path: path, name: :action_log_fresh_stamp})
+    assert user_version(path) == 3
+  end
+
+  test "an unstamped file already at the current schema is stamped, not rewritten" do
+    path = tmp_db()
+
+    log = start_supervised!({ActionLog, path: path, name: :action_log_stamp_a}, id: :stamp_first)
+    session_id = ActionLog.create_session("s", log)
+
+    _action_id =
+      ActionLog.start_action(
+        %{session_id: session_id, topic_id: nil, tool: "exec", intent: "keep", arguments: "{}"},
+        log
+      )
+
+    stop_supervised!(:stamp_first)
+
+    # Rewind the stamp: this is exactly what a current-schema file written by
+    # a pre-user_version server (any #3536-era binary) looks like on disk.
+    {:ok, conn} = Sqlite3.open(path)
+    :ok = Sqlite3.execute(conn, "PRAGMA user_version = 0")
+    :ok = Sqlite3.close(conn)
+
+    reopened = start_supervised!({ActionLog, path: path, name: :action_log_stamp_b})
+    assert [%{intent: "keep"}] = ActionLog.recent(10, reopened)
+    assert user_version(path) == 3
+  end
+
+  test "a database stamped by a newer server disables logging instead of crashing" do
+    path = tmp_db()
+
+    {:ok, conn} = Sqlite3.open(path)
+    :ok = Sqlite3.execute(conn, "PRAGMA user_version = 9000")
+    :ok = Sqlite3.close(conn)
+
+    {log, output} =
+      with_log(fn ->
+        start_supervised!({ActionLog, path: path, name: :action_log_future})
+      end)
+
+    # The refusal names both versions, so the operator knows which side moves.
+    assert output =~ "user_version 9000"
+    assert output =~ "supported 3"
+    assert output =~ "index#3539"
+
+    # The server stays useful: writes are absorbed, reads answer empty.
+    session_id = ActionLog.create_session("ignored", log)
+    topic_id = ActionLog.create_topic(session_id, "t", log)
+
+    action_id =
+      ActionLog.start_action(
+        %{session_id: session_id, topic_id: topic_id, tool: "exec", intent: "x", arguments: "{}"},
+        log
+      )
+
+    :ok = ActionLog.update_stack(action_id, "[]", log)
+    :ok = ActionLog.finish_action(action_id, "done", false, 1, log)
+    assert ActionLog.recent(10, log) == []
+    assert ActionLog.sessions(log) == []
+    assert ActionLog.topics(log) == []
+
+    # The newer file is left exactly as found, for the newer server.
+    assert user_version(path) == 9000
+
+    {:ok, conn} = Sqlite3.open(path)
+    {:ok, statement} = Sqlite3.prepare(conn, "SELECT name FROM sqlite_master")
+    {:ok, tables} = Sqlite3.fetch_all(conn, statement)
+    :ok = Sqlite3.release(conn, statement)
+    :ok = Sqlite3.close(conn)
+    assert tables == []
   end
 end


### PR DESCRIPTION
Fixes #3539.

## What happened

The 2026-07-17 22:46:25Z crash had the causality inverted in the issue body: an OLD #3513-era binary (flat `actions` schema with a `session` TEXT column) started against the NEWER normalized database that #3533 had already created on disk, failed to prepare its INSERT, and the failed `IxMcp.ActionLog` child took the whole application down. Its 3.6MB `erl_crash.dump` landed in the inherited cwd (`~/.config/nix`) and got committed by accident. Details: https://github.com/indexable-inc/index/issues/3539#issuecomment-5008501092

Old binaries cannot be fixed retroactively; this hardens current and future code.

## Changes

- **`PRAGMA user_version`-stamped ordered migrations** replace per-open column sniffing. The ladder: 1 = flat #3513 log, 2 = #3533 normalization, 3 = #3540 live rows. Unstamped files (always `user_version` 0 on disk today) are classified by inspection once -- fresh, flat v1, normalized v2, or current -- migrated stepwise (one stamping transaction per step, losslessly), and leave stamped.
- **A FUTURE `user_version` no longer kills the server.** A newer stamp means a newer server already ran against the file; the log opens disabled with a precise `Logger.error` naming found vs supported versions, writes are absorbed, reads answer empty, and the newer file is left untouched. Taking down every tool call over a log nothing on the hot path reads is the wrong blast radius.
- **`ERL_CRASH_DUMP` is exported into the state dir** (the action log's directory) before the supervision tree starts, so BEAM crash dumps stop landing in whatever cwd the MCP client ran the server from. The runtime reads the variable at dump time (verified empirically), so the app-start setting covers the incident class. The release smoke test now probes the routing end to end.

## Tests

- v1-flat fixture migrates losslessly and leaves the stamp (extended existing test)
- pre-live v2 fixture gains live columns and the stamp
- fresh database is created stamped; an unstamped current-schema file is stamped in place without a rewrite
- higher `user_version` disables logging with the precise error, keeps serving, leaves the file byte-identical

Validated locally exactly as CI runs it: `.#mcp-ex.passthru.tests.elixir` (compile --warnings-as-errors, format, credo --strict, 45 tests) and `.#mcp-ex.passthru.tests.smoke` both build green.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Version the action log schema via `PRAGMA user_version` and route crash dumps to the state directory
> - Introduces schema versioning in [`action_log.ex`](https://github.com/indexable-inc/index/pull/3543/files#diff-3e72adde29b4a1c32aaa66b83a963485a2f67735bd45ed8c1652532de4c4adab) using `PRAGMA user_version`, with ordered transactional migrations from v1→v2→v3 (v3 adds `status`, `stack`, and `stack_at` columns).
> - On startup, if the database was stamped by a newer server version, logging is disabled gracefully (GenServer state becomes `:disabled`) rather than crashing; API calls return neutral values.
> - Exposes `IxMcp.ActionLog.db_path/0` as a public function so other modules can resolve the action log path.
> - Routes Erlang crash dumps to `<action-log-dir>/erl_crash.dump` at application start via a new `route_crash_dumps/0` in [`application.ex`](https://github.com/indexable-inc/index/pull/3543/files#diff-bcb4fab743d7788d22bd4ea40d7b9569e8c1df5be6dd7207c7fd6a9b8c3e5ec7), unless `ERL_CRASH_DUMP` is already set or the DB is in-memory.
> - Behavioral Change: databases stamped with a future `user_version` silently disable action logging for that server instance instead of failing startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6809202.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->