### PR TITLE
agent: fail eval when systemPrompt.omitRules rides an explicit package

### DIFF
--- a/packages/agent/home-manager/claude-code.nix
+++ b/packages/agent/home-manager/claude-code.nix
@@ -13,6 +13,7 @@
 }: {
   config,
   lib,
+  options,
   pkgs,
   ...
 }: let
@@ -274,6 +275,21 @@ in {
       {
         assertion = cfg.systemPrompt.source == "house" || cfg.systemPrompt.omitRules == [];
         message = "programs.claude-code.systemPrompt.omitRules only applies when source = \"house\".";
+      }
+      {
+        # omitRules reaches the shipped wrapper only through defaultedPackage
+        # (basePackage.override packageOverrides); an explicit `package =`
+        # discards that override. Left unchecked this shipped a half-applied
+        # policy: the explicit package's permissions allowed force-merging
+        # while its baked prompt still forbade it (index#3537). The package
+        # stays defaulted only while no definition beats the module's own
+        # `lib.mkDefault defaultedPackage` (numerically lower highestPrio
+        # wins), so compare against that same mkDefault priority.
+        assertion =
+          cfg.systemPrompt.omitRules
+          == []
+          || options.programs.claude-code.package.highestPrio >= (lib.mkDefault null).priority;
+        message = "programs.claude-code.systemPrompt.omitRules is ignored when package is set explicitly; pass omitRules to that package's override instead (index#3537).";
       }
       {
         # The upstream module renders settings.json as a read-only store

--- a/packages/agent/home-manager/codex.nix
+++ b/packages/agent/home-manager/codex.nix
@@ -6,6 +6,7 @@
 }: {
   config,
   lib,
+  options,
   pkgs,
   ...
 }: let
@@ -274,6 +275,21 @@ in {
       {
         assertion = cfg.systemPrompt.source == "house" || cfg.systemPrompt.omitRules == [];
         message = "programs.codex.systemPrompt.omitRules only applies when source = \"house\".";
+      }
+      {
+        # omitRules reaches the shipped wrapper only through the defaulted
+        # finalPackage (basePackage.override packageOverrides); an explicit
+        # `package =` discards that override. Left unchecked this shipped a
+        # half-applied policy: the explicit package's permissions allowed
+        # force-merging while its baked prompt still forbade it (index#3537).
+        # The package stays defaulted only while no definition beats the
+        # module's own `lib.mkDefault finalPackage` (numerically lower
+        # highestPrio wins), so compare against that same mkDefault priority.
+        assertion =
+          cfg.systemPrompt.omitRules
+          == []
+          || options.programs.codex.package.highestPrio >= (lib.mkDefault null).priority;
+        message = "programs.codex.systemPrompt.omitRules is ignored when package is set explicitly; pass omitRules to that package's override instead (index#3537).";
       }
     ];
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -216,40 +216,56 @@
     overlays = [ix.overlay];
   };
   homeAgentIndexPackages = _: ix.packageSetFor homeAgentPkgs;
-  homeAgentConfig =
-    (home-manager.lib.homeManagerConfiguration {
-      pkgs = homeAgentPkgs;
-      modules = [
-        (import (paths.packagesRoot + "/agent/home-manager/claude-code.nix") {
-          indexPackages = homeAgentIndexPackages;
-          promptModule = paths.packagesRoot + "/agent/prompt";
-          mutableJsonModule = ix.mutableJson.homeModule;
-        })
-        (import (paths.packagesRoot + "/agent/home-manager/codex.nix") {
-          indexPackages = homeAgentIndexPackages;
-          promptModule = paths.packagesRoot + "/agent/prompt";
-        })
-        {
-          home = {
-            username = "agent";
-            homeDirectory = "/home/agent";
-            stateVersion = "25.05";
-          };
-          programs.claude-code = {
-            enable = true;
-            systemPrompt.omitRules = ["reportToPlaybook"];
-            houseContext.enable = true;
-            personalStartupContext = true;
-          };
-          programs.codex = {
-            enable = true;
-            configDir = ".config/codex-test";
-            defaults.agents.max_depth = 4;
-            systemPrompt.omitRules = ["reportToPlaybook"];
-          };
-        }
-      ];
-    }).config;
+  homeAgentHome = home-manager.lib.homeManagerConfiguration {
+    pkgs = homeAgentPkgs;
+    modules = [
+      (import (paths.packagesRoot + "/agent/home-manager/claude-code.nix") {
+        indexPackages = homeAgentIndexPackages;
+        promptModule = paths.packagesRoot + "/agent/prompt";
+        mutableJsonModule = ix.mutableJson.homeModule;
+      })
+      (import (paths.packagesRoot + "/agent/home-manager/codex.nix") {
+        indexPackages = homeAgentIndexPackages;
+        promptModule = paths.packagesRoot + "/agent/prompt";
+      })
+      {
+        home = {
+          username = "agent";
+          homeDirectory = "/home/agent";
+          stateVersion = "25.05";
+        };
+        programs.claude-code = {
+          enable = true;
+          systemPrompt.omitRules = ["reportToPlaybook"];
+          houseContext.enable = true;
+          personalStartupContext = true;
+        };
+        programs.codex = {
+          enable = true;
+          configDir = ".config/codex-test";
+          defaults.agents.max_depth = 4;
+          systemPrompt.omitRules = ["reportToPlaybook"];
+        };
+      }
+    ];
+  };
+  homeAgentConfig = homeAgentHome.config;
+  # index#3537: an explicit `package =` outprioritizes the modules'
+  # mkDefault-ed wrapper, so the systemPrompt.omitRules fold can no longer
+  # reach the shipped package; the modules must fail eval loudly instead of
+  # silently shipping prompts that still carry the omitted rules. Home
+  # Manager checks assertions eagerly on any config access, so tryEval
+  # failing here is the guard tripping: the same fixpoint with the package
+  # left defaulted (homeAgentConfig above) passes every assertion, making
+  # the explicit package the only delta.
+  homeAgentExplicitPackageFails = program:
+    !(builtins.tryEval (
+      builtins.seq
+      (homeAgentHome.extendModules {
+        modules = [{programs.${program}.package = homeAgentPkgs.hello;}];
+      }).config
+      true
+    )).success;
   macosGuestsConfig =
     (lib.evalModules {
       specialArgs.pkgs = homeAgentPkgs;
@@ -4471,6 +4487,25 @@
             builtins.readFile homeAgentConfig.programs.codex.finalPackage.passthru.modelInstructionsFile
           );
         message = "Codex Home Manager module should thread systemPrompt.omitRules into the package wrapper";
+      }
+      {
+        # Claude counterpart of the codex threading check above: the package
+        # is left defaulted here, so the module's omitRules fold must strip
+        # the omitted rule's text from the baked prompt (index#3537).
+        assertion =
+          !lib.strings.hasInfix "Publish substantial investigations"
+          homeAgentConfig.programs.claude-code.package.passthru.systemPrompt;
+        message = "Claude Code Home Manager module should thread systemPrompt.omitRules into the package wrapper";
+      }
+      {
+        # index#3537: with an explicitly-set package the omitRules fold is
+        # discarded, which once shipped permissions that allowed force-merge
+        # under a prompt that forbade it; both modules must trip their guard
+        # assertion instead of half-applying the policy.
+        assertion =
+          homeAgentExplicitPackageFails "claude-code"
+          && homeAgentExplicitPackageFails "codex";
+        message = "agent Home Manager modules should fail eval when systemPrompt.omitRules rides an explicitly-set package";
       }
       {
         # When explicitly enabled, the native `context` option carries the

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -137,6 +137,11 @@
 
   # Andrew deliberately permits direct merge-protection bypasses. The shared
   # prompt owns the rule text, so suppress its named rule in system prompts.
+  # Threaded into the claudeCode/codex override args below, NOT into
+  # programs.<agent>.systemPrompt.omitRules: the modules fold that option only
+  # into their defaulted package, and this profile sets `package =` explicitly,
+  # which discarded the fold and shipped prompts WITH the forceMerge rule
+  # (index#3537).
   agentPromptOmitRules = ["forceMerge"];
 
   # claude-code from the index FLAKE PACKAGE SET (packages/claude-code in the
@@ -171,12 +176,23 @@
     # Personal opt-outs from the fleet posture: run the model's native 1M
     # window (no DISABLE_1M clamp, no AUTO_COMPACT_WINDOW override) and keep
     # the harness subagent/task tool schemas loaded. Pairs with the
-    # `backgroundSubagents` omit on programs.claude-code below, whose rule
-    # text declares these tools absent.
+    # `backgroundSubagents` omit in `omitRules` below, whose rule text
+    # declares these tools absent.
     features = {
       context1M = true;
       autoCompactWindow = null;
     };
+    # Prompt rule opt-outs live HERE, not on
+    # programs.claude-code.systemPrompt.omitRules: the module folds that
+    # option only into basePackage.override, and the explicit `package =
+    # claudeCode` below discards the defaulted package, so the option
+    # silently shipped prompts WITH the forceMerge rule while
+    # protectedMergeGuard below already allowed force-merging (index#3537).
+    # backgroundSubagents claims the subagent/task tools are absent; the
+    # features/systemTools opt-ins here re-enable them on this machine, so
+    # the rule is omitted for Claude only (Codex still has no harness
+    # subagent tool).
+    omitRules = agentPromptOmitRules ++ ["backgroundSubagents"];
     # Matches agentPromptOmitRules `forceMerge` above: without this the baked
     # `Bash(gh pr merge*--admin*)` denies still hard-block what the omitted
     # rule permits.
@@ -284,6 +300,11 @@
       mcpServers = {};
       settings = {};
       forcedSettings = {};
+      # On the override, not programs.codex.systemPrompt.omitRules, for the
+      # same reason as claudeCode above: the module folds that option only
+      # into its defaulted package, and the explicit `package = codex` below
+      # discarded it, shipping prompts WITH the forceMerge rule (index#3537).
+      omitRules = agentPromptOmitRules;
     })
     // {
       # Upstream main keeps Cargo's workspace version at 0.0.0. Home Manager
@@ -1054,10 +1075,6 @@ in {
   programs.claude-code = {
     enable = true;
     package = claudeCode;
-    # backgroundSubagents claims the subagent/task tools are absent; the
-    # claudeCode override above re-enables them on this machine, so the rule
-    # is omitted for Claude only (Codex still has no harness subagent tool).
-    systemPrompt.omitRules = agentPromptOmitRules ++ ["backgroundSubagents"];
     # All agents, BARE, sourced straight from the index repo (index's agents
     # package now holds my former personal agents too). Bare (not plugin) so
     # `subagent_type code-reviewer` keeps resolving.
@@ -1086,7 +1103,6 @@ in {
     # Codex otherwise writes a second global context file. The generated system
     # prompt is the single source of agent instructions.
     houseContext.enable = false;
-    systemPrompt.omitRules = agentPromptOmitRules;
     # hooks.json stays owned by the manual home.file declaration below (from
     # `codexBase.passthru.hooksJson`, matching the package on PATH). Without
     # this the imported codex module also claims ~/.codex/hooks.json with


### PR DESCRIPTION
Fixes #3537.

`programs.claude-code` / `programs.codex` fold `systemPrompt.omitRules` into `basePackage.override packageOverrides` only for their `mkDefault`-ed package. When a profile sets `package =` explicitly, that defaulted package is discarded and the option was silently ignored: the workstation generation built from 2c4d7d14 still shipped a `--system-prompt-file` containing the forceMerge and backgroundSubagents rule texts while `protectedMergeGuard = false` (set in the override args) already allowed force-merging -- a half-applied policy split across two surfaces.

Changes:
- **Both HM modules**: assert that `systemPrompt.omitRules != []` with an explicitly-set `package` fails eval loudly, using `options.programs.<name>.package.highestPrio` against the module's own `mkDefault` priority (no package instantiation just to compare).
- **workstation.nix**: thread `omitRules` into the `claudeCode` / `codex` override args (where the shipped packages are actually built) and drop the now-dead `systemPrompt.omitRules` module lines; prose comments updated to match the new wiring.
- **tests/default.nix**: claude-code counterpart of the existing codex omit-threading check, plus a guard-trip check (per-module `extendModules` fixpoint with an explicit package; home-manager checks assertions eagerly on config access, so `tryEval` failing is the guard tripping).

Validation:
- Workstation build (private HM config with `--override-input index` to this branch): `share/claude-code-launch-spec.json` -> `--system-prompt-file` no longer contains "Never bypass required checks" nor "harness subagent and task tools are absent"; codex `modelInstructionsFile` drops the forceMerge text while keeping backgroundSubagents (Codex genuinely has no harness subagent tools).
- Default `.#claude-code` build still contains both rule texts.
- Full private `homeConfigurations."andrewgazelka@hydra".activationPackage` evals with the branch.
- `checks.x86_64-linux.eval` (ix-eval-tests) evals green locally; `nix run .#lint` green; `nix fmt` clean on changed files.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail eval when `systemPrompt.omitRules` is set alongside an explicit package
> - Adds an assertion in the `claude-code` and `codex` Home Manager modules that triggers when `systemPrompt.omitRules` is non-empty but `package` has been set explicitly (i.e. at higher priority than `mkDefault`), emitting a clear error directing users to pass `omitRules` via the package override instead.
> - Updates [workstation.nix](https://github.com/indexable-inc/index/pull/3545/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962) to move `omitRules` from the module option into the respective `claudeCode.override` and `codex.override` calls to comply with the new guard.
> - Adds tests in [tests/default.nix](https://github.com/indexable-inc/index/pull/3545/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) that verify `omitRules` is threaded into the baked prompt when the default package is used, and that evaluation fails when an explicit package is combined with `omitRules`.
> - Behavioral Change: configurations that previously silently ignored `omitRules` when an explicit package was set will now fail evaluation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31e2fc7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->