### PR TITLE
mcp-ex: sample the running cell's own line into the action log

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/action_log.ex
+++ b/packages/mcp-ex/lib/ix_mcp/action_log.ex
@@ -13,8 +13,10 @@ defmodule IxMcp.ActionLog do
   `cancelled` when its work completes (`finish_action/5`) -- for `exec` that
   is when the eval finishes, which for a backgrounded job is after the wire
   response shipped. While an exec runs, its job samples the eval process's
-  `current_stacktrace` into `stack`/`stack_at` (`update_stack/3`), so a
-  reader can show the line a hung cell sits on. There is deliberately no
+  `current_stacktrace` into `stack`/`stack_at` -- plus, when the stack has a
+  frame the cell itself owns, the 1-based cell source line into `line`
+  (`update_stack/4`, #3546) -- so a reader can show the line a hung cell
+  sits on and highlight it in the rendered cell source. There is deliberately no
   startup sweep of leftover `running` rows: several server instances share
   one database, so a sweep would clobber a live sibling's rows. A row whose
   kernel died stays `running` with a frozen `stack_at`; readers judge
@@ -53,7 +55,7 @@ defmodule IxMcp.ActionLog do
   """
 
   @create_actions """
-  CREATE TABLE actions (id INTEGER PRIMARY KEY, at TEXT NOT NULL, session_id INTEGER NOT NULL REFERENCES sessions(id), topic_id INTEGER REFERENCES topics(id), tool TEXT NOT NULL, intent TEXT, arguments TEXT NOT NULL, is_error INTEGER NOT NULL, elapsed_ms INTEGER NOT NULL, status TEXT NOT NULL DEFAULT 'done', stack TEXT, stack_at TEXT)
+  CREATE TABLE actions (id INTEGER PRIMARY KEY, at TEXT NOT NULL, session_id INTEGER NOT NULL REFERENCES sessions(id), topic_id INTEGER REFERENCES topics(id), tool TEXT NOT NULL, intent TEXT, arguments TEXT NOT NULL, is_error INTEGER NOT NULL, elapsed_ms INTEGER NOT NULL, status TEXT NOT NULL DEFAULT 'done', stack TEXT, stack_at TEXT, line INTEGER)
   """
 
   # index#3539: the schema version is stamped into SQLite's `PRAGMA
@@ -65,8 +67,9 @@ defmodule IxMcp.ActionLog do
   # and the mismatch surfaces as a match-crash deep in a prepare. A stamped
   # version makes older shapes migratable in order, the current shape a
   # no-op, and a future shape explicitly detectable. The ladder: 1 = the
-  # flat #3512 log, 2 = the #3532 normalization, 3 = the #3536 live rows.
-  @user_version 3
+  # flat #3512 log, 2 = the #3532 normalization, 3 = the #3536 live rows,
+  # 4 = the #3546 live cell line.
+  @user_version 4
 
   # Frozen historical DDL for the 1 -> 2 step: the actions shape exactly as
   # #3532 shipped it, before the live-row columns. A migration must never
@@ -116,11 +119,17 @@ defmodule IxMcp.ActionLog do
     "ALTER TABLE actions ADD COLUMN stack_at TEXT"
   ]
 
+  # A v3 database predates the sampled cell line (#3546); NULL is exactly
+  # right for its rows, whose samples never carried one.
+  @migrate_v3_to_v4 [
+    "ALTER TABLE actions ADD COLUMN line INTEGER"
+  ]
+
   # Ordered migrations keyed by the user_version each upgrades FROM. Every
   # step runs in one immediate transaction that also stamps the version it
   # produces, so an interrupted migration leaves the previous consistent,
   # correctly-stamped version on disk.
-  @migrations [{1, @migrate_v1_to_v2}, {2, @migrate_v2_to_v3}]
+  @migrations [{1, @migrate_v1_to_v2}, {2, @migrate_v2_to_v3}, {3, @migrate_v3_to_v4}]
 
   @insert """
   INSERT INTO actions (at, session_id, topic_id, tool, intent, arguments, is_error, elapsed_ms, status)
@@ -130,16 +139,16 @@ defmodule IxMcp.ActionLog do
   # Both updates guard on status = 'running': a finalize is idempotent and a
   # stack sample racing the finish can never resurrect a finished row.
   @finish """
-  UPDATE actions SET status = ?, is_error = ?, elapsed_ms = ?, stack = NULL, stack_at = NULL
+  UPDATE actions SET status = ?, is_error = ?, elapsed_ms = ?, stack = NULL, stack_at = NULL, line = NULL
   WHERE id = ? AND status = 'running'
   """
 
   @update_stack """
-  UPDATE actions SET stack = ?, stack_at = ? WHERE id = ? AND status = 'running'
+  UPDATE actions SET stack = ?, stack_at = ?, line = ? WHERE id = ? AND status = 'running'
   """
 
   @select_recent """
-  SELECT a.at, s.name, t.name, a.tool, a.intent, a.arguments, a.is_error, a.elapsed_ms, a.status, a.stack
+  SELECT a.at, s.name, t.name, a.tool, a.intent, a.arguments, a.is_error, a.elapsed_ms, a.status, a.stack, a.line
   FROM actions a
   JOIN sessions s ON s.id = a.session_id
   LEFT JOIN topics t ON t.id = a.topic_id
@@ -156,7 +165,8 @@ defmodule IxMcp.ActionLog do
           is_error: boolean(),
           elapsed_ms: non_neg_integer(),
           status: String.t(),
-          stack: String.t() | nil
+          stack: String.t() | nil,
+          line: pos_integer() | nil
         }
 
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -196,10 +206,14 @@ defmodule IxMcp.ActionLog do
     GenServer.call(server, {:finish_action, id, status, is_error, elapsed_ms})
   end
 
-  @doc "Refresh a running action row's sampled stack (JSON frames); a no-op once finished."
-  @spec update_stack(integer(), String.t(), GenServer.server()) :: :ok
-  def update_stack(id, stack_json, server \\ __MODULE__) do
-    GenServer.call(server, {:update_stack, id, stack_json, now()})
+  @doc """
+  Refresh a running action row's sampled stack (JSON frames) and the cell
+  source line the eval currently sits on (nil when the sample has no frame
+  the cell owns, #3546); a no-op once finished.
+  """
+  @spec update_stack(integer(), String.t(), pos_integer() | nil, GenServer.server()) :: :ok
+  def update_stack(id, stack_json, line, server \\ __MODULE__) do
+    GenServer.call(server, {:update_stack, id, stack_json, line, now()})
   end
 
   @doc "Latest `n` recorded actions, newest first, with session/topic names joined in."
@@ -326,8 +340,8 @@ defmodule IxMcp.ActionLog do
     {:reply, :ok, state}
   end
 
-  def handle_call({:update_stack, id, stack_json, at}, _from, %{conn: conn} = state) do
-    run(conn, @update_stack, [stack_json, at, id])
+  def handle_call({:update_stack, id, stack_json, line, at}, _from, %{conn: conn} = state) do
+    run(conn, @update_stack, [stack_json, at, line, id])
     {:reply, :ok, state}
   end
 
@@ -394,6 +408,7 @@ defmodule IxMcp.ActionLog do
         cond do
           "session_id" not in columns -> 1
           "status" not in columns -> 2
+          "line" not in columns -> 3
           true -> @user_version
         end
     end
@@ -469,7 +484,8 @@ defmodule IxMcp.ActionLog do
          is_error,
          elapsed_ms,
          status,
-         stack
+         stack,
+         line
        ]) do
     %{
       at: at,
@@ -481,7 +497,8 @@ defmodule IxMcp.ActionLog do
       is_error: is_error == 1,
       elapsed_ms: elapsed_ms,
       status: status,
-      stack: stack
+      stack: stack,
+      line: line
     }
   end
 end

--- a/packages/mcp-ex/lib/ix_mcp/evaluator.ex
+++ b/packages/mcp-ex/lib/ix_mcp/evaluator.ex
@@ -77,9 +77,14 @@ defmodule IxMcp.Evaluator do
   defp format_position(line) when is_integer(line), do: "#{line}"
   defp format_position(_), do: "?"
 
-  # Everything below the compiler's eval frames is evaluator machinery the
-  # cell author did not write; cut it the way Livebook does.
-  defp prune_stacktrace(stacktrace) do
+  @doc """
+  Cut evaluator machinery out of a stacktrace the way Livebook does:
+  everything below the compiler's eval frames is plumbing the cell author
+  did not write. Used for error stacktraces and for the live stack samples
+  the running job stores in the action log (#3546).
+  """
+  @spec prune_stacktrace(Exception.stacktrace()) :: Exception.stacktrace()
+  def prune_stacktrace(stacktrace) do
     stacktrace
     |> Enum.take_while(fn {mod, fun, _arity, _meta} -> {mod, fun} != {:elixir, :eval_forms} end)
     |> Enum.reject(fn {mod, _fun, _arity, _meta} ->

--- a/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
@@ -271,8 +271,19 @@ defmodule IxMcp.Jobs.Job do
   def handle_info(:sample_stack, %{status: :running} = state) do
     case Process.info(state.eval_pid, :current_stacktrace) do
       {:current_stacktrace, frames} ->
-        stack = JSON.encode!(Enum.map(frames, &Exception.format_stacktrace_entry/1))
-        ActionLog.update_stack(state.action_id, stack)
+        # The machinery below the eval boundary (:erl_eval, :elixir, Code) is
+        # plumbing the cell author did not write; cut it like the error path
+        # does so the innermost stored frame is one the author can act on. A
+        # stack with no author frames at all (a cell still compiling, say)
+        # keeps the raw frames rather than storing an empty stack.
+        shown =
+          case Evaluator.prune_stacktrace(frames) do
+            [] -> frames
+            pruned -> pruned
+          end
+
+        stack = JSON.encode!(Enum.map(shown, &Exception.format_stacktrace_entry/1))
+        ActionLog.update_stack(state.action_id, stack, cell_line(frames))
 
       # The eval exited between the tick and the probe; the finish path owns
       # the row now.
@@ -289,6 +300,20 @@ defmodule IxMcp.Jobs.Job do
   def handle_info(_msg, state), do: {:noreply, state}
 
   # -- internals ---------------------------------------------------------------
+
+  # The 1-based line of cell source the eval currently sits on, from the
+  # deepest frame the cell itself owns: Workspace evals with
+  # `Code.env_for_eval(file: "cell")`, so frames from code compiled in the
+  # cell (a module the cell defined) carry `file: ~c"cell"`. Top-level cell
+  # statements and anonymous fns run interpreted through :erl_eval and leave
+  # no such frame -- then there is no cell line and the viewer falls back to
+  # the formatted top frame (#3546).
+  defp cell_line(frames) do
+    Enum.find_value(frames, fn {_mod, _fun, _arity, meta} ->
+      line = meta[:line]
+      if meta[:file] == ~c"cell" and is_integer(line) and line > 0, do: line
+    end)
+  end
 
   defp finish(state, status, result, diags) do
     state = %{

--- a/packages/mcp-ex/test/action_log_test.exs
+++ b/packages/mcp-ex/test/action_log_test.exs
@@ -130,16 +130,24 @@ defmodule IxMcp.ActionLogTest do
     %{"job" => job_id} = text |> String.split("\n") |> hd() |> JSON.decode!()
 
     # The sampler ticks every 25ms under test config; give it a few ticks.
-    stack =
+    entry =
       poll_until(fn ->
         case ActionLog.recent(1) do
-          [%{status: "running", stack: stack} | _] when is_binary(stack) -> stack
+          [%{status: "running", stack: stack} = entry | _] when is_binary(stack) -> entry
           _ -> nil
         end
       end)
 
-    frames = JSON.decode!(stack)
+    frames = JSON.decode!(entry.stack)
     assert Enum.any?(frames, &(&1 =~ "sleep")), "expected a sleep frame in #{inspect(frames)}"
+
+    # Machinery below the eval boundary is pruned from the sample, so the
+    # innermost stored frame is one the cell author can act on (#3546).
+    refute Enum.any?(frames, &(&1 =~ "erl_eval")), "expected pruned frames in #{inspect(frames)}"
+
+    # A top-level statement runs interpreted: no frame is the cell's own, so
+    # there is no cell line and a viewer falls back to the top frame.
+    assert entry.line == nil
 
     :ok = IxMcp.Jobs.cancel(job_id)
 
@@ -147,6 +155,53 @@ defmodule IxMcp.ActionLogTest do
     assert entry.status == "cancelled"
     refute entry.is_error
     assert entry.stack == nil, "finalizing clears the sampled stack"
+    assert entry.line == nil, "finalizing clears the sampled cell line"
+  end
+
+  test "a cell-owned frame's line is sampled into the row as the live cell line" do
+    # Code compiled in the cell (the module it defines) carries
+    # `file: "cell"` in its frames; line 3 is the Process.sleep call site.
+    code = """
+    defmodule IxMcp.ActionLogTest.CellLineProbe do
+      def loop do
+        Process.sleep(50)
+        loop()
+      end
+    end
+
+    IxMcp.ActionLogTest.CellLineProbe.loop()
+    """
+
+    response =
+      Server.handle(%{
+        "jsonrpc" => "2.0",
+        "id" => 7,
+        "method" => "tools/call",
+        "params" => %{
+          "name" => "exec",
+          "arguments" => %{"code" => code, "intent" => "loop for line sampling", "budget" => 0.05}
+        }
+      })
+
+    [%{"text" => text}] = response["result"]["content"]
+    %{"job" => job_id} = text |> String.split("\n") |> hd() |> JSON.decode!()
+
+    entry =
+      poll_until(fn ->
+        case ActionLog.recent(1) do
+          [%{status: "running", line: line} = entry | _] when is_integer(line) -> entry
+          _ -> nil
+        end
+      end)
+
+    assert entry.line == 3
+
+    # The stored frames name the cell line too, right under the sleep frame.
+    frames = JSON.decode!(entry.stack)
+    assert Enum.any?(frames, &(&1 =~ "cell:3")), "expected a cell:3 frame in #{inspect(frames)}"
+
+    :ok = IxMcp.Jobs.cancel(job_id)
+    assert [%{status: "cancelled", line: nil} | _] = ActionLog.recent(1)
   end
 
   defp poll_until(fun, deadline_ms \\ 2_000) do
@@ -259,13 +314,13 @@ defmodule IxMcp.ActionLogTest do
         log
       )
 
-    :ok = ActionLog.update_stack(action_id, ~s(["frame"]), log)
-    assert [%{status: "running", stack: ~s(["frame"])} | _] = ActionLog.recent(10, log)
+    :ok = ActionLog.update_stack(action_id, ~s(["frame"]), 2, log)
+    assert [%{status: "running", stack: ~s(["frame"]), line: 2} | _] = ActionLog.recent(10, log)
     :ok = ActionLog.finish_action(action_id, "done", false, 3, log)
-    assert [%{status: "done", stack: nil} | _] = ActionLog.recent(10, log)
+    assert [%{status: "done", stack: nil, line: nil} | _] = ActionLog.recent(10, log)
 
-    # The 2 -> 3 step stamped the file on its way through (index#3539).
-    assert user_version(path) == 3
+    # The 2 -> 3 -> 4 steps stamped the file on their way through (index#3539).
+    assert user_version(path) == 4
   end
 
   test "a v1 database migrates losslessly to the normalized schema, once" do
@@ -349,8 +404,8 @@ defmodule IxMcp.ActionLogTest do
 
     stop_supervised!(:migrate)
 
-    # The ladder ran 1 -> 2 -> 3 and left the stamp behind (index#3539).
-    assert user_version(path) == 3
+    # The ladder ran 1 -> 2 -> 3 -> 4 and left the stamp behind (index#3539).
+    assert user_version(path) == 4
 
     # The migrated file is the v2 shape on disk: normalized columns, no v1
     # leftovers, and a reopen (no-op detection) does not duplicate rows.
@@ -372,7 +427,8 @@ defmodule IxMcp.ActionLogTest do
              "elapsed_ms",
              "status",
              "stack",
-             "stack_at"
+             "stack_at",
+             "line"
            ]
 
     {:ok, statement} =
@@ -394,7 +450,7 @@ defmodule IxMcp.ActionLogTest do
   test "a fresh database is created stamped with the current schema version" do
     path = tmp_db()
     start_supervised!({ActionLog, path: path, name: :action_log_fresh_stamp})
-    assert user_version(path) == 3
+    assert user_version(path) == 4
   end
 
   test "an unstamped file already at the current schema is stamped, not rewritten" do
@@ -419,7 +475,32 @@ defmodule IxMcp.ActionLogTest do
 
     reopened = start_supervised!({ActionLog, path: path, name: :action_log_stamp_b})
     assert [%{intent: "keep"}] = ActionLog.recent(10, reopened)
-    assert user_version(path) == 3
+    assert user_version(path) == 4
+  end
+
+  test "an unstamped pre-line file (the #3536 shape) sniffs as v3 and gains the line column" do
+    path = tmp_db()
+
+    # The v3 shape exactly as pre-stamping #3536-era binaries wrote it:
+    # status/stack columns present, line absent, user_version still 0.
+    {:ok, conn} = Sqlite3.open(path)
+
+    for statement <- [
+          "CREATE TABLE sessions (id INTEGER PRIMARY KEY, name TEXT, started_at TEXT NOT NULL)",
+          "CREATE TABLE topics (id INTEGER PRIMARY KEY, session_id INTEGER NOT NULL REFERENCES sessions(id), name TEXT NOT NULL, started_at TEXT NOT NULL)",
+          "CREATE TABLE actions (id INTEGER PRIMARY KEY, at TEXT NOT NULL, session_id INTEGER NOT NULL REFERENCES sessions(id), topic_id INTEGER REFERENCES topics(id), tool TEXT NOT NULL, intent TEXT, arguments TEXT NOT NULL, is_error INTEGER NOT NULL, elapsed_ms INTEGER NOT NULL, status TEXT NOT NULL DEFAULT 'done', stack TEXT, stack_at TEXT)",
+          "INSERT INTO sessions (id, name, started_at) VALUES (1, 'old', '2026-07-17T10:00:00Z')",
+          "INSERT INTO actions (at, session_id, topic_id, tool, intent, arguments, is_error, elapsed_ms) VALUES ('2026-07-17T10:00:01Z', 1, NULL, 'exec', 'pre-line row', '{}', 0, 5)"
+        ] do
+      :ok = Sqlite3.execute(conn, statement)
+    end
+
+    :ok = Sqlite3.close(conn)
+
+    log = start_supervised!({ActionLog, path: path, name: :action_log_pre_line})
+
+    assert [%{intent: "pre-line row", status: "done", line: nil}] = ActionLog.recent(10, log)
+    assert user_version(path) == 4
   end
 
   test "a database stamped by a newer server disables logging instead of crashing" do
@@ -436,7 +517,7 @@ defmodule IxMcp.ActionLogTest do
 
     # The refusal names both versions, so the operator knows which side moves.
     assert output =~ "user_version 9000"
-    assert output =~ "supported 3"
+    assert output =~ "supported 4"
     assert output =~ "index#3539"
 
     # The server stays useful: writes are absorbed, reads answer empty.
@@ -449,7 +530,7 @@ defmodule IxMcp.ActionLogTest do
         log
       )
 
-    :ok = ActionLog.update_stack(action_id, "[]", log)
+    :ok = ActionLog.update_stack(action_id, "[]", nil, log)
     :ok = ActionLog.finish_action(action_id, "done", false, 1, log)
     assert ActionLog.recent(10, log) == []
     assert ActionLog.sessions(log) == []


### PR DESCRIPTION
Fixes #3546.

While an exec runs, its job samples the eval process's stacktrace into the action log (#3540). The innermost formatted frame was nearly always stdlib machinery -- `(elixir 1.18.4) lib/process.ex:327: Process.sleep/1` for any sleeping cell -- and nothing recorded which cell line the run actually sat on.

Producer-side fix, all in mcp-ex:

- **Sample the cell's own line.** Workspace evals with `Code.env_for_eval(file: "cell")`, so frames from code the cell compiled (a module it defines) carry `file: ~c"cell", line: N` with N a 1-based line into the submitted source. Each sample now walks the raw frames for the deepest cell-owned frame and stores its line in a new `line` column (`update_stack/4`). Verified empirically: top-level statements and anonymous fns run interpreted through `:erl_eval` and leave no cell frame -- then `line` is NULL and a viewer falls back to the top frame.
- **Prune machinery from the stored stack.** The live sample now reuses `Evaluator.prune_stacktrace/1` (the Livebook-style cut already applied to error stacktraces), so the stored top frame is one the author can act on; an all-machinery stack keeps the raw frames rather than storing nothing.
- **Schema v4.** `PRAGMA user_version` 4 with a `3 -> 4` migration (`ALTER TABLE actions ADD COLUMN line INTEGER`), unstamped-file sniffing extended for the pre-line shape, `finish_action` clears `line` with the stack, `recent/2` entries expose it.

Note on the viewer half of #3546: nothing in this repo currently reads the `stack` column back (verified: `ActionLog.recent/2` is the only reader and is test-only), so there is no in-repo render to change. The `line` column is the contract a viewer needs, and the dashboard's `CodeBlock`/`Pane.line` already support live-line highlighting (the python MCP live-lines path) once an actions.db consumer exists.

Tested: `mix test` (63 tests -- new live cell-line test, pruning + fallback assertions on the sampling test, migration ladder/sniff/refusal tests updated for v4, new unstamped-v3-shape migration test), `mix format --check-formatted`, `mix credo --strict` against the shared config, `nix run .#lint`.

Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sample the running cell's source line into the action log during stack sampling
> - Adds a `line` column to the `actions` table in [action_log.ex](https://github.com/indexable-inc/index/pull/3547/files#diff-3e72adde29b4a1c32aaa66b83a963485a2f67735bd45ed8c1652532de4c4adab), populated during stack sampling with the deepest cell-owned frame's 1-based line number, cleared on finalize/cancel, and returned by `recent/2`.
> - Adds `ActionLog.update_stack/4` (previously arity 3), requiring callers to pass a line value (or `nil`).
> - Prunes plumbing frames from sampled stacktraces in [job.ex](https://github.com/indexable-inc/index/pull/3547/files#diff-cd26f23adf8d8e75fd1b4f9fd5f7cc906cd5aba85c413011e10200c5c85351c4) before storage, falling back to unpruned frames if pruning yields an empty list.
> - Makes `Evaluator.prune_stacktrace/1` public so it can be called from `Job`.
> - Bumps schema version to 4 with a v3→v4 migration that `ALTER TABLE`s the `actions` table to add `line`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4ba066.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->