### PR TITLE
ci-budget: widen queue admission to 7200s while ix fleet concurrency deploys

### DIFF
--- a/.github/actions/ci-budget/catalog/policy.json
+++ b/.github/actions/ci-budget/catalog/policy.json
@@ -1,7 +1,7 @@
 {
   "big_change_label": "ci/big-change",
   "extended_validation_seconds": 10800,
-  "queue_start_seconds": 1800,
+  "queue_start_seconds": 7200,
   "repositories": {
     "indexable-inc/index": {
       "costly_paths": [


### PR DESCRIPTION
Backlog placement latency on the ix fleet is currently 58-66 minutes (runs 29621145336, 29621330160, 29621399129 all failed Enforce worker queue admission at 2026-07-18 00:41-00:42Z after ~1h queued), so the 1800s window from #3541 now converts every backlog job into a placement-slot-burning instant failure. 7200s bridges until typed resource classes (ix#7682, merged; deploy in flight) raise fleet concurrency ~5x and queue waits collapse; then this reverts to a tight window per ix#7658.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Widen CI budget queue admission window from 1800s to 7200s
> Increases `queue_start_seconds` in [policy.json](https://github.com/indexable-inc/index/pull/3549/files#diff-8f21aab076c62de6c8ce200f623b760868bc5ffef5b79976e37c13de48af697c) from 1800 to 7200 as a temporary measure while the ix fleet concurrency rollout completes. Behavioral Change: CI jobs will now wait up to 7200s before queue admission triggers budget enforcement instead of 1800s.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a49bd9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->