### PR TITLE
mcp-ex: teach two-signal PR watching (PrWatch state + gh pr checks --watch --fail-fast)

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -33,9 +33,13 @@ defmodule IxMcp.MCP.Tools do
       Ix.restart()                          cancel running jobs (sparing the calling
                                             cell), restart the workspace, restore
                                             bindings from the checkpoint
-      PrWatch.start(pr, cwd)                watch a PR via gh; notification on
+      PrWatch.start(pr, cwd)                watch PR state via gh; notification on
                                             merge/close/error/timeout (optional
-                                            interval and timeout args)
+                                            interval and timeout args). Babysitting
+                                            CI? Pair it with `gh pr checks <pr>
+                                            --watch --fail-fast`: checks alone hang
+                                            forever on a CONFLICTING PR (dirty PRs
+                                            skip CI) and never show a merge (#3548)
       Tui.act(uri, send_keys)               drive a federated TUI resource (optional
                                             peer arg)
       Api.api("tail") / Api.help(Jobs, :tail)   discovery over this whole surface

--- a/packages/mcp-ex/lib/ix_mcp/pr_watch.ex
+++ b/packages/mcp-ex/lib/ix_mcp/pr_watch.ex
@@ -6,6 +6,12 @@ defmodule IxMcp.PrWatch do
   a hung `gh` invocation stalls that watch alone, and the notification carries
   the final state -- no hand-written polling loops in agent sessions.
 
+  This watches PR state, not CI. When a green gate matters, pair it with
+  `gh pr checks <pr> --watch --fail-fast`; state is the half agents forget
+  (#3548): a CONFLICTING PR skips pull_request CI entirely, and another actor
+  can rebase and merge underneath, so a checks-only poll waits forever on
+  signals that will never arrive.
+
   Divergence from the Python tool, on purpose: no auto-merge arming. Watching
   is read-only here; merging stays an explicit act by the caller.
   """


### PR DESCRIPTION
Fixes #3548.

Encodes the lesson from #3543's babysitting: a checks-only watcher waited ~35 minutes on signals that could never arrive -- the PR went CONFLICTING (dirty PRs skip pull_request CI) and was rebased and merged underneath by the orchestrator.

- `@surface_guide` (shipped as both the `exec` tool description and the server instructions) now says: `PrWatch.start` watches PR *state*; when babysitting CI, pair it with `gh pr checks <pr> --watch --fail-fast`, because checks alone hang forever on a CONFLICTING PR and never show a merge.
- `IxMcp.PrWatch` moduledoc explains the same why.

Docs-only strings; validated with the full local lane (compile --warnings-as-errors, format, credo --strict, 61 tests) and green builds of `.#mcp-ex.passthru.tests.elixir` and `.#mcp-ex.passthru.tests.smoke`.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document two-signal PR watching by pairing `PrWatch` with `gh pr checks --watch --fail-fast`
> Updates docs in [`pr_watch.ex`](https://github.com/indexable-inc/index/pull/3550/files#diff-ad798641f06abf92e9dd72e23bb9510393ae565337fb6b70db725bd7815f60eb) and the tools help text in [`tools.ex`](https://github.com/indexable-inc/index/pull/3550/files#diff-c1967b7edcd9f2a8628cd2ebf989cfe1e0daf0af2416367f04b4e816c897e776) to clarify that `PrWatch` watches PR state (merge/close), not CI checks. Both now recommend pairing with `gh pr checks <pr> --watch --fail-fast` when babysitting CI, explaining that CONFLICTING PRs skip CI entirely and that checks-only polling will hang indefinitely if a merge happens via another actor.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3df85e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->