### PR TITLE
mcp-ex: bake gh's store path into PrWatch and report watcher crashes

### DIFF
--- a/packages/mcp-ex/default.nix
+++ b/packages/mcp-ex/default.nix
@@ -115,10 +115,15 @@
       # RELEASE_DISTRIBUTION=none: a stdio MCP server needs no Erlang
       # distribution, and the default sname mode wants an epmd listen socket
       # (denied in sandboxes, pointless everywhere else).
+      # PrWatch execs the GitHub CLI; baking gh's store path into IX_MCP_GH
+      # keeps the watcher independent of whatever PATH the MCP client
+      # launched the server with (#3553). set-default, not set: mix test and
+      # operators may point the watcher at a different gh.
       makeWrapper "$out/lib/ix-mcp-ex/bin/ix_mcp" "$out/bin/ix-mcp-ex" \
         --set IX_MCP_STDIO 1 \
         --set RELEASE_DISTRIBUTION none \
         --set-default RELEASE_TMP /tmp \
+        --set-default IX_MCP_GH ${lib.getExe pkgs.gh} \
         --add-flags start
       runHook postInstall
     '';

--- a/packages/mcp-ex/lib/ix_mcp/pr_watch.ex
+++ b/packages/mcp-ex/lib/ix_mcp/pr_watch.ex
@@ -6,6 +6,11 @@ defmodule IxMcp.PrWatch do
   a hung `gh` invocation stalls that watch alone, and the notification carries
   the final state -- no hand-written polling loops in agent sessions.
 
+  The notification is a promise, kept unconditionally: the release bakes gh's
+  store path into `IX_MCP_GH` so a watch never depends on the PATH the MCP
+  client launched the server with, and a watcher that crashes anyway reports
+  the crash over the channel instead of vanishing (#3553).
+
   This watches PR state, not CI. When a green gate matters, pair it with
   `gh pr checks <pr> --watch --fail-fast`; state is the half agents forget
   (#3548): a CONFLICTING PR skips pull_request CI entirely, and another actor
@@ -22,8 +27,8 @@ defmodule IxMcp.PrWatch do
           {:ok, String.t()} | {:error, String.t()}
   def start(pr, cwd, interval_s \\ 15, timeout_s \\ 3600) do
     cond do
-      System.find_executable("gh") == nil ->
-        {:error, "gh not found on PATH; PrWatch.start needs the GitHub CLI"}
+      gh() == nil ->
+        {:error, "gh not found (no IX_MCP_GH, none on PATH); PrWatch needs the GitHub CLI"}
 
       not File.dir?(cwd) ->
         {:error, "cwd does not exist: #{cwd}"}
@@ -32,11 +37,31 @@ defmodule IxMcp.PrWatch do
         {:ok, pid} =
           Task.Supervisor.start_child(IxMcp.PrWatch.Supervisor, fn ->
             deadline = System.monotonic_time(:millisecond) + round(timeout_s * 1000)
-            watch(pr, cwd, round(interval_s * 1000), deadline)
+            watch_loudly(pr, cwd, round(interval_s * 1000), deadline)
           end)
 
         {:ok, "watching PR #{pr} (#{inspect(pid)}); a channel notification reports the outcome"}
     end
+  end
+
+  # The release wrapper bakes the GitHub CLI's store path into IX_MCP_GH, so
+  # a watch never depends on whatever PATH the MCP client launched the server
+  # with (#3553: gh lived outside the release and the watcher died at the
+  # first poll). The PATH lookup remains only for mix test / IEx runs outside
+  # the release.
+  defp gh do
+    System.get_env("IX_MCP_GH") || System.find_executable("gh")
+  end
+
+  # start/4 promised the caller a notification, so a crashing watcher must
+  # not vanish into the supervisor's logs (#3553): deliver the crash over the
+  # channel first, then re-raise so the crash report still reaches the logger.
+  defp watch_loudly(pr, cwd, interval_ms, deadline) do
+    watch(pr, cwd, interval_ms, deadline)
+  catch
+    kind, reason ->
+      notify(pr, "error", String.slice(Exception.format(kind, reason, __STACKTRACE__), 0, 800))
+      :erlang.raise(kind, reason, __STACKTRACE__)
   end
 
   defp watch(pr, cwd, interval_ms, deadline) do
@@ -58,7 +83,7 @@ defmodule IxMcp.PrWatch do
   end
 
   defp poll(pr, cwd) do
-    case System.cmd("gh", ["pr", "view", pr, "--json", "state,mergedAt,url"],
+    case System.cmd(gh(), ["pr", "view", pr, "--json", "state,mergedAt,url"],
            cd: cwd,
            stderr_to_stdout: true
          ) do
@@ -77,9 +102,15 @@ defmodule IxMcp.PrWatch do
 
   defp notify(pr, state, detail) do
     Notifier.notify("notifications/message", %{
-      "level" => if(state == "merged", do: "info", else: "warning"),
+      "level" => level(state),
       "logger" => "ix_mcp.pr_watch",
       "data" => %{"event" => "pr_watch", "pr" => pr, "state" => state, "detail" => detail}
     })
   end
+
+  # "error" rode as "warning" before #3553; a watch that will never report
+  # again is an error, not something to skim past.
+  defp level("merged"), do: "info"
+  defp level("error"), do: "error"
+  defp level(_state), do: "warning"
 end

--- a/packages/mcp-ex/test/ix_mcp/pr_watch_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/pr_watch_test.exs
@@ -1,0 +1,34 @@
+defmodule IxMcp.PrWatchTest do
+  use ExUnit.Case, async: false
+
+  alias IxMcp.MCP.Notifier
+  alias IxMcp.PrWatch
+
+  # The dying watcher's crash report is expected noise here.
+  @moduletag :capture_log
+
+  # Regression for #3553: IX_MCP_GH points at a gh that passes the start-time
+  # guard but cannot exec -- the shape of a release whose runtime PATH lost
+  # gh. The watcher crashes, and the promised channel notification must still
+  # arrive as a loud error instead of dying silently in the supervisor logs.
+  test "a crashed watcher still notifies the channel" do
+    previous = System.get_env("IX_MCP_GH")
+    System.put_env("IX_MCP_GH", "/nonexistent/gh")
+
+    on_exit(fn ->
+      if previous, do: System.put_env("IX_MCP_GH", previous), else: System.delete_env("IX_MCP_GH")
+    end)
+
+    Notifier.register(self())
+    # register/1 is a cast; sync on the Notifier so the watcher's own notify
+    # cast cannot be processed ahead of the registration.
+    _ = :sys.get_state(Notifier)
+
+    assert {:ok, _} = PrWatch.start("1", File.cwd!())
+
+    assert_receive {:mcp_send, %{"method" => "notifications/message", "params" => params}}, 5_000
+    assert %{"level" => "error", "logger" => "ix_mcp.pr_watch", "data" => data} = params
+    assert %{"event" => "pr_watch", "pr" => "1", "state" => "error"} = data
+    assert data["detail"] =~ "enoent"
+  end
+end


### PR DESCRIPTION
Fixes #3553.

PrWatch resolved `gh` from the runtime PATH inside the BEAM release, so a client that launched the server without `gh` on PATH got a watcher that died at the first poll -- silently, because the crash only reached the supervisor's logs, never the promised channel notification.

Two fixes:
- The release wrapper bakes `gh`'s store path into `IX_MCP_GH` (`lib.getExe`), so a watch never depends on the client's PATH; the PATH lookup remains only for `mix test` / IEx runs outside the release. `--set-default`, so tests and operators can still override.
- A crashing watcher now delivers the crash over the channel as an error-level notification before re-raising, and the `error` state rides as level `error` rather than `warning`.

Regression test: `IX_MCP_GH` pointing at a nonexistent `gh` passes the start-time guard, crashes the watcher, and must still notify the channel.

Validated: `nix build .#mcp-ex.tests.elixir` (credo clean, 62 tests / 0 failures), `.#mcp-ex`, `.#mcp-ex.tests.smoke` all green; built wrapper verified to export the gh store path.

Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bake `gh` store path into `IxMcp.PrWatch` and report watcher crashes via notifications
> - The `mcp-ex` wrapper now sets `IX_MCP_GH` to the Nix store path of the GitHub CLI via `makeWrapper`, so `gh` is found even when it is absent from `PATH`.
> - `IxMcp.PrWatch` resolves the `gh` binary by preferring `IX_MCP_GH` over `PATH`; `start/1` returns `{:error, "gh not found"}` if neither is available.
> - A new `watch_loudly/4` wrapper catches crashes from `watch/4` and sends a `level=error`, `state="error"` channel notification (with up to 800 chars of exception detail) before re-raising.
> - Notifications for `state="error"` now use `level="error"` instead of `"warning"` via a new `level/1` mapping function.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06f0ba8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->