### PR TITLE
ci: bound every job with measured timeout-minutes

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -131,6 +131,8 @@ jobs:
   comment:
     needs: evaluate
     runs-on: ubuntu-latest
+    # p95 <1m over last 30 green runs (2026-07-17); 10m floor.
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -53,7 +53,9 @@ jobs:
     # `-cache-push` and attaches the push-only ix-public token as a per-job
     # systemd credential (spawn.rs ix_public_push_eligible).
     runs-on: ["${{ format('ix-ci-run-{0}-{1}-cache-push', github.run_id, github.run_attempt) }}"]
-    timeout-minutes: 180
+    # p95 51m, worst 138m over last 30 green runs (2026-07-17); 150 covers the
+    # worst observed cold push with headroom instead of the old 3h cap.
+    timeout-minutes: 150
     outputs:
       # Realise-failure count for advance-cache-ready's publish-hole gate (#3195).
       failed-roots: ${{ steps.publish.outputs.failed-roots }}
@@ -622,6 +624,8 @@ jobs:
     # makes its failed-roots output addressable.
     needs: [push, darwin-build, darwin-push]
     runs-on: ubuntu-latest
+    # p95 <1m over last 30 green runs (2026-07-17); 10m floor.
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:

--- a/.github/workflows/cve-scan-watchdog.yml
+++ b/.github/workflows/cve-scan-watchdog.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   watchdog:
     runs-on: ubuntu-latest
+    # Single API sweep; sibling cache-push-watchdog is capped at 10m. 10m floor.
+    timeout-minutes: 10
     steps:
       - name: Check scan heartbeat and deadline
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -465,6 +465,9 @@ jobs:
     if: always() && needs.live.outputs.terminal-state != ''
     needs: live
     runs-on: ubuntu-latest
+    # Artifact download + attestation; sibling post-processing jobs run <1m p95
+    # (2026-07-17). 10m floor.
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
@@ -485,6 +488,9 @@ jobs:
     if: always() && (needs.live.outputs.terminal-state == 'clean' || needs.live.outputs.terminal-state == 'actionable')
     needs: live
     runs-on: ubuntu-latest
+    # Artifact download + SARIF upload; sibling post-processing jobs run <1m p95
+    # (2026-07-17). 10m floor.
+    timeout-minutes: 10
     permissions:
       actions: read
       security-events: write
@@ -504,6 +510,9 @@ jobs:
     if: always() && (needs.live.outputs.terminal-state == 'clean' || needs.live.outputs.terminal-state == 'actionable')
     needs: live
     runs-on: ubuntu-latest
+    # Issue bookkeeping via the API; sibling post-processing jobs run <1m p95
+    # (2026-07-17). 10m floor.
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
@@ -575,6 +584,9 @@ jobs:
     if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     needs: live
     runs-on: ubuntu-latest
+    # Issue bookkeeping via the API; sibling post-processing jobs run <1m p95
+    # (2026-07-17). 10m floor.
+    timeout-minutes: 10
     permissions:
       actions: read
       issues: write

--- a/.github/workflows/fork-closure-gates.yml
+++ b/.github/workflows/fork-closure-gates.yml
@@ -22,6 +22,8 @@ concurrency:
 jobs:
   closure-gates:
     runs-on: ubuntu-latest
+    # p95 1m over the 15 green runs to date (2026-07-17); 10m floor.
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -26,6 +26,9 @@ concurrency:
 jobs:
   fork-sync:
     runs-on: ubuntu-latest
+    # p95 64m, worst 68m over the 21 green runs to date (2026-07-17); 1.5x
+    # headroom on an hour-scale lane.
+    timeout-minutes: 100
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # p95 2m over last 30 green runs (2026-07-17); 10m floor. Without a cap a
+    # substitution stall here sits at GitHub's 6h default (2026-07-17 wedge).
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -54,6 +57,8 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    # p95 <1m over last 30 green runs (2026-07-17); 10m floor.
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -15,6 +15,9 @@ concurrency:
 jobs:
   validate-tag:
     runs-on: ubuntu-latest
+    # No green samples yet; checkout + ancestry check, sized like the other
+    # sub-minute gates (2026-07-17). 10m floor.
+    timeout-minutes: 10
     steps:
       - name: Checkout tag
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,6 +14,8 @@ permissions: read-all
 jobs:
   analysis:
     runs-on: ubuntu-latest
+    # p95 1m over last 30 green runs (2026-07-17); 10m floor.
+    timeout-minutes: 10
     permissions:
       security-events: write
       id-token: write

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -24,6 +24,8 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
+    # p95 44m, worst 48m over last 30 green runs (2026-07-17); 2x headroom.
+    timeout-minutes: 90
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Jobs without `timeout-minutes` inherit GitHub's 6-hour default. Tonight the Pages `build` job wedged on a daemon substitution stall and sat the full 6 hours; nothing killed it because it had no timeout. This bounds every job from measured history.

## Method

For each job: last 30 successful run durations via `gh api .../actions/runs/<id>/jobs`, p95 computed per job (2026-07-17). Short jobs get ~2x p95 headroom with a 10-minute floor; hour-scale lanes get ~1.5x p95. Jobs with fewer than 5 samples borrow the closest sibling (noted inline). Caps are deliberately generous first-pass values, to be tightened after typed-classes concurrency lands.

The `ci-budget` worker clock (dynamic `timeout-minutes` on `flake-check`) and the cache-push watchdog are different layers (queue admission / no-progress reaping) and are untouched; `timeout-minutes` bounds total job wall time above both.

## Timeout table

| Workflow / job | n | p95 | worst | old | new |
| --- | --- | --- | --- | --- | --- |
| pages / build (tonight's 6h wedge) | 30 | 2m | 2m | none (6h) | 10 |
| pages / deploy | 30 | <1m | <1m | none (6h) | 10 |
| blast-radius / comment | 30 | <1m | <1m | none (6h) | 10 |
| cache-push / push | 30 | 51m | 138m | 180 | 150 |
| cache-push / advance-cache-ready | 30 | <1m | <1m | none (6h) | 10 |
| cve-scan / attest, sarif, findings, monitor | 0 on green paths | sibling <1m | - | none (6h) | 10 each |
| cve-scan-watchdog / watchdog | 0 | sibling cache-push-watchdog 10m | - | none (6h) | 10 |
| fork-closure-gates / closure-gates | 15 | 1m | 1m | none (6h) | 10 |
| fork-sync / fork-sync | 21 | 64m | 68m | none (6h) | 100 |
| release-tag / validate-tag | 0 | sibling sub-minute gates | - | none (6h) | 10 |
| scorecard / analysis | 30 | 1m | 1m | none (6h) | 10 |
| update / update | 30 | 44m | 48m | none (6h) | 90 |

Left alone: `check.yml flake-check` (dynamic ci-budget clock), `cache-push darwin-build` (330m cap documents cold-path evidence from run 28772327218 my warm-heavy sample can't refute), and every job already carrying a sub-hour cap.

## Validation

- `nix run .#lint` green locally (10/10 tasks).
- Values checked against worst observed green duration per job; no cap is below a previously green run's duration.

(sent by Claude, an AI agent)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `timeout-minutes` to all CI workflow jobs
> Sets explicit `timeout-minutes` on every job across all GitHub Actions workflows to prevent runaway jobs from consuming CI minutes indefinitely. Most lightweight jobs are capped at 10 minutes; longer-running jobs use measured values (90–150 minutes based on observed runtimes). The `cache-push` push job timeout is also reduced from 180 to 150 minutes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 421c223.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->