### PR TITLE
site: add vm-disk-apfs-bypass update entry

### DIFF
--- a/packages/site/src/lib/updates/vm-disk-apfs-bypass.svx
+++ b/packages/site/src/lib/updates/vm-disk-apfs-bypass.svx
@@ -1,0 +1,33 @@
+---
+id: vm-disk-apfs-bypass
+postedAt: 2026-07-17T21:23:36-07:00
+title: A raw NVMe partition loses to a plain APFS image file for the builder VM
+tags: [interesting, nix, darwin, vm, builder]
+links:
+  - label: nix#138 (plan and A/B numbers)
+    href: https://github.com/andrewgazelka/nix/issues/138
+  - label: nix#143
+    href: https://github.com/andrewgazelka/nix/pull/143
+  - label: index#3554
+    href: https://github.com/indexable-inc/index/issues/3554
+  - label: VZDiskBlockDeviceStorageDeviceAttachment
+    href: https://developer.apple.com/documentation/virtualization/vzdiskblockdevicestoragedeviceattachment
+---
+
+The aarch64 NixOS builder VM on hydra (a Mac Studio) does all of its disk I/O through an image file sitting on APFS, so every guest write crosses vfkit, the host page cache, and a copy-on-write filesystem. Virtualization.framework can instead attach a raw block device via `VZDiskBlockDeviceStorageDeviceAttachment` (vfkit `type=dev`), skipping APFS entirely. The question: does a dedicated raw internal-NVMe partition beat the image file for nix-builder workloads?
+
+The A/B ran on hydra's builder VM under vfkit 0.6.3, a GPT/repart appliance image with an xfs root. A 256 GiB partition was carved out of the live internal NVMe with `diskutil apfs resizeContainer` and the image was dd'd onto `/dev/rdisk0s5` at 5.9 GB/s. In-guest benchmarks: fio 4k randwrite QD8 O_DIRECT, plain and with `fsync=1`, plus a cold `nix copy` of the 3.3 GiB ghc closure.
+
+| backing                     | randwrite IOPS | fsync IOPS | fsync p99 | nix copy   |
+| --------------------------- | -------------- | ---------- | --------- | ---------- |
+| image file (sparse, noatime) | 34,123        | 14,651     | 1.7 ms    | 131.6 MiB/s |
+| partition, sync Full        | 12,048         | 1,024      | 16.7 ms   | 116.0 MiB/s |
+| partition, raw node         | 14,581         | 524        | 32.4 ms   | 70.8 MiB/s  |
+
+File backing wins every axis on this stack. The builder stays file-backed, and the partition machinery landed dormant behind a UUID-pinned spec knob (nix#143).
+
+The mechanism is the synchronization mode, not APFS. VZ block-device attachments offer only `synchronizationMode` Full or None: Full turns every guest write barrier into `F_FULLFSYNC` on the physical disk, 13 to 28x slower on registration-shaped fsync paths, while file-backed attachments get the host page cache plus plain-fsync semantics. Next to that, APFS overhead is noise. Two side findings along the way: vfkit rejects macOS raw `/dev/rdiskN` character nodes for `type=dev` (an unaligned header read plus an `S_IFBLK` stat check; a 2-line patch boots fine off rdisk), and VZ propagates the internal SSD's 4Kn sector geometry into the guest, so images need `sectorSize 4096`.
+
+Prior art is thin: `VZDiskBlockDeviceStorageDeviceAttachment` shipped in macOS 14, lima tracks the same idea in lima-vm/lima#4866, and vfkit exposes it as `type=dev`. The open cell in the matrix is partition plus sync None, which the vmkit work in index#3554 makes testable.
+
+*Written by an AI agent via Claude Code (Claude Opus 4.5).*


### PR DESCRIPTION
Adds a site updates entry (`vm-disk-apfs-bypass`) reporting the builder-VM raw-partition investigation: whether a raw internal-NVMe partition attached via `VZDiskBlockDeviceStorageDeviceAttachment` (vfkit `type=dev`) beats the APFS image file for nix-builder workloads. It does not: file backing won every axis (randwrite, fsync, fsync p99, nix copy), because VZ block-device attachments only offer synchronizationMode Full (every guest barrier becomes F_FULLFSYNC) or None, while file backing gets page cache plus plain-fsync semantics. The builder stays file-backed; partition machinery landed dormant behind a UUID-pinned spec knob.

Validated locally: `nix build .#site` builds clean and the rendered `vm-disk-apfs-bypass.html` contains the entry.

Refs https://github.com/andrewgazelka/nix/issues/138, https://github.com/andrewgazelka/nix/pull/143, #3554

*Written by an AI agent via Claude Code (Claude Opus 4.5).*


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add vm-disk-apfs-bypass update post to site
> Adds a new post at [vm-disk-apfs-bypass.svx](https://github.com/indexable-inc/index/pull/3561/files#diff-17ffcf7c135b0579632cc37bbd9a336a284cc863be72233d04896e627896ca93) covering performance comparisons between APFS image-backed and raw NVMe partition-backed disks for a builder VM, including a benchmark table and attribution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1374d63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->