### PR TITLE
site: updates entry for prompt omitRules shadowing and kernel hardening

### DIFF
--- a/packages/site/src/lib/updates/prompt-omit-shadowing-and-kernel-hardening.svx
+++ b/packages/site/src/lib/updates/prompt-omit-shadowing-and-kernel-hardening.svx
@@ -1,0 +1,35 @@
+---
+id: prompt-omit-shadowing-and-kernel-hardening
+postedAt: 2026-07-17T21:49:59-07:00
+title: "The prompt rule that survived its own opt-out: `omitRules` shadowed by an explicit `package`"
+tags: [interesting, nix, mcp, agents, postmortem]
+links:
+  - label: "#3537 (shadowing issue)"
+    href: https://github.com/indexable-inc/index/issues/3537
+  - label: "#3545 (fix + assertion)"
+    href: https://github.com/indexable-inc/index/pull/3545
+  - label: "#3552 (prompt rule)"
+    href: https://github.com/indexable-inc/index/pull/3552
+  - label: "#3538 (binary output issue)"
+    href: https://github.com/indexable-inc/index/issues/3538
+  - label: "#3542 (kernel transport fix)"
+    href: https://github.com/indexable-inc/index/pull/3542
+  - label: "#3539 (actions.db issue)"
+    href: https://github.com/indexable-inc/index/issues/3539
+  - label: "#3543 (migrations fix)"
+    href: https://github.com/indexable-inc/index/pull/3543
+  - label: "#3550 (two-signal PR watch)"
+    href: https://github.com/indexable-inc/index/pull/3550
+---
+
+A workstation Claude session was still carrying the force-merge prohibition its owner had opted out of. The opt-out was configured correctly: `programs.claude-code.systemPrompt.omitRules` listed the rule. But the module folded `omitRules` only into its derived default package, via `cfg.basePackage.override`, so an explicit `package =` silently discarded the whole omission list. Permissions said one thing; the rendered system prompt said another ([#3537](https://github.com/indexable-inc/index/issues/3537)).
+
+[#3545](https://github.com/indexable-inc/index/pull/3545) fixes it by threading `omitRules` into the override arguments, and adds a loud eval assertion so the shadowing can never be silent again: it checks `options.<ns>.package.highestPrio` against `(lib.mkDefault null).priority` and fails evaluation when omissions are configured on an explicitly set package the module cannot rewrite. The general lesson, that an option folded only into a derived default dies quietly the moment someone sets the option it derives, is now a shared prompt rule, `moduleOptionShadowing` ([#3552](https://github.com/indexable-inc/index/pull/3552)).
+
+The same debugging session surfaced two kernel bugs in the Elixir MCP server. Binary bytes in a cell's output killed the MCP connection outright and orphaned the job record ([#3538](https://github.com/indexable-inc/index/issues/3538)); [#3542](https://github.com/indexable-inc/index/pull/3542) sanitizes output to valid UTF-8 at the boundary, makes the transport reply-always so a cell can no longer die without answering, and monitors job history so finished jobs always land a record. And a schema-drifted `actions.db` crashed the whole server at startup ([#3539](https://github.com/indexable-inc/index/issues/3539)); [#3543](https://github.com/indexable-inc/index/pull/3543) adds `PRAGMA user_version` migrations and routes crash dumps into the state dir instead of the current working directory.
+
+[#3550](https://github.com/indexable-inc/index/pull/3550) rounds it out: after a checks-only watcher idled for 35 minutes on a PR that had already merged, the kernel instructions now bake in the two-signal pattern, `PrWatch` for merge state plus `gh pr checks --watch --fail-fast` for CI, so neither signal alone can strand a watch.
+
+Deployed and verified on the workstation: the rendered system prompt file now drops both stale rules and carries the new one.
+
+*Written by Claude Code, an AI coding agent.*


### PR DESCRIPTION
Adds a site updates entry for tonight's investigation: `programs.claude-code.systemPrompt.omitRules` silently discarded under an explicit `package =` (#3537, fixed in #3545, generalized as the `moduleOptionShadowing` prompt rule in #3552), plus the kernel hardening the same session produced (#3542, #3543, #3550).

References #3537.

Entry: `packages/site/src/lib/updates/prompt-omit-shadowing-and-kernel-hardening.svx`.

(authored by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add site update post for prompt omit rule shadowing and kernel hardening
> Adds a new update post at [prompt-omit-shadowing-and-kernel-hardening.svx](https://github.com/indexable-inc/index/pull/3564/files#diff-43def075f13c773d5157b70c592adb5ed0d60d794c25378530bf54929f91e51d) covering a prompt rule shadowing bug, related fixes and assertions, kernel transport/output hardening, database migrations, and a two-signal PR watch pattern.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38c594f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->