### PR TITLE
mcp: drop stale test_build_info.py references

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -2738,9 +2738,6 @@
       # sh Output rendering regressions (issue #1766: a failed build must not
       # read as success/still-running); imports the site-packages sh module.
       cp ${./tests/test_sh_module.py} test_sh_module.py
-      # In-band kernel build staleness (#2110): the api() header row and the
-      # TypeError-hint build stamp; imports the site-packages ix_notebook_mcp.
-      cp ${./tests/test_build_info.py} test_build_info.py
       # Issue #2355: per-serve kernel trace file + sweep of orphaned dumps.
       cp ${./tests/test_kernel_trace_path.py} test_kernel_trace_path.py
       # The kernel host seam: local/ray selection, the actor's connection-info
@@ -2774,7 +2771,6 @@
         test_fsearch_files_only.py \
         test_claude_history.py \
         test_sh_module.py \
-        test_build_info.py \
         test_kernel_trace_path.py \
         test_kernel_host.py \
         test_store_kernel_lease.py \


### PR DESCRIPTION
Main is red since 808ce1fe (#3534): `tests/test_build_info.py` was deleted with the build-stamp surface, but the typecheck smoke in `packages/mcp/default.nix` still copies it and lists it for pytest, so every flake-check eval on main fails with `Path 'packages/mcp/tests/test_build_info.py' does not exist in Git repository`. Drop the two stale references (and their comment).

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove stale `test_build_info.py` references from MCP package build
> Removes the copy step and test execution entry for `test_build_info.py` from [default.nix](https://github.com/indexable-inc/index/pull/3565/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db). The file no longer exists, so these references were dead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a069f8b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->