### PR TITLE
ci: notify the dispatching human on automation PRs

### DIFF
--- a/.github/actions/triggering-actor/action.yml
+++ b/.github/actions/triggering-actor/action.yml
@@ -1,0 +1,77 @@
+name: Resolve triggering human
+description: >-
+  The GitHub login of the human whose action caused this run, so a
+  PR-generating lane can notify them (@mention in the body, review request,
+  assignee). Bot PRs opened by the update/fork-sync lanes are otherwise
+  unattributed: nobody is subscribed, so they sit unnoticed until someone
+  trawls the PR list. Resolution is per event: `workflow_dispatch` names the
+  dispatching actor, `push` the head-commit author, `pull_request` the PR
+  author; `schedule` has no human, and a bot actor (github-actions, any
+  `*[bot]` app) resolves to empty rather than re-notifying automation, which
+  also breaks mention loops between bots. Owns the resolution so lanes cannot
+  drift apart.
+
+outputs:
+  user:
+    description: >-
+      GitHub login to notify, or empty when the run has no human trigger
+      (schedule) or the triggering actor is itself a bot. Feed it directly to
+      create-pull-request's `assignees`/`reviewers`, which treat empty as
+      "none".
+    value: ${{ steps.resolve.outputs.user }}
+  mention:
+    description: >-
+      Markdown attribution line ("Triggered by <sha> (<event>) from @<user>.")
+      for the generated PR body, or empty when `user` is empty. An @mention in
+      the body notifies even when the review request is rejected (a token
+      without the reviewer's read access, say).
+    value: ${{ steps.resolve.outputs.mention }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve triggering human
+      id: resolve
+      shell: bash
+      # Context reaches the script through env, never inline `${{ }}` in
+      # `run:`: an actor login or commit-author name is attacker-adjacent
+      # text and interpolating it into the script body would be injectable.
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        ACTOR: ${{ github.actor }}
+        HEAD_COMMIT_AUTHOR: ${{ github.event.head_commit.author.username }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        SHA: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+
+        # `:-` defaults: a missing context field (a push whose head commit
+        # has no linked GitHub account, say) renders the env var empty, and
+        # under `set -u` the fallback keeps that a skip, not a crash.
+        case "$EVENT_NAME" in
+          # `github.actor` (not `triggering_actor`): on a re-run the original
+          # dispatcher still owns the change the run advances.
+          workflow_dispatch) user="${ACTOR:-}" ;;
+          push) user="${HEAD_COMMIT_AUTHOR:-}" ;;
+          pull_request|pull_request_target) user="${PR_AUTHOR:-}" ;;
+          # schedule and everything else: no human to notify.
+          *) user="" ;;
+        esac
+
+        # Bot guard: never tag automation. App actors end in `[bot]`;
+        # github-actions and dependabot also appear bare in commit-author
+        # usernames.
+        case "$user" in
+          *"[bot]"|github-actions|dependabot) user="" ;;
+        esac
+
+        mention=""
+        if [ -n "$user" ]; then
+          short_sha="${SHA:0:11}"
+          mention="Triggered by \`${short_sha}\` (\`${EVENT_NAME}\`) from @${user}."
+        fi
+
+        {
+          echo "user=$user"
+          echo "mention=$mention"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -104,9 +104,17 @@ jobs:
       # only when the tool itself cannot run. The table lands in the job's step
       # summary and in the rolling PR body (`body-path` below); the body file is
       # written outside the workspace so create-pull-request cannot commit it.
+      # Notify the human behind a manual dispatch: review request + assignee +
+      # body mention, all empty (a no-op) on the scheduled runs, which have no
+      # triggering human.
+      - name: Resolve triggering human
+        id: trigger
+        uses: ./.github/actions/triggering-actor
+
       - name: Fork drift report
         env:
           GH_TOKEN: ${{ github.token }}
+          TRIGGER_MENTION: ${{ steps.trigger.outputs.mention }}
         run: |
           set -euo pipefail
           nix run .#upstream-sync -- drift --markdown > "$RUNNER_TEMP/drift.md"
@@ -131,12 +139,18 @@ jobs:
             cat "$RUNNER_TEMP/drift.md"
             echo ""
             echo "Auto-bump, made with Claude Opus 4.8."
+            if [ -n "${TRIGGER_MENTION}" ]; then
+              echo ""
+              echo "${TRIGGER_MENTION}"
+            fi
           } > "$RUNNER_TEMP/pr-body.md"
 
       - name: Open pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.AUTOBUMP_TOKEN || github.token }}
+          assignees: ${{ steps.trigger.outputs.user }}
+          reviewers: ${{ steps.trigger.outputs.user }}
           base: main
           branch: fork-sync
           delete-branch: true

--- a/.github/workflows/update-cargo.yml
+++ b/.github/workflows/update-cargo.yml
@@ -92,10 +92,19 @@ jobs:
       # block the merge. Set an `AUTOBUMP_TOKEN` repo secret (a PAT or GitHub
       # App token) to make the PR run CI; without it this falls back to
       # GITHUB_TOKEN and a maintainer must re-trigger `flake-check`.
+      # Notify the human behind a manual dispatch: review request + assignee +
+      # body mention, all empty (a no-op) on the scheduled runs, which have no
+      # triggering human.
+      - name: Resolve triggering human
+        id: trigger
+        uses: ./.github/actions/triggering-actor
+
       - name: Open pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.AUTOBUMP_TOKEN || github.token }}
+          assignees: ${{ steps.trigger.outputs.user }}
+          reviewers: ${{ steps.trigger.outputs.user }}
           base: main
           branch: update-cargo
           delete-branch: true
@@ -109,3 +118,5 @@ jobs:
             `flake-check` is what proves the new versions actually build, so review its result before merging.
 
             Auto-bump, made with Claude Opus 4.8.
+
+            ${{ steps.trigger.outputs.mention }}

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -99,6 +99,17 @@ jobs:
           client-id: ${{ inputs.app-client-id }}
           private-key: ${{ secrets.app-private-key }}
 
+      # Notify the human behind a manual dispatch (of this workflow or of a
+      # cross-repo caller such as ix: a reusable workflow shares the caller's
+      # event and actor): review request + assignee, both empty (a no-op) on
+      # the scheduled runs, which have no triggering human. The PR body stays
+      # the update-flake-lock action's own template, so the review request is
+      # the notification channel here. Fully qualified like install-nix above
+      # because a reusable workflow checks out the caller's repository.
+      - name: Resolve triggering human
+        id: trigger
+        uses: indexable-inc/index/.github/actions/triggering-actor@main
+
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28
         with:
@@ -106,6 +117,8 @@ jobs:
           branch: update-flake-lock
           commit-msg: "flake.lock: update"
           pr-title: "Update Nix flake inputs"
+          pr-assignees: ${{ steps.trigger.outputs.user }}
+          pr-reviewers: ${{ steps.trigger.outputs.user }}
           # Empty for schedule/dispatch on index (all inputs public); a caller
           # scopes this to avoid fetching private inputs it can't auth for.
           inputs: ${{ inputs.flake-inputs }}

--- a/.github/workflows/update-rust-nightly.yml
+++ b/.github/workflows/update-rust-nightly.yml
@@ -52,10 +52,19 @@ jobs:
       # would block the merge. Set an `AUTOBUMP_TOKEN` repo secret (a PAT or
       # GitHub App token) to make the PR run CI; without it this falls back
       # to GITHUB_TOKEN and a maintainer must re-trigger `flake-check`.
+      # Notify the human behind a manual dispatch: review request + assignee +
+      # body mention, all empty (a no-op) on the scheduled runs, which have no
+      # triggering human.
+      - name: Resolve triggering human
+        id: trigger
+        uses: ./.github/actions/triggering-actor
+
       - name: Open pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.AUTOBUMP_TOKEN || github.token }}
+          assignees: ${{ steps.trigger.outputs.user }}
+          reviewers: ${{ steps.trigger.outputs.user }}
           base: main
           branch: update-rust-nightly
           delete-branch: true
@@ -73,3 +82,5 @@ jobs:
             Refs indexable-inc/index#1698.
 
             (sent by an AI agent via Claude Code)
+
+            ${{ steps.trigger.outputs.mention }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -112,10 +112,19 @@ jobs:
       # block the merge. Set an `AUTOBUMP_TOKEN` repo secret (a PAT or GitHub
       # App token) to make the PR run CI; without it this falls back to
       # GITHUB_TOKEN and a maintainer must re-trigger `flake-check`.
+      # Notify the human behind a manual dispatch: review request + assignee +
+      # body mention, all empty (a no-op) on the scheduled runs, which have no
+      # triggering human.
+      - name: Resolve triggering human
+        id: trigger
+        uses: ./.github/actions/triggering-actor
+
       - name: Open pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.AUTOBUMP_TOKEN || github.token }}
+          assignees: ${{ steps.trigger.outputs.user }}
+          reviewers: ${{ steps.trigger.outputs.user }}
           base: main
           branch: update-content
           delete-branch: true
@@ -129,3 +138,5 @@ jobs:
             Each changed updater package also built on `x86_64-linux`, which proves the new hash fetches and builds but **not** that it is authentic. claude-code's updater verified Anthropic's detached GPG signature over all four platform checksums before writing. **Most pins have no upstream signature**, so please eyeball those hash changes before merging: the build only covers x86_64-linux, and the updater pins whatever bytes the release host served.
 
             Auto-bump, made with Claude Opus 4.8.
+
+            ${{ steps.trigger.outputs.mention }}


### PR DESCRIPTION
## Problem

Every automation PR in this repo is authored by `github-actions[bot]` with nobody subscribed, so bot PRs sit unnoticed until someone trawls the PR list.

## What changed

New composite action `.github/actions/triggering-actor` resolves the human whose action caused the run and owns that logic for every lane:

- `workflow_dispatch` -> the dispatching actor (`github.actor`)
- `push` -> the head-commit author, `pull_request` -> the PR author (for future lanes; no current lane uses these events)
- `schedule` -> empty (no human)
- bot guard: `github-actions`, `dependabot`, and any `*[bot]` app resolve to empty, so automation is never tagged and bots cannot mention-loop each other

Each PR-generating lane feeds the outputs to its existing PR step: `assignees` + `reviewers` (a review request is the strongest notification) plus a `Triggered by <sha> (<event>) from @<user>.` body line rendered through each lane's existing body construction (inline `body:`, or the `pr-body.md` assembly in fork-sync).

## Lane inventory

| lane | trigger | who gets tagged | mechanism |
|---|---|---|---|
| `update.yml` (content) | hourly cron + dispatch | dispatcher on dispatch; nobody on cron | create-pull-request `assignees`/`reviewers` + body mention |
| `update-cargo.yml` | hourly cron + dispatch | same | same |
| `update-rust-nightly.yml` | daily cron + dispatch | same | same |
| `fork-sync.yml` | 3-hourly cron + dispatch | same | same (mention appended in the `pr-body.md` assembly) |
| `update-flake-lock.yml` (reusable; ix calls it) | hourly cron + dispatch (caller's event) | same | DetSys update-flake-lock `pr-assignees`/`pr-reviewers`; body stays the action's own template |
| dependabot | weekly cron | nobody (GitHub-native, no dynamic attribution surface) | unchanged |

Deliberate decisions:

- **Scheduled runs stay untagged.** There is no triggering human, and the repo encodes no global maintainer to fall back to (`.github/user-owners.json` is scoped to the approve-user-change lane), so no invented hardcoded username.
- **No clippy/lint-fix PR lane exists today.** `.#lint-fix-patch` is applied locally via `nix run .#lint -- --fix`; no workflow opens PRs from it. If such a lane is added, the helper's `push` branch already resolves the triggering commit's author.
- **upstream-sync** opens PRs on external upstream repos (de-fork flow) and is human-run; out of scope.

## What ix gets for free vs needs follow-up

ix's `update-flake-lock.yml` calls this repo's reusable workflow, so it inherits the attribution as soon as this merges (a reusable workflow shares the caller's event and actor, and the `triggering-actor` action is referenced fully qualified at `index@main`). ix's own `update-rust-nightly.yml` is a local peter-evans copy and needs the same two-line wiring: filed as an ix issue (linked below).

## Validation

- `nix run .#lint`: 10/10 tasks green (the repo lint suite does not cover workflow YAML)
- `actionlint` over all five changed workflows: clean
- The resolve script was exercised against a 7-case event matrix (dispatch by human, schedule, dispatch by `*[bot]` app, push by human / bot / unlinked-account commit, dependabot): outputs exactly as the table above; `shellcheck` clean
- **Live-run proof still needed**: only a real dispatch exercises the GitHub side. After merge: `gh workflow run update-cargo.yml` and confirm the rolling `update-cargo` PR gains the dispatcher as reviewer + assignee and the mention line. Note the review request needs the tagged user to have repo read access (true for anyone who can dispatch); the body @mention notifies regardless, and on the reusable lane the review request is the only channel since the body template is owned by the DetSys action.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Notify dispatching human on automation PRs by assigning and mentioning them
> - Adds a new composite action [`triggering-actor`](.github/actions/triggering-actor/action.yml) that resolves the human who triggered a workflow run (via `workflow_dispatch`, `push`, or PR event), outputting their login and a formatted mention line; outputs are empty for scheduled runs or bot actors.
> - Integrates the action into `fork-sync`, `update-cargo`, `update-flake-lock`, `update-rust-nightly`, `update`, and related automation workflows to auto-assign and request review from the triggering human on generated PRs.
> - Appends an attribution line (including short SHA, event, and `@user`) to the PR body when a human actor is detected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4926b8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->