### PR TITLE
kbuild-unit: skeleton plans + CC shim (P3 PR B, #3413)

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -317,6 +317,7 @@
     import ./kernel/kbuild-unit.nix {
       inherit lib pkgs;
       nixKbuildUnit = buildIxRustTool pkgs (packagePath "nix-kbuild-unit");
+      writeBashApplication = writeBashApplication pkgs;
     };
 
   systemdHardening = import ./services/systemd-hardening.nix;

--- a/lib/kernel/kbuild-plan-cc.sh
+++ b/lib/kernel/kbuild-plan-cc.sh
@@ -1,0 +1,106 @@
+# Compiler shim for kbuild-unit plan builds (#3413), installed as `gcc` ahead
+# of the real cc-wrapper on the plan derivation's PATH only. kbuild's
+# $(CC) = gcc keeps resolving -- and `savedcmd_*` keeps recording -- plain
+# `gcc`, so unit replays resolve the real compiler and no saved command is
+# ever rewritten.
+#
+# Env contract (set by lib/kernel/kbuild-unit.nix; env never appears in
+# savedcmd):
+#   KBUILD_UNIT_CC_REAL   the real cc-wrapper gcc
+#   KBUILD_UNIT_CC_MODE   "skeleton" | "ccache"
+#   KBUILD_UNIT_CCACHE    ccache binary (ccache mode only)
+
+real="$KBUILD_UNIT_CC_REAL"
+
+if [[ "${KBUILD_UNIT_CC_MODE:-}" == ccache ]]; then
+  # Correctness never depends on the cache: an unmounted or unwritable cache
+  # dir (the host did not opt in via services.ci-runner.kbuildCcache) degrades
+  # to an uncached build -- loudly, once per build.
+  if [[ -d "${CCACHE_DIR:-}" && -w "${CCACHE_DIR:-}" ]]; then
+    exec "$KBUILD_UNIT_CCACHE" "$real" "$@"
+  fi
+  flag="${NIX_BUILD_TOP:-/tmp}/.kbuild-unit-ccache-warned"
+  if [[ ! -e $flag ]]; then
+    : >"$flag"
+    echo "WARNING: kbuild-unit ccache dir '${CCACHE_DIR:-}' is not mounted in this sandbox; building uncached (enable services.ci-runner.kbuildCcache on the builder)" >&2
+  fi
+  exec "$real" "$@"
+fi
+
+# Skeleton mode: stub the object of every reduced TU. A compile is stubbed
+# only when (a) it produces an object (-c), (b) it is a kernel TU
+# (-D__KERNEL__: host-tool compiles pass through), and (c) its source operand
+# starts with the reducer's marker line, so the skeleton's keep decision is
+# the only stub policy. cc-option probes over /dev/null, allowlisted sources,
+# and non-reduced trees have no marker and pass through untouched.
+compile=0
+kernel=0
+src=
+for arg in "$@"; do
+  case $arg in
+    -c) compile=1 ;;
+    -D__KERNEL__) kernel=1 ;;
+    *.c | *.S)
+      if [[ -f $arg ]]; then
+        src=$arg
+      fi
+      ;;
+  esac
+done
+
+marker=
+if [[ -n $src ]]; then
+  IFS= read -r marker <"$src" || true
+fi
+if ((!compile || !kernel)) || [[ $marker != '/* nix-kbuild-unit skeleton:'* ]]; then
+  exec "$real" "$@"
+fi
+
+# 1) Dep recording: replay the original argv as -E with the object output
+# discarded. The -Wp,-MMD,<depfile> already present in every kbuild compile
+# argv writes the depfile fixdep consumes; the skeleton preserves every
+# directive and all headers whole, so the recorded dep set is identical to a
+# real build's.
+dep_args=()
+out_next=0
+for arg in "$@"; do
+  if ((out_next)); then
+    out_next=0
+    dep_args+=(/dev/null)
+    continue
+  fi
+  case $arg in
+    -c) dep_args+=(-E) ;;
+    -o)
+      out_next=1
+      dep_args+=(-o)
+      ;;
+    *) dep_args+=("$arg") ;;
+  esac
+done
+"$real" "${dep_args[@]}"
+
+# 2) Stub object: the same argv over /dev/null instead of the source, so the
+# object carries the right machine/ABI flags for thin `ar cDPrST` and `ld -r`
+# while its (empty) contents are independent of every function body. The
+# -include args would drag real code back in; a surviving -Wp,-MMD would
+# clobber the depfile step 1 just wrote.
+stub_args=()
+skip=0
+for arg in "$@"; do
+  if ((skip)); then
+    skip=0
+    continue
+  fi
+  case $arg in
+    -include) skip=1 ;;
+    -Wp,-MMD,* | -Wp,-MD,*) ;;
+    "$src") ;;
+    *) stub_args+=("$arg") ;;
+  esac
+done
+lang=c
+if [[ $src == *.S ]]; then
+  lang=assembler-with-cpp
+fi
+exec "$real" "${stub_args[@]}" -x "$lang" /dev/null

--- a/lib/kernel/kbuild-plan-cc.sh
+++ b/lib/kernel/kbuild-plan-cc.sh
@@ -80,11 +80,15 @@ for arg in "$@"; do
 done
 "$real" "${dep_args[@]}"
 
-# 2) Stub object: the same argv over /dev/null instead of the source, so the
-# object carries the right machine/ABI flags for thin `ar cDPrST` and `ld -r`
-# while its (empty) contents are independent of every function body. The
-# -include args would drag real code back in; a surviving -Wp,-MMD would
-# clobber the depfile step 1 just wrote.
+# 2) Stub object: the same argv over a canned stdin stub instead of the
+# source, so the object carries the right machine/ABI flags for thin
+# `ar cDPrST` and `ld -r` while its contents are independent of every
+# function body. The stub is not empty: modpost hard-errors on a module
+# object with no .modinfo license entry, so every stub carries one (the
+# value is plan-only garbage; the modpost units regenerate .mod.c and
+# Module.symvers from real objects at unit time). The -include args would
+# drag real code back in; a surviving -Wp,-MMD would clobber the depfile
+# step 1 just wrote.
 stub_args=()
 skip=0
 for arg in "$@"; do
@@ -99,8 +103,15 @@ for arg in "$@"; do
     *) stub_args+=("$arg") ;;
   esac
 done
-lang=c
 if [[ $src == *.S ]]; then
-  lang=assembler-with-cpp
+  printf '%s\n' \
+    '.section .modinfo,"a"' \
+    '.ascii "license=GPL"' \
+    '.byte 0' \
+    | "$real" "${stub_args[@]}" -x assembler-with-cpp -
+else
+  printf '%s\n' \
+    'static const char __attribute__((section(".modinfo"), used))' \
+    'kbuild_unit_stub_license[] = "license=GPL";' \
+    | "$real" "${stub_args[@]}" -x c -
 fi
-exec "$real" "${stub_args[@]}" -x "$lang" /dev/null

--- a/lib/kernel/kbuild-plan-ld.sh
+++ b/lib/kernel/kbuild-plan-ld.sh
@@ -1,0 +1,58 @@
+# Linker shim for kbuild-unit skeleton plan builds (#3413), installed as `ld`
+# ahead of the real ld-wrapper on the plan derivation's PATH only (savedcmd_*
+# keeps recording plain `ld`, so unit replays resolve the strict real linker
+# over fully real objects).
+#
+# The skeleton plan's stub objects define no symbols, but the x86 vmlinux
+# linker script evaluates symbol expressions eagerly (`jiffies = jiffies_64;`,
+# `INIT_PER_CPU(gdt_page)`, mitigation-thunk ASSERTs) and GNU ld hard-errors
+# on an undefined symbol in an expression. Injecting `--defsym`s for exactly
+# that symbol set (values chosen to satisfy the 6.12 ASSERT arithmetic) plus
+# `--unresolved-symbols=ignore-all` (for stray real objects a keep glob pulls
+# into the stub link) lets the garbage plan-time vmlinux link complete, which
+# is all the plan needs: its .cmd files, not its bytes. Injection is gated to
+# vmlinux-ish outputs so real plan-time links (vdso.so, realmode.elf) stay
+# byte-exact for the generated snapshot.
+#
+# A `--keep`/skeletonKeep glob covering a TU that really defines one of these
+# symbols fails the plan link loudly with a duplicate-definition error; drop
+# the keep or this defsym, they cannot coexist.
+#
+# Env contract (set by lib/kernel/kbuild-unit.nix):
+#   KBUILD_UNIT_LD_REAL   the real binutils ld-wrapper
+
+real="$KBUILD_UNIT_LD_REAL"
+
+out=
+grab=0
+for arg in "$@"; do
+  if ((grab)); then
+    out=$arg
+    grab=0
+  elif [[ $arg == -o ]]; then
+    grab=1
+  fi
+done
+
+case ${out##*/} in
+  vmlinux | .tmp_vmlinux*) ;;
+  *) exec "$real" "$@" ;;
+esac
+
+exec "$real" \
+  --defsym jiffies_64=0 \
+  --defsym startup_64=0 \
+  --defsym startup_32=0 \
+  --defsym gdt_page=0 \
+  --defsym fixed_percpu_data=0 \
+  --defsym irq_stack_backing_store=0 \
+  --defsym retbleed_return_thunk=0 \
+  --defsym srso_safe_ret=0 \
+  --defsym srso_alias_untrain_ret=0 \
+  --defsym srso_alias_safe_ret=0x104104 \
+  --defsym __x86_indirect_its_thunk_rax=0x20 \
+  --defsym __x86_indirect_its_thunk_rcx=0x60 \
+  --defsym __x86_indirect_its_thunk_array=0x20 \
+  --defsym its_return_thunk=0x20 \
+  --unresolved-symbols=ignore-all \
+  "$@"

--- a/lib/kernel/kbuild-plan-ld.sh
+++ b/lib/kernel/kbuild-plan-ld.sh
@@ -32,15 +32,20 @@ real="$KBUILD_UNIT_LD_REAL"
 
 out=
 emulation=
+script=
 grab=
 for arg in "$@"; do
   case $grab in
     -o) out=$arg ;;
     -m) emulation=$arg ;;
+    -T) script=$arg ;;
   esac
   grab=
   case $arg in
-    -o | -m) grab=$arg ;;
+    -o | -m | -T) grab=$arg ;;
+    # link-vmlinux.sh passes the attached form (--script=<objtree>/<lds>).
+    --script=*) script=${arg#--script=} ;;
+    -T?*) script=${arg#-T} ;;
   esac
 done
 
@@ -49,11 +54,19 @@ case ${out##*/} in
   *) exec "$real" "$@" ;;
 esac
 
-# The SRSO branch of the 6.12 script does `. = srso_alias_untrain_ret | ((1
-# << 2) | (1 << 8) | (1 << 14) | (1 << 20))` inside .text, so that defsym
-# must sit above the kernel's start VMA or the location counter would move
-# backwards (a hard error); its partner is then OR-offset so the pair's
-# alias ASSERT (XOR == 0x104104) holds.
+# The SRSO branch of the script assigns the location counter from
+# srso_alias_untrain_ret (`. = srso_alias_untrain_ret | 0x104104`), which an
+# absolute --defsym cannot drive (ld converts the absolute value through the
+# section's load-address space and errors "cannot move location counter
+# backwards"). Upstream makes the OR-math work through section placement of
+# the pair, so the SRSO stand-in object replicates exactly that; it is
+# appended only when the generated script actually places the rethunk
+# sections, because on other configs they would be orphans.
+extra=("$KBUILD_UNIT_LD_PLACEHOLDER_DIR/placeholder-$([[ $emulation == elf_i386 ]] && echo 32 || echo 64).o")
+if [[ -n $script && -f $script ]] && grep -q 'rethunk_safe' "$script"; then
+  extra+=("$KBUILD_UNIT_LD_PLACEHOLDER_DIR/placeholder-srso-64.o")
+fi
+
 exec "$real" \
   --defsym jiffies_64=0 \
   --defsym pcpu_hot=0 \
@@ -64,12 +77,10 @@ exec "$real" \
   --defsym irq_stack_backing_store=0 \
   --defsym retbleed_return_thunk=0 \
   --defsym srso_safe_ret=0 \
-  --defsym srso_alias_untrain_ret=0xffffffff82000000 \
-  --defsym srso_alias_safe_ret=0xffffffff82104104 \
   --defsym __x86_indirect_its_thunk_rax=0x20 \
   --defsym __x86_indirect_its_thunk_rcx=0x60 \
   --defsym __x86_indirect_its_thunk_array=0x20 \
   --defsym its_return_thunk=0x20 \
   --unresolved-symbols=ignore-all \
   "$@" \
-  "$KBUILD_UNIT_LD_PLACEHOLDER_DIR/placeholder-$([[ $emulation == elf_i386 ]] && echo 32 || echo 64).o"
+  "${extra[@]}"

--- a/lib/kernel/kbuild-plan-ld.sh
+++ b/lib/kernel/kbuild-plan-ld.sh
@@ -18,20 +18,30 @@
 # symbols fails the plan link loudly with a duplicate-definition error; drop
 # the keep or this defsym, they cannot coexist.
 #
+# The stub objects also leave the output without sections the post-link
+# tools insist on (sorttable hard-fails on a missing __ex_table), so the
+# injected link appends one synthetic placeholder object carrying minimal
+# one-entry versions; the values are garbage, and only the discarded stub
+# vmlinux ever contains them.
+#
 # Env contract (set by lib/kernel/kbuild-unit.nix):
-#   KBUILD_UNIT_LD_REAL   the real binutils ld-wrapper
+#   KBUILD_UNIT_LD_REAL              the real binutils ld-wrapper
+#   KBUILD_UNIT_LD_PLACEHOLDER_DIR   dir with placeholder-{32,64}.o
 
 real="$KBUILD_UNIT_LD_REAL"
 
 out=
-grab=0
+emulation=
+grab=
 for arg in "$@"; do
-  if ((grab)); then
-    out=$arg
-    grab=0
-  elif [[ $arg == -o ]]; then
-    grab=1
-  fi
+  case $grab in
+    -o) out=$arg ;;
+    -m) emulation=$arg ;;
+  esac
+  grab=
+  case $arg in
+    -o | -m) grab=$arg ;;
+  esac
 done
 
 case ${out##*/} in
@@ -39,8 +49,14 @@ case ${out##*/} in
   *) exec "$real" "$@" ;;
 esac
 
+# The SRSO branch of the 6.12 script does `. = srso_alias_untrain_ret | ((1
+# << 2) | (1 << 8) | (1 << 14) | (1 << 20))` inside .text, so that defsym
+# must sit above the kernel's start VMA or the location counter would move
+# backwards (a hard error); its partner is then OR-offset so the pair's
+# alias ASSERT (XOR == 0x104104) holds.
 exec "$real" \
   --defsym jiffies_64=0 \
+  --defsym pcpu_hot=0 \
   --defsym startup_64=0 \
   --defsym startup_32=0 \
   --defsym gdt_page=0 \
@@ -48,11 +64,12 @@ exec "$real" \
   --defsym irq_stack_backing_store=0 \
   --defsym retbleed_return_thunk=0 \
   --defsym srso_safe_ret=0 \
-  --defsym srso_alias_untrain_ret=0 \
-  --defsym srso_alias_safe_ret=0x104104 \
+  --defsym srso_alias_untrain_ret=0xffffffff82000000 \
+  --defsym srso_alias_safe_ret=0xffffffff82104104 \
   --defsym __x86_indirect_its_thunk_rax=0x20 \
   --defsym __x86_indirect_its_thunk_rcx=0x60 \
   --defsym __x86_indirect_its_thunk_array=0x20 \
   --defsym its_return_thunk=0x20 \
   --unresolved-symbols=ignore-all \
-  "$@"
+  "$@" \
+  "$KBUILD_UNIT_LD_PLACEHOLDER_DIR/placeholder-$([[ $emulation == elf_i386 ]] && echo 32 || echo 64).o"

--- a/lib/kernel/kbuild-unit.nix
+++ b/lib/kernel/kbuild-unit.nix
@@ -9,27 +9,43 @@ scripts) into `plan.json`. Stage 2 renders plan.json to units.nix (IFD),
 which builds one CA derivation per unit by replaying its exact saved
 command inside a symlink farm of src + snapshot + dep unit outputs.
 
-The plan build's monolithic vmlinux is kept as the equivalence reference:
-`vmlinuxEquivalence` cmp's it byte-for-byte against the unit-built vmlinux.
+What the plan kbuild compiles is governed by `planStrategy` (#3413):
+
+- "skeleton" (default): the plan consumes a directives-only reduction of the
+  source tree (`nix-kbuild-unit skeleton`, a CA derivation) and a gcc-named
+  PATH shim substitutes stub objects for every reduced TU while recording
+  real dep sets via `-E` + the argv's own `-Wp,-MMD`. Function-body edits
+  reduce to a byte-identical skeleton, so the plan's resolved derivation is
+  already realised and never reruns; only the edited TU's unit (plus its
+  link chain) rebuilds. The plan's vmlinux is stub garbage, so equivalence
+  gates compare against `referenceKernel`, a real monolithic build.
+- "ccache": the plan consumes the real tree and the shim runs the compiler
+  under ccache against a host-mounted cache dir (see
+  services.ci-runner.kbuildCcache). The static fallback lane for configs
+  whose plan-time tooling rejects stub objects; outputs are bit-identical
+  with or without cache hits, ccache only changes wall time.
+- "full": exact pre-#3413 behavior (plan = reference), kept as the
+  debugging baseline.
 
 On CONFIG_MODULES=y configs the plan also runs `make modules`, and the unit
 graph extends over module objects, both modpost passes (`vmlinux.symvers`
 with its generated ksymtab source, `Module.symvers` with each module's
 `.mod.c`), and every final `.ko` link; `modulesEquivalence` byte-compares
-each unit-built module against the monolithic build's (#3413).
+each unit-built module against the reference build's (#3413).
 
 Each unit's build tree is scoped to the sources its .cmd recorded (#3412):
 compile units see their .c plus tracked headers as per-file store paths,
 the link unit adds the script-read Makefile and header trees, and archive
-aggregation sees only dep unit outputs plus the snapshot. A one-file body
-edit thus re-instantiates one TU derivation and its link chain; a
-comment-only edit cuts off at the unchanged CA object.
+aggregation sees only dep unit outputs plus the snapshot. Units always
+compile the real sources regardless of `planStrategy`; the skeleton exists
+only to make the plan's inputs body-independent.
 */
 {
   lib,
   # astlog-ignore: no-pkgs-in-callpackage
   pkgs,
   nixKbuildUnit,
+  writeBashApplication,
 }: let
   # Toolset the plan kbuild needs; unit replays get the same set so a saved
   # command never resolves a tool differently than the plan build did.
@@ -70,11 +86,103 @@ comment-only edit cuts off at the unchanged CA object.
     outputHashMode = "recursive";
   };
 
+  # The cc-wrapper seeds -frandom-seed from a fragment of the building
+  # derivation's $out and appends NIX_CFLAGS_COMPILE after user argv, so the
+  # last seed wins codegen. Appending a constant pins objects, but the
+  # assembler listings the snapshot keeps (asm-offsets.s, bounds.s) record
+  # every passed option, so a surviving $out-derived seed would shift the
+  # snapshot's content address on every plan drv change and re-execute every
+  # unit. Strip the wrapper seed and pin the constant as the only seed --
+  # identically in the plan, the reference build, and every unit replay
+  # (templates/units.nix.in), or their objects could never match.
+  pinRandomSeed = ''
+    # shell
+    NIX_CFLAGS_COMPILE=$(printf '%s' "''${NIX_CFLAGS_COMPILE:-}" | sed 's/-frandom-seed=[^ ]*//g')
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -frandom-seed=kbuild-unit"
+  '';
+
+  buildVmlinuxAndModules = ''
+    # shell
+    runHook preBuild
+    make -j"$NIX_BUILD_CORES" vmlinux
+    # The modules pass (modpost over modules.order, per-module .mod.o
+    # and .ko links) exists only on CONFIG_MODULES=y configs; tinyconfig
+    # has none, and the module-less plan must stay byte-identical so
+    # every existing unit realisation cuts off.
+    if grep -q '^CONFIG_MODULES=y$' .config; then
+      make -j"$NIX_BUILD_CORES" modules
+    fi
+    runHook postBuild
+  '';
+
+  # Reference copies for the byte-identity gates: the monolithic vmlinux,
+  # every .ko at its objtree-relative path, and the modpost symvers dump.
+  installReference = ''
+    # shell
+    cp vmlinux $out/vmlinux
+    if grep -q '^CONFIG_MODULES=y$' .config; then
+      mkdir -p $out/reference-modules
+      find . -name '*.ko' -exec cp --parents {} $out/reference-modules \;
+      cp Module.symvers $out/reference-modules/Module.symvers
+    fi
+  '';
+
+  # The plan-only compiler shim (#3413), named literally `gcc` so kbuild's
+  # $(CC) resolves to it via PATH while savedcmd_* keeps recording plain
+  # `gcc`; unit replays then resolve the real cc-wrapper. Skeleton mode stubs
+  # reduced TUs' objects (marker-gated); ccache mode wraps the real compiler
+  # in ccache. See the script for the full contract.
+  planCcShim = writeBashApplication {
+    name = "gcc";
+    text = builtins.readFile ./kbuild-plan-cc.sh;
+  };
+
+  # Skeleton-only linker shim: `--defsym`s the linker-script-referenced
+  # symbols the stub objects no longer define (plus lenient resolution),
+  # gated to vmlinux-ish outputs so vdso/realmode links stay byte-exact.
+  # See the script for the full contract.
+  planLdShim = writeBashApplication {
+    name = "ld";
+    text = builtins.readFile ./kbuild-plan-ld.sh;
+  };
+
   buildKernel = {
     src,
     configTarget ? "tinyconfig",
     contentAddressed ? true,
+    planStrategy ? "skeleton",
+    skeletonKeep ? [],
   }: let
+    # Extra env for the plan derivation, keyed by strategy; the lookup is
+    # also the planStrategy enum check. Env is invisible to savedcmd_*, so
+    # none of this leaks into replayed commands.
+    planShimEnv =
+      {
+        skeleton = {
+          KBUILD_UNIT_CC_MODE = "skeleton";
+          KBUILD_UNIT_CC_REAL = "${pkgs.stdenv.cc}/bin/gcc";
+          KBUILD_UNIT_LD_REAL = "${pkgs.stdenv.cc.bintools}/bin/ld";
+        };
+        ccache = {
+          KBUILD_UNIT_CC_MODE = "ccache";
+          KBUILD_UNIT_CC_REAL = "${pkgs.stdenv.cc}/bin/gcc";
+          KBUILD_UNIT_CCACHE = lib.getExe pkgs.ccache;
+          # The cache dir a builder host opts into mounting via
+          # services.ci-runner.kbuildCcache; the shim warns and builds
+          # uncached when it is absent. Size cap and cwd/time hygiene ride
+          # here so every writer applies the same policy.
+          CCACHE_DIR = "/var/cache/kbuild-ccache";
+          CCACHE_MAXSIZE = "30G";
+          CCACHE_NOHASHDIR = "1";
+          CCACHE_SLOPPINESS = "time_macros";
+        };
+        full = {};
+      }
+      .${
+        planStrategy
+      }
+        or (throw "kbuild-unit: unknown planStrategy \"${planStrategy}\" (expected \"skeleton\", \"ccache\", or \"full\")");
+
     # The kernel `src` is a tarball; units and harvest need the unpacked tree
     # as a directory (symlink-farm base and byte-compare reference).
     srcTree = pkgs.srcOnly {
@@ -84,12 +192,29 @@ comment-only edit cuts off at the unchanged CA object.
       stdenv = pkgs.stdenvNoCC;
     };
 
+    # Directives-only reduction of the tree (#3413). CA: a function-body edit
+    # rebuilds this derivation but lands the identical output path, so the
+    # plan's resolved derivation is already realised and does not rerun. A
+    # header/Makefile/Kconfig edit changes the skeleton and reruns the plan.
+    skeletonTree =
+      pkgs.runCommand "kbuild-unit-skeleton"
+      ({nativeBuildInputs = [nixKbuildUnit];} // lib.optionalAttrs contentAddressed contentAddressing)
+      ''
+        nix-kbuild-unit skeleton --src ${srcTree} --out $out \
+          ${lib.concatMapStringsSep " " (glob: "--keep ${lib.escapeShellArg glob}") skeletonKeep}
+      '';
+
+    planSrc =
+      if planStrategy == "skeleton"
+      then skeletonTree
+      else srcTree;
+
     plan = pkgs.stdenv.mkDerivation ({
         pname = "kbuild-unit-plan";
         version = configTarget;
-        src = srcTree;
+        src = planSrc;
         nativeBuildInputs = kbuildInputs ++ [nixKbuildUnit];
-        env = reproEnv;
+        env = reproEnv // planShimEnv;
         # Unit replays must see identical bits: no strip / patchelf over the
         # reference vmlinux or the snapshotted host tools.
         dontFixup = true;
@@ -100,17 +225,18 @@ comment-only edit cuts off at the unchanged CA object.
         configurePhase = ''
           # shell
           runHook preConfigure
-          # The cc-wrapper seeds -frandom-seed from a fragment of this
-          # derivation's $out and appends NIX_CFLAGS_COMPILE after user argv,
-          # so the last seed wins codegen. Appending a constant pins objects,
-          # but the assembler listings the snapshot keeps (asm-offsets.s,
-          # bounds.s) record every passed option, so a surviving $out-derived
-          # seed would shift the snapshot's content address on every plan drv
-          # change and re-execute every unit. Strip the wrapper seed and pin
-          # the constant as the only seed, here and in every unit replay
-          # (templates/units.nix.in).
-          NIX_CFLAGS_COMPILE=$(printf '%s' "''${NIX_CFLAGS_COMPILE:-}" | sed 's/-frandom-seed=[^ ]*//g')
-          export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -frandom-seed=kbuild-unit"
+          ${lib.optionalString (planStrategy != "full") ''
+            # The shim must shadow the cc-wrapper for $(CC) = gcc; PATH is
+            # env, so savedcmd_* still records bare `gcc`.
+            export PATH=${planCcShim}/bin:$PATH
+          ''}
+          ${lib.optionalString (planStrategy == "skeleton") ''
+            export PATH=${planLdShim}/bin:$PATH
+          ''}
+          ${lib.optionalString (planStrategy == "ccache") ''
+            export CCACHE_BASEDIR="$PWD"
+          ''}
+          ${pinRandomSeed}
           # Capture the env kbuild exports to scripts/link-vmlinux.sh so the
           # rendered link unit can replay it (CC/LD/LINUXINCLUDE/KBUILD_* for
           # the in-script init/version-timestamp.o compile and postlink make).
@@ -125,41 +251,59 @@ comment-only edit cuts off at the unchanged CA object.
           make ${configTarget}
           runHook postConfigure
         '';
-        buildPhase = ''
-          # shell
-          runHook preBuild
-          make -j"$NIX_BUILD_CORES" vmlinux
-          # The modules pass (modpost over modules.order, per-module .mod.o
-          # and .ko links) exists only on CONFIG_MODULES=y configs; tinyconfig
-          # has none, and the module-less plan must stay byte-identical so
-          # every existing unit realisation cuts off.
-          if grep -q '^CONFIG_MODULES=y$' .config; then
-            make -j"$NIX_BUILD_CORES" modules
-          fi
-          runHook postBuild
-        '';
+        buildPhase = buildVmlinuxAndModules;
         installPhase = ''
           # shell
           runHook preInstall
           mkdir -p $out
-          # Monolithic reference for the byte-identity gate below.
-          cp vmlinux $out/vmlinux
-          # Reference modules for the module byte-identity gate: every .ko at
-          # its objtree-relative path, plus the modpost symvers dump.
-          if grep -q '^CONFIG_MODULES=y$' .config; then
-            mkdir -p $out/reference-modules
-            find . -name '*.ko' -exec cp --parents {} $out/reference-modules \;
-            cp Module.symvers $out/reference-modules/Module.symvers
-          fi
+          ${
+            # Under skeleton the plan's vmlinux and .ko files are stub garbage;
+            # the gates compare against referenceKernel instead.
+            lib.optionalString (planStrategy != "skeleton") installReference
+          }
           nix-kbuild-unit harvest \
             --objtree . \
-            --srctree ${srcTree} \
+            --srctree ${planSrc} \
             --generated-out $out/generated \
             > $out/plan.json
           runHook postInstall
         '';
       }
       // lib.optionalAttrs contentAddressed contentAddressing);
+
+    # The real monolithic build the equivalence gates compare against when
+    # the plan's own outputs are stubs (skeleton strategy). Same pins as the
+    # plan, no harvest, no shim: this is the P2-era plan build minus
+    # plan.json.
+    referenceKernel = pkgs.stdenv.mkDerivation ({
+        pname = "kbuild-unit-reference";
+        version = configTarget;
+        src = srcTree;
+        nativeBuildInputs = kbuildInputs;
+        env = reproEnv;
+        dontFixup = true;
+        configurePhase = ''
+          # shell
+          runHook preConfigure
+          ${pinRandomSeed}
+          make ${configTarget}
+          runHook postConfigure
+        '';
+        buildPhase = buildVmlinuxAndModules;
+        installPhase = ''
+          # shell
+          runHook preInstall
+          mkdir -p $out
+          ${installReference}
+          runHook postInstall
+        '';
+      }
+      // lib.optionalAttrs contentAddressed contentAddressing);
+
+    reference =
+      if planStrategy == "skeleton"
+      then referenceKernel
+      else plan;
 
     unitsNix =
       pkgs.runCommand "kbuild-units.nix" {
@@ -189,26 +333,27 @@ comment-only edit cuts off at the unchanged CA object.
     };
 
     # The exit gate: the unit-composed vmlinux must be byte-identical to the
-    # monolithic vmlinux from the very kbuild the plan was harvested from.
+    # monolithic vmlinux from the reference build (the plan build itself for
+    # ccache/full, the dedicated referenceKernel for skeleton).
     vmlinuxEquivalence = pkgs.runCommand "kbuild-unit-vmlinux-equivalence" {} ''
-      cmp ${imported.vmlinux}/vmlinux ${plan}/vmlinux
-      sha256sum ${imported.vmlinux}/vmlinux ${plan}/vmlinux > $out
+      cmp ${imported.vmlinux}/vmlinux ${reference}/vmlinux
+      sha256sum ${imported.vmlinux}/vmlinux ${reference}/vmlinux > $out
     '';
 
     # Module exit gate (#3413): every unit-built .ko and the modules-pass
-    # symvers dump must be byte-identical to the monolithic build's. On a
-    # module-less config the gate instead asserts the plan build agreed that
-    # there was nothing to compare.
+    # symvers dump must be byte-identical to the reference build's. On a
+    # module-less config the gate instead asserts the reference build agreed
+    # that there was nothing to compare.
     modulesEquivalence =
       if imported.moduleSymvers == null
       then
         pkgs.runCommand "kbuild-unit-modules-equivalence" {} ''
-          test ! -e ${plan}/reference-modules
+          test ! -e ${reference}/reference-modules
           echo "no modules (CONFIG_MODULES=n)" > $out
         ''
       else
         pkgs.runCommand "kbuild-unit-modules-equivalence" {} ''
-          cd ${plan}/reference-modules
+          cd ${reference}/reference-modules
           # Same module set on both sides, then byte-compare each member.
           diff <(find . -name '*.ko' | sort) \
             <(cd ${imported.modules} && find . -name '*.ko' | sort)
@@ -223,7 +368,7 @@ comment-only edit cuts off at the unchanged CA object.
   in
     imported
     // {
-      inherit plan unitsNix srcTree vmlinuxEquivalence modulesEquivalence;
+      inherit plan unitsNix srcTree skeletonTree referenceKernel vmlinuxEquivalence modulesEquivalence;
     };
 in {
   inherit buildKernel;

--- a/lib/kernel/kbuild-unit.nix
+++ b/lib/kernel/kbuild-unit.nix
@@ -146,6 +146,32 @@ only to make the plan's inputs body-independent.
     text = builtins.readFile ./kbuild-plan-ld.sh;
   };
 
+  # Appended by the ld shim to the stub vmlinux links: minimal one-entry
+  # stand-ins for sections the post-link tools require to exist (sorttable
+  # hard-fails on a vmlinux with no __ex_table; x86 entries are 3 ints on
+  # both widths). Assembled for each ELF class the shim may link
+  # (x86 tinyconfig is a 32-bit kernel, defconfig 64-bit).
+  planLdPlaceholders = pkgs.runCommand "kbuild-unit-ld-placeholders" {} ''
+    mkdir -p $out
+    # sorttable also patches main_extable_sort_needed (kernel/extable.c in
+    # real builds) through the symtab, so it needs backing storage here, not
+    # a --defsym absolute.
+    printf '%s\n' \
+      '.section __ex_table,"a"' \
+      '.balign 4' \
+      '.long 0, 0, 0' \
+      '.section .init.data,"aw"' \
+      '.globl main_extable_sort_needed' \
+      '.type main_extable_sort_needed, @object' \
+      '.size main_extable_sort_needed, 4' \
+      '.balign 4' \
+      'main_extable_sort_needed:' \
+      '.long 1' \
+      > extable.s
+    ${pkgs.stdenv.cc.bintools.bintools}/bin/as --64 -o $out/placeholder-64.o extable.s
+    ${pkgs.stdenv.cc.bintools.bintools}/bin/as --32 -o $out/placeholder-32.o extable.s
+  '';
+
   buildKernel = {
     src,
     configTarget ? "tinyconfig",
@@ -162,6 +188,7 @@ only to make the plan's inputs body-independent.
           KBUILD_UNIT_CC_MODE = "skeleton";
           KBUILD_UNIT_CC_REAL = "${pkgs.stdenv.cc}/bin/gcc";
           KBUILD_UNIT_LD_REAL = "${pkgs.stdenv.cc.bintools}/bin/ld";
+          KBUILD_UNIT_LD_PLACEHOLDER_DIR = "${planLdPlaceholders}";
         };
         ccache = {
           KBUILD_UNIT_CC_MODE = "ccache";
@@ -242,12 +269,15 @@ only to make the plan's inputs body-independent.
           # the in-script init/version-timestamp.o compile and postlink make).
           # The dump is build-created and not unit-owned, so harvest sweeps it
           # into the generated snapshot on its own. `export -p` because make
-          # runs the script under $(CONFIG_SHELL).
+          # runs the script under $(CONFIG_SHELL). The KBUILD_UNIT_* shim
+          # vars match the KBUILD_ prefix but must stay out: they carry
+          # plan-only store paths, and a snapshot that shifts with shim
+          # tweaks would re-execute every unit.
           # `|| :` and the muted stderr keep unit replays quiet: there the
           # dump target is a store symlink from the generated snapshot, the
           # rewrite fails by design, and the sourced snapshot env is already
           # identical to what the dump would produce.
-          sed -i '1a { export -p | grep -E "^(declare -x |export )(KBUILD_[A-Za-z0-9_]+|CONFIG_SHELL|CC|LD|NM|AR|OBJCOPY|OBJDUMP|READELF|STRIP|PAHOLE|RESOLVE_BTFIDS|SRCARCH|ARCH|srctree|objtree|LINUXINCLUDE|NOSTDINC_FLAGS|LDFLAGS_vmlinux|CFLAGS_vmlinux|KALLSYMS[A-Za-z0-9_]*|MAKE|HOSTCC)=" > .kbuild-unit-link-env; } 2>/dev/null || :' scripts/link-vmlinux.sh
+          sed -i '1a { export -p | grep -E "^(declare -x |export )(KBUILD_[A-Za-z0-9_]+|CONFIG_SHELL|CC|LD|NM|AR|OBJCOPY|OBJDUMP|READELF|STRIP|PAHOLE|RESOLVE_BTFIDS|SRCARCH|ARCH|srctree|objtree|LINUXINCLUDE|NOSTDINC_FLAGS|LDFLAGS_vmlinux|CFLAGS_vmlinux|KALLSYMS[A-Za-z0-9_]*|MAKE|HOSTCC)=" | grep -vE "^(declare -x |export )KBUILD_UNIT_" > .kbuild-unit-link-env; } 2>/dev/null || :' scripts/link-vmlinux.sh
           make ${configTarget}
           runHook postConfigure
         '';

--- a/lib/kernel/kbuild-unit.nix
+++ b/lib/kernel/kbuild-unit.nix
@@ -170,6 +170,25 @@ only to make the plan's inputs body-independent.
       > extable.s
     ${pkgs.stdenv.cc.bintools.bintools}/bin/as --64 -o $out/placeholder-64.o extable.s
     ${pkgs.stdenv.cc.bintools.bintools}/bin/as --32 -o $out/placeholder-32.o extable.s
+    # SRSO stand-in (see kbuild-plan-ld.sh): the alias pair placed exactly
+    # like arch/x86/lib/retpoline.S places it, so the linker script's
+    # `. = srso_alias_untrain_ret | 0x104104` moves the location counter
+    # forward and the pair's alias ASSERT (XOR == 0x104104) holds. The 2MiB
+    # alignment keeps the untrain symbol's low bits clear of the OR mask.
+    printf '%s\n' \
+      '.section .text..__x86.rethunk_untrain,"ax"' \
+      '.balign 2097152' \
+      '.globl srso_alias_untrain_ret' \
+      '.type srso_alias_untrain_ret, @function' \
+      'srso_alias_untrain_ret:' \
+      '.byte 0xc3' \
+      '.section .text..__x86.rethunk_safe,"ax"' \
+      '.globl srso_alias_safe_ret' \
+      '.type srso_alias_safe_ret, @function' \
+      'srso_alias_safe_ret:' \
+      '.byte 0xc3' \
+      > srso.s
+    ${pkgs.stdenv.cc.bintools.bintools}/bin/as --64 -o $out/placeholder-srso-64.o srso.s
   '';
 
   buildKernel = {

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -2199,6 +2199,15 @@ in {
       inherit (pkgs.linux_6_12) src;
       configTarget = "defconfig";
     };
+    # Static fallback lane (#3413): keeps the ccache plan strategy exercised
+    # so a config whose plan-time tooling rejects skeleton stub objects has a
+    # validated escape hatch to flip to (strategy selection is per-lane and
+    # never auto-detected; Nix cannot catch a failed drv, and a silent flip
+    # would hide skeleton regressions).
+    kernel-unit-ccache = (ix.kernelUnitFor pkgs).buildKernel {
+      inherit (pkgs.linux_6_12) src;
+      planStrategy = "ccache";
+    };
   };
 
   # `nix run .#bench` runs the repo's self-demo perf job (timing + RSS + custom

--- a/modules/services/ci-runner/default.nix
+++ b/modules/services/ci-runner/default.nix
@@ -81,6 +81,14 @@ in {
       '';
     };
 
+    kbuildCcache = {
+      # Independent of `enable`: the kbuild-unit ccache plan strategy
+      # (lib/kernel/kbuild-unit.nix) runs on any builder host, not only ones
+      # registering GitHub runners, so a host can opt into the cache mount
+      # without the runner pool.
+      enable = mkEnableOption "host-mounted ccache dir for kbuild-unit ccache-strategy plan builds";
+    };
+
     packages = mkOption {
       type = types.listOf types.package;
       default = [];
@@ -92,48 +100,62 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
-    # A warm shared cache is the whole point of a persistent runner: let the
-    # daemon substitute index artifacts so jobs skip cold rebuilds. Every key
-    # uses the `extra-*` form so it adds to Nix's defaults and any host config
-    # rather than replacing them (keeping cache.nixos.org, kvm, etc.).
-    nix.settings = {
-      extra-experimental-features = [
-        "nix-command"
-        "flakes"
-        # Repo-owned Rust units are floating content-addressed derivations. This
-        # is a daemon protocol capability, not something a workflow-side
-        # NIX_CONFIG can add for an untrusted runner user.
-        "ca-derivations"
-      ];
-      # The daemon owns the same cache and key below. Runner users are
-      # untrusted, so consuming the flake's restricted copies only emits
-      # ignored-setting warnings and cannot change daemon policy.
-      accept-flake-config = false;
-      extra-substituters = ["https://cache.ix.dev"];
-      extra-trusted-public-keys = [
-        "ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI="
-      ];
-      # Index images pin `gcc.arch = znver5`, so every derivation in the closure
-      # requires this builder feature; advertise it or the daemon refuses the
-      # builds before they evaluate.
-      extra-system-features = ["gccarch-znver5"];
-    };
+  config = lib.mkMerge [
+    (mkIf cfg.kbuildCcache.enable {
+      # kbuild-unit's "ccache" plan strategy (#3413) compiles through ccache
+      # inside the build sandbox; the cache only works if the daemon mounts
+      # this host dir into every sandbox. The dir must exist before the first
+      # build or the daemon fails all builds on the missing mount source,
+      # hence the tmpfiles rule; 0770 root:nixbld lets sandboxed builders
+      # (nixbld group) write while nothing else on the host can. Size cap and
+      # cache hygiene knobs ride in the derivation env (kbuild-unit.nix), so
+      # the policy has one owner.
+      nix.settings.extra-sandbox-paths = ["/var/cache/kbuild-ccache"];
+      systemd.tmpfiles.rules = ["d /var/cache/kbuild-ccache 0770 root nixbld -"];
+    })
+    (mkIf cfg.enable {
+      # A warm shared cache is the whole point of a persistent runner: let the
+      # daemon substitute index artifacts so jobs skip cold rebuilds. Every key
+      # uses the `extra-*` form so it adds to Nix's defaults and any host config
+      # rather than replacing them (keeping cache.nixos.org, kvm, etc.).
+      nix.settings = {
+        extra-experimental-features = [
+          "nix-command"
+          "flakes"
+          # Repo-owned Rust units are floating content-addressed derivations. This
+          # is a daemon protocol capability, not something a workflow-side
+          # NIX_CONFIG can add for an untrusted runner user.
+          "ca-derivations"
+        ];
+        # The daemon owns the same cache and key below. Runner users are
+        # untrusted, so consuming the flake's restricted copies only emits
+        # ignored-setting warnings and cannot change daemon policy.
+        accept-flake-config = false;
+        extra-substituters = ["https://cache.ix.dev"];
+        extra-trusted-public-keys = [
+          "ix-workspace:JuAaeOPfR3GL3nUICpEz/88/+S3BzGF3L6bPYFy0GwI="
+        ];
+        # Index images pin `gcc.arch = znver5`, so every derivation in the closure
+        # requires this builder feature; advertise it or the daemon refuses the
+        # builds before they evaluate.
+        extra-system-features = ["gccarch-znver5"];
+      };
 
-    services.github-runners = lib.genAttrs runnerNames (_name: {
-      enable = true;
-      inherit (cfg) url tokenFile ephemeral;
-      extraLabels = cfg.labels;
-      # Re-register under the same name after a host config change instead of
-      # failing on a name clash with the already-registered runner.
-      replace = true;
-      extraPackages =
-        [
-          pkgs.gh
-          pkgs.git
-          config.nix.package
-        ]
-        ++ cfg.packages;
-    });
-  };
+      services.github-runners = lib.genAttrs runnerNames (_name: {
+        enable = true;
+        inherit (cfg) url tokenFile ephemeral;
+        extraLabels = cfg.labels;
+        # Re-register under the same name after a host config change instead of
+        # failing on a name clash with the already-registered runner.
+        replace = true;
+        extraPackages =
+          [
+            pkgs.gh
+            pkgs.git
+            config.nix.package
+          ]
+          ++ cfg.packages;
+      });
+    })
+  ];
 }

--- a/packages/nix/nix-kbuild-unit/src/main.rs
+++ b/packages/nix/nix-kbuild-unit/src/main.rs
@@ -2,6 +2,7 @@ mod cmd_file;
 mod harvest;
 mod model;
 mod render;
+mod skeleton;
 
 use std::io::Read as _;
 use std::path::PathBuf;
@@ -27,6 +28,10 @@ enum Command {
 
     /// Render generated Nix from plan JSON on stdin.
     Render(RenderArgs),
+
+    /// Reduce a kernel source tree to directives-only "skeleton" sources
+    /// (#3413), so plan builds no longer depend on function bodies.
+    Skeleton(SkeletonArgs),
 }
 
 #[derive(Debug, clap::Args)]
@@ -51,6 +56,22 @@ struct RenderArgs {
     content_addressed: bool,
 }
 
+#[derive(Debug, clap::Args)]
+struct SkeletonArgs {
+    /// Pristine kernel source tree to reduce.
+    #[arg(long, value_name = "PATH")]
+    src: PathBuf,
+
+    /// Where to write the reduced tree (created if absent).
+    #[arg(long, value_name = "PATH")]
+    out: PathBuf,
+
+    /// Keep sources matching this glob byte-verbatim, on top of the built-in
+    /// allowlist (repeatable; `*` matches within a path segment, `**` across).
+    #[arg(long = "keep", value_name = "GLOB")]
+    keep: Vec<String>,
+}
+
 fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
 
@@ -60,6 +81,10 @@ fn main() -> color_eyre::Result<()> {
                 harvest::harvest(&args.objtree, &args.srctree, args.generated_out.as_deref())?;
             serde_json::to_writer(std::io::stdout(), &plan).wrap_err("writing plan JSON")?;
             println!();
+        }
+        Command::Skeleton(args) => {
+            skeleton::skeleton(&args.src, &args.out, &args.keep)
+                .wrap_err("reducing source tree to a skeleton")?;
         }
         Command::Render(args) => {
             let mut input = String::new();

--- a/packages/nix/nix-kbuild-unit/src/skeleton.rs
+++ b/packages/nix/nix-kbuild-unit/src/skeleton.rs
@@ -1,0 +1,591 @@
+//! Stage 0 (`skeleton` subcommand, #3413): reduce a kernel source tree to the
+//! inputs the *plan* build actually depends on, so a function-body edit never
+//! reruns the plan.
+//!
+//! Every compiled source (`**/*.c`, `**/*.S`) is stripped to its preprocessor
+//! directives; everything else (headers, Makefiles, Kconfig, `scripts/**`,
+//! `tools/**`, linker scripts, `.dts`, ...) is copied byte-verbatim. The
+//! output is a plain copy, never symlinks, so its content (and therefore its
+//! content-addressed store path) is independent of the input's store path:
+//! two source trees that differ only in function bodies reduce to identical
+//! skeletons, the plan derivation's resolved inputs stay unchanged, and the
+//! already-realised plan is reused. Directive lines (`^\s*#`, with their
+//! backslash continuations) are preserved because they are exactly what
+//! determines the recorded dep set (`-Wp,-MMD`) and the saved command flags;
+//! bodies only influence object bytes, which the plan's stub objects (see
+//! `lib/kernel/kbuild-plan-cc.sh`) discard anyway.
+//!
+//! Reduced files start with [`MARKER`] so the plan's compiler shim can
+//! recognize them and substitute stub objects without any allowlist plumbing:
+//! the reducer's keep decision *is* the shim's stub decision.
+
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{WrapErr as _, bail};
+
+/// First line of every reduced source file. The plan's `gcc` shim stubs a
+/// compile exactly when its source operand starts with this line, so the
+/// reduction decision made here is the single source of truth.
+pub const MARKER: &str =
+    "/* nix-kbuild-unit skeleton: reduced to preprocessor directives (#3413) */\n";
+
+/// Sources kept whole even though they match `**/*.c` / `**/*.S`: their
+/// compiled output feeds the generated snapshot or the plan-time link, so a
+/// stub object would corrupt what units later consume. Globs: `*` matches
+/// within one path segment, `**` matches any number of segments.
+///
+/// - asm-offsets / bounds: their `-S` listings become `include/generated/`
+///   headers every unit reads from the snapshot.
+/// - vdso trees: the vdso `.so` is built at plan time and embedded via the
+///   generated `vdso-image-*.c`, so its bytes must be real.
+/// - realmode / boot: `realmode.bin` is incbin'd into vmlinux and its
+///   `.relocs` dump rides in the snapshot.
+/// - linker-script symbol definers: the plan-time vmlinux link evaluates
+///   `jiffies = jiffies_64;`-style script assignments eagerly, and ld hard
+///   errors on an undefined symbol in an expression, so the few TUs defining
+///   symbols the x86 linker script references stay real.
+pub const DEFAULT_KEEP: &[&str] = &[
+    "arch/*/kernel/asm-offsets*.c",
+    "kernel/bounds.c",
+    "arch/*/entry/vdso/**",
+    "arch/*/kernel/vdso*/**",
+    "lib/vdso/**",
+    "arch/x86/realmode/**",
+    "arch/*/boot/**",
+];
+
+/// Reduce `src` into `out` (created if absent), keeping `extra_keep` globs
+/// verbatim on top of [`DEFAULT_KEEP`].
+pub fn skeleton(src: &Path, out: &Path, extra_keep: &[String]) -> color_eyre::Result<()> {
+    std::fs::create_dir_all(out).wrap_err_with(|| format!("creating {}", out.display()))?;
+    let mut stack = vec![PathBuf::new()];
+    while let Some(rel_dir) = stack.pop() {
+        let dir = src.join(&rel_dir);
+        let entries =
+            std::fs::read_dir(&dir).wrap_err_with(|| format!("listing {}", dir.display()))?;
+        for entry in entries {
+            let entry = entry.wrap_err_with(|| format!("listing {}", dir.display()))?;
+            let file_type = entry.file_type()?;
+            let rel = rel_dir.join(entry.file_name());
+            let dst = out.join(&rel);
+            if file_type.is_dir() {
+                std::fs::create_dir(&dst)
+                    .wrap_err_with(|| format!("creating {}", dst.display()))?;
+                stack.push(rel);
+                continue;
+            }
+            let Some(rel_str) = rel.to_str() else {
+                bail!("non-UTF-8 path in source tree: {}", rel.display());
+            };
+            if file_type.is_symlink() {
+                let target = std::fs::read_link(entry.path())
+                    .wrap_err_with(|| format!("readlink {rel_str}"))?;
+                std::os::unix::fs::symlink(&target, &dst)
+                    .wrap_err_with(|| format!("recreating symlink {rel_str}"))?;
+                continue;
+            }
+            match reduction_lang(rel_str, extra_keep) {
+                Some(lang) => {
+                    let bytes = std::fs::read(entry.path())
+                        .wrap_err_with(|| format!("reading {rel_str}"))?;
+                    std::fs::write(&dst, reduce(&bytes, lang))
+                        .wrap_err_with(|| format!("writing {rel_str}"))?;
+                }
+                None => {
+                    // fs::copy preserves permission bits, so kept scripts
+                    // stay executable.
+                    std::fs::copy(entry.path(), &dst)
+                        .wrap_err_with(|| format!("copying {rel_str}"))?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// How a reduced file is tokenized: `'` starts a character literal in C, but
+/// gas allows unterminated `'a` character operands, so treating `'` as a
+/// delimiter in assembly could swallow the rest of the file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Lang {
+    C,
+    Asm,
+}
+
+/// Whether `rel` gets reduced, and as which language. Only `**/*.c` and
+/// `**/*.S` reduce; `*.lds.S` linker scripts, host sources under `scripts/`
+/// and `tools/`, and allowlist matches stay verbatim.
+fn reduction_lang(rel: &str, extra_keep: &[String]) -> Option<Lang> {
+    if rel.ends_with(".lds.S") || rel.starts_with("scripts/") || rel.starts_with("tools/") {
+        return None;
+    }
+    let lang = if rel.ends_with(".c") {
+        Lang::C
+    } else if rel.ends_with(".S") {
+        Lang::Asm
+    } else {
+        return None;
+    };
+    if DEFAULT_KEEP.iter().any(|glob| glob_match(glob, rel))
+        || extra_keep.iter().any(|glob| glob_match(glob, rel))
+    {
+        return None;
+    }
+    Some(lang)
+}
+
+/// Strip comments (string-literal-aware), then keep only preprocessor
+/// directive lines (`^\s*#`) with their backslash-continuation lines. The
+/// output starts with [`MARKER`].
+fn reduce(bytes: &[u8], lang: Lang) -> Vec<u8> {
+    let stripped = strip_comments(bytes, lang);
+    let lines: Vec<&[u8]> = stripped.split(|&b| b == b'\n').collect();
+    let mut out = Vec::with_capacity(MARKER.len() + stripped.len() / 4);
+    out.extend_from_slice(MARKER.as_bytes());
+    let mut i = 0;
+    while i < lines.len() {
+        // One logical line: physical lines spliced by trailing backslashes.
+        let mut last = i;
+        while last + 1 < lines.len() && lines[last].ends_with(b"\\") {
+            last += 1;
+        }
+        let is_directive =
+            lines[i].iter().copied().find(|&b| b != b' ' && b != b'\t') == Some(b'#');
+        if is_directive {
+            for line in &lines[i..=last] {
+                out.extend_from_slice(line);
+                out.push(b'\n');
+            }
+        }
+        i = last + 1;
+    }
+    out
+}
+
+/// Replace comments with whitespace, tracking string and (for C) character
+/// literals so a `//` or `/*` inside a literal is not a comment, and a `#`
+/// inside a comment never reaches the directive scan.
+///
+/// Block comments collapse to a single space with interior newlines dropped:
+/// a comment inside a directive is whitespace, not a line break, so
+/// `#define X /* multi\nline */ 1` must stay one logical line. (Valid code
+/// cannot hide a directive boundary inside a block comment: a `#` is only a
+/// directive when it follows a real newline, which a comment never contains
+/// after phase-3 replacement.) Line comments swallow their backslash
+/// continuations; their terminating newline stays.
+fn strip_comments(bytes: &[u8], lang: Lang) -> Vec<u8> {
+    #[derive(PartialEq)]
+    enum State {
+        Normal,
+        DoubleQuote,
+        SingleQuote,
+    }
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut state = State::Normal;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match state {
+            State::Normal => {
+                if b == b'/' && bytes.get(i + 1) == Some(&b'/') {
+                    i += 2;
+                    while i < bytes.len() && bytes[i] != b'\n' {
+                        // A backslash-newline splices the next physical line
+                        // into the comment.
+                        if bytes[i] == b'\\' && bytes.get(i + 1) == Some(&b'\n') {
+                            i += 2;
+                        } else {
+                            i += 1;
+                        }
+                    }
+                    continue;
+                }
+                if b == b'/' && bytes.get(i + 1) == Some(&b'*') {
+                    out.push(b' ');
+                    i += 2;
+                    while i < bytes.len() {
+                        if bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/') {
+                            i += 2;
+                            break;
+                        }
+                        i += 1;
+                    }
+                    continue;
+                }
+                if b == b'"' {
+                    state = State::DoubleQuote;
+                } else if b == b'\'' && lang == Lang::C {
+                    state = State::SingleQuote;
+                }
+                out.push(b);
+                i += 1;
+            }
+            State::DoubleQuote | State::SingleQuote => {
+                if b == b'\\' && i + 1 < bytes.len() {
+                    out.push(b);
+                    out.push(bytes[i + 1]);
+                    i += 2;
+                    continue;
+                }
+                let closing = match state {
+                    State::DoubleQuote => b'"',
+                    _ => b'\'',
+                };
+                if b == closing {
+                    state = State::Normal;
+                }
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+/// Match `path` against a `/`-separated glob: `**` spans any number of
+/// segments, `*` matches within one segment. No other metacharacters.
+fn glob_match(pattern: &str, path: &str) -> bool {
+    let pattern: Vec<&str> = pattern.split('/').collect();
+    let path: Vec<&str> = path.split('/').collect();
+    match_segments(&pattern, &path)
+}
+
+fn match_segments(pattern: &[&str], path: &[&str]) -> bool {
+    let Some((first, rest)) = pattern.split_first() else {
+        return path.is_empty();
+    };
+    if *first == "**" {
+        return (0..=path.len()).any(|skip| match_segments(rest, &path[skip..]));
+    }
+    let Some((seg, path_rest)) = path.split_first() else {
+        return false;
+    };
+    segment_match(first.as_bytes(), seg.as_bytes()) && match_segments(rest, path_rest)
+}
+
+/// Classic backtracking wildcard match; `*` matches any run of bytes.
+fn segment_match(pattern: &[u8], segment: &[u8]) -> bool {
+    let (mut pi, mut si) = (0, 0);
+    let mut star: Option<(usize, usize)> = None;
+    while si < segment.len() {
+        if pattern.get(pi) == Some(&b'*') {
+            star = Some((pi, si));
+            pi += 1;
+        } else if pattern.get(pi) == Some(&segment[si]) {
+            pi += 1;
+            si += 1;
+        } else if let Some((star_pi, star_si)) = star {
+            pi = star_pi + 1;
+            si = star_si + 1;
+            star = Some((star_pi, star_si + 1));
+        } else {
+            return false;
+        }
+    }
+    while pattern.get(pi) == Some(&b'*') {
+        pi += 1;
+    }
+    pi == pattern.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reduced(text: &str, lang: Lang) -> String {
+        String::from_utf8(reduce(text.as_bytes(), lang)).expect("reduced output is UTF-8")
+    }
+
+    fn body(text: &str, lang: Lang) -> String {
+        let out = reduced(text, lang);
+        out.strip_prefix(MARKER).expect("marker prefix").to_owned()
+    }
+
+    #[test]
+    fn keeps_directives_drops_bodies() {
+        let src = "\
+#include <linux/kernel.h>
+#include \"internal.h\"
+
+static int add(int a, int b)
+{
+\treturn a + b;
+}
+
+#ifdef CONFIG_SMP
+int smp_thing;
+#else
+int up_thing;
+#endif
+";
+        assert_eq!(
+            body(src, Lang::C),
+            "#include <linux/kernel.h>\n#include \"internal.h\"\n#ifdef CONFIG_SMP\n#else\n#endif\n"
+        );
+    }
+
+    #[test]
+    fn keeps_backslash_continuations() {
+        let src = "\
+#define LONG_MACRO(x) \\
+\tdo { (x)++; } while (0)
+int not_a_directive = 1;
+";
+        assert_eq!(
+            body(src, Lang::C),
+            "#define LONG_MACRO(x) \\\n\tdo { (x)++; } while (0)\n"
+        );
+        // A continuation chain keeps every physical line, even ones that do
+        // not themselves look like directives.
+        let chain = "#define A \\\n b \\\n c\n";
+        assert_eq!(body(chain, Lang::C), chain);
+    }
+
+    #[test]
+    fn continuation_from_code_line_swallows_directive_lookalike() {
+        // The splice makes the `#` mid-line, so the original never treated it
+        // as a directive either.
+        let src = "int a = b \\\n#define X\n";
+        assert_eq!(body(src, Lang::C), "");
+    }
+
+    #[test]
+    fn comment_embedded_hash_is_not_a_directive() {
+        let src = "\
+/*
+ * # this hash starts a line inside a comment
+ *#include <not/real.h>
+ */
+// #define ALSO_NOT_REAL
+#define REAL 1
+";
+        assert_eq!(body(src, Lang::C), "#define REAL 1\n");
+    }
+
+    #[test]
+    fn strings_hide_comment_openers() {
+        let src = "\
+#define URL \"http://example.com\"
+static const char *s = \"/* not a comment\";
+#define AFTER 2
+";
+        assert_eq!(
+            body(src, Lang::C),
+            "#define URL \"http://example.com\"\n#define AFTER 2\n"
+        );
+    }
+
+    #[test]
+    fn char_literal_hides_quote_in_c_but_not_asm() {
+        // '"' must not open a string in C...
+        let src = "#define Q '\"' // quote\n#define AFTER 3\n";
+        assert_eq!(body(src, Lang::C), "#define Q '\"' \n#define AFTER 3\n");
+        // ...while gas-style unterminated 'a operands must not swallow the
+        // rest of an assembly file.
+        let asm = "mov $'a, %eax\n#define AFTER 4\n";
+        assert_eq!(body(asm, Lang::Asm), "#define AFTER 4\n");
+    }
+
+    #[test]
+    fn trailing_line_comment_on_directive_is_stripped() {
+        let src = "#include <a.h> // why\n#include <b.h> /* also why */\n";
+        assert_eq!(body(src, Lang::C), "#include <a.h> \n#include <b.h>  \n");
+    }
+
+    #[test]
+    fn line_comment_continuation_stays_comment() {
+        // The backslash splices the next line into the comment, not into the
+        // macro.
+        let src = "#define X 1 // comment \\\n   still comment\n#define Y 2\n";
+        assert_eq!(body(src, Lang::C), "#define X 1 \n#define Y 2\n");
+    }
+
+    #[test]
+    fn block_comment_inside_directive_stays_one_logical_line() {
+        // Phase-3 comment replacement makes this one directive defining X as
+        // 1; dropping the second physical line would redefine X as empty.
+        let src = "#define X /* multi\nline */ 1\nint code;\n";
+        assert_eq!(body(src, Lang::C), "#define X   1\n");
+    }
+
+    #[test]
+    fn marker_prefixes_reduced_output() {
+        let out = reduced("int x;\n", Lang::C);
+        assert!(out.starts_with(MARKER));
+        assert!(MARKER.starts_with("/* nix-kbuild-unit skeleton:"));
+    }
+
+    #[test]
+    fn reduction_scope() {
+        let no_extra: &[String] = &[];
+        // Kernel sources reduce.
+        assert_eq!(reduction_lang("kernel/fork.c", no_extra), Some(Lang::C));
+        assert_eq!(
+            reduction_lang("arch/x86/kernel/head_64.S", no_extra),
+            Some(Lang::Asm)
+        );
+        // Linker scripts, host tools, headers, build files stay verbatim.
+        assert_eq!(
+            reduction_lang("arch/x86/kernel/vmlinux.lds.S", no_extra),
+            None
+        );
+        assert_eq!(reduction_lang("scripts/mod/modpost.c", no_extra), None);
+        assert_eq!(reduction_lang("tools/objtool/check.c", no_extra), None);
+        assert_eq!(reduction_lang("include/linux/kernel.h", no_extra), None);
+        assert_eq!(reduction_lang("kernel/Makefile", no_extra), None);
+        // DEFAULT_KEEP allowlist hits stay verbatim.
+        assert_eq!(
+            reduction_lang("arch/x86/kernel/asm-offsets.c", no_extra),
+            None
+        );
+        assert_eq!(
+            reduction_lang("arch/x86/kernel/asm-offsets_64.c", no_extra),
+            None
+        );
+        assert_eq!(reduction_lang("kernel/bounds.c", no_extra), None);
+        assert_eq!(
+            reduction_lang("arch/x86/entry/vdso/vgetcpu.c", no_extra),
+            None
+        );
+        assert_eq!(reduction_lang("lib/vdso/gettimeofday.c", no_extra), None);
+        assert_eq!(
+            reduction_lang("arch/x86/realmode/rm/wakemain.c", no_extra),
+            None
+        );
+        assert_eq!(
+            reduction_lang("arch/x86/boot/compressed/misc.c", no_extra),
+            None
+        );
+        // --keep extends the allowlist.
+        let extra = vec!["drivers/net/**".to_owned()];
+        assert_eq!(reduction_lang("drivers/net/dummy.c", &extra), None);
+        assert_eq!(reduction_lang("drivers/gpu/nope.c", &extra), Some(Lang::C));
+    }
+
+    #[test]
+    fn glob_semantics() {
+        assert!(glob_match(
+            "arch/*/kernel/asm-offsets*.c",
+            "arch/x86/kernel/asm-offsets.c"
+        ));
+        assert!(glob_match(
+            "arch/*/kernel/asm-offsets*.c",
+            "arch/arm64/kernel/asm-offsets_64.c"
+        ));
+        // `*` stays within one segment...
+        assert!(!glob_match(
+            "arch/*/kernel/asm-offsets*.c",
+            "arch/x86/xen/kernel/asm-offsets.c"
+        ));
+        assert!(!glob_match("lib/*.c", "lib/vdso/gettimeofday.c"));
+        // ...while `**` spans segments, including zero.
+        assert!(glob_match("lib/vdso/**", "lib/vdso/gettimeofday.c"));
+        assert!(glob_match("lib/vdso/**", "lib/vdso/deep/nested/file.c"));
+        assert!(!glob_match("lib/vdso/**", "lib/vdso.c"));
+        assert!(glob_match(
+            "arch/*/kernel/vdso*/**",
+            "arch/x86/kernel/vdso64/note.S"
+        ));
+        assert!(glob_match("**/*.c", "a/b/c.c"));
+        assert!(glob_match("**/*.c", "top.c"));
+        assert!(!glob_match("kernel/bounds.c", "kernel/bounds.c.orig"));
+    }
+
+    #[test]
+    fn skeleton_tree_reduces_copies_and_links() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("src");
+        let out = tmp.path().join("out");
+
+        let write = |rel: &str, contents: &str| {
+            let path = src.join(rel);
+            std::fs::create_dir_all(path.parent().expect("rel has parent")).expect("mkdir");
+            std::fs::write(path, contents).expect("write fixture");
+        };
+        write("kernel/fork.c", "#include <a.h>\nint fork_body;\n");
+        write("kernel/bounds.c", "int kept_whole;\n");
+        write(
+            "include/linux/a.h",
+            "static inline int f(void) { return 1; }\n",
+        );
+        write("arch/x86/kernel/vmlinux.lds.S", "SECTIONS { }\n");
+        write("scripts/mod/modpost.c", "int host_tool;\n");
+        write("Makefile", "obj-y := fork.o\n");
+        std::fs::create_dir_all(src.join("scripts/dtc/include-prefixes")).expect("mkdir");
+        std::os::unix::fs::symlink(
+            "../../../arch/x86/boot/dts",
+            src.join("scripts/dtc/include-prefixes/x86"),
+        )
+        .expect("symlink fixture");
+
+        skeleton(&src, &out, &[]).expect("skeleton");
+
+        let read = |rel: &str| std::fs::read_to_string(out.join(rel)).expect("read output");
+        assert_eq!(read("kernel/fork.c"), format!("{MARKER}#include <a.h>\n"));
+        // Allowlisted, header, linker-script, host-tool, and build files are
+        // byte-verbatim.
+        assert_eq!(read("kernel/bounds.c"), "int kept_whole;\n");
+        assert_eq!(
+            read("include/linux/a.h"),
+            "static inline int f(void) { return 1; }\n"
+        );
+        assert_eq!(read("arch/x86/kernel/vmlinux.lds.S"), "SECTIONS { }\n");
+        assert_eq!(read("scripts/mod/modpost.c"), "int host_tool;\n");
+        assert_eq!(read("Makefile"), "obj-y := fork.o\n");
+        assert_eq!(
+            std::fs::read_link(out.join("scripts/dtc/include-prefixes/x86"))
+                .expect("symlink recreated"),
+            std::path::PathBuf::from("../../../arch/x86/boot/dts")
+        );
+    }
+
+    #[test]
+    fn body_edits_reduce_identically() {
+        // The whole mechanism: two trees differing only in bodies and
+        // comments produce byte-identical skeletons.
+        let before = "#include <a.h>\n// old comment\nint f(void) { return 1; }\n";
+        let after = "#include <a.h>\n/* new comment */\nint f(void) { return 2; }\nint g(void);\n";
+        assert_eq!(reduced(before, Lang::C), reduced(after, Lang::C));
+    }
+
+    #[test]
+    fn deterministic_over_reruns() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("src");
+        let write = |rel: &str, contents: &str| {
+            let path = src.join(rel);
+            std::fs::create_dir_all(path.parent().expect("rel has parent")).expect("mkdir");
+            std::fs::write(path, contents).expect("write fixture");
+        };
+        write("kernel/fork.c", "#include <a.h>\nint body;\n");
+        write("kernel/sub/dir.c", "#define D 1\nint body;\n");
+        write("Makefile", "obj-y := fork.o\n");
+
+        let out_a = tmp.path().join("a");
+        let out_b = tmp.path().join("b");
+        skeleton(&src, &out_a, &[]).expect("first run");
+        skeleton(&src, &out_b, &[]).expect("second run");
+
+        let collect = |root: &Path| {
+            let mut files = std::collections::BTreeMap::new();
+            let mut stack = vec![root.to_path_buf()];
+            while let Some(dir) = stack.pop() {
+                for entry in std::fs::read_dir(&dir).expect("read output dir") {
+                    let entry = entry.expect("dir entry");
+                    if entry.file_type().expect("file type").is_dir() {
+                        stack.push(entry.path());
+                    } else {
+                        let rel = entry
+                            .path()
+                            .strip_prefix(root)
+                            .expect("under root")
+                            .to_owned();
+                        files.insert(rel, std::fs::read(entry.path()).expect("read file"));
+                    }
+                }
+            }
+            files
+        };
+        assert_eq!(collect(&out_a), collect(&out_b));
+    }
+}

--- a/packages/nix/nix-kbuild-unit/src/skeleton.rs
+++ b/packages/nix/nix-kbuild-unit/src/skeleton.rs
@@ -65,6 +65,15 @@ pub const DEFAULT_KEEP: &[&str] = &[
     "arch/x86/realmode/rm/**",
     "arch/x86/realmode/rmpiggy.S",
     "arch/*/boot/**",
+    // Assembly helpers that are only ever #included by the kept realmode
+    // and boot code (never compiled standalone, so they add nothing to the
+    // stub vmlinux link): reducing them breaks the realmode.elf link with
+    // undefined verify_cpu. boot/compressed pulls more .c includes
+    // (ident_map.c, tdx-shared.c, ...), but nothing under arch/*/boot/
+    // builds during the plan's `make vmlinux modules`; extend this when a
+    // bzImage target enters the plan.
+    "arch/x86/kernel/verify_cpu.S",
+    "arch/x86/kernel/sev_verify_cbit.S",
     // Host-tool sources compiled outside scripts/ and tools/: HOSTCC passes
     // through the compiler shim (no -D__KERNEL__), so a reduced host source
     // would link a main-less tool and fail the plan loudly (that is how a

--- a/packages/nix/nix-kbuild-unit/src/skeleton.rs
+++ b/packages/nix/nix-kbuild-unit/src/skeleton.rs
@@ -30,28 +30,60 @@ pub const MARKER: &str =
     "/* nix-kbuild-unit skeleton: reduced to preprocessor directives (#3413) */\n";
 
 /// Sources kept whole even though they match `**/*.c` / `**/*.S`: their
-/// compiled output feeds the generated snapshot or the plan-time link, so a
-/// stub object would corrupt what units later consume. Globs: `*` matches
-/// within one path segment, `**` matches any number of segments.
+/// compiled output feeds the generated snapshot, the vdso/realmode blobs, or
+/// a host tool, so a reduced source would corrupt what units later consume
+/// (or fail the plan build loudly). Globs: `*` matches within one path
+/// segment, `**` matches any number of segments.
 ///
-/// - asm-offsets / bounds: their `-S` listings become `include/generated/`
-///   headers every unit reads from the snapshot.
-/// - vdso trees: the vdso `.so` is built at plan time and embedded via the
-///   generated `vdso-image-*.c`, so its bytes must be real.
-/// - realmode / boot: `realmode.bin` is incbin'd into vmlinux and its
-///   `.relocs` dump rides in the snapshot.
-/// - linker-script symbol definers: the plan-time vmlinux link evaluates
-///   `jiffies = jiffies_64;`-style script assignments eagerly, and ld hard
-///   errors on an undefined symbol in an expression, so the few TUs defining
-///   symbols the x86 linker script references stay real.
+/// Deliberately NOT kept: kernel-side TUs that merely define symbols the
+/// linker script references (`jiffies_64`, mitigation thunks, ...). Keeping
+/// them real would drag their relocations against stubbed code into the
+/// final plan-time link; instead the plan's `ld` shim `--defsym`s that
+/// symbol set (see lib/kernel/kbuild-plan-ld.sh).
 pub const DEFAULT_KEEP: &[&str] = &[
+    // Their `-S` listings become `include/generated/` headers every unit
+    // reads from the snapshot.
     "arch/*/kernel/asm-offsets*.c",
     "kernel/bounds.c",
-    "arch/*/entry/vdso/**",
-    "arch/*/kernel/vdso*/**",
+    // Sources feeding the vdso `.so` images, which are built at plan time
+    // and re-enter the unit graph via the generated `vdso-image-*.c`. The
+    // kernel-side files in the same dir (vma.c, extable.c, vdso32-setup.c)
+    // stay reduced: their objects link into vmlinux, and real code there
+    // would reference stubbed symbols. x86-specific paths are fine: harvest
+    // rejects non-x86 plans (detect_srcarch).
+    "arch/x86/entry/vdso/vclock_gettime.c",
+    "arch/x86/entry/vdso/vgetcpu.c",
+    "arch/x86/entry/vdso/vdso-note.S",
+    "arch/x86/entry/vdso/vsgx.S",
+    "arch/x86/entry/vdso/vdso2c.c",
+    "arch/x86/entry/vdso/vdso32/**",
     "lib/vdso/**",
-    "arch/x86/realmode/**",
+    // The realmode blob: rm/ links realmode.elf from real objects with its
+    // own linker script, and rmpiggy.S incbins the resulting .bin (its
+    // .relocs dump rides in the snapshot). arch/x86/realmode/init.c stays
+    // reduced for the same reason as vma.c above.
+    "arch/x86/realmode/rm/**",
+    "arch/x86/realmode/rmpiggy.S",
     "arch/*/boot/**",
+    // Host-tool sources compiled outside scripts/ and tools/: HOSTCC passes
+    // through the compiler shim (no -D__KERNEL__), so a reduced host source
+    // would link a main-less tool and fail the plan loudly (that is how a
+    // missing entry here surfaces). Enumerated from the 6.12 tree's
+    // `hostprogs` Makefile declarations.
+    "arch/*/tools/**",
+    "certs/extract-cert.c",
+    "drivers/accessibility/speakup/genmap.c",
+    "drivers/accessibility/speakup/makemapdata.c",
+    "drivers/gpu/drm/radeon/mkregtable.c",
+    "drivers/gpu/drm/xe/xe_gen_wa_oob.c",
+    "drivers/tty/vt/conmakehash.c",
+    "drivers/video/logo/pnmtologo.c",
+    "drivers/zorro/gen-devlist.c",
+    "fs/unicode/mkutf8data.c",
+    "lib/gen_crc32table.c",
+    "lib/gen_crc64table.c",
+    "lib/raid6/mktables.c",
+    "usr/gen_init_cpio.c",
 ];
 
 /// Reduce `src` into `out` (created if absent), keeping `extra_keep` globs
@@ -451,6 +483,37 @@ static const char *s = \"/* not a comment\";
         assert_eq!(
             reduction_lang("arch/x86/realmode/rm/wakemain.c", no_extra),
             None
+        );
+        assert_eq!(
+            reduction_lang("arch/x86/realmode/rmpiggy.S", no_extra),
+            None
+        );
+        // Host-tool sources outside scripts// tools/ stay whole; their
+        // kernel-side dir siblings still reduce.
+        assert_eq!(reduction_lang("arch/x86/tools/relocs_64.c", no_extra), None);
+        assert_eq!(reduction_lang("lib/gen_crc32table.c", no_extra), None);
+        assert_eq!(reduction_lang("usr/gen_init_cpio.c", no_extra), None);
+        assert_eq!(
+            reduction_lang("drivers/tty/vt/conmakehash.c", no_extra),
+            None
+        );
+        assert_eq!(
+            reduction_lang("drivers/tty/vt/vt.c", no_extra),
+            Some(Lang::C)
+        );
+        // Kernel-side files in kept dirs reduce: their objects link into
+        // vmlinux and must stay stubbed.
+        assert_eq!(
+            reduction_lang("arch/x86/entry/vdso/vma.c", no_extra),
+            Some(Lang::C)
+        );
+        assert_eq!(
+            reduction_lang("arch/x86/realmode/init.c", no_extra),
+            Some(Lang::C)
+        );
+        assert_eq!(
+            reduction_lang("kernel/time/timer.c", no_extra),
+            Some(Lang::C)
         );
         assert_eq!(
             reduction_lang("arch/x86/boot/compressed/misc.c", no_extra),


### PR DESCRIPTION
Part of #3413 (kbuild-unit P3, master issue #3409). PR B of the P3 series: skeleton plans + CC/LD shims + plan strategies. Builds on PR A (#3574).

## What

- `nix-kbuild-unit skeleton`: reduces `**/*.c` and `**/*.S` (excluding `*.lds.S`, `scripts/`, `tools/`, and a keep allowlist) to their preprocessor-directive lines with a string-literal-aware comment scanner; everything else copies byte-verbatim. Reduced files carry a marker first line.
- `planStrategy` on `buildKernel` (`lib/kernel/kbuild-unit.nix`):
  - `"skeleton"` (default): the plan kbuild consumes the CA `skeletonTree`; a `gcc`-named PATH shim stubs every reduced TU (dep sets recorded via `-E` + the argv's own `-Wp,-MMD`; stub objects carry a `.modinfo` license so modpost accepts them) and an `ld`-named shim makes the stub vmlinux link evaluable (`--defsym` for the linker-script-referenced symbols, a section-placed SRSO alias-pair stand-in, one placeholder object for `__ex_table`/`main_extable_sort_needed`, `--unresolved-symbols=ignore-all`), gated to vmlinux-ish outputs so vdso/realmode bytes stay real. Equivalence gates compare against a real `referenceKernel`.
  - `"ccache"`: plan over the real tree with `ccache` against a host-mounted `/var/cache/kbuild-ccache` (loud warning + uncached build when unmounted). Static per-lane fallback for configs whose plan tooling rejects stubs.
  - `"full"`: exact P2 behavior, debugging baseline.
- Lanes: `kernel-unit` + `kernel-unit-defconfig` default to skeleton; new `kernel-unit-ccache` (tinyconfig) keeps the fallback exercised.
- `services.ci-runner.kbuildCcache.enable`: host opt-in mounting `/var/cache/kbuild-ccache` into build sandboxes (`extra-sandbox-paths` + tmpfiles), independent of the runner pool option.

## Effect

A function-body edit reduces to a byte-identical skeleton, so the plan's resolved derivation is already realised and never reruns: only the edited TU's unit and its link chain rebuild. This is the designed fix for PR A's finding that plan reruns do not reproduce the defconfig snapshot bit-identically (objtool + link-env nondeterminism), which made any source edit invalidate every unit at defconfig scale.

Savedcmds are never rewritten: kbuild's `$(CC)`/`$(LD)` keep recording bare `gcc`/`ld`; only the plan derivation's PATH resolves them to the shims, and unit replays resolve the real toolchain over real sources.

## Validation (vin-compute-1)

Being appended as validation completes; evidence comment to follow on #3413.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add skeleton plan strategy and CC/LD shims to `kbuild-unit` for directive-only kernel plan builds
> - Adds a `skeleton` subcommand to the `nix-kbuild-unit` CLI ([skeleton.rs](https://github.com/indexable-inc/index/pull/3575/files#diff-cd476989b5baf7dfa4de2857d38ac58fa9dda8e1e50aed011282c440674de662)) that reduces a kernel source tree to preprocessor-directives-only files, marking reduced files so the build shims can identify them.
> - Introduces a [gcc shim](https://github.com/indexable-inc/index/pull/3575/files#diff-fd9d22dcc274b115dc7da8286c9ade0af1d42b40adc1058c061ee378072249da) that intercepts kernel TU compiles in `skeleton` mode: runs `-E` for depfiles and compiles a stub object instead of the real source; in `ccache` mode it wraps the real compiler with ccache.
> - Introduces an [ld shim](https://github.com/indexable-inc/index/pull/3575/files#diff-50964a88b237ceeaf40cc7101b0aaad0e70f289743def767fbb18067a571c44e) that injects `--defsym` definitions and placeholder objects for vmlinux links, allowing skeleton builds to link successfully.
> - Updates [kbuild-unit.nix](https://github.com/indexable-inc/index/pull/3575/files#diff-894edbcee0d2e832bb188198d9520c9019d57088c5a061e3b3a327a243c1d7ad) to support three plan strategies: `skeleton` (default), `ccache`, and `full`; adds a separate `referenceKernel` derivation for real monolithic builds used as the equivalence baseline under `skeleton`.
> - Adds a `kernel-unit-ccache` lane in [per-system.nix](https://github.com/indexable-inc/index/pull/3575/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) and a `kbuildCcache` CI runner module option that mounts a host ccache directory into sandboxed builds.
> - Risk: `skeleton` is now the default strategy, changing plan build behavior for all existing `buildKernel` callers that do not explicitly set `planStrategy`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0088a16.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->