### PR TITLE
mcp-ex: warn in exec prompt that stdin-reading tools hang without a path

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -71,6 +71,10 @@ defmodule IxMcp.MCP.Tools do
         File.ls!/1, File.stat!/1 -- instead of shelling out. Reserve
         System.cmd/3 for real external programs (git, nix, gh), and always
         pass its arguments as a list: System.cmd("git", ["-C", dir, "status"]).
+        A subprocess's stdin is a pipe that never closes, so tools that read
+        stdin when given no input path -- rg and grep especially -- hang
+        forever, even with cd: set. Always pass an explicit path argument:
+        System.cmd("rg", ["-n", "pat", "."], cd: dir).
         Never build shell command strings, and never use bash here-docs or
         nested quoting to pass multi-line text -- they are brittle and can
         wedge this transport. To hand multi-line text to a program, write it


### PR DESCRIPTION
Agents keep hanging the elixir kernel by running rg via System.cmd without a path argument, e.g.:

    System.cmd("rg", ["-n", "dev-node", "--type", "nix", "-l"], cd: dir)

Under the kernel a subprocess's stdin is a pipe that never closes, and rg falls back to searching stdin when given no input path, so the call blocks forever and the exec job sits at "running" indefinitely. Adding an explicit "." path fixes it.

This is a prompt fix, not a code fix, deliberately: the server has no blessed subprocess wrapper (IxMcp.OsProc moduledoc), and closing stdin at spawn would make rg silently search empty stdin instead of the cwd, trading a visible hang for silent wrong results. So the exec tool description now warns about stdin-reading tools and shows the correct call shape.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Warn in exec prompt that stdin-reading tools hang without an explicit path
> Adds guidance comments in [tools.ex](https://github.com/indexable-inc/index/pull/3576/files#diff-c1967b7edcd9f2a8628cd2ebf989cfe1e0daf0af2416367f04b4e816c897e776) noting that subprocess stdin is a non-closing pipe, which causes tools like `rg` and `grep` to hang when no input path is given. The comments advise always passing an explicit path argument to `System.cmd` calls (e.g., `["-n", "pat", "."]` with `cd: dir`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df9cc8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->