### PR TITLE
claude: SessionStart hook injects the session id

### DIFF
--- a/packages/agent/claude-hooks/src/main.rs
+++ b/packages/agent/claude-hooks/src/main.rs
@@ -78,6 +78,7 @@ fn main() -> ExitCode {
         Some("worktree-guard") => worktree_guard(),
         Some("prompt-priors") => prompt_priors(),
         Some("session-banner") => session_banner::session_banner(),
+        Some("session-id") => session_id(),
         Some("review-log-edit") => review::review_log_edit(),
         Some("review-gate") => review::review_gate(),
         Some("retro-gate") => retro::retro_gate(),
@@ -187,6 +188,34 @@ fn session_digest() {
         hook_event_name: "SessionStart",
         additional_context: context,
     });
+}
+
+// --- session-id ---
+
+/// Session-scoped artifacts (status boards, scratch dirs) are keyed by the
+/// session id, but nothing ambient tells the agent its own id, so this echoes
+/// the payload's `session_id` back as startup context. Shared by Claude Code
+/// and Codex: both send `session_id` on `SessionStart`.
+fn session_id() {
+    let Some(input) = read_stdin() else { return };
+    let Ok(payload) = serde_json::from_str::<Value>(&input) else {
+        return;
+    };
+    let Some(context) = session_id_context(&payload) else {
+        return;
+    };
+    emit(ContextOutput {
+        hook_event_name: "SessionStart",
+        additional_context: context,
+    });
+}
+
+fn session_id_context(payload: &Value) -> Option<String> {
+    let session = safe_session(payload)?;
+    Some(format!(
+        "Your session id: {session}. Use it wherever a session-scoped path is needed \
+         (e.g. test-ide boards: canvas/boards/{session}/main.svelte)."
+    ))
 }
 
 // --- worktree-guard ---
@@ -447,6 +476,7 @@ fn provenance(hit: &Value) -> String {
 mod tests {
     use super::{
         cap_chars, has_fleet_noun, matches_protected, passes_word_gate, provenance, render_priors,
+        session_id_context,
     };
     use serde_json::json;
 
@@ -518,6 +548,20 @@ mod tests {
         })];
         let out = render_priors(&hits).expect("hit");
         assert_eq!(out.chars().count(), 4800);
+    }
+
+    #[test]
+    fn session_id_context_echoes_id_and_rejects_unsafe_ids() {
+        let ctx = session_id_context(&json!({ "session_id": "abc-123" })).expect("context");
+        assert!(ctx.contains("Your session id: abc-123"));
+        assert!(ctx.contains("canvas/boards/abc-123/main.svelte"));
+        for bad in [
+            json!({}),
+            json!({ "session_id": "" }),
+            json!({ "session_id": "../x" }),
+        ] {
+            assert!(session_id_context(&bad).is_none());
+        }
     }
 
     #[test]

--- a/packages/agent/policy/hooks.nix
+++ b/packages/agent/policy/hooks.nix
@@ -14,6 +14,7 @@
   hookCommands = {
     cachedStartupNotes = hookRunnerSubcommand "session-digest";
     hostInventoryBanner = hookRunnerSubcommand "session-banner";
+    sessionIdContext = hookRunnerSubcommand "session-id";
     protectedCheckoutGuard = hookRunnerSubcommand "worktree-guard";
     nixCargoGuard = hookRunnerSubcommand "cargo-guard";
     shellHabitGuard = hookRunnerSubcommand "bash-habits-guard";
@@ -39,6 +40,12 @@
 
   declarations = {
     SessionStart = [
+      # Unconditional: agents key session-scoped artifacts (status boards,
+      # scratch dirs) by session id, and nothing else tells them their own id.
+      {
+        command = hookCommands.sessionIdContext;
+        timeout = 5;
+      }
       {
         command = hookCommands.cachedStartupNotes;
         enable = personalStartupContext;


### PR DESCRIPTION
Every Claude Code session now learns its own session id at startup, so session-scoped paths (e.g. test-ide boards, `canvas/boards/<sessionId>/main.svelte`) no longer require the agent to infer its id.

## What

- New `session-id` subcommand in `packages/agent/claude-hooks`: reads the hook payload from stdin, extracts `session_id` (via the existing `safe_session` path-safety gate), and emits `hookSpecificOutput.additionalContext` with `hookEventName: "SessionStart"`. Like every hook in this crate it fails OPEN and SILENT: malformed or missing input exits 0 with no output.
- Declared in `packages/agent/policy/hooks.nix` under `SessionStart`, unconditionally (not gated on `personalStartupContext`): the id is universal, tiny, and purely local.

The repo pattern for hooks is subcommands of the compiled `claude-hooks` binary, not shell scripts (`hook-runner.nix` bans hand-rolled scripts; `writeShellApplication` is banned repo-wide), so this is a Rust subcommand rather than a jq one-liner.

## Codex

The repo's patched Codex fork already has the equivalent mechanism: `packages/agent/codex/default.nix` renders the same shared `policy/hooks.nix` into `codex-hooks.json`, and the fork's hook payloads carry `session_id` (see `packages/agent/codex/patches/rerere/f1765ded.../postimage.1`, `"session_id": session.session_id()`). The new declaration keeps the default `agents = ["claude" "codex"]`, so Codex sessions get the same context with zero extra machinery. The wording is agent-neutral ("Your session id: ...") because one hook serves both harnesses.

## Verification

- `cargo test -p claude-hooks`: 49 passed (includes new unit test for the context formatting and unsafe-id rejection).
- Built binary exercised end to end: valid payload emits the exact JSON line; malformed JSON, empty stdin, and path-escaping ids all exit 0 silently.
- `nix run .#lint`: 10/10 lanes green; `cargo fmt --check` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Inject session ID into Claude agent context via `SessionStart` hook
> - Adds a `session-id` subcommand to the Claude hooks binary ([main.rs](https://github.com/indexable-inc/index/pull/3577/files#diff-2d219c1873e0f6f8db7cbd30aeabac405d384c224e26f89100fa1eafed6c62eb)) that reads a JSON payload from stdin, validates the session ID, and emits a `SessionStart` `ContextOutput` containing the session ID and an example session-scoped path.
> - Registers an unconditional `SessionStart` hook in [hooks.nix](https://github.com/indexable-inc/index/pull/3577/files#diff-24259d26867d29930c34306344c2664467b358d809c32c92ee35e26d811e7c32) that runs the new `sessionIdContext` command with a 5-second timeout.
> - Session IDs are validated via `safe_session()` to reject empty, absent, or path-traversal-like values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d8f8c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->