### PR TITLE
plumb: inspectable bash-subset shell, library-first (#3578)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8952,6 +8952,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "plumb"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "plumb-core",
+ "reedline",
+ "serde_json",
+]
+
+[[package]]
+name = "plumb-core"
+version = "0.1.0"
+dependencies = [
+ "glob",
+ "libc",
+ "plumb-syntax",
+ "serde",
+ "serde_json",
+ "snafu",
+]
+
+[[package]]
+name = "plumb-syntax"
+version = "0.1.0"
+dependencies = [
+ "snafu",
+]
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,9 @@ members = [
   "packages/nix/nix-web-monitor/server",
   "packages/nix/oci-image-builder",
   "packages/nu-py",
+  "packages/plumb/cli",
+  "packages/plumb/core",
+  "packages/plumb/syntax",
   "packages/progress-style",
   "packages/repo-walker",
   "packages/screencast/screencast",
@@ -239,6 +242,8 @@ efx-engine = { path = "packages/efx/engine" }
 efx-ir = { path = "packages/efx/ir" }
 efx-lang = { path = "packages/efx/lang" }
 file-language = { path = "packages/code/file-language" }
+plumb-core = { path = "packages/plumb/core" }
+plumb-syntax = { path = "packages/plumb/syntax" }
 flate2 = "1"
 flecs-query-core = { path = "packages/flecs-query/core" }
 fontdue = "0.9"
@@ -326,6 +331,7 @@ reqwest = { version = "0.12", default-features = false, features = [
   "rustls-tls",
   "multipart",
 ] }
+reedline = "0.49"
 rmp-serde = "1"
 rodio = { version = "0.22", default-features = false, features = ["playback", "vorbis"] }
 rusqlite = { version = "0.40", features = ["bundled"] }

--- a/packages/plumb/cli/Cargo.toml
+++ b/packages/plumb/cli/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "plumb"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "An inspectable bash-subset shell: every run is a value; pipe stages are captured and auto-bound to variables"
+
+[lints]
+workspace = true
+
+[dependencies]
+plumb-core.workspace = true
+clap = { workspace = true, features = ["derive"] }
+reedline.workspace = true
+serde_json.workspace = true
+
+[[bin]]
+name = "plumb"
+path = "src/main.rs"

--- a/packages/plumb/cli/README.md
+++ b/packages/plumb/cli/README.md
@@ -1,0 +1,75 @@
+<p align="center"><img src="assets/hero.svg" width="720" alt="a pipeline whose every stream is tapped into a run value, whose variables feed a later command"></p>
+
+# plumb
+
+Ever run `cargo clippy | tail -n 5` and then wanted the 400 lines you just threw away? plumb is a shell where every run is a value: each pipe stage's stdout and stderr are captured (bounded, with exact byte counts), the whole run becomes an inspectable report, and outputs auto-bind to variables so later commands can reuse any earlier stream, including the intermediate pipe data, without re-running anything. It is a Rust library first (`plumb-core`), with a reedline REPL and a one-shot CLI on top, built for programs (LLM agents especially) that run commands and need what actually happened, not a scrollback.
+
+The syntax is a strict bash subset: everything plumb accepts pastes into bash unchanged and means the same thing there. Everything else is a loud parse error naming the construct, never a silent reinterpretation.
+
+## Runs are values
+
+```console
+plumb tmp> sh -c 'echo warn >&2; seq 1 10000' | tail -n 3
+9998
+9999
+10000
+[0] sh -c echo warn >&2; seq 1 10000  exit 0  11ms  out 48.9KB  err 5B
+[1] tail -n 3  exit 0  11ms  out 15B  err 0B
+run 3: exit 0  ${o3} ${e3} ${s3}
+plumb tmp> echo $o3_0 | head -n 1
+1
+```
+
+Every run `N` binds, automatically:
+
+| variable | value |
+| --- | --- |
+| `$oN` / `$eN` / `$sN` | final stdout / stderr / status |
+| `$oN_K` / `$eN_K` | stdout / stderr of pipe stage `K` (what stage `K+1` consumed) |
+| `$o` / `$e` / `$s` | same, for the most recent run |
+| `$?` | last status, as in bash |
+
+`:runs` lists retained runs, `:json N` dumps a run's full report (argv after expansion, per-stage status, timing, byte counts, truncation flags), `:out N K` prints a captured stream raw. Captures are head+tail bounded (256KiB per stream by default) with exact totals, so a gigabyte through a pipe costs fixed memory and truncation is always marked, never silent.
+
+## Strict where bash is treacherous
+
+- Unset variable expansion is an error (no `rm -rf /$TYPO`).
+- A glob matching nothing is an error (`failglob`).
+- `pipefail` semantics, except SIGPIPE deaths (`yes | head` succeeds).
+- Expansions never word-split: `$X` is exactly one argument.
+- Unsupported bash (keywords, subshells, backticks, here-docs, fancy expansions) is a parse error with a span, so nothing runs under a wrong reading.
+- State builtins (`cd`, `export`, ...) refuse to be pipeline stages instead of silently mutating a subshell.
+
+Supported: pipes, `&&` `||` `;`, redirections (`>` `>>` `<` `2>` `2>&1` `&>` `>&2`), quoting, `$VAR`/`${VAR}`, `$(...)` command substitution, globs, `~`, `NAME=v cmd` prefixes, `&` background runs, comments.
+
+## A library first
+
+```rust
+let shell = plumb_core::Shell::new(plumb_core::Config::default())?;
+let report = shell.eval("cargo clippy 2>&1 | tail -n 5")?;
+report.status;                       // pipefail status
+report.pipelines[0].stages[0].stdout // everything tail consumed
+    .render();
+shell.var("o1_0");                   // same thing, as a variable
+serde_json::to_string(&report)?;     // the whole run, machine-readable
+```
+
+`Shell` is a cheap cloneable handle over shared state: concurrent evals from threads (`eval_detached`) or `&` background items see each other's variables, cwd, and run history; `wait` joins them. `exit` surfaces as `Error::ExitRequested` so the embedder decides what dying means.
+
+One-shot and script modes stream live and exit with the run's status; `--json` prints the report instead:
+
+```console
+$ plumb -c 'echo hi | tr a-z A-Z' --json | jq .pipelines[0].stages[1].stdout.text
+"HI\n"
+$ plumb build.plumb
+$ some-generator | plumb
+```
+
+## Install
+
+```sh
+nix run github:indexable-inc/index#plumb
+cargo install --git https://github.com/indexable-inc/plumb
+```
+
+The crates live in the [index monorepo](https://github.com/indexable-inc/index) under `packages/plumb/` (`plumb-syntax` parser, `plumb-core` library, `plumb` CLI); this repo is a read-only mirror.

--- a/packages/plumb/cli/assets/hero.svg
+++ b/packages/plumb/cli/assets/hero.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 240" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted  { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .accent-stroke { stroke: #8250df; }
+    .box    { stroke: currentColor; fill: none; rx: 6; }
+    text    { fill: currentColor; font-size: 14px; }
+    .mono   { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 13px; }
+    .small  { font-size: 11px; }
+    .edge   { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    .tap    { stroke: #8250df; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow-accent); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted  { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .accent-stroke { stroke: #a371f7; }
+      .tap    { stroke: #a371f7; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"/>
+    </marker>
+    <marker id="arrow-accent" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="accent"/>
+    </marker>
+  </defs>
+
+  <!-- pipeline row -->
+  <rect class="box" x="30" y="40" width="150" height="40"/>
+  <text class="mono" x="105" y="65" text-anchor="middle">cargo clippy</text>
+  <line class="edge" x1="180" y1="60" x2="270" y2="60"/>
+  <rect class="box" x="270" y="40" width="120" height="40"/>
+  <text class="mono" x="330" y="65" text-anchor="middle">tail -n 5</text>
+  <line class="edge" x1="390" y1="60" x2="470" y2="60"/>
+  <text class="mono muted" x="478" y="65">stdout</text>
+
+  <!-- taps from every stream -->
+  <line class="tap" x1="105" y1="80" x2="105" y2="140"/>
+  <line class="tap" x1="225" y1="60" x2="225" y2="140"/>
+  <line class="tap" x1="330" y1="80" x2="330" y2="140"/>
+
+  <!-- the run-as-value box -->
+  <rect class="box accent-stroke" x="60" y="140" width="360" height="60"/>
+  <text class="accent" x="75" y="162">run 7 = a value</text>
+  <text class="mono" x="75" y="184">$o7_0 full clippy  $o7 last 5  $e7  $s7</text>
+
+  <!-- reuse edge -->
+  <line class="edge" x1="420" y1="170" x2="500" y2="170"/>
+  <rect class="box" x="500" y="150" width="190" height="40"/>
+  <text class="mono" x="595" y="175" text-anchor="middle">echo $o7_0 | rg dead</text>
+  <text class="small muted" x="595" y="212" text-anchor="middle">re-use any stream later, without re-running</text>
+</svg>

--- a/packages/plumb/cli/default.nix
+++ b/packages/plumb/cli/default.nix
@@ -1,0 +1,13 @@
+{
+  ix,
+  lib,
+  ...
+}:
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "plumb";
+  meta = {
+    description = "Inspectable bash-subset shell: runs are values, pipe stages are captured, outputs auto-bind to variables";
+    license = lib.licenses.mit;
+    mainProgram = "plumb";
+  };
+}

--- a/packages/plumb/cli/package.nix
+++ b/packages/plumb/cli/package.nix
@@ -1,0 +1,20 @@
+{
+  id = "plumb";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+  inRustWorkspace = true;
+  mirror = {
+    repo = "indexable-inc/plumb";
+    description = "An inspectable bash-subset shell, library-first: every run is a value, pipe stages are captured, outputs auto-bind to variables.";
+    topics = [
+      "shell"
+      "bash"
+      "repl"
+      "rust"
+      "llm"
+      "ix"
+    ];
+  };
+  passthruTests = true;
+}

--- a/packages/plumb/cli/src/main.rs
+++ b/packages/plumb/cli/src/main.rs
@@ -102,5 +102,6 @@ fn one_shot(shell: &Shell, source: &str, json: bool) -> ExitCode {
 
 /// Map a wait status onto the 0..=255 process exit range, like a shell.
 fn exit_code(status: i32) -> ExitCode {
-    ExitCode::from(u8::try_from(status.rem_euclid(256)).unwrap_or(1))
+    // rem_euclid(256) yields 0..=255, always within u8, so this never fails.
+    ExitCode::from(u8::try_from(status.rem_euclid(256)).expect("status mod 256 fits in u8"))
 }

--- a/packages/plumb/cli/src/main.rs
+++ b/packages/plumb/cli/src/main.rs
@@ -1,0 +1,106 @@
+//! plumb: an inspectable bash-subset shell. No arguments starts the REPL;
+//! `-c` evaluates a string; a file argument runs a script; `--json` prints
+//! the run's full report.
+
+mod repl;
+
+use std::io::{IsTerminal as _, Read as _};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+use plumb_core::{Config, Error, Shell};
+
+#[derive(Parser)]
+#[command(
+    name = "plumb",
+    about = "An inspectable bash-subset shell: every run is a value",
+    long_about = "An inspectable bash-subset shell. Every run returns a report with per-stage \
+                  argv, status, timing, and captured stdout/stderr (including what each pipe \
+                  stage fed the next). Outputs auto-bind to variables: $oN/$eN/$sN for run N, \
+                  $oN_K/$eN_K per stage, $o/$e/$s for the last run."
+)]
+struct Args {
+    /// Evaluate this source string and exit.
+    #[arg(short = 'c', long = "command", conflicts_with = "script")]
+    command: Option<String>,
+
+    /// Print the run's report as JSON instead of streaming output.
+    #[arg(long)]
+    json: bool,
+
+    /// Script file to run.
+    script: Option<PathBuf>,
+}
+
+fn main() -> ExitCode {
+    let args = Args::parse();
+    let source = match (&args.command, &args.script) {
+        (Some(command), _) => Some(command.clone()),
+        (None, Some(path)) => match std::fs::read_to_string(path) {
+            Ok(source) => Some(source),
+            Err(error) => {
+                eprintln!("plumb: {}: {error}", path.display());
+                return ExitCode::FAILURE;
+            }
+        },
+        (None, None) => {
+            if std::io::stdin().is_terminal() {
+                None
+            } else {
+                // `plumb < script` and `... | plumb` run stdin as a script,
+                // like bash.
+                let mut source = String::new();
+                if let Err(error) = std::io::stdin().read_to_string(&mut source) {
+                    eprintln!("plumb: stdin: {error}");
+                    return ExitCode::FAILURE;
+                }
+                Some(source)
+            }
+        }
+    };
+
+    let config = Config {
+        echo_output: !args.json,
+        ..Config::default()
+    };
+    let shell = match Shell::new(config) {
+        Ok(shell) => shell,
+        Err(error) => {
+            eprintln!("plumb: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match source {
+        Some(source) => one_shot(&shell, &source, args.json),
+        None => repl::run(&shell),
+    }
+}
+
+fn one_shot(shell: &Shell, source: &str, json: bool) -> ExitCode {
+    match shell.eval(source) {
+        Ok(report) => {
+            if json {
+                match serde_json::to_string_pretty(&report) {
+                    Ok(rendered) => println!("{rendered}"),
+                    Err(error) => {
+                        eprintln!("plumb: {error}");
+                        return ExitCode::FAILURE;
+                    }
+                }
+            }
+            exit_code(report.status)
+        }
+        Err(Error::ExitRequested { code }) => exit_code(code),
+        Err(error) => {
+            eprintln!("plumb: {error}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+/// Map a wait status onto the 0..=255 process exit range, like a shell.
+fn exit_code(status: i32) -> ExitCode {
+    ExitCode::from(u8::try_from(status.rem_euclid(256)).unwrap_or(1))
+}

--- a/packages/plumb/cli/src/repl.rs
+++ b/packages/plumb/cli/src/repl.rs
@@ -72,7 +72,7 @@ pub fn run(shell: &Shell) -> ExitCode {
                 match shell.eval(trimmed) {
                     Ok(report) => summarize(&report),
                     Err(Error::ExitRequested { code }) => {
-                        return ExitCode::from(u8::try_from(code.rem_euclid(256)).unwrap_or(1));
+                        return crate::exit_code(code);
                     }
                     Err(error) => eprintln!("plumb: {error}"),
                 }
@@ -173,10 +173,12 @@ fn summarize(report: &Report) {
 }
 
 fn human_bytes(count: u64) -> String {
+    #[expect(clippy::cast_precision_loss, reason = "a rounded size label needs no exact mantissa")]
+    let bytes = count as f64;
     if count >= 1024 * 1024 {
-        format!("{:.1}MB", f64::from(u32::try_from(count / 1024).unwrap_or(u32::MAX)) / 1024.0)
+        format!("{:.1}MB", bytes / (1024.0 * 1024.0))
     } else if count >= 1024 {
-        format!("{:.1}KB", f64::from(u32::try_from(count).unwrap_or(u32::MAX)) / 1024.0)
+        format!("{:.1}KB", bytes / 1024.0)
     } else {
         format!("{count}B")
     }

--- a/packages/plumb/cli/src/repl.rs
+++ b/packages/plumb/cli/src/repl.rs
@@ -1,0 +1,183 @@
+//! The interactive shell: reedline for line editing, a stage summary after
+//! every run, `:` commands for inspecting past runs.
+
+use std::borrow::Cow;
+use std::process::ExitCode;
+
+use plumb_core::{Error, Report, Shell};
+use reedline::{FileBackedHistory, Prompt, PromptEditMode, PromptHistorySearch, Reedline, Signal};
+
+struct PlumbPrompt {
+    shell: Shell,
+}
+
+impl Prompt for PlumbPrompt {
+    fn render_prompt_left(&self) -> Cow<'_, str> {
+        let cwd = self.shell.cwd();
+        let short = cwd
+            .file_name()
+            .map_or_else(|| cwd.display().to_string(), |name| name.to_string_lossy().into_owned());
+        Cow::Owned(format!("plumb {short}"))
+    }
+
+    fn render_prompt_right(&self) -> Cow<'_, str> {
+        let pending = self.shell.background_pending();
+        if pending == 0 {
+            Cow::Borrowed("")
+        } else {
+            Cow::Owned(format!("bg:{pending}"))
+        }
+    }
+
+    fn render_prompt_indicator(&self, _edit_mode: PromptEditMode) -> Cow<'_, str> {
+        Cow::Borrowed("> ")
+    }
+
+    fn render_prompt_multiline_indicator(&self) -> Cow<'_, str> {
+        Cow::Borrowed("... ")
+    }
+
+    fn render_prompt_history_search_indicator(
+        &self,
+        _history_search: PromptHistorySearch,
+    ) -> Cow<'_, str> {
+        Cow::Borrowed("search: ")
+    }
+}
+
+/// Run the REPL until `exit` or ctrl-d.
+pub fn run(shell: &Shell) -> ExitCode {
+    let mut editor = Reedline::create().with_history(Box::new(FileBackedHistory::new(1000).unwrap_or_default()));
+    let prompt = PlumbPrompt {
+        shell: shell.clone(),
+    };
+    println!(
+        "plumb: runs are values. `:runs` lists them, `:json N` dumps one, \
+         `$oN`/`$eN`/`$oN_K` reuse their output. ctrl-d exits."
+    );
+    loop {
+        for report in shell.finished_background() {
+            println!("[bg run {} finished: exit {}]", report.id, report.status);
+        }
+        match editor.read_line(&prompt) {
+            Ok(Signal::Success(line)) => {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                if let Some(command) = trimmed.strip_prefix(':') {
+                    inspect(shell, command);
+                    continue;
+                }
+                match shell.eval(trimmed) {
+                    Ok(report) => summarize(&report),
+                    Err(Error::ExitRequested { code }) => {
+                        return ExitCode::from(u8::try_from(code.rem_euclid(256)).unwrap_or(1));
+                    }
+                    Err(error) => eprintln!("plumb: {error}"),
+                }
+            }
+            Ok(Signal::CtrlD) => return ExitCode::SUCCESS,
+            Ok(_) => {}
+            Err(error) => {
+                eprintln!("plumb: {error}");
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+}
+
+/// `:` inspection commands.
+fn inspect(shell: &Shell, command: &str) {
+    let mut words = command.split_whitespace();
+    match words.next() {
+        Some("runs") => {
+            for report in shell.reports() {
+                let source: String = report.source.chars().take(48).collect();
+                println!(
+                    "[{}] exit {} {}ms  {}",
+                    report.id, report.status, report.duration_ms, source
+                );
+            }
+        }
+        Some("json") => match target_report(shell, words.next()) {
+            Some(report) => match serde_json::to_string_pretty(&*report) {
+                Ok(rendered) => println!("{rendered}"),
+                Err(error) => eprintln!("plumb: {error}"),
+            },
+            None => eprintln!("plumb: no such run"),
+        },
+        Some(stream @ ("out" | "err")) => {
+            let Some(report) = target_report(shell, words.next()) else {
+                eprintln!("plumb: no such run");
+                return;
+            };
+            let stage = words.next().and_then(|raw| raw.parse::<usize>().ok());
+            let stages: Vec<&plumb_core::Stage> = report.stages().collect();
+            let chosen = stage.map_or_else(
+                || stages.last(),
+                |index| stages.iter().find(|s| s.index == index),
+            );
+            match chosen {
+                Some(chosen) => {
+                    let capture = if stream == "out" {
+                        &chosen.stdout
+                    } else {
+                        &chosen.stderr
+                    };
+                    print!("{}", capture.render());
+                }
+                None => eprintln!("plumb: no such stage"),
+            }
+        }
+        _ => {
+            println!(
+                ":runs           list retained runs\n\
+                 :json [N]       full report of run N (default: last)\n\
+                 :out [N] [K]    stdout of run N stage K (default: last run, final stage)\n\
+                 :err [N] [K]    stderr of run N stage K"
+            );
+        }
+    }
+}
+
+fn target_report(shell: &Shell, id: Option<&str>) -> Option<std::sync::Arc<Report>> {
+    id.map_or_else(
+        || shell.reports().pop(),
+        |raw| raw.parse().ok().and_then(|id| shell.report(id)),
+    )
+}
+
+/// One line per stage, then the variable names the run bound.
+fn summarize(report: &Report) {
+    for id in &report.background_started {
+        println!("[bg run {id} started]");
+    }
+    let stages: Vec<&plumb_core::Stage> = report.stages().collect();
+    if stages.is_empty() {
+        return;
+    }
+    for stage in &stages {
+        println!(
+            "[{}] {}  exit {}  {}ms  out {}  err {}",
+            stage.index,
+            stage.argv.join(" "),
+            stage.status,
+            stage.duration_ms,
+            human_bytes(stage.stdout.total_bytes()),
+            human_bytes(stage.stderr.total_bytes()),
+        );
+    }
+    let id = report.id;
+    println!("run {id}: exit {}  ${{o{id}}} ${{e{id}}} ${{s{id}}}", report.status);
+}
+
+fn human_bytes(count: u64) -> String {
+    if count >= 1024 * 1024 {
+        format!("{:.1}MB", f64::from(u32::try_from(count / 1024).unwrap_or(u32::MAX)) / 1024.0)
+    } else if count >= 1024 {
+        format!("{:.1}KB", f64::from(u32::try_from(count).unwrap_or(u32::MAX)) / 1024.0)
+    } else {
+        format!("{count}B")
+    }
+}

--- a/packages/plumb/core/Cargo.toml
+++ b/packages/plumb/core/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "plumb-core"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "libplumb: embeddable shell where every run is a value with per-stage capture and auto-bound variables"
+
+[lints]
+workspace = true
+
+[dependencies]
+plumb-syntax.workspace = true
+serde = { workspace = true, features = ["derive"] }
+snafu.workspace = true
+glob.workspace = true
+libc.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/packages/plumb/core/package.nix
+++ b/packages/plumb/core/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "plumb-core";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/plumb/core/src/engine.rs
+++ b/packages/plumb/core/src/engine.rs
@@ -1,0 +1,432 @@
+//! Pipeline execution: spawn the stages, tee every stream through a bounded
+//! [`Capture`], preserve streaming and backpressure.
+//!
+//! Every inter-stage edge is a copy thread reading the upstream stage's
+//! stdout pipe and writing both the capture and the downstream stage's
+//! stdin. When the downstream half closes (EPIPE), the thread stops reading
+//! so the upstream process takes SIGPIPE exactly as it would under bash
+//! (`yes | head` must terminate).
+
+use std::fs::{File, OpenOptions};
+use std::io::{PipeReader, PipeWriter, Read, Write};
+use std::os::unix::process::ExitStatusExt;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::thread::JoinHandle;
+use std::time::Instant;
+
+use snafu::ResultExt;
+
+use crate::error::{Error, IoSnafu, RedirectSnafu};
+use crate::report::{Capture, PipelineRun, Stage};
+
+/// Where the first stage's stdin comes from.
+pub enum StdinSpec {
+    /// `/dev/null`: commands must not wait on a terminal that isn't there.
+    Null,
+    /// `< file`
+    File(PathBuf),
+}
+
+/// A `>`/`>>`-style file sink.
+pub struct FileSink {
+    pub path: PathBuf,
+    pub append: bool,
+}
+
+/// One stage, resolved and expanded, ready to run.
+pub enum StageSpec {
+    /// An external process.
+    External(Box<ExternalSpec>),
+    /// Builtin `echo`: pure output, safe anywhere in a pipeline.
+    Echo {
+        /// Bytes to emit (trailing newline already applied unless `-n`).
+        text: Vec<u8>,
+        /// The argv to show in the report.
+        argv: Vec<String>,
+    },
+    /// Builtin `true`/`false`: pure status, safe anywhere in a pipeline.
+    Quiet {
+        /// The fixed status.
+        status: i32,
+        /// The argv to show in the report.
+        argv: Vec<String>,
+    },
+}
+
+/// An external process stage.
+pub struct ExternalSpec {
+    pub argv: Vec<String>,
+    /// Complete child environment (PATH lookup uses this, not the parent's).
+    pub env: Vec<EnvPair>,
+    pub cwd: PathBuf,
+    /// First stage only; later stages read the previous stage's stdout.
+    pub stdin: StdinSpec,
+    pub stdout_file: Option<FileSink>,
+    pub stderr_file: Option<FileSink>,
+    /// `2>&1`: stderr flows into the stdout stream (kernel-interleaved).
+    pub stderr_to_stdout: bool,
+    /// `>&2`: stdout flows into the stderr stream.
+    pub stdout_to_stderr: bool,
+}
+
+/// One child-environment entry.
+pub struct EnvPair {
+    pub name: String,
+    pub value: String,
+}
+
+/// Engine knobs for one pipeline run.
+pub struct EngineConfig {
+    /// Per-stream capture budget in bytes.
+    pub capture_limit: usize,
+    /// Also copy the final stage's stdout to the parent's stdout (live
+    /// streaming in the REPL / CLI).
+    pub echo_stdout: bool,
+    /// Also copy every stage's stderr to the parent's stderr.
+    pub echo_stderr: bool,
+}
+
+/// The forward half of a tee: at most one place bytes flow to besides the
+/// capture.
+enum Forward {
+    Pipe(PipeWriter),
+    File(File),
+    ParentStdout,
+    ParentStderr,
+    Discard,
+}
+
+impl Forward {
+    /// Write to the forward sink; false means the sink is gone (EPIPE) and
+    /// the caller must stop reading so upstream sees the close.
+    fn write(&mut self, buf: &[u8]) -> bool {
+        let result = match self {
+            Self::Pipe(writer) => writer.write_all(buf),
+            Self::File(file) => file.write_all(buf),
+            Self::ParentStdout => {
+                let stdout = std::io::stdout();
+                let mut lock = stdout.lock();
+                lock.write_all(buf).and_then(|()| lock.flush())
+            }
+            Self::ParentStderr => {
+                let stderr = std::io::stderr();
+                let mut lock = stderr.lock();
+                lock.write_all(buf).and_then(|()| lock.flush())
+            }
+            Self::Discard => Ok(()),
+        };
+        result.is_ok()
+    }
+}
+
+/// Either a live tee thread or a capture that is already complete
+/// (builtins, spawn failures, merged streams).
+enum StageStream {
+    Tee(JoinHandle<Capture>),
+    Ready(Capture),
+}
+
+impl StageStream {
+    fn spawn(mut reader: PipeReader, mut forward: Forward, limit: usize) -> Self {
+        let handle = std::thread::spawn(move || {
+            let mut capture = Capture::new(limit);
+            let mut buf = [0_u8; 8192];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        capture.write(&buf[..n]);
+                        if !forward.write(&buf[..n]) {
+                            // Downstream hung up: stop reading entirely so
+                            // the upstream process gets SIGPIPE, matching
+                            // bash. The capture keeps what already flowed.
+                            break;
+                        }
+                    }
+                }
+            }
+            capture
+        });
+        Self::Tee(handle)
+    }
+
+    fn finish(self) -> Capture {
+        match self {
+            Self::Tee(handle) => handle.join().unwrap_or_else(|_| Capture::new(0)),
+            Self::Ready(capture) => capture,
+        }
+    }
+}
+
+/// A stage in flight.
+struct Running {
+    argv: Vec<String>,
+    builtin: bool,
+    /// `None` for builtins and stages that failed to spawn.
+    child: Option<Child>,
+    /// Status used when there is no child (builtin / spawn failure).
+    fixed_status: i32,
+    stdout: StageStream,
+    stderr: StageStream,
+    stderr_merged: bool,
+    spawned_at: Instant,
+}
+
+fn open_sink(sink: &FileSink) -> Result<File, Error> {
+    OpenOptions::new()
+        .create(true)
+        .append(sink.append)
+        .write(true)
+        .truncate(!sink.append)
+        .open(&sink.path)
+        .context(RedirectSnafu {
+            path: sink.path.display().to_string(),
+        })
+}
+
+/// Run one pipeline to completion. `first_stage_index` numbers the stages
+/// across the whole run for `$oN_K` addressing.
+pub fn run_pipeline(
+    stages: Vec<StageSpec>,
+    config: &EngineConfig,
+    first_stage_index: usize,
+) -> Result<PipelineRun, Error> {
+    let count = stages.len();
+    let mut running: Vec<Running> = Vec::with_capacity(count);
+    // Reader for the next stage's stdin, produced by the previous iteration.
+    let mut next_stdin: Option<PipeReader> = None;
+
+    for (position, spec) in stages.into_iter().enumerate() {
+        let is_last = position + 1 == count;
+        let stdin_reader = next_stdin.take();
+        let mut edge_writer = if is_last {
+            None
+        } else {
+            let (reader, writer) = std::io::pipe().context(IoSnafu)?;
+            next_stdin = Some(reader);
+            Some(writer)
+        };
+        let default_stdout_forward = |edge_writer: &mut Option<PipeWriter>| {
+            edge_writer.take().map_or(
+                if config.echo_stdout && is_last {
+                    Forward::ParentStdout
+                } else {
+                    Forward::Discard
+                },
+                Forward::Pipe,
+            )
+        };
+        let stage = match spec {
+            StageSpec::Echo { text, argv } => {
+                let mut forward = default_stdout_forward(&mut edge_writer);
+                let mut capture = Capture::new(config.capture_limit);
+                capture.write(&text);
+                forward.write(&text);
+                Running {
+                    argv,
+                    builtin: true,
+                    child: None,
+                    fixed_status: 0,
+                    stdout: StageStream::Ready(capture),
+                    stderr: StageStream::Ready(Capture::new(0)),
+                    stderr_merged: false,
+                    spawned_at: Instant::now(),
+                }
+            }
+            StageSpec::Quiet { status, argv } => Running {
+                argv,
+                builtin: true,
+                child: None,
+                fixed_status: status,
+                stdout: StageStream::Ready(Capture::new(0)),
+                stderr: StageStream::Ready(Capture::new(0)),
+                stderr_merged: false,
+                spawned_at: Instant::now(),
+            },
+            StageSpec::External(spec) => spawn_external(
+                *spec,
+                stdin_reader,
+                &mut edge_writer,
+                is_last,
+                config,
+            )?,
+        };
+        drop(edge_writer);
+        running.push(stage);
+    }
+
+    let mut result_stages = Vec::with_capacity(count);
+    for (position, mut stage) in running.into_iter().enumerate() {
+        let status = match stage.child.as_mut() {
+            Some(child) => {
+                let exit = child.wait().context(IoSnafu)?;
+                exit.code()
+                    .or_else(|| exit.signal().map(|sig| 128 + sig))
+                    .unwrap_or(1)
+            }
+            None => stage.fixed_status,
+        };
+        let stdout = stage.stdout.finish();
+        let stderr = stage.stderr.finish();
+        let duration = stage.spawned_at.elapsed();
+        result_stages.push(Stage {
+            index: first_stage_index + position,
+            argv: stage.argv,
+            builtin: stage.builtin,
+            status,
+            duration_ms: crate::report::duration_millis(duration),
+            stdout,
+            stderr,
+            stderr_merged: stage.stderr_merged,
+        });
+    }
+
+    // Pipefail, except a stage killed by SIGPIPE (141): that is the normal
+    // fate of an upstream whose reader finished (`yes | head`), and calling
+    // it a failure would fail almost every early-exiting pipeline.
+    let status = result_stages
+        .iter()
+        .rev()
+        .map(|stage| stage.status)
+        .find(|status| *status != 0 && *status != 128 + libc::SIGPIPE)
+        .unwrap_or(0);
+    Ok(PipelineRun {
+        stages: result_stages,
+        status,
+    })
+}
+
+fn spawn_external(
+    spec: ExternalSpec,
+    stdin_reader: Option<PipeReader>,
+    edge_writer: &mut Option<PipeWriter>,
+    is_last: bool,
+    config: &EngineConfig,
+) -> Result<Running, Error> {
+    let mut command = Command::new(&spec.argv[0]);
+    command.args(&spec.argv[1..]);
+    command.env_clear();
+    for pair in &spec.env {
+        command.env(&pair.name, &pair.value);
+    }
+    command.current_dir(&spec.cwd);
+    restore_default_signals(&mut command);
+
+    // stdin
+    match stdin_reader {
+        Some(reader) => {
+            command.stdin(Stdio::from(reader));
+        }
+        None => match &spec.stdin {
+            StdinSpec::Null => {
+                command.stdin(Stdio::null());
+            }
+            StdinSpec::File(path) => {
+                let file = File::open(path).context(RedirectSnafu {
+                    path: path.display().to_string(),
+                })?;
+                command.stdin(Stdio::from(file));
+            }
+        },
+    }
+
+    // `&> file` writes one shared file; detect it so truncation happens once.
+    let shared_both = match (&spec.stdout_file, &spec.stderr_file) {
+        (Some(out), Some(err)) if out.path == err.path && out.append == err.append => {
+            Some(open_sink(out)?)
+        }
+        _ => None,
+    };
+
+    // stdout / stderr plumbing. Each stream is either a pipe back to us
+    // (tee'd to capture + forward) or, for the fd-duplication forms, a clone
+    // of the sibling stream's writer so the kernel interleaves exactly as
+    // bash would.
+    let (out_reader, out_writer) = std::io::pipe().context(IoSnafu)?;
+    let (err_reader, err_writer) = std::io::pipe().context(IoSnafu)?;
+    if spec.stdout_to_stderr {
+        command.stdout(Stdio::from(err_writer.try_clone().context(IoSnafu)?));
+    } else {
+        command.stdout(Stdio::from(out_writer.try_clone().context(IoSnafu)?));
+    }
+    if spec.stderr_to_stdout {
+        command.stderr(Stdio::from(out_writer.try_clone().context(IoSnafu)?));
+    } else {
+        command.stderr(Stdio::from(err_writer.try_clone().context(IoSnafu)?));
+    }
+    drop(out_writer);
+    drop(err_writer);
+
+    let mut shared_err: Option<File> = None;
+    let stdout_forward = if let Some(file) = shared_both {
+        let clone = file.try_clone().context(IoSnafu)?;
+        shared_err = Some(file);
+        Forward::File(clone)
+    } else if let Some(sink) = &spec.stdout_file {
+        Forward::File(open_sink(sink)?)
+    } else if let Some(writer) = edge_writer.take() {
+        Forward::Pipe(writer)
+    } else if config.echo_stdout && is_last {
+        Forward::ParentStdout
+    } else {
+        Forward::Discard
+    };
+    let stderr_forward = if let Some(file) = shared_err {
+        Forward::File(file)
+    } else if let Some(sink) = &spec.stderr_file {
+        Forward::File(open_sink(sink)?)
+    } else if config.echo_stderr {
+        Forward::ParentStderr
+    } else {
+        Forward::Discard
+    };
+
+    let spawned_at = Instant::now();
+    match command.spawn() {
+        Ok(child) => Ok(Running {
+            argv: spec.argv,
+            builtin: false,
+            child: Some(child),
+            fixed_status: 0,
+            stdout: StageStream::spawn(out_reader, stdout_forward, config.capture_limit),
+            stderr: StageStream::spawn(err_reader, stderr_forward, config.capture_limit),
+            stderr_merged: spec.stderr_to_stdout,
+            spawned_at,
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let mut stderr = Capture::new(config.capture_limit);
+            stderr.write(
+                format!("plumb: command not found: {}\n", spec.argv[0]).as_bytes(),
+            );
+            Ok(Running {
+                argv: spec.argv,
+                builtin: false,
+                child: None,
+                fixed_status: 127,
+                stdout: StageStream::Ready(Capture::new(0)),
+                stderr: StageStream::Ready(stderr),
+                stderr_merged: false,
+                spawned_at,
+            })
+        }
+        Err(error) => Err(Error::Io { source: error }),
+    }
+}
+
+/// Give children the default signal dispositions. Rust ignores SIGPIPE
+/// process-wide, and children must take the default or `yes | head` never
+/// terminates; SIGINT likewise so terminal ctrl-c stops the pipeline, not
+/// the shell that is waiting on it.
+fn restore_default_signals(command: &mut Command) {
+    use std::os::unix::process::CommandExt as _;
+    // SAFETY: the closure runs post-fork pre-exec and only calls
+    // async-signal-safe signal(2).
+    unsafe {
+        command.pre_exec(|| {
+            libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+            libc::signal(libc::SIGINT, libc::SIG_DFL);
+            Ok(())
+        });
+    }
+}

--- a/packages/plumb/core/src/error.rs
+++ b/packages/plumb/core/src/error.rs
@@ -1,0 +1,86 @@
+//! Error taxonomy. `Err` means the shell itself could not carry the run
+//! forward; a command merely exiting nonzero is data in the [`Report`],
+//! never an error.
+//!
+//! [`Report`]: crate::Report
+
+use plumb_syntax::ParseError;
+use snafu::Snafu;
+
+/// Why an eval could not complete.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum Error {
+    /// The source string is not in the plumb subset.
+    #[snafu(display("{source}"), context(false))]
+    Parse {
+        /// The parser's diagnosis.
+        source: ParseError,
+    },
+
+    /// Expansion referenced a variable that is not set (strict mode: bash
+    /// would silently expand to nothing, which is how `rm -rf /$TYPO`
+    /// happens).
+    #[snafu(display("unset variable `${name}`"))]
+    UnsetVar {
+        /// The variable name.
+        name: String,
+    },
+
+    /// A glob pattern matched nothing (strict, like bash `failglob`).
+    #[snafu(display("glob matched nothing: `{pattern}`"))]
+    GlobNoMatch {
+        /// The pattern after expansion.
+        pattern: String,
+    },
+
+    /// A redirection target could not be opened.
+    #[snafu(display("cannot open `{path}` for redirection: {source}"))]
+    Redirect {
+        /// The file path.
+        path: String,
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// Plumbing failed (pipe creation, spawn machinery); not a command
+    /// exiting nonzero.
+    #[snafu(display("i/o error: {source}"))]
+    Io {
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// A state-mutating builtin (`cd`, `export`, ...) was used as a pipeline
+    /// stage, where bash would run it in a subshell and silently discard its
+    /// effect.
+    #[snafu(display("builtin `{name}` cannot be a pipeline stage"))]
+    BuiltinInPipeline {
+        /// The builtin name.
+        name: String,
+    },
+
+    /// A builtin was misused; the message says how.
+    #[snafu(display("{name}: {message}"))]
+    BuiltinUsage {
+        /// The builtin name.
+        name: String,
+        /// What was wrong.
+        message: String,
+    },
+
+    /// A `$(...)` substitution produced more output than the configured
+    /// budget; its value would have been silently wrong.
+    #[snafu(display("command substitution output exceeded {limit} bytes"))]
+    SubstitutionOverflow {
+        /// The configured substitution budget.
+        limit: usize,
+    },
+
+    /// The `exit` builtin ran: the embedder should wind down with `code`.
+    #[snafu(display("exit {code}"))]
+    ExitRequested {
+        /// Requested exit code.
+        code: i32,
+    },
+}

--- a/packages/plumb/core/src/lib.rs
+++ b/packages/plumb/core/src/lib.rs
@@ -1,0 +1,35 @@
+//! libplumb: an embeddable shell where every run is a value.
+//!
+//! [`Shell::eval`] runs a strict bash subset (pipes, redirections, quoting,
+//! `$VAR`, globs, `$(...)`, `&&`/`||`/`;`, `&`) and returns a [`Report`]:
+//! per-stage argv, status, timing, and bounded captures of every stream
+//! that flowed through the pipeline, including what each pipe stage fed the
+//! next. Outputs auto-bind to shell variables (`$oN`, `$eN`, `$sN`,
+//! `$oN_K`, `$eN_K`, and `$o`/`$e`/`$s` for the last run), so any earlier
+//! run's data, including intermediate pipe data, can feed later commands
+//! without re-running anything.
+//!
+//! ```no_run
+//! let shell = plumb_core::Shell::new(plumb_core::Config::default())?;
+//! let report = shell.eval("cargo clippy 2>&1 | tail -n 5")?;
+//! assert_eq!(report.pipelines[0].stages.len(), 2);
+//! let full_clippy = shell.var("o1_0"); // everything tail consumed
+//! # let _ = full_clippy;
+//! # Ok::<(), plumb_core::Error>(())
+//! ```
+//!
+//! [`Shell`] is a cheap cloneable handle over shared state: concurrent
+//! evals (threads, `&` background items) see each other's variables, cwd,
+//! and run history.
+
+mod engine;
+mod error;
+mod report;
+mod shell;
+#[cfg(test)]
+mod tests;
+
+pub use error::Error;
+pub use plumb_syntax as syntax;
+pub use report::{Capture, PipelineRun, Report, Stage};
+pub use shell::{Config, RunHandle, Shell};

--- a/packages/plumb/core/src/report.rs
+++ b/packages/plumb/core/src/report.rs
@@ -1,0 +1,200 @@
+//! The value a run produces: per-stage argv, status, timing, and bounded
+//! captures of every stream that flowed through the pipeline.
+
+use std::collections::VecDeque;
+
+use serde::Serialize;
+
+/// Bounded byte capture: an exact byte count plus a head buffer and a tail
+/// ring, so a multi-gigabyte stream costs a fixed amount of memory while the
+/// interesting ends survive.
+#[derive(Debug, Clone)]
+pub struct Capture {
+    head: Vec<u8>,
+    tail: VecDeque<u8>,
+    head_limit: usize,
+    tail_limit: usize,
+    total: u64,
+}
+
+impl Capture {
+    /// A capture keeping at most `limit` bytes (3/4 head, 1/4 tail).
+    #[must_use]
+    pub const fn new(limit: usize) -> Self {
+        let head_limit = limit / 4 * 3;
+        Self {
+            head: Vec::new(),
+            tail: VecDeque::new(),
+            head_limit,
+            tail_limit: limit - head_limit,
+            total: 0,
+        }
+    }
+
+    /// Record bytes flowing through the stream.
+    pub fn write(&mut self, buf: &[u8]) {
+        self.total += buf.len() as u64;
+        let head_room = self.head_limit.saturating_sub(self.head.len());
+        let (to_head, to_tail) = buf.split_at(head_room.min(buf.len()));
+        self.head.extend_from_slice(to_head);
+        self.tail.extend(to_tail.iter().copied());
+        while self.tail.len() > self.tail_limit {
+            self.tail.pop_front();
+        }
+    }
+
+    /// Exact number of bytes that flowed through, kept or not.
+    #[must_use]
+    pub const fn total_bytes(&self) -> u64 {
+        self.total
+    }
+
+    /// True when bytes were dropped between head and tail.
+    #[must_use]
+    pub fn truncated(&self) -> bool {
+        self.total > (self.head.len() + self.tail.len()) as u64
+    }
+
+    /// The captured stream as text (lossy UTF-8). A truncated capture marks
+    /// the gap loudly so the reader never mistakes it for the full stream.
+    #[must_use]
+    pub fn render(&self) -> String {
+        let head = String::from_utf8_lossy(&self.head);
+        if self.truncated() {
+            let omitted = self.total - (self.head.len() + self.tail.len()) as u64;
+            let tail_bytes: Vec<u8> = self.tail.iter().copied().collect();
+            let tail = String::from_utf8_lossy(&tail_bytes);
+            format!("{head}\n[plumb: {omitted} bytes omitted]\n{tail}")
+        } else if self.tail.is_empty() {
+            head.into_owned()
+        } else {
+            let tail_bytes: Vec<u8> = self.tail.iter().copied().collect();
+            format!("{head}{}", String::from_utf8_lossy(&tail_bytes))
+        }
+    }
+}
+
+impl Serialize for Capture {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        #[derive(Serialize)]
+        struct Repr {
+            text: String,
+            total_bytes: u64,
+            truncated: bool,
+        }
+        Repr {
+            text: self.render(),
+            total_bytes: self.total,
+            truncated: self.truncated(),
+        }
+        .serialize(serializer)
+    }
+}
+
+/// One pipeline stage after it ran.
+#[derive(Debug, Clone, Serialize)]
+pub struct Stage {
+    /// Index of the stage across the whole run (the `K` in `$oN_K`).
+    pub index: usize,
+    /// The argv actually spawned, after expansion (empty for builtins that
+    /// take no arguments? never: argv[0] is always present).
+    pub argv: Vec<String>,
+    /// True when the stage ran in-process as a builtin.
+    pub builtin: bool,
+    /// Exit status (128+signal for signal deaths, 127 for not found).
+    pub status: i32,
+    /// Wall time of this stage in milliseconds.
+    pub duration_ms: u64,
+    /// Captured stdout of this stage. For stage K, this is also exactly what
+    /// stage K+1 received on stdin.
+    pub stdout: Capture,
+    /// Captured stderr of this stage.
+    pub stderr: Capture,
+    /// True when `2>&1` merged this stage's stderr into its stdout capture.
+    pub stderr_merged: bool,
+}
+
+/// One executed pipeline (`a | b | c`).
+#[derive(Debug, Clone, Serialize)]
+pub struct PipelineRun {
+    /// The stages, left to right.
+    pub stages: Vec<Stage>,
+    /// Pipeline status: the last nonzero stage status, else 0 (pipefail).
+    pub status: i32,
+}
+
+/// The value of one run: everything that happened when a source string was
+/// evaluated.
+#[derive(Debug, Clone, Serialize)]
+pub struct Report {
+    /// Run id: the `N` in `$oN` / `$eN` / `$sN`.
+    pub id: u64,
+    /// The source text that was evaluated.
+    pub source: String,
+    /// Final status of the run (status of the last pipeline that ran).
+    pub status: i32,
+    /// Executed pipelines in order (connector short-circuiting means a
+    /// source pipeline may not appear here).
+    pub pipelines: Vec<PipelineRun>,
+    /// Reports of `$(...)` command substitutions, in evaluation order.
+    pub substitutions: Vec<Self>,
+    /// Run ids of `&` background items this run started.
+    pub background_started: Vec<u64>,
+    /// Wall time of the whole run in milliseconds.
+    pub duration_ms: u64,
+    /// When the run aborted early (unset variable, failed glob, redirect
+    /// error), the error message; the pipelines above still ran.
+    pub aborted: Option<String>,
+}
+
+impl Report {
+    /// The final stdout of the run: the last stage of the last pipeline.
+    #[must_use]
+    pub fn output(&self) -> String {
+        self.pipelines
+            .last()
+            .and_then(|p| p.stages.last())
+            .map(|s| s.stdout.render())
+            .unwrap_or_default()
+    }
+
+    /// All stages of the run in execution order.
+    pub fn stages(&self) -> impl Iterator<Item = &Stage> {
+        self.pipelines.iter().flat_map(|p| p.stages.iter())
+    }
+}
+
+/// Duration in whole milliseconds without a fallible narrowing conversion.
+#[must_use]
+pub fn duration_millis(duration: std::time::Duration) -> u64 {
+    duration
+        .as_secs()
+        .saturating_mul(1000)
+        .saturating_add(u64::from(duration.subsec_millis()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Capture;
+
+    #[test]
+    fn capture_keeps_head_and_tail() {
+        let mut capture = Capture::new(8);
+        capture.write(b"0123456789abcdef");
+        assert_eq!(capture.total_bytes(), 16);
+        assert!(capture.truncated());
+        let text = capture.render();
+        assert!(text.starts_with("012345"), "{text}");
+        assert!(text.ends_with("ef"), "{text}");
+        assert!(text.contains("omitted"), "{text}");
+    }
+
+    #[test]
+    fn capture_small_stream_is_exact() {
+        let mut capture = Capture::new(64);
+        capture.write(b"hello ");
+        capture.write(b"world");
+        assert!(!capture.truncated());
+        assert_eq!(capture.render(), "hello world");
+    }
+}

--- a/packages/plumb/core/src/shell.rs
+++ b/packages/plumb/core/src/shell.rs
@@ -1,0 +1,945 @@
+//! The shell itself: shared state, evaluation, expansion, builtins, and the
+//! automatic binding of every run's outputs to variables.
+
+use std::collections::{HashMap, VecDeque};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::thread::JoinHandle;
+use std::time::Instant;
+
+use plumb_syntax::{
+    AndOr, Command as AstCommand, Connector, Part, Pipeline as AstPipeline, Program, RedirOp,
+    Word, parse,
+};
+
+use crate::engine::{
+    self, EngineConfig, EnvPair, ExternalSpec, FileSink, StageSpec, StdinSpec,
+};
+use crate::error::Error;
+use crate::report::{Capture, PipelineRun, Report, Stage};
+
+/// Shell construction knobs.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Per-stream capture budget in bytes (head + tail; exact byte counts
+    /// are always kept).
+    pub capture_limit: usize,
+    /// Capture budget for `$(...)` output. Substitution output becomes
+    /// argument data, so exceeding this is an error rather than a silent
+    /// truncation.
+    pub substitution_limit: usize,
+    /// How many runs (reports + their auto-bound variables) to retain.
+    pub keep_runs: usize,
+    /// Stream final stdout / all stderr to the parent's stdio while running
+    /// (the REPL and CLI turn this on; embedders usually want it off).
+    pub echo_output: bool,
+    /// Initial environment; `None` inherits the process environment.
+    pub env: Option<HashMap<String, String>>,
+    /// Initial working directory; `None` uses the process cwd.
+    pub cwd: Option<PathBuf>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            capture_limit: 256 * 1024,
+            substitution_limit: 8 * 1024 * 1024,
+            keep_runs: 64,
+            echo_output: false,
+            env: None,
+            cwd: None,
+        }
+    }
+}
+
+/// A handle to one shell. Cheap to clone; clones share state, so concurrent
+/// evals (REPL background jobs, embedder threads) see each other's
+/// variables, cwd, and run history.
+#[derive(Clone)]
+pub struct Shell {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    config: Config,
+    state: Mutex<State>,
+}
+
+struct State {
+    cwd: PathBuf,
+    /// Exported: becomes child process environment.
+    env: HashMap<String, String>,
+    /// Shell-only variables (user assignments and auto-bound run outputs).
+    vars: HashMap<String, String>,
+    last_status: i32,
+    next_run: u64,
+    runs: VecDeque<Arc<Report>>,
+    jobs: Vec<Job>,
+}
+
+struct Job {
+    run_id: u64,
+    handle: JoinHandle<()>,
+}
+
+/// A run evaluating on another thread (from [`Shell::eval_detached`]).
+pub struct RunHandle {
+    run_id: u64,
+    handle: JoinHandle<Result<Report, Error>>,
+}
+
+impl RunHandle {
+    /// The run id this eval will report under.
+    #[must_use]
+    pub const fn id(&self) -> u64 {
+        self.run_id
+    }
+
+    /// Wait for the eval to finish.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the eval's error; a panic on the eval thread surfaces as
+    /// [`Error::Io`].
+    pub fn join(self) -> Result<Report, Error> {
+        self.handle.join().unwrap_or_else(|_| {
+            Err(Error::Io {
+                source: std::io::Error::other("eval thread panicked"),
+            })
+        })
+    }
+}
+
+/// Per-eval context (differs between foreground evals and substitutions).
+#[derive(Clone, Copy)]
+struct RunCtx {
+    echo_stdout: bool,
+    capture_limit: usize,
+}
+
+impl Shell {
+    /// Create a shell.
+    ///
+    /// # Errors
+    ///
+    /// Fails when no working directory can be determined.
+    pub fn new(config: Config) -> Result<Self, Error> {
+        let cwd = match &config.cwd {
+            Some(cwd) => cwd.clone(),
+            None => std::env::current_dir().map_err(|source| Error::Io { source })?,
+        };
+        let env = config
+            .env
+            .clone()
+            .unwrap_or_else(|| std::env::vars().collect());
+        Ok(Self {
+            inner: Arc::new(Inner {
+                state: Mutex::new(State {
+                    cwd,
+                    env,
+                    vars: HashMap::new(),
+                    last_status: 0,
+                    next_run: 1,
+                    runs: VecDeque::new(),
+                    jobs: Vec::new(),
+                }),
+                config,
+            }),
+        })
+    }
+
+    /// Evaluate `src` to completion and return the run's [`Report`].
+    /// Background items (`&`) start their own runs and are listed in
+    /// [`Report::background_started`].
+    ///
+    /// # Errors
+    ///
+    /// Parse errors, strictness violations (unset variable, empty glob),
+    /// redirect failures, and [`Error::ExitRequested`] from the `exit`
+    /// builtin. Commands exiting nonzero are not errors; read the report.
+    /// Even on error the partial report is committed to [`Shell::reports`].
+    pub fn eval(&self, src: &str) -> Result<Report, Error> {
+        let program = parse(src)?;
+        let run_id = self.alloc_run_id();
+        let ctx = RunCtx {
+            echo_stdout: self.inner.config.echo_output,
+            capture_limit: self.inner.config.capture_limit,
+        };
+        self.run_program(run_id, src.to_owned(), program, ctx, true)
+    }
+
+    /// Evaluate `src` on a new thread, sharing this shell's state.
+    #[must_use]
+    pub fn eval_detached(&self, src: &str) -> RunHandle {
+        let shell = self.clone();
+        let source = src.to_owned();
+        let run_id = self.alloc_run_id();
+        let handle = std::thread::spawn(move || {
+            let program = parse(&source)?;
+            let ctx = RunCtx {
+                echo_stdout: shell.inner.config.echo_output,
+                capture_limit: shell.inner.config.capture_limit,
+            };
+            shell.run_program(run_id, source, program, ctx, true)
+        });
+        RunHandle { run_id, handle }
+    }
+
+    /// The report for a run id, if still retained.
+    #[must_use]
+    pub fn report(&self, id: u64) -> Option<Arc<Report>> {
+        self.lock().runs.iter().find(|r| r.id == id).cloned()
+    }
+
+    /// All retained reports, oldest first.
+    #[must_use]
+    pub fn reports(&self) -> Vec<Arc<Report>> {
+        self.lock().runs.iter().cloned().collect()
+    }
+
+    /// Read a variable (shell variables shadow the environment).
+    #[must_use]
+    pub fn var(&self, name: &str) -> Option<String> {
+        let state = self.lock();
+        state
+            .vars
+            .get(name)
+            .or_else(|| state.env.get(name))
+            .cloned()
+    }
+
+    /// Set a shell variable.
+    pub fn set_var(&self, name: &str, value: &str) {
+        self.lock().vars.insert(name.to_owned(), value.to_owned());
+    }
+
+    /// Status of the most recent pipeline.
+    #[must_use]
+    pub fn last_status(&self) -> i32 {
+        self.lock().last_status
+    }
+
+    /// The shell's working directory.
+    #[must_use]
+    pub fn cwd(&self) -> PathBuf {
+        self.lock().cwd.clone()
+    }
+
+    /// Number of background runs still in flight.
+    #[must_use]
+    pub fn background_pending(&self) -> usize {
+        self.lock().jobs.iter().filter(|j| !j.handle.is_finished()).count()
+    }
+
+    /// Reap finished background runs, returning their reports.
+    #[must_use]
+    pub fn finished_background(&self) -> Vec<Arc<Report>> {
+        let finished: Vec<Job> = {
+            let mut state = self.lock();
+            let (done, pending): (Vec<Job>, Vec<Job>) = state
+                .jobs
+                .drain(..)
+                .partition(|job| job.handle.is_finished());
+            state.jobs = pending;
+            done
+        };
+        finished
+            .into_iter()
+            .filter_map(|job| {
+                let _ = job.handle.join();
+                self.report(job.run_id)
+            })
+            .collect()
+    }
+
+    fn lock(&self) -> MutexGuard<'_, State> {
+        self.inner
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn alloc_run_id(&self) -> u64 {
+        let mut state = self.lock();
+        let id = state.next_run;
+        state.next_run += 1;
+        id
+    }
+
+    /// Run a parsed program as run `run_id`, committing the report (and its
+    /// auto-bound variables) even when an error cuts the run short.
+    fn run_program(
+        &self,
+        run_id: u64,
+        source: String,
+        program: Program,
+        ctx: RunCtx,
+        commit: bool,
+    ) -> Result<Report, Error> {
+        let started = Instant::now();
+        let mut report = Report {
+            id: run_id,
+            source,
+            status: 0,
+            pipelines: Vec::new(),
+            substitutions: Vec::new(),
+            background_started: Vec::new(),
+            duration_ms: 0,
+            aborted: None,
+        };
+        let mut error = None;
+        for item in program.items {
+            if item.background {
+                let bg_id = self.spawn_background(&report.source, item.and_or);
+                report.background_started.push(bg_id);
+                continue;
+            }
+            if let Err(e) = self.run_and_or(&item.and_or, &mut report, ctx) {
+                report.aborted = Some(e.to_string());
+                error = Some(e);
+                break;
+            }
+        }
+        report.status = report.pipelines.last().map_or(0, |p| p.status);
+        report.duration_ms = crate::report::duration_millis(started.elapsed());
+        if commit {
+            self.commit(&report);
+        }
+        error.map_or(Ok(report), Err)
+    }
+
+    /// Start a background run for one `&` item; returns its run id.
+    fn spawn_background(&self, parent_source: &str, and_or: AndOr) -> u64 {
+        let bg_id = self.alloc_run_id();
+        let source = and_or.span.text(parent_source).to_owned();
+        let shell = self.clone();
+        let ctx = RunCtx {
+            echo_stdout: self.inner.config.echo_output,
+            capture_limit: self.inner.config.capture_limit,
+        };
+        let handle = std::thread::spawn(move || {
+            let program = Program {
+                items: vec![plumb_syntax::Item {
+                    and_or,
+                    background: false,
+                }],
+            };
+            // The report (including any abort reason) is committed; the
+            // error itself has no foreground to land in.
+            drop(shell.run_program(bg_id, source, program, ctx, true));
+        });
+        self.lock().jobs.push(Job {
+            run_id: bg_id,
+            handle,
+        });
+        bg_id
+    }
+
+    fn run_and_or(
+        &self,
+        and_or: &AndOr,
+        report: &mut Report,
+        ctx: RunCtx,
+    ) -> Result<(), Error> {
+        self.run_pipeline_ast(&and_or.first, report, ctx)?;
+        let mut status = report.pipelines.last().map_or(0, |p| p.status);
+        for tail in &and_or.rest {
+            let run = match tail.connector {
+                Connector::And => status == 0,
+                Connector::Or => status != 0,
+            };
+            if run {
+                self.run_pipeline_ast(&tail.pipeline, report, ctx)?;
+                status = report.pipelines.last().map_or(0, |p| p.status);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// State-mutating builtins refuse to be pipeline stages (bash would run
+/// them in a subshell and silently discard their effect).
+const STATE_BUILTINS: &[&str] = &["cd", "export", "unset", "exit", "wait"];
+
+impl Shell {
+    fn run_pipeline_ast(
+        &self,
+        pipeline: &AstPipeline,
+        report: &mut Report,
+        ctx: RunCtx,
+    ) -> Result<(), Error> {
+        let first_index = report.stages().count();
+        let solo = pipeline.commands.len() == 1;
+
+        // Bare assignment: `X=1` (no argv words).
+        if let [command] = pipeline.commands.as_slice()
+            && command.words.is_empty()
+        {
+            return self.run_bare_assignment(command, report, ctx, first_index);
+        }
+
+        let mut specs = Vec::with_capacity(pipeline.commands.len());
+        for command in &pipeline.commands {
+            if command.words.is_empty() {
+                return Err(Error::BuiltinInPipeline {
+                    name: "assignment".to_owned(),
+                });
+            }
+            let argv = self.expand_words(&command.words, report, ctx)?;
+            let name = argv[0].as_str();
+            if STATE_BUILTINS.contains(&name) {
+                if !solo {
+                    return Err(Error::BuiltinInPipeline {
+                        name: name.to_owned(),
+                    });
+                }
+                if !command.redirects.is_empty() {
+                    return Err(Error::BuiltinUsage {
+                        name: name.to_owned(),
+                        message: "redirections are not supported on builtins".to_owned(),
+                    });
+                }
+                return self.run_state_builtin(&argv, report, ctx, first_index);
+            }
+            let spec = if command.redirects.is_empty() && name == "echo" {
+                echo_spec(argv)
+            } else if command.redirects.is_empty() && (name == "true" || name == "false") {
+                StageSpec::Quiet {
+                    status: i32::from(name == "false"),
+                    argv,
+                }
+            } else {
+                self.external_spec(command, argv, report, ctx)?
+            };
+            specs.push(spec);
+        }
+
+        let engine_config = EngineConfig {
+            capture_limit: ctx.capture_limit,
+            echo_stdout: ctx.echo_stdout,
+            echo_stderr: self.inner.config.echo_output,
+        };
+        let run = engine::run_pipeline(specs, &engine_config, first_index)?;
+        self.lock().last_status = run.status;
+        report.pipelines.push(run);
+        Ok(())
+    }
+
+    fn run_bare_assignment(
+        &self,
+        command: &AstCommand,
+        report: &mut Report,
+        ctx: RunCtx,
+        first_index: usize,
+    ) -> Result<(), Error> {
+        let mut shown = Vec::with_capacity(command.assigns.len() + 1);
+        shown.push("set".to_owned());
+        for assign in &command.assigns {
+            let value = self.expand_single(&assign.value, report, ctx)?;
+            self.assign_var(&assign.name, &value);
+            shown.push(format!("{}={value}", assign.name));
+        }
+        self.push_builtin_pipeline(report, first_index, shown, 0, None, ctx);
+        Ok(())
+    }
+
+    /// Record a builtin's execution as a one-stage pipeline in the report.
+    fn push_builtin_pipeline(
+        &self,
+        report: &mut Report,
+        first_index: usize,
+        argv: Vec<String>,
+        status: i32,
+        stderr_message: Option<String>,
+        ctx: RunCtx,
+    ) {
+        let mut stderr = Capture::new(ctx.capture_limit);
+        if let Some(message) = stderr_message {
+            stderr.write(message.as_bytes());
+            if self.inner.config.echo_output {
+                use std::io::Write as _;
+                let _ = std::io::stderr().write_all(message.as_bytes());
+            }
+        }
+        report.pipelines.push(PipelineRun {
+            stages: vec![Stage {
+                index: first_index,
+                argv,
+                builtin: true,
+                status,
+                duration_ms: 0,
+                stdout: Capture::new(0),
+                stderr,
+                stderr_merged: false,
+            }],
+            status,
+        });
+        self.lock().last_status = status;
+    }
+
+    fn run_state_builtin(
+        &self,
+        argv: &[String],
+        report: &mut Report,
+        ctx: RunCtx,
+        first_index: usize,
+    ) -> Result<(), Error> {
+        let rest = &argv[1..];
+        let outcome = match argv[0].as_str() {
+            "cd" => self.builtin_cd(rest),
+            "export" => self.builtin_export(rest),
+            "unset" => {
+                let mut state = self.lock();
+                for name in rest {
+                    state.vars.remove(name);
+                    state.env.remove(name);
+                }
+                drop(state);
+                Ok(())
+            }
+            "exit" => {
+                let code = match rest {
+                    [] => self.lock().last_status,
+                    [code] => code.parse().map_err(|_| Error::BuiltinUsage {
+                        name: "exit".to_owned(),
+                        message: format!("not a number: `{code}`"),
+                    })?,
+                    _ => {
+                        return Err(Error::BuiltinUsage {
+                            name: "exit".to_owned(),
+                            message: "too many arguments".to_owned(),
+                        });
+                    }
+                };
+                return Err(Error::ExitRequested { code });
+            }
+            "wait" => {
+                self.builtin_wait(rest)?;
+                Ok(())
+            }
+            other => unreachable!("not a state builtin: {other}"),
+        };
+        match outcome {
+            Ok(()) => {
+                self.push_builtin_pipeline(report, first_index, argv.to_vec(), 0, None, ctx);
+            }
+            Err(message) => {
+                self.push_builtin_pipeline(
+                    report,
+                    first_index,
+                    argv.to_vec(),
+                    1,
+                    Some(message),
+                    ctx,
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// `cd [dir]`; failure is a status-1 stage, not a shell error.
+    fn builtin_cd(&self, args: &[String]) -> Result<(), String> {
+        let target = match args {
+            [] => self
+                .var("HOME")
+                .ok_or_else(|| "cd: HOME is not set\n".to_owned())?,
+            [dir] => dir.clone(),
+            _ => return Err("cd: too many arguments\n".to_owned()),
+        };
+        let cwd = self.lock().cwd.clone();
+        let joined = if Path::new(&target).is_absolute() {
+            PathBuf::from(&target)
+        } else {
+            cwd.join(&target)
+        };
+        let resolved = joined
+            .canonicalize()
+            .map_err(|error| format!("cd: {target}: {error}\n"))?;
+        if !resolved.is_dir() {
+            return Err(format!("cd: {target}: not a directory\n"));
+        }
+        self.lock().cwd = resolved;
+        Ok(())
+    }
+
+    fn builtin_export(&self, args: &[String]) -> Result<(), String> {
+        let mut state = self.lock();
+        for arg in args {
+            if let Some(name_value) = arg.split_once('=') {
+                let (name, value) = name_value;
+                state.env.insert(name.to_owned(), value.to_owned());
+                state.vars.remove(name);
+            } else {
+                let Some(value) = state.vars.remove(arg) else {
+                    return Err(format!("export: {arg}: not a shell variable\n"));
+                };
+                state.env.insert(arg.clone(), value);
+            }
+        }
+        drop(state);
+        Ok(())
+    }
+
+    /// `wait [id ...]`: join background runs (all of them without args).
+    fn builtin_wait(&self, args: &[String]) -> Result<(), Error> {
+        let wanted: Vec<u64> = args
+            .iter()
+            .map(|arg| {
+                arg.parse().map_err(|_| Error::BuiltinUsage {
+                    name: "wait".to_owned(),
+                    message: format!("not a run id: `{arg}`"),
+                })
+            })
+            .collect::<Result<_, _>>()?;
+        // Take the handles out of the lock before joining: the background
+        // threads need the same lock to commit their reports.
+        let handles: Vec<Job> = {
+            let mut state = self.lock();
+            if wanted.is_empty() {
+                state.jobs.drain(..).collect()
+            } else {
+                let (take, keep): (Vec<Job>, Vec<Job>) = state
+                    .jobs
+                    .drain(..)
+                    .partition(|job| wanted.contains(&job.run_id));
+                state.jobs = keep;
+                take
+            }
+        };
+        for job in handles {
+            let _ = job.handle.join();
+        }
+        Ok(())
+    }
+
+    fn assign_var(&self, name: &str, value: &str) {
+        let mut state = self.lock();
+        if state.env.contains_key(name) {
+            // Assigning to an exported variable keeps it exported.
+            state.env.insert(name.to_owned(), value.to_owned());
+        } else {
+            state.vars.insert(name.to_owned(), value.to_owned());
+        }
+    }
+}
+
+/// Builtin `echo` (`-n` suppresses the newline; everything else is literal,
+/// like POSIX echo).
+fn echo_spec(argv: Vec<String>) -> StageSpec {
+    let mut rest = argv[1..].iter().peekable();
+    let newline = if rest.peek().is_some_and(|arg| *arg == "-n") {
+        rest.next();
+        false
+    } else {
+        true
+    };
+    let mut text = rest.cloned().collect::<Vec<String>>().join(" ").into_bytes();
+    if newline {
+        text.push(b'\n');
+    }
+    StageSpec::Echo { text, argv }
+}
+
+impl Shell {
+    /// Build the engine spec for one external command.
+    fn external_spec(
+        &self,
+        command: &AstCommand,
+        argv: Vec<String>,
+        report: &mut Report,
+        ctx: RunCtx,
+    ) -> Result<StageSpec, Error> {
+        let mut env: Vec<EnvPair> = {
+            let state = self.lock();
+            state
+                .env
+                .iter()
+                .map(|(name, value)| EnvPair {
+                    name: name.clone(),
+                    value: value.clone(),
+                })
+                .collect()
+        };
+        for assign in &command.assigns {
+            let value = self.expand_single(&assign.value, report, ctx)?;
+            env.push(EnvPair {
+                name: assign.name.clone(),
+                value,
+            });
+        }
+
+        let mut stdin = StdinSpec::Null;
+        let mut stdout_file = None;
+        let mut stderr_file = None;
+        let mut stderr_to_stdout = false;
+        let mut stdout_to_stderr = false;
+        for redirect in &command.redirects {
+            let target = match &redirect.target {
+                Some(word) => Some(self.expand_single(word, report, ctx)?),
+                None => None,
+            };
+            let sink = |append: bool| {
+                target.clone().map(|path| FileSink {
+                    path: PathBuf::from(path),
+                    append,
+                })
+            };
+            match redirect.op {
+                RedirOp::In => {
+                    stdin = StdinSpec::File(PathBuf::from(target.unwrap_or_default()));
+                }
+                RedirOp::OutTrunc => stdout_file = sink(false),
+                RedirOp::OutAppend => stdout_file = sink(true),
+                RedirOp::ErrTrunc => stderr_file = sink(false),
+                RedirOp::ErrAppend => stderr_file = sink(true),
+                RedirOp::BothTrunc => {
+                    stdout_file = sink(false);
+                    stderr_file = sink(false);
+                }
+                RedirOp::BothAppend => {
+                    stdout_file = sink(true);
+                    stderr_file = sink(true);
+                }
+                RedirOp::ErrToOut => stderr_to_stdout = true,
+                RedirOp::OutToErr => stdout_to_stderr = true,
+            }
+        }
+        if stderr_to_stdout && stdout_to_stderr {
+            return Err(Error::BuiltinUsage {
+                name: "redirection".to_owned(),
+                message: "`2>&1` combined with `>&2` swaps nothing; pick one".to_owned(),
+            });
+        }
+        // Relative redirect targets are cwd-relative.
+        let cwd = self.lock().cwd.clone();
+        let absolutize = |sink: Option<FileSink>| {
+            sink.map(|sink| FileSink {
+                path: if sink.path.is_absolute() {
+                    sink.path
+                } else {
+                    cwd.join(sink.path)
+                },
+                append: sink.append,
+            })
+        };
+        let stdin = match stdin {
+            StdinSpec::File(path) if !path.is_absolute() => StdinSpec::File(cwd.join(path)),
+            other => other,
+        };
+        let stdout_file = absolutize(stdout_file);
+        let stderr_file = absolutize(stderr_file);
+        Ok(StageSpec::External(Box::new(ExternalSpec {
+            argv,
+            env,
+            cwd,
+            stdin,
+            stdout_file,
+            stderr_file,
+            stderr_to_stdout,
+            stdout_to_stderr,
+        })))
+    }
+
+    /// Expand argv words: variable and command substitution, then glob.
+    fn expand_words(
+        &self,
+        words: &[Word],
+        report: &mut Report,
+        ctx: RunCtx,
+    ) -> Result<Vec<String>, Error> {
+        let mut argv = Vec::with_capacity(words.len());
+        for word in words {
+            let expanded = self.expand_parts(word, report, ctx)?;
+            if expanded.has_glob {
+                let cwd = self.lock().cwd.clone();
+                argv.extend(glob_word(&expanded, &cwd)?);
+            } else {
+                argv.push(expanded.text);
+            }
+        }
+        Ok(argv)
+    }
+
+    /// Expand a word to exactly one string (assignments, redirect targets):
+    /// no globbing, no splitting.
+    fn expand_single(
+        &self,
+        word: &Word,
+        report: &mut Report,
+        ctx: RunCtx,
+    ) -> Result<String, Error> {
+        Ok(self.expand_parts(word, report, ctx)?.text)
+    }
+
+    fn expand_parts(
+        &self,
+        word: &Word,
+        report: &mut Report,
+        ctx: RunCtx,
+    ) -> Result<Expanded, Error> {
+        let mut expanded = Expanded {
+            text: String::new(),
+            pattern: String::new(),
+            has_glob: false,
+        };
+        for part in &word.parts {
+            match part {
+                Part::Text { text, quoted } => {
+                    expanded.text.push_str(text);
+                    if *quoted {
+                        expanded.pattern.push_str(&glob::Pattern::escape(text));
+                    } else {
+                        expanded.pattern.push_str(text);
+                        if text.contains(['*', '?', '[']) {
+                            expanded.has_glob = true;
+                        }
+                    }
+                }
+                Part::Var { name, .. } => {
+                    let value = if name == "?" {
+                        self.lock().last_status.to_string()
+                    } else {
+                        self.var(name).ok_or_else(|| Error::UnsetVar {
+                            name: name.clone(),
+                        })?
+                    };
+                    expanded.text.push_str(&value);
+                    // Expansion results are data, never glob patterns.
+                    expanded.pattern.push_str(&glob::Pattern::escape(&value));
+                }
+                Part::CommandSub { program, span } => {
+                    let value = self.run_substitution(program, span, report, ctx)?;
+                    expanded.text.push_str(&value);
+                    expanded.pattern.push_str(&glob::Pattern::escape(&value));
+                }
+            }
+        }
+        Ok(expanded)
+    }
+
+    /// Run a `$(...)` substitution: a nested run whose report lands in
+    /// `report.substitutions` (id 0: substitutions are not addressable
+    /// runs). Its final stdout, with trailing newlines trimmed, is the
+    /// value.
+    fn run_substitution(
+        &self,
+        program: &Program,
+        span: &plumb_syntax::Span,
+        report: &mut Report,
+        ctx: RunCtx,
+    ) -> Result<String, Error> {
+        let source = span.text(&report.source).to_owned();
+        let sub_ctx = RunCtx {
+            echo_stdout: false,
+            capture_limit: self.inner.config.substitution_limit,
+        };
+        let sub_report = self.run_program(0, source, program.clone(), sub_ctx, false)?;
+        let truncated = sub_report
+            .pipelines
+            .last()
+            .and_then(|p| p.stages.last())
+            .is_some_and(|stage| stage.stdout.truncated());
+        let value = sub_report.output();
+        report.substitutions.push(sub_report);
+        if truncated {
+            return Err(Error::SubstitutionOverflow {
+                limit: self.inner.config.substitution_limit,
+            });
+        }
+        let _ = ctx;
+        Ok(value.trim_end_matches('\n').to_owned())
+    }
+
+    /// Commit a finished run: store the report and auto-bind its outputs.
+    ///
+    /// Variables bound for run N: `$oN` / `$eN` (final stdout / stderr),
+    /// `$sN` (status), `$oN_K` / `$eN_K` per stage K, plus the unnumbered
+    /// aliases `$o` / `$e` / `$s` for the most recently finished run.
+    fn commit(&self, report: &Report) {
+        let arc = Arc::new(report.clone());
+        let id = arc.id;
+        let trim = |text: String| text.trim_end_matches('\n').to_owned();
+        let out = trim(arc.output());
+        let err = trim(
+            arc.pipelines
+                .last()
+                .and_then(|p| p.stages.last())
+                .map(|s| s.stderr.render())
+                .unwrap_or_default(),
+        );
+        let status = arc.status.to_string();
+        let mut state = self.lock();
+        state.vars.insert(format!("o{id}"), out.clone());
+        state.vars.insert(format!("e{id}"), err.clone());
+        state.vars.insert(format!("s{id}"), status.clone());
+        state.vars.insert("o".to_owned(), out);
+        state.vars.insert("e".to_owned(), err);
+        state.vars.insert("s".to_owned(), status);
+        for stage in arc.stages() {
+            state
+                .vars
+                .insert(format!("o{id}_{}", stage.index), trim(stage.stdout.render()));
+            state
+                .vars
+                .insert(format!("e{id}_{}", stage.index), trim(stage.stderr.render()));
+        }
+        state.runs.push_back(arc);
+        while state.runs.len() > self.inner.config.keep_runs {
+            if let Some(evicted) = state.runs.pop_front() {
+                let old = evicted.id;
+                state.vars.remove(&format!("o{old}"));
+                state.vars.remove(&format!("e{old}"));
+                state.vars.remove(&format!("s{old}"));
+                for stage in evicted.stages() {
+                    state.vars.remove(&format!("o{old}_{}", stage.index));
+                    state.vars.remove(&format!("e{old}_{}", stage.index));
+                }
+            }
+        }
+        drop(state);
+    }
+}
+
+/// A word after variable/substitution expansion, with the parallel glob
+/// pattern (expansion results escaped) when any unquoted metacharacter
+/// appeared.
+struct Expanded {
+    text: String,
+    pattern: String,
+    has_glob: bool,
+}
+
+/// Expand a glob word against `cwd`. No match is an error (failglob); a
+/// syntactically invalid pattern (a lone `[`) falls back to the literal
+/// text so `[ -f x ]` keeps working.
+fn glob_word(expanded: &Expanded, cwd: &Path) -> Result<Vec<String>, Error> {
+    let anchored = if Path::new(&expanded.pattern).is_absolute() {
+        expanded.pattern.clone()
+    } else {
+        format!("{}/{}", cwd.display(), expanded.pattern)
+    };
+    let options = glob::MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: false,
+        // `*` must not match dotfiles, same as bash.
+        require_literal_leading_dot: true,
+    };
+    let Ok(paths) = glob::glob_with(&anchored, options) else {
+        return Ok(vec![expanded.text.clone()]);
+    };
+    let matches: Vec<String> = paths
+        .filter_map(Result::ok)
+        .map(|path| {
+            path.strip_prefix(cwd).map_or_else(
+                |_| path.display().to_string(),
+                |relative| relative.display().to_string(),
+            )
+        })
+        .collect();
+    if matches.is_empty() {
+        return Err(Error::GlobNoMatch {
+            pattern: expanded.text.clone(),
+        });
+    }
+    Ok(matches)
+}

--- a/packages/plumb/core/src/tests.rs
+++ b/packages/plumb/core/src/tests.rs
@@ -1,0 +1,270 @@
+//! End-to-end shell behavior. External commands are limited to coreutils
+//! and `sh`, which the nix check sandbox provides on PATH.
+
+use crate::{Config, Error, Shell};
+
+fn shell() -> Shell {
+    Shell::new(Config::default()).expect("shell")
+}
+
+fn echoing() -> Shell {
+    Shell::new(Config {
+        echo_output: false,
+        ..Config::default()
+    })
+    .expect("shell")
+}
+
+#[test]
+fn pipeline_captures_every_stage() {
+    let sh = shell();
+    let report = sh.eval("echo hello | tr a-z A-Z").expect("eval");
+    assert_eq!(report.status, 0);
+    assert_eq!(report.output(), "HELLO\n");
+    let stages = &report.pipelines[0].stages;
+    assert_eq!(stages.len(), 2);
+    assert_eq!(stages[0].stdout.render(), "hello\n");
+    assert_eq!(stages[1].stdout.render(), "HELLO\n");
+    // Auto-bound variables, including the intermediate pipe data.
+    assert_eq!(sh.var("o1").as_deref(), Some("HELLO"));
+    assert_eq!(sh.var("o1_0").as_deref(), Some("hello"));
+    assert_eq!(sh.var("s1").as_deref(), Some("0"));
+    assert_eq!(sh.var("o").as_deref(), Some("HELLO"));
+}
+
+#[test]
+fn pipefail_reports_upstream_failure() {
+    let report = shell().eval("sh -c 'exit 3' | cat").expect("eval");
+    assert_eq!(report.status, 3);
+}
+
+#[test]
+fn sigpipe_death_is_not_a_failure() {
+    // `yes | head` must terminate (backpressure + SIGPIPE) and count as
+    // success even though `yes` died of SIGPIPE.
+    let report = shell().eval("yes | head -n 2").expect("eval");
+    assert_eq!(report.output(), "y\ny\n");
+    assert_eq!(report.status, 0);
+    assert_eq!(report.pipelines[0].stages[0].status, 141);
+}
+
+#[test]
+fn stderr_capture_and_merge() {
+    let sh = shell();
+    let report = sh.eval("sh -c 'echo oops >&2'").expect("eval");
+    assert_eq!(report.pipelines[0].stages[0].stderr.render(), "oops\n");
+    assert_eq!(sh.var("e1").as_deref(), Some("oops"));
+
+    let merged = sh.eval("sh -c 'echo mixed >&2' 2>&1 | cat").expect("eval");
+    let stages = &merged.pipelines[0].stages;
+    assert!(stages[0].stderr_merged);
+    assert_eq!(stages[1].stdout.render(), "mixed\n");
+}
+
+#[test]
+fn redirections_write_and_read_files() {
+    let dir = std::env::temp_dir().join(format!("plumb-test-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let sh = Shell::new(Config {
+        cwd: Some(dir.clone()),
+        ..Config::default()
+    })
+    .expect("shell");
+    sh.eval("echo first > f.txt").expect("write");
+    sh.eval("echo second >> f.txt").expect("append");
+    let report = sh.eval("cat < f.txt").expect("read");
+    assert_eq!(report.output(), "first\nsecond\n");
+    // The redirected stream was still captured.
+    assert_eq!(sh.var("o1").as_deref(), Some("first"));
+    std::fs::remove_dir_all(&dir).expect("cleanup");
+}
+
+#[test]
+fn command_not_found_is_status_127() {
+    let report = shell()
+        .eval("definitely-not-a-command-xyz")
+        .expect("eval");
+    assert_eq!(report.status, 127);
+    assert!(
+        report.pipelines[0].stages[0]
+            .stderr
+            .render()
+            .contains("command not found")
+    );
+}
+
+#[test]
+fn strictness_errors() {
+    let sh = shell();
+    assert!(matches!(
+        sh.eval("echo $DEFINITELY_UNSET_VARIABLE"),
+        Err(Error::UnsetVar { .. })
+    ));
+    // The aborted run is still committed for inspection.
+    let report = sh.reports().pop().expect("committed");
+    assert!(report.aborted.is_some());
+    assert!(matches!(
+        sh.eval("cat /nonexistent-dir-xyz/*.rs"),
+        Err(Error::GlobNoMatch { .. })
+    ));
+}
+
+#[test]
+fn command_substitution_feeds_arguments() {
+    let sh = shell();
+    let report = sh.eval("echo prefix-$(echo -n inner)").expect("eval");
+    assert_eq!(report.output(), "prefix-inner\n");
+    assert_eq!(report.substitutions.len(), 1);
+    assert_eq!(report.substitutions[0].output(), "inner");
+}
+
+#[test]
+fn auto_bound_variables_cross_runs() {
+    let sh = shell();
+    sh.eval("echo alpha | tr a-z A-Z").expect("first");
+    let report = sh.eval("echo $o1 and $o1_0").expect("second");
+    assert_eq!(report.output(), "ALPHA and alpha\n");
+}
+
+#[test]
+fn last_status_variable() {
+    let sh = shell();
+    drop(sh.eval("sh -c 'exit 5'").expect("first"));
+    let report = sh.eval("echo $?").expect("second");
+    assert_eq!(report.output(), "5\n");
+}
+
+#[test]
+fn connectors_short_circuit() {
+    let report = shell().eval("false && echo skipped; echo ran").expect("eval");
+    // `echo skipped` never ran: false, then `echo ran`.
+    assert_eq!(report.pipelines.len(), 2);
+    assert_eq!(report.output(), "ran\n");
+
+    let fallback = shell().eval("false || echo rescued").expect("eval");
+    assert_eq!(fallback.output(), "rescued\n");
+}
+
+#[test]
+fn assignment_and_environment() {
+    let sh = shell();
+    sh.eval("GREETING=hi").expect("assign");
+    assert_eq!(sh.var("GREETING").as_deref(), Some("hi"));
+    // Not exported: children do not see it.
+    let unexported = sh.eval("sh -c 'echo value:$GREETING'").expect("child");
+    assert_eq!(unexported.output(), "value:\n");
+    sh.eval("export GREETING").expect("export");
+    let exported = sh.eval("sh -c 'echo value:$GREETING'").expect("child");
+    assert_eq!(exported.output(), "value:hi\n");
+    // Per-command env prefix.
+    let prefixed = shell().eval("ONLY=here sh -c 'echo got:$ONLY'").expect("eval");
+    assert_eq!(prefixed.output(), "got:here\n");
+}
+
+#[test]
+fn cd_changes_shared_cwd() {
+    let sh = shell();
+    sh.eval("cd /").expect("cd");
+    assert_eq!(sh.cwd(), std::path::PathBuf::from("/"));
+    let report = sh.eval("sh -c pwd").expect("pwd");
+    assert_eq!(report.output(), "/\n");
+    let bad = sh.eval("cd /nonexistent-dir-xyz").expect("cd failure is a status");
+    assert_eq!(bad.status, 1);
+}
+
+#[test]
+fn exit_is_a_request_to_the_embedder() {
+    assert!(matches!(
+        shell().eval("exit 7"),
+        Err(Error::ExitRequested { code: 7 })
+    ));
+}
+
+#[test]
+fn state_builtins_refuse_pipelines() {
+    assert!(matches!(
+        shell().eval("cd / | cat"),
+        Err(Error::BuiltinInPipeline { .. })
+    ));
+}
+
+#[test]
+fn background_runs_share_state_and_wait_joins() {
+    let sh = shell();
+    let report = sh.eval("echo bg-value & wait").expect("eval");
+    assert_eq!(report.background_started.len(), 1);
+    let bg_id = report.background_started[0];
+    let bg = sh.report(bg_id).expect("background report committed");
+    assert_eq!(bg.output(), "bg-value\n");
+    assert_eq!(sh.var(&format!("o{bg_id}")).as_deref(), Some("bg-value"));
+}
+
+#[test]
+fn detached_evals_share_state() {
+    let sh = shell();
+    let handle = sh.eval_detached("SHARED=from-detached");
+    handle.join().expect("join");
+    assert_eq!(sh.var("SHARED").as_deref(), Some("from-detached"));
+    let concurrent = sh.eval_detached("sleep 0.1; echo slow");
+    let fast = sh.eval("echo fast").expect("fast");
+    assert_eq!(fast.output(), "fast\n");
+    let slow = concurrent.join().expect("slow");
+    assert_eq!(slow.output(), "slow\n");
+}
+
+#[test]
+fn truncation_is_loud_and_bounded() {
+    let sh = Shell::new(Config {
+        capture_limit: 64,
+        ..Config::default()
+    })
+    .expect("shell");
+    let report = sh.eval("yes abcdefgh | head -n 1000").expect("eval");
+    let stage = &report.pipelines[0].stages[1];
+    assert_eq!(stage.stdout.total_bytes(), 9000);
+    assert!(stage.stdout.truncated());
+    assert!(stage.stdout.render().contains("omitted"));
+}
+
+#[test]
+fn reports_serialize_to_json() {
+    let report = shell().eval("echo json | cat").expect("eval");
+    let json = serde_json::to_value(&report).expect("serialize");
+    assert_eq!(json["pipelines"][0]["stages"][1]["stdout"]["text"], "json\n");
+    assert_eq!(json["status"], 0);
+}
+
+#[test]
+fn echo_dash_n() {
+    let report = shell().eval("echo -n bare").expect("eval");
+    assert_eq!(report.output(), "bare");
+}
+
+#[test]
+fn quoting_reaches_argv_intact() {
+    let report = shell()
+        .eval(r#"printf '%s|' "a b" 'c d' e"#)
+        .expect("eval");
+    assert_eq!(report.output(), "a b|c d|e|");
+}
+
+#[test]
+fn keep_runs_evicts_old_variables() {
+    let sh = Shell::new(Config {
+        keep_runs: 2,
+        ..Config::default()
+    })
+    .expect("shell");
+    sh.eval("echo one").expect("run 1");
+    sh.eval("echo two").expect("run 2");
+    sh.eval("echo three").expect("run 3");
+    assert_eq!(sh.var("o1"), None, "run 1 evicted");
+    assert_eq!(sh.var("o3").as_deref(), Some("three"));
+    assert_eq!(sh.reports().len(), 2);
+}
+
+#[test]
+fn echoing_config_still_captures() {
+    let report = echoing().eval("echo visible").expect("eval");
+    assert_eq!(report.output(), "visible\n");
+}

--- a/packages/plumb/syntax/Cargo.toml
+++ b/packages/plumb/syntax/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "plumb-syntax"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Lexer and parser for the plumb shell's bash-subset grammar: spanned AST, loud errors on unsupported bash"
+
+[lints]
+workspace = true
+
+[dependencies]
+snafu.workspace = true

--- a/packages/plumb/syntax/package.nix
+++ b/packages/plumb/syntax/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "plumb-syntax";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/plumb/syntax/src/ast.rs
+++ b/packages/plumb/syntax/src/ast.rs
@@ -1,0 +1,171 @@
+//! Spanned AST for the plumb grammar (a strict bash subset).
+//!
+//! Everything the parser accepts pastes into bash unchanged and means the
+//! same thing there; anything else is a loud [`crate::ParseError`], never a
+//! silent reinterpretation.
+
+/// Byte range into the original source string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Span {
+    /// Inclusive start byte offset.
+    pub start: usize,
+    /// Exclusive end byte offset.
+    pub end: usize,
+}
+
+impl Span {
+    /// Slice `src` to this span.
+    #[must_use]
+    pub fn text<'a>(&self, src: &'a str) -> &'a str {
+        src.get(self.start..self.end).unwrap_or("")
+    }
+}
+
+/// One component of a [`Word`] after quote processing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Part {
+    /// Literal text. `quoted` records whether it came from inside quotes or
+    /// an escape, which makes it inert to glob expansion.
+    Text {
+        /// The literal text, with quotes and escapes already resolved.
+        text: String,
+        /// True when the text originated inside quotes or a backslash escape.
+        quoted: bool,
+    },
+    /// `$NAME` / `${NAME}` / `$?` variable reference.
+    Var {
+        /// Variable name (`?` for the last-status special).
+        name: String,
+        /// Location of the reference in the source.
+        span: Span,
+    },
+    /// `$(...)` command substitution holding the nested program.
+    CommandSub {
+        /// The parsed program between the parentheses.
+        program: Program,
+        /// Location of the substitution in the source.
+        span: Span,
+    },
+}
+
+/// A single shell word: the concatenation of its parts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Word {
+    /// Components in source order.
+    pub parts: Vec<Part>,
+    /// Location of the whole word.
+    pub span: Span,
+}
+
+/// `NAME=value` assignment (command prefix or standalone).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Assign {
+    /// Variable name.
+    pub name: String,
+    /// Assigned value (empty word for `NAME=`).
+    pub value: Word,
+    /// Location of the whole assignment.
+    pub span: Span,
+}
+
+/// Redirection operator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RedirOp {
+    /// `> file`
+    OutTrunc,
+    /// `>> file`
+    OutAppend,
+    /// `2> file`
+    ErrTrunc,
+    /// `2>> file`
+    ErrAppend,
+    /// `&> file` (stdout and stderr)
+    BothTrunc,
+    /// `&>> file`
+    BothAppend,
+    /// `< file`
+    In,
+    /// `2>&1`
+    ErrToOut,
+    /// `1>&2`
+    OutToErr,
+}
+
+/// One redirection attached to a command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Redirect {
+    /// Which operator.
+    pub op: RedirOp,
+    /// File target; `None` for the fd-duplication forms (`2>&1`, `1>&2`).
+    pub target: Option<Word>,
+    /// Location of the redirection.
+    pub span: Span,
+}
+
+/// A simple command: optional assignment prefix, argv words, redirections.
+/// A command with assignments and no words assigns shell variables.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Command {
+    /// `NAME=value` prefixes (or the whole command when `words` is empty).
+    pub assigns: Vec<Assign>,
+    /// Argv words (element 0 is the program).
+    pub words: Vec<Word>,
+    /// Redirections in source order.
+    pub redirects: Vec<Redirect>,
+    /// Location of the whole command.
+    pub span: Span,
+}
+
+/// `a | b | c`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Pipeline {
+    /// Stages, left to right.
+    pub commands: Vec<Command>,
+    /// Location of the whole pipeline.
+    pub span: Span,
+}
+
+/// Connector between pipelines in an and-or chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Connector {
+    /// `&&`: run only when the previous pipeline succeeded.
+    And,
+    /// `||`: run only when the previous pipeline failed.
+    Or,
+}
+
+/// One `&& pipeline` / `|| pipeline` continuation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AndOrTail {
+    /// The connector before the pipeline.
+    pub connector: Connector,
+    /// The pipeline it guards.
+    pub pipeline: Pipeline,
+}
+
+/// `p1 && p2 || p3` chain, evaluated left to right.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AndOr {
+    /// The first pipeline.
+    pub first: Pipeline,
+    /// The chained continuations.
+    pub rest: Vec<AndOrTail>,
+    /// Location of the whole chain.
+    pub span: Span,
+}
+
+/// A top-level item: an and-or chain, optionally backgrounded with `&`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Item {
+    /// The chain to run.
+    pub and_or: AndOr,
+    /// True when terminated by `&`.
+    pub background: bool,
+}
+
+/// A parsed source string: items separated by `;` or newlines.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Program {
+    /// Items in source order.
+    pub items: Vec<Item>,
+}

--- a/packages/plumb/syntax/src/lib.rs
+++ b/packages/plumb/syntax/src/lib.rs
@@ -1,0 +1,17 @@
+//! Parser for the plumb shell: a strict, spanned bash subset.
+//!
+//! The grammar covers simple commands, quoting, `$VAR`/`${VAR}`/`$?`,
+//! command substitution `$(...)`, pipes, `&&`/`||`/`;`, redirections,
+//! globs, `NAME=value` prefixes, and a trailing `&`. Every construct the
+//! parser accepts means the same thing in bash; everything else (keywords,
+//! subshells, backticks, here-docs, fancy parameter expansion, brace
+//! expansion) is a [`ParseError`] naming the unsupported construct.
+
+mod ast;
+mod parse;
+
+pub use ast::{
+    Assign, AndOr, AndOrTail, Command, Connector, Item, Part, Pipeline, Program, Redirect,
+    RedirOp, Span, Word,
+};
+pub use parse::{parse, ParseError};

--- a/packages/plumb/syntax/src/parse.rs
+++ b/packages/plumb/syntax/src/parse.rs
@@ -1,0 +1,893 @@
+//! Hand-rolled recursive-descent parser. Character-level (no token stream):
+//! quoting context decides what a byte means, so a separate lexer would need
+//! the same state anyway.
+
+use snafu::Snafu;
+
+use crate::ast::{
+    AndOr, AndOrTail, Assign, Command, Connector, Item, Part, Pipeline, Program, RedirOp,
+    Redirect, Span, Word,
+};
+
+/// Parse failure: an unsupported construct or malformed input, with the byte
+/// span of the offending text.
+#[derive(Debug, Snafu)]
+#[snafu(display("parse error at byte {}: {message}", span.start))]
+pub struct ParseError {
+    /// What went wrong, naming the unsupported construct where relevant.
+    pub message: String,
+    /// Byte range of the offending source text.
+    pub span: Span,
+}
+
+/// Bash keywords and compound-command openers the subset refuses at command
+/// position; running them as argv[0] would silently mean something else than
+/// it does in bash.
+const KEYWORDS: &[&str] = &[
+    "if", "then", "else", "elif", "fi", "for", "while", "until", "do", "done", "case", "esac",
+    "function", "select", "coproc", "time", "in", "!", "[[", "]]",
+];
+
+/// Parse a source string into a [`Program`].
+///
+/// # Errors
+///
+/// Returns [`ParseError`] on malformed input or on any bash construct outside
+/// the plumb subset (keywords, subshells, backticks, here-docs, brace or
+/// fancy parameter expansion, positional parameters).
+pub fn parse(src: &str) -> Result<Program, ParseError> {
+    let mut parser = Parser::new(src);
+    let program = parser.program(None)?;
+    if let Some(unexpected) = parser.peek() {
+        return parser.fail_at(parser.byte_pos(), format!("unexpected `{unexpected}`"));
+    }
+    Ok(program)
+}
+
+struct Parser<'src> {
+    src: &'src str,
+    chars: Vec<CharAt>,
+    pos: usize,
+}
+
+#[derive(Clone, Copy)]
+struct CharAt {
+    byte: usize,
+    ch: char,
+}
+
+/// Word-part accumulator: merges runs of literal text that share a quoting
+/// context and remembers whether any quotes appeared (so `''` still yields an
+/// empty argument).
+#[derive(Default)]
+struct WordAcc {
+    parts: Vec<Part>,
+    pending: String,
+    pending_quoted: bool,
+    saw_quotes: bool,
+}
+
+impl WordAcc {
+    fn push(&mut self, c: char, quoted: bool) {
+        if self.pending_quoted != quoted && !self.pending.is_empty() {
+            self.flush();
+        }
+        self.pending_quoted = quoted;
+        self.pending.push(c);
+    }
+
+    fn push_part(&mut self, part: Part) {
+        self.flush();
+        self.parts.push(part);
+    }
+
+    fn flush(&mut self) {
+        if !self.pending.is_empty() {
+            self.parts.push(Part::Text {
+                text: std::mem::take(&mut self.pending),
+                quoted: self.pending_quoted,
+            });
+        }
+    }
+
+    const fn is_empty(&self) -> bool {
+        self.parts.is_empty() && self.pending.is_empty()
+    }
+
+    fn finish(mut self) -> Vec<Part> {
+        self.flush();
+        if self.parts.is_empty() && self.saw_quotes {
+            self.parts.push(Part::Text {
+                text: String::new(),
+                quoted: true,
+            });
+        }
+        self.parts
+    }
+}
+
+impl<'src> Parser<'src> {
+    fn new(src: &'src str) -> Self {
+        Self {
+            src,
+            chars: src
+                .char_indices()
+                .map(|(byte, ch)| CharAt { byte, ch })
+                .collect(),
+            pos: 0,
+        }
+    }
+
+    fn peek(&self) -> Option<char> {
+        self.chars.get(self.pos).map(|c| c.ch)
+    }
+
+    fn peek_at(&self, ahead: usize) -> Option<char> {
+        self.chars.get(self.pos + ahead).map(|c| c.ch)
+    }
+
+    fn bump(&mut self) -> Option<char> {
+        let c = self.peek();
+        if c.is_some() {
+            self.pos += 1;
+        }
+        c
+    }
+
+    fn byte_pos(&self) -> usize {
+        self.chars.get(self.pos).map_or(self.src.len(), |c| c.byte)
+    }
+
+    fn span_from(&self, start: usize) -> Span {
+        Span {
+            start,
+            end: self.byte_pos(),
+        }
+    }
+
+    fn fail_at<T>(&self, start: usize, message: String) -> Result<T, ParseError> {
+        ParseSnafu {
+            message,
+            span: Span {
+                start,
+                end: self.byte_pos().max(start + 1),
+            },
+        }
+        .fail()
+    }
+
+    /// Skip spaces, tabs, backslash-newline continuations, and comments.
+    /// Comments only start at token boundaries, which is exactly where this
+    /// is called, matching bash.
+    fn skip_blank(&mut self) {
+        loop {
+            match self.peek() {
+                Some(' ' | '\t') => {
+                    self.pos += 1;
+                }
+                Some('\\') if self.peek_at(1) == Some('\n') => {
+                    self.pos += 2;
+                }
+                Some('#') => {
+                    while !matches!(self.peek(), None | Some('\n')) {
+                        self.pos += 1;
+                    }
+                }
+                _ => return,
+            }
+        }
+    }
+
+    fn skip_blank_and_newlines(&mut self) {
+        loop {
+            self.skip_blank();
+            if self.peek() == Some('\n') {
+                self.pos += 1;
+            } else {
+                return;
+            }
+        }
+    }
+
+    /// `program := item*` (until EOF or `stop`)
+    fn program(&mut self, stop: Option<char>) -> Result<Program, ParseError> {
+        let mut items = Vec::new();
+        loop {
+            self.skip_blank_and_newlines();
+            match self.peek() {
+                None => return Ok(Program { items }),
+                Some(c) if Some(c) == stop => return Ok(Program { items }),
+                _ => {}
+            }
+            items.push(self.item(stop)?);
+        }
+    }
+
+    /// `item := and_or ('&' | ';' | newline)?`
+    fn item(&mut self, stop: Option<char>) -> Result<Item, ParseError> {
+        let and_or = self.and_or(stop)?;
+        self.skip_blank();
+        if self.peek() == Some('&') && self.peek_at(1) != Some('&') {
+            // `&` is itself the item separator: `a & b` runs `a` in the
+            // background and continues with `b` immediately.
+            self.pos += 1;
+            return Ok(Item {
+                and_or,
+                background: true,
+            });
+        }
+        match self.peek() {
+            Some(';') => {
+                if self.peek_at(1) == Some(';') {
+                    return self.fail_at(self.byte_pos(), "unsupported: `;;`".to_owned());
+                }
+                self.pos += 1;
+            }
+            Some('\n') => {
+                self.pos += 1;
+            }
+            None => {}
+            Some(c) if Some(c) == stop => {}
+            Some(c) => {
+                return self.fail_at(self.byte_pos(), format!("unexpected `{c}`"));
+            }
+        }
+        Ok(Item {
+            and_or,
+            background: false,
+        })
+    }
+
+    /// `and_or := pipeline (('&&' | '||') pipeline)*`
+    fn and_or(&mut self, stop: Option<char>) -> Result<AndOr, ParseError> {
+        self.skip_blank();
+        let start = self.byte_pos();
+        let first = self.pipeline(stop)?;
+        let mut rest = Vec::new();
+        loop {
+            self.skip_blank();
+            let connector = match (self.peek(), self.peek_at(1)) {
+                (Some('&'), Some('&')) => Connector::And,
+                (Some('|'), Some('|')) => Connector::Or,
+                _ => break,
+            };
+            self.pos += 2;
+            self.skip_blank_and_newlines();
+            let pipeline = self.pipeline(stop)?;
+            rest.push(AndOrTail {
+                connector,
+                pipeline,
+            });
+        }
+        Ok(AndOr {
+            first,
+            rest,
+            span: self.span_from(start),
+        })
+    }
+
+    /// `pipeline := command ('|' command)*`
+    fn pipeline(&mut self, stop: Option<char>) -> Result<Pipeline, ParseError> {
+        self.skip_blank();
+        let start = self.byte_pos();
+        let mut commands = vec![self.command(stop)?];
+        loop {
+            self.skip_blank();
+            match (self.peek(), self.peek_at(1)) {
+                (Some('|'), Some('|')) => break,
+                (Some('|'), Some('&')) => {
+                    return self
+                        .fail_at(self.byte_pos(), "unsupported: `|&`; use `2>&1 |`".to_owned());
+                }
+                (Some('|'), _) => {
+                    self.pos += 1;
+                    self.skip_blank_and_newlines();
+                    commands.push(self.command(stop)?);
+                }
+                _ => break,
+            }
+        }
+        Ok(Pipeline {
+            commands,
+            span: self.span_from(start),
+        })
+    }
+
+    /// `command := assign* (word | redirect)+`
+    fn command(&mut self, stop: Option<char>) -> Result<Command, ParseError> {
+        self.skip_blank();
+        let start = self.byte_pos();
+        let mut assigns = Vec::new();
+        let mut words: Vec<Word> = Vec::new();
+        let mut redirects = Vec::new();
+        loop {
+            self.skip_blank();
+            let element_start = self.byte_pos();
+            match self.peek() {
+                None | Some('\n' | ';' | '|') => break,
+                Some(c) if Some(c) == stop => break,
+                Some('&') if !matches!(self.peek_at(1), Some('>')) => break,
+                Some('(') => {
+                    return self.fail_at(
+                        element_start,
+                        "unsupported: subshell / function definition".to_owned(),
+                    );
+                }
+                _ => {}
+            }
+            if let Some(redirect) = self.try_redirect()? {
+                redirects.push(redirect);
+                continue;
+            }
+            if words.is_empty()
+                && let Some(assign) = self.try_assign()?
+            {
+                assigns.push(assign);
+                continue;
+            }
+            let word = self.word()?;
+            if words.is_empty()
+                && let Some(keyword) = unquoted_literal(&word)
+                && KEYWORDS.contains(&keyword.as_str())
+            {
+                return self.fail_at(
+                    element_start,
+                    format!("unsupported: bash keyword `{keyword}`"),
+                );
+            }
+            words.push(word);
+        }
+        if assigns.is_empty() && words.is_empty() && redirects.is_empty() {
+            return self.fail_at(start, "expected a command".to_owned());
+        }
+        Ok(Command {
+            assigns,
+            words,
+            redirects,
+            span: self.span_from(start),
+        })
+    }
+}
+
+impl Parser<'_> {
+    /// Recognize a redirection operator at the current position, if any.
+    /// Must be called at a token boundary: a digit only introduces a
+    /// redirect when `>` follows immediately, so `2 > f` is the word `2`
+    /// plus a stdout redirect, same as bash.
+    fn try_redirect(&mut self) -> Result<Option<Redirect>, ParseError> {
+        let start = self.byte_pos();
+        let (op, len) = match (self.peek(), self.peek_at(1), self.peek_at(2), self.peek_at(3)) {
+            (Some('2'), Some('>'), Some('&'), Some('1')) => (RedirOp::ErrToOut, 4),
+            (Some('1'), Some('>'), Some('&'), Some('2')) => (RedirOp::OutToErr, 4),
+            (Some('>'), Some('&'), Some('2'), _) => (RedirOp::OutToErr, 3),
+            (Some('>'), Some('&'), next, _) => {
+                let shown = next.map_or(String::new(), |c| c.to_string());
+                return self.fail_at(start, format!("unsupported redirection `>&{shown}`"));
+            }
+            (Some('2'), Some('>'), Some('>'), _) => (RedirOp::ErrAppend, 3),
+            (Some('2'), Some('>'), _, _) => (RedirOp::ErrTrunc, 2),
+            (Some('1'), Some('>'), Some('>'), _) => (RedirOp::OutAppend, 3),
+            (Some('1'), Some('>'), _, _) => (RedirOp::OutTrunc, 2),
+            (Some('&'), Some('>'), Some('>'), _) => (RedirOp::BothAppend, 3),
+            (Some('&'), Some('>'), _, _) => (RedirOp::BothTrunc, 2),
+            (Some('>'), Some('>'), _, _) => (RedirOp::OutAppend, 2),
+            (Some('>'), _, _, _) => (RedirOp::OutTrunc, 1),
+            (Some('<'), Some('<'), _, _) => {
+                return self.fail_at(start, "unsupported: here-doc / here-string".to_owned());
+            }
+            (Some('<'), Some('('), _, _) => {
+                return self.fail_at(start, "unsupported: process substitution".to_owned());
+            }
+            (Some('<'), _, _, _) => (RedirOp::In, 1),
+            _ => return Ok(None),
+        };
+        self.pos += len;
+        let target = if matches!(op, RedirOp::ErrToOut | RedirOp::OutToErr) {
+            None
+        } else {
+            self.skip_blank();
+            match self.peek() {
+                None | Some('\n' | ';' | '|' | '&' | '<' | '>') => {
+                    return self
+                        .fail_at(start, "redirection is missing its file target".to_owned());
+                }
+                _ => Some(self.word()?),
+            }
+        };
+        Ok(Some(Redirect {
+            op,
+            target,
+            span: self.span_from(start),
+        }))
+    }
+
+    /// Recognize `NAME=` at the current position and parse the value word.
+    fn try_assign(&mut self) -> Result<Option<Assign>, ParseError> {
+        let start_pos = self.pos;
+        let start = self.byte_pos();
+        let mut name = String::new();
+        while let Some(c) = self.peek() {
+            if c == '_' || c.is_ascii_alphabetic() || (!name.is_empty() && c.is_ascii_digit()) {
+                name.push(c);
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        if name.is_empty() || self.peek() != Some('=') {
+            self.pos = start_pos;
+            return Ok(None);
+        }
+        self.pos += 1;
+        let value = if matches!(self.peek(), None | Some(' ' | '\t' | '\n' | ';' | '|' | '&')) {
+            Word {
+                parts: Vec::new(),
+                span: self.span_from(self.byte_pos()),
+            }
+        } else {
+            self.word()?
+        };
+        Ok(Some(Assign {
+            name,
+            value,
+            span: self.span_from(start),
+        }))
+    }
+
+    /// `word := (run | quotes | escape | dollar-form)+`
+    fn word(&mut self) -> Result<Word, ParseError> {
+        let start = self.byte_pos();
+        let mut acc = WordAcc::default();
+        while let Some(c) = self.peek() {
+            match c {
+                ' ' | '\t' | '\n' | ';' | '|' | '&' | '<' | '>' | ')' => break,
+                '(' => {
+                    return self.fail_at(self.byte_pos(), "unsupported: `(` in a word".to_owned());
+                }
+                '`' => {
+                    return self.fail_at(
+                        self.byte_pos(),
+                        "unsupported: backtick command substitution; use $(...)".to_owned(),
+                    );
+                }
+                '{' | '}' => {
+                    return self.fail_at(
+                        self.byte_pos(),
+                        format!("unsupported: brace expansion; quote the `{c}`"),
+                    );
+                }
+                '\\' => {
+                    self.pos += 1;
+                    match self.bump() {
+                        Some('\n') => {}
+                        Some(escaped) => acc.push(escaped, true),
+                        None => {
+                            return self
+                                .fail_at(self.byte_pos(), "trailing backslash".to_owned());
+                        }
+                    }
+                }
+                '\'' => self.single_quoted(&mut acc)?,
+                '"' => self.double_quoted(&mut acc)?,
+                '$' => {
+                    if !self.dollar(&mut acc)? {
+                        acc.push('$', false);
+                    }
+                }
+                '~' if acc.is_empty() => {
+                    // Bare `~` or `~/...` at word start is $HOME, same as
+                    // bash; `~user` is out of the subset.
+                    self.pos += 1;
+                    match self.peek() {
+                        None | Some(' ' | '\t' | '\n' | ';' | '|' | '&' | '<' | '>' | '/') => {
+                            acc.push_part(Part::Var {
+                                name: "HOME".to_owned(),
+                                span: Span {
+                                    start,
+                                    end: self.byte_pos(),
+                                },
+                            });
+                        }
+                        Some(_) => {
+                            return self
+                                .fail_at(start, "unsupported: `~user` expansion".to_owned());
+                        }
+                    }
+                }
+                _ => {
+                    acc.push(c, false);
+                    self.pos += 1;
+                }
+            }
+        }
+        let parts = acc.finish();
+        if parts.is_empty() {
+            return self.fail_at(start, "expected a word".to_owned());
+        }
+        Ok(Word {
+            parts,
+            span: self.span_from(start),
+        })
+    }
+
+    fn single_quoted(&mut self, acc: &mut WordAcc) -> Result<(), ParseError> {
+        let quote_start = self.byte_pos();
+        self.pos += 1;
+        acc.saw_quotes = true;
+        loop {
+            match self.bump() {
+                Some('\'') => return Ok(()),
+                Some(inner) => acc.push(inner, true),
+                None => {
+                    return self.fail_at(quote_start, "unterminated single quote".to_owned());
+                }
+            }
+        }
+    }
+
+    fn double_quoted(&mut self, acc: &mut WordAcc) -> Result<(), ParseError> {
+        let quote_start = self.byte_pos();
+        self.pos += 1;
+        acc.saw_quotes = true;
+        loop {
+            match self.peek() {
+                None => {
+                    return self.fail_at(quote_start, "unterminated double quote".to_owned());
+                }
+                Some('"') => {
+                    self.pos += 1;
+                    return Ok(());
+                }
+                Some('\\') => {
+                    self.pos += 1;
+                    match self.bump() {
+                        Some(escaped @ ('$' | '"' | '\\' | '`')) => acc.push(escaped, true),
+                        Some('\n') => {}
+                        Some(other) => {
+                            acc.push('\\', true);
+                            acc.push(other, true);
+                        }
+                        None => {
+                            return self
+                                .fail_at(quote_start, "unterminated double quote".to_owned());
+                        }
+                    }
+                }
+                Some('`') => {
+                    return self.fail_at(
+                        self.byte_pos(),
+                        "unsupported: backtick command substitution; use $(...)".to_owned(),
+                    );
+                }
+                Some('$') => {
+                    if !self.dollar(acc)? {
+                        acc.push('$', true);
+                    }
+                }
+                Some(inner) => {
+                    acc.push(inner, true);
+                    self.pos += 1;
+                }
+            }
+        }
+    }
+
+    /// Parse a `$`-introduced form; the `$` has not been consumed yet.
+    /// Returns false when the `$` turns out to be literal (end of word or
+    /// before plain punctuation), leaving the caller to emit it.
+    fn dollar(&mut self, acc: &mut WordAcc) -> Result<bool, ParseError> {
+        let start = self.byte_pos();
+        match self.peek_at(1) {
+            Some('(') if self.peek_at(2) == Some('(') => self.fail_at(
+                start,
+                "unsupported: arithmetic expansion $((...))".to_owned(),
+            ),
+            Some('(') => {
+                self.pos += 2;
+                let program = self.program(Some(')'))?;
+                if self.bump() != Some(')') {
+                    return self
+                        .fail_at(start, "unterminated $( command substitution".to_owned());
+                }
+                acc.push_part(Part::CommandSub {
+                    program,
+                    span: Span {
+                        start,
+                        end: self.byte_pos(),
+                    },
+                });
+                Ok(true)
+            }
+            Some('{') => {
+                self.pos += 2;
+                let mut name = String::new();
+                while let Some(c) = self.peek() {
+                    if c == '_' || c.is_ascii_alphanumeric() {
+                        name.push(c);
+                        self.pos += 1;
+                    } else {
+                        break;
+                    }
+                }
+                let plain = self.peek() == Some('}')
+                    && !name.is_empty()
+                    && !name.starts_with(|c: char| c.is_ascii_digit());
+                if !plain {
+                    return self.fail_at(
+                        start,
+                        "unsupported parameter expansion: only a plain variable name in braces"
+                            .to_owned(),
+                    );
+                }
+                self.pos += 1;
+                acc.push_part(Part::Var {
+                    name,
+                    span: Span {
+                        start,
+                        end: self.byte_pos(),
+                    },
+                });
+                Ok(true)
+            }
+            Some('?') => {
+                self.pos += 2;
+                acc.push_part(Part::Var {
+                    name: "?".to_owned(),
+                    span: Span {
+                        start,
+                        end: self.byte_pos(),
+                    },
+                });
+                Ok(true)
+            }
+            Some(first) if first == '_' || first.is_ascii_alphabetic() => {
+                self.pos += 1;
+                let mut name = String::new();
+                while let Some(inner) = self.peek() {
+                    if inner == '_' || inner.is_ascii_alphanumeric() {
+                        name.push(inner);
+                        self.pos += 1;
+                    } else {
+                        break;
+                    }
+                }
+                acc.push_part(Part::Var {
+                    name,
+                    span: Span {
+                        start,
+                        end: self.byte_pos(),
+                    },
+                });
+                Ok(true)
+            }
+            Some(c) if c.is_ascii_digit() || "@*#!-$".contains(c) => {
+                self.fail_at(start, format!("unsupported: special parameter `${c}`"))
+            }
+            _ => {
+                self.pos += 1;
+                Ok(false)
+            }
+        }
+    }
+}
+
+/// The word's text when it is a single unquoted literal (keyword detection).
+fn unquoted_literal(word: &Word) -> Option<String> {
+    match word.parts.as_slice() {
+        [Part::Text { text, quoted: false }] => Some(text.clone()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse, Command, Connector, Part, RedirOp};
+
+    fn one_command(src: &str) -> Command {
+        let program = parse(src).expect("should parse");
+        assert_eq!(program.items.len(), 1, "one item in {src:?}");
+        let item = program.items.into_iter().next().expect("item");
+        assert!(item.and_or.rest.is_empty());
+        item.and_or
+            .first
+            .commands
+            .into_iter()
+            .next()
+            .expect("command")
+    }
+
+    fn literal_argv(src: &str) -> Vec<String> {
+        one_command(src)
+            .words
+            .iter()
+            .map(|w| {
+                w.parts
+                    .iter()
+                    .map(|p| match p {
+                        Part::Text { text, .. } => text.clone(),
+                        other => panic!("expected literal, got {other:?}"),
+                    })
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn simple_command() {
+        assert_eq!(literal_argv("echo hello world"), ["echo", "hello", "world"]);
+    }
+
+    #[test]
+    fn quoting_resolves() {
+        assert_eq!(
+            literal_argv(r#"printf "a b" 'c  d' e\ f"#),
+            ["printf", "a b", "c  d", "e f"]
+        );
+    }
+
+    #[test]
+    fn empty_quotes_are_an_empty_argument() {
+        assert_eq!(literal_argv("printf ''"), ["printf", ""]);
+    }
+
+    #[test]
+    fn pipeline_and_connectors() {
+        let program = parse("a | b | c && d || e; f\ng &").expect("should parse");
+        assert_eq!(program.items.len(), 3);
+        assert_eq!(program.items[0].and_or.first.commands.len(), 3);
+        assert_eq!(program.items[0].and_or.rest.len(), 2);
+        assert_eq!(program.items[0].and_or.rest[0].connector, Connector::And);
+        assert_eq!(program.items[0].and_or.rest[1].connector, Connector::Or);
+        assert!(!program.items[0].background);
+        assert!(program.items[2].background);
+    }
+
+    #[test]
+    fn background_then_next_item() {
+        let program = parse("sleep 5 & echo hi").expect("should parse");
+        assert_eq!(program.items.len(), 2);
+        assert!(program.items[0].background);
+        assert!(!program.items[1].background);
+    }
+
+    #[test]
+    fn variables() {
+        let command = one_command("echo $FOO ${BAR} $?");
+        let names: Vec<&str> = command.words[1..]
+            .iter()
+            .map(|w| match &w.parts[0] {
+                Part::Var { name, .. } => name.as_str(),
+                other => panic!("expected var, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(names, ["FOO", "BAR", "?"]);
+    }
+
+    #[test]
+    fn tilde_is_home() {
+        let command = one_command("ls ~/src");
+        match &command.words[1].parts[0] {
+            Part::Var { name, .. } => assert_eq!(name, "HOME"),
+            other => panic!("expected var, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn command_substitution_nests() {
+        let command = one_command("echo $(basename $(pwd))");
+        match &command.words[1].parts[0] {
+            Part::CommandSub { program, .. } => {
+                let inner = &program.items[0].and_or.first.commands[0];
+                match &inner.words[1].parts[0] {
+                    Part::CommandSub { .. } => {}
+                    other => panic!("expected nested substitution, got {other:?}"),
+                }
+            }
+            other => panic!("expected substitution, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn command_substitution_in_double_quotes() {
+        let command = one_command(r#"echo "now: $(date)""#);
+        assert!(
+            command.words[1]
+                .parts
+                .iter()
+                .any(|p| matches!(p, Part::CommandSub { .. }))
+        );
+    }
+
+    #[test]
+    fn redirections() {
+        let command = one_command("cmd > out.txt 2>> err.txt < in.txt 2>&1");
+        let ops: Vec<RedirOp> = command.redirects.iter().map(|r| r.op).collect();
+        assert_eq!(
+            ops,
+            [
+                RedirOp::OutTrunc,
+                RedirOp::ErrAppend,
+                RedirOp::In,
+                RedirOp::ErrToOut
+            ]
+        );
+        assert!(command.redirects[3].target.is_none());
+    }
+
+    #[test]
+    fn both_redirect_and_stderr_shorthand() {
+        assert_eq!(
+            one_command("cmd &> all.log").redirects[0].op,
+            RedirOp::BothTrunc
+        );
+        assert_eq!(one_command("echo oops >&2").redirects[0].op, RedirOp::OutToErr);
+    }
+
+    #[test]
+    fn assignments() {
+        let command = one_command("FOO=bar BAZ= cmd arg");
+        assert_eq!(command.assigns.len(), 2);
+        assert_eq!(command.assigns[0].name, "FOO");
+        assert!(command.assigns[1].value.parts.is_empty());
+        assert_eq!(command.words.len(), 2);
+
+        let bare = one_command("X=1");
+        assert_eq!(bare.assigns.len(), 1);
+        assert!(bare.words.is_empty());
+    }
+
+    #[test]
+    fn comments_ignored() {
+        let program = parse("echo hi # trailing\n# whole line\necho bye").expect("should parse");
+        assert_eq!(program.items.len(), 2);
+    }
+
+    #[test]
+    fn digit_word_is_not_a_redirect() {
+        assert_eq!(literal_argv("echo 2"), ["echo", "2"]);
+        let redirected = one_command("echo 2> f");
+        assert_eq!(redirected.words.len(), 1);
+        assert_eq!(redirected.redirects[0].op, RedirOp::ErrTrunc);
+    }
+
+    #[test]
+    fn unsupported_constructs_error_loudly() {
+        let fancy_expansion = concat!("echo ${", "X:-default}");
+        for (src, needle) in [
+            ("if true; then echo hi; fi", "keyword `if`"),
+            ("for x in a b; do echo $x; done", "keyword `for`"),
+            ("echo `date`", "backtick"),
+            ("cat << EOF", "here-doc"),
+            ("echo $((1+2))", "arithmetic"),
+            (fancy_expansion, "parameter expansion"),
+            ("echo $1", "special parameter"),
+            ("echo $@", "special parameter"),
+            ("echo {a,b}", "brace expansion"),
+            ("(cd /tmp && ls)", "subshell"),
+            ("ls ~user", "~user"),
+            ("a |& b", "|&"),
+            ("case x in esac", "keyword `case`"),
+            ("diff <(sort a) <(sort b)", "process substitution"),
+        ] {
+            let error = parse(src).expect_err(src);
+            assert!(
+                error.message.contains(needle),
+                "{src:?}: {} should mention {needle:?}",
+                error.message
+            );
+        }
+    }
+
+    #[test]
+    fn spans_point_into_source() {
+        let src = "echo `date`";
+        let error = parse(src).expect_err("backtick");
+        assert_eq!(&src[error.span.start..=error.span.start], "`");
+    }
+
+    #[test]
+    fn empty_input_is_empty_program() {
+        assert!(parse("").expect("empty ok").items.is_empty());
+        assert!(parse("  \n # comment\n").expect("blank ok").items.is_empty());
+    }
+}

--- a/packages/plumb/syntax/src/parse.rs
+++ b/packages/plumb/syntax/src/parse.rs
@@ -572,6 +572,20 @@ impl Parser<'_> {
         }
     }
 
+    /// Consume a run of identifier characters (`[A-Za-z0-9_]*`).
+    fn ident_run(&mut self) -> String {
+        let mut name = String::new();
+        while let Some(c) = self.peek() {
+            if c == '_' || c.is_ascii_alphanumeric() {
+                name.push(c);
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        name
+    }
+
     /// Parse a `$`-introduced form; the `$` has not been consumed yet.
     /// Returns false when the `$` turns out to be literal (end of word or
     /// before plain punctuation), leaving the caller to emit it.
@@ -600,15 +614,7 @@ impl Parser<'_> {
             }
             Some('{') => {
                 self.pos += 2;
-                let mut name = String::new();
-                while let Some(c) = self.peek() {
-                    if c == '_' || c.is_ascii_alphanumeric() {
-                        name.push(c);
-                        self.pos += 1;
-                    } else {
-                        break;
-                    }
-                }
+                let name = self.ident_run();
                 let plain = self.peek() == Some('}')
                     && !name.is_empty()
                     && !name.starts_with(|c: char| c.is_ascii_digit());
@@ -642,15 +648,7 @@ impl Parser<'_> {
             }
             Some(first) if first == '_' || first.is_ascii_alphabetic() => {
                 self.pos += 1;
-                let mut name = String::new();
-                while let Some(inner) = self.peek() {
-                    if inner == '_' || inner.is_ascii_alphanumeric() {
-                        name.push(inner);
-                        self.pos += 1;
-                    } else {
-                        break;
-                    }
-                }
+                let name = self.ident_run();
                 acc.push_part(Part::Var {
                     name,
                     span: Span {


### PR DESCRIPTION
Closes #3578.

**plumb**: a bash-subset shell where every run is a value, built library-first for LLM agents. Three crates under `packages/plumb/`:

- `plumb-syntax`: hand-rolled spanned parser for a strict bash subset (pipes, `&&`/`||`/`;`, redirections, quoting, `$VAR`, `$(...)`, globs, `&`). Unsupported bash (keywords, subshells, backticks, here-docs, fancy expansions) is a loud parse error, never a misparse. Fuzz-friendly: pure, no I/O.
- `plumb-core`: `Shell` is a cloneable handle over shared state (concurrent evals see each other's vars/cwd/history). Every pipeline stage is tee-captured (head+tail bounded, exact byte totals, truncation flagged) while streaming with backpressure preserved (`yes | head` terminates; SIGPIPE handling included since Rust ignores it process-wide). Runs commit to history and auto-bind `$oN`/`$eN`/`$sN`, per-stage `$oN_K`/`$eN_K`, and `$o`/`$e`/`$s` aliases, so any earlier stream (including intermediate pipe data) can feed later commands without re-running. Strict: pipefail (minus SIGPIPE deaths), unset var = error, failglob, no word splitting. `Report` is fully `Serialize`.
- `plumb` (CLI): reedline REPL with per-stage summaries and `:runs`/`:json`/`:out` inspection, `-c` one-shots, script/stdin modes, `--json`.

Nix wiring: three `package.nix` markers with `passthruTests`, `selectBinaryWithTests` for the bin, hand-edited `Cargo.lock`, `mirror` attr publishing to `indexable-inc/plumb` (public repo auto-created by mirror-sync on merge).

Validated locally: 43 tests green on darwin, repo lint 10/10, `nix build .#plumb` succeeds, stock-clippy clean with pedantic+nursery (org-fork lints checked by CI).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `plumb`, an inspectable bash-subset shell library and CLI
> - Introduces three new crates: [`plumb-syntax`](https://github.com/indexable-inc/index/pull/3579/files#diff-7f170813829c0c77b3d4c7c0b765b983deeaae6fe67e036b32cf0eff4de56666) (recursive-descent parser for a bash subset), [`plumb-core`](https://github.com/indexable-inc/index/pull/3579/files#diff-1ed2148acf123fc26a6e221c61ae626b65a275d08194899825fbd7ba816267c7) (pipeline execution engine and shell state), and [`plumb`](https://github.com/indexable-inc/index/pull/3579/files#diff-3cd3ae950e4f07946700ca5410f22f7fead9942aaf32be097025d7b71eb1cc98) (CLI binary with one-shot and REPL modes).
> - The parser supports pipelines, `&&`/`||` chains, backgrounding (`&`), redirections (`>`, `>>`, `2>&1`, `&>`, etc.), `$VAR`/`$(...)` substitution, globbing, and quoting; unsupported bash constructs (brace expansion, here-docs, subshells) produce explicit errors.
> - The engine runs pipelines with per-stage stdout/stderr capture (bounded head+tail), pipefail semantics, SIGPIPE/SIGINT signal restoration for child processes, and produces structured `Report` objects serializable as JSON.
> - The shell layer implements builtins (`cd`, `export`, `unset`, `exit`, `wait`, `echo`), auto-binds `o`/`e`/`s` variables to run outputs, supports detached background evaluation, and exposes a library-first `Shell` API.
> - The CLI supports `-c <cmd>`, script file, stdin, and an interactive REPL (via `reedline`) with `:runs`, `:json`, `:out`, `:err` inspection commands and per-run summaries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89c0a11.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->