### PR TITLE
cross: smoke-check the darwin codex artifact (#3583)

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -233,9 +233,11 @@ jobs:
           fi
 
   # Native aarch64-darwin lane (#1890). The linux lane covers the cross-compiled
-  # packages, but the genuinely-native darwin artifacts (codex from the patched
-  # fork, btop, nix-output-monitor, the config-launch launcher units, the native
-  # cargo-unit IFD graph) were never published anywhere, so every darwin
+  # packages -- since #2690 that includes codex: `packages.aarch64-darwin.codex`
+  # is the cross alias, so the system filter below drops it from this lane --
+  # but the genuinely-native darwin artifacts (btop, nix-output-monitor, the
+  # config-launch launcher units, the native cargo-unit IFD graph) were never
+  # published anywhere, so every darwin
   # consumer compiled them locally. `cachePushRoots.aarch64-darwin` post-alias
   # is the honest "what a darwin consumer can install" set; filtering the eval
   # rows to `system == "aarch64-darwin"` drops the cross aliases, example-fleet

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1943,6 +1943,42 @@
               test -f "$pkg/share/nix-web-monitor/index.html"
               mkdir -p "$out"
             '';
+          # codex reaches Macs exclusively through the cross alias (#2690): the
+          # required gate already builds `codex-aarch64-apple-darwin` as a
+          # closure root, but a green build cannot assert architecture. Walk
+          # the shipped entrypoint exactly as a Mac would: the shim must be
+          # portable /bin/sh (a compiled wrapper would be a dead Linux ELF),
+          # and both binaries it execs -- config-launch and the codex-rs
+          # binary named by the launch spec -- must be Mach-O arm64 (#3583).
+          cross-darwin-codex-smoke =
+            pkgs.runCommand "cross-darwin-codex-smoke" {nativeBuildInputs = [pkgs.file pkgs.jq];}
+            ''
+              pkg=${crossPackages.codex-aarch64-apple-darwin}
+              read -r shebang < "$pkg/bin/codex"
+              case "$shebang" in
+                "#!/bin/sh") ;;
+                *)
+                  echo "expected /bin/sh shim, got: $shebang" >&2
+                  exit 1
+                  ;;
+              esac
+              spec=$(sed -n 's/^export IX_LAUNCH_SPEC=//p' "$pkg/bin/codex")
+              test -f "$spec"
+              launcher=$(grep -o '/nix/store/[^ "]*/bin/config-launch' "$pkg/bin/codex")
+              target=$(jq -r .target "$spec")
+              for bin in "$launcher" "$target"; do
+                info=$(file -b "$bin")
+                echo "$bin: $info"
+                case "$info" in
+                  *Mach-O*arm64*) ;;
+                  *)
+                    echo "expected Mach-O arm64 for $bin, got: $info" >&2
+                    exit 1
+                    ;;
+                esac
+              done
+              mkdir -p "$out"
+            '';
           site-test = siteTests.all;
         };
         checkNameCollisions = lib.intersectLists (lib.attrNames explicitChecks) (lib.attrNames rustChecks);


### PR DESCRIPTION
Closes #3583.

codex already rides the RFC 0009 cross lane (`cross = true` since #2690): `packages.aarch64-darwin.codex` is the alias for the x86_64-linux-built `codex-aarch64-apple-darwin`, and the linux cache-push lane publishes its closure. What was missing is verification, so this PR:

- adds `cross-darwin-codex-smoke` next to the dag-runner and nix-web-monitor smokes. The required gate already builds `codex-aarch64-apple-darwin` as a closure root, but a green build cannot assert architecture. The check walks the shipped entrypoint exactly as a Mac would: `bin/codex` must be a portable `#!/bin/sh` shim, and both binaries it execs -- `config-launch` and the codex-rs binary named by the launch spec -- must be Mach-O arm64. The wrong-arch failure class it guards against (a Linux ELF launcher riding into the alias) builds green today and only dies on the Mac.
- retires the `darwin-build` lane comment claiming codex is a genuinely-native darwin artifact; that predates the cross switch, and the lane's `system == "aarch64-darwin"` filter has dropped codex since the alias took over.

Receipt, built on vin-compute-2 (x86_64-linux) from main 720f1431:

```
$ nix build .#codex-aarch64-apple-darwin --print-out-paths
/nix/store/2wigfqdqx03lg34929i63m6fkb5m354y-codex-0.0.0   (all but 2 trivial drvs substituted from cache.ix.dev)
$ head -1 result/bin/codex
#!/bin/sh
$ file -b <spec .target>   # /nix/store/d5ngcw7jwqq16g1kbsp0ypmwc8krai5b-codex-0.0.0/bin/codex
Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
$ file -b <shim config-launch>
Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|PIE|HAS_TLV_DESCRIPTORS>
```

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add smoke check for the cross-built darwin `codex` artifact
> Adds a `cross-darwin-codex-smoke` derivation in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/3588/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) that validates the cross-built `codex` package for `aarch64-apple-darwin`.
>
> - Verifies that `bin/codex` is a `/bin/sh` shim (checks the shebang line)
> - Locates the `config-launch` binary referenced in `IX_LAUNCH_SPEC` and the target binary parsed from the spec via `jq`
> - Asserts both binaries are Mach-O arm64 using the `file` command, failing the build if not
> - Also updates a comment in [.github/workflows/cache-push.yml](https://github.com/indexable-inc/index/pull/3588/files#diff-56c6f531ecd11b28cb14d6aa2ec8abf63b2cb701d82ce2f772c5a324c3bbbfb8) to clarify that `codex` is included via the `cross` alias and dropped from the native lane by the system filter
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0013795.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->