### PR TITLE
btop: cross-compile for aarch64-darwin from Linux; document nom cross infeasibility (#3584)

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -233,12 +233,14 @@ jobs:
           fi
 
   # Native aarch64-darwin lane (#1890). The linux lane covers the cross-compiled
-  # packages -- since #2690 that includes codex: `packages.aarch64-darwin.codex`
-  # is the cross alias, so the system filter below drops it from this lane --
-  # but the genuinely-native darwin artifacts (btop, nix-output-monitor, the
-  # config-launch launcher units, the native cargo-unit IFD graph) were never
-  # published anywhere, so every darwin
-  # consumer compiled them locally. `cachePushRoots.aarch64-darwin` post-alias
+  # packages -- since #2690 that includes codex (`packages.aarch64-darwin.codex`
+  # is the cross alias, so the system filter below drops it from this lane) and
+  # since #3584 btop, cross-built as a CMake/C++ package with the apple-sdk
+  # cross toolchain -- but the genuinely-native darwin artifacts
+  # (nix-output-monitor: GHC cannot cross-compile Linux->Darwin,
+  # nixpkgs#405893; the config-launch launcher units; the native cargo-unit
+  # IFD graph) were never published anywhere, so every darwin consumer
+  # compiled them locally. `cachePushRoots.aarch64-darwin` post-alias
   # is the honest "what a darwin consumer can install" set; filtering the eval
   # rows to `system == "aarch64-darwin"` drops the cross aliases, example-fleet
   # system closures, and linux images that resolve to x86_64-linux drvs the

--- a/doc/btop/overview.md
+++ b/doc/btop/overview.md
@@ -29,6 +29,11 @@ flags, the rest of `meta`) is inherited from nixpkgs `btop` unchanged.
   There is no `manifest.json` and no `updateScript`; the flake lock owns the
   pin.
 - Platforms: inherited from nixpkgs `btop` (unix); no extra `systems` gate.
+- Darwin consumers substitute a Linux cross build: `package.nix` sets
+  `cross = true` (#3584), so the RFC 0009 lane compiles a Mach-O arm64 btop
+  with the apple-sdk cross toolchain (clang + macOS SDK) and aliases it into
+  `packages.aarch64-darwin.btop`; the darwin cache-push lane no longer builds
+  btop natively.
 
 Because the derivation is `overrideAttrs` over the upstream package, a nixpkgs
 bump to `btop` (new build inputs, phase changes) flows through automatically;

--- a/lib/darwin/apple-sdk-toolchain.nix
+++ b/lib/darwin/apple-sdk-toolchain.nix
@@ -218,6 +218,56 @@
   appleAr = lib.getExe' appleArPackage arName;
   appleRanlib = lib.getExe' appleRanlibPackage ranlibName;
 
+  clangxx = lib.getExe' pkgs.llvmPackages.clang-unwrapped "clang++";
+
+  standaloneCcName = "apple-sdk-standalone-cc-${target}";
+  standaloneCxxName = "apple-sdk-standalone-cxx-${target}";
+
+  # Standalone C/C++ packages (CMake or make builds outside the cargo-unit
+  # lane; btop is the first, #3584) need the compiler driver to also *link*
+  # executables, which the zig wrappers above cannot do: `zig cc` insists on
+  # building its bundled libc++/compiler_rt for the target and zig 0.16's
+  # Mach-O lane segfaults doing so, and objects compiled against zig's libc++
+  # headers are ABI-incompatible with the SDK's system libc++ a Mac binary
+  # must link anyway. So this lane is plain clang/clang++ with the SDK's own
+  # libc++ headers (-nostdinc++ + c++/v1) and ld64.lld resolving the SDK's
+  # .tbd stubs -- the same header/dylib pairing Xcode uses natively. The
+  # linker flags ride along at compile time (unused there, hence
+  # -Wno-unused-command-line-argument) so one wrapper serves both CMake's
+  # compile and link steps.
+  standaloneFlags = "--target=${target} -mmacosx-version-min=11.0 -isysroot ${appleSdk} -B${pkgs.lld}/bin -fuse-ld=lld -Wno-unused-command-line-argument";
+  appleStandaloneCcPackage = writeBashApplication pkgs {
+    name = standaloneCcName;
+    text = ''
+      exec ${clang} ${standaloneFlags} "$@"
+    '';
+  };
+  appleStandaloneCxxPackage = writeBashApplication pkgs {
+    name = standaloneCxxName;
+    text = ''
+      exec ${clangxx} ${standaloneFlags} -nostdinc++ -isystem ${appleSdk}/usr/include/c++/v1 "$@"
+    '';
+  };
+  appleStandaloneCc = lib.getExe' appleStandaloneCcPackage standaloneCcName;
+  appleStandaloneCxx = lib.getExe' appleStandaloneCxxPackage standaloneCxxName;
+
+  appleStandaloneCmakeToolchain = pkgs.writeText "apple-sdk-standalone-toolchain-${target}.cmake" ''
+    set(CMAKE_SYSTEM_NAME Darwin)
+    set(CMAKE_SYSTEM_PROCESSOR ${cmakeArch})
+    set(CMAKE_OSX_ARCHITECTURES ${cmakeArch})
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0)
+    set(CMAKE_OSX_SYSROOT ${appleSdk})
+    set(CMAKE_C_COMPILER ${appleStandaloneCc})
+    set(CMAKE_CXX_COMPILER ${appleStandaloneCxx})
+    set(CMAKE_AR ${appleAr})
+    set(CMAKE_RANLIB ${appleRanlib})
+    set(CMAKE_FIND_ROOT_PATH ${appleSdk})
+    set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+    set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+    set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+  '';
+
   appleCmakeToolchain = pkgs.writeText "apple-sdk-toolchain-${target}.cmake" ''
     set(CMAKE_SYSTEM_NAME Darwin)
     set(CMAKE_SYSTEM_PROCESSOR ${cmakeArch})
@@ -267,6 +317,11 @@ in
     # host units at the Darwin toolchain, so no unqualified tool vars either.
     # MACOSX_DEPLOYMENT_TARGET and SDKROOT stay unqualified: they have
     # Apple-target semantics only, so host compiles never read them.
+    # CMake toolchain for standalone (non-cargo-unit) C/C++ packages: clang +
+    # SDK libc++, linking through ld64.lld. See the standalone lane comment
+    # above for why this is not the zig toolchain.
+    standaloneCmakeToolchain = appleStandaloneCmakeToolchain;
+
     env = {
       MACOSX_DEPLOYMENT_TARGET = "11.0";
       SDKROOT = appleSdk;

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1979,6 +1979,23 @@
               done
               mkdir -p "$out"
             '';
+          # btop is the first non-Rust cross package: a plain CMake/C++ build
+          # driven by the cross toolchain's standalone clang + macOS SDK lane,
+          # outside the cargo unit DAG the other smokes exercise. Assert the
+          # C++ lane also emits a real Mach-O arm64 binary (#3584).
+          cross-darwin-btop-smoke = pkgs.runCommand "cross-darwin-btop-smoke" {nativeBuildInputs = [pkgs.file];} ''
+            bin=${crossPackages.btop-aarch64-apple-darwin}/bin/btop
+            info=$(file -b "$bin")
+            echo "$info"
+            case "$info" in
+              *Mach-O*arm64*) ;;
+              *)
+                echo "expected Mach-O arm64, got: $info" >&2
+                exit 1
+                ;;
+            esac
+            mkdir -p "$out"
+          '';
           site-test = siteTests.all;
         };
         checkNameCollisions = lib.intersectLists (lib.attrNames explicitChecks) (lib.attrNames rustChecks);

--- a/packages/terminal/btop/default.nix
+++ b/packages/terminal/btop/default.nix
@@ -1,45 +1,106 @@
 {
   lib,
   btop,
+  cmake,
   ix,
+  lowdown,
   nix,
+  stdenv,
   # Sibling package set (flake path only), for the `rebase-patches` binary the
   # fork updater invokes. `{ }` on the overlay path.
   repoPackages ? {},
   # Nushell writer for `passthru.updateScript`, pre-bound on the flake path
   # (lib/packages.nix); `null` on the overlay path -> omit the fork updater.
   updateScriptWriter ? null,
-}:
-# Upstream aristocratos/btop (btop-src input) with the in-repo patch series
-# (./patches) applied: macOS process disk IO sorting, and kernel cwd in the
-# process detail box. De-forking replacement for the old `indexable-inc/btop`
-# pinned input.
-btop.overrideAttrs (old: {
-  src = ix.patchedSrc {
+}: let
+  # Upstream aristocratos/btop (btop-src input) with the in-repo patch series
+  # (./patches) applied: macOS process disk IO sorting, and kernel cwd in the
+  # process detail box. De-forking replacement for the old `indexable-inc/btop`
+  # pinned input. Shared verbatim between the native build and the cross build
+  # below, so a Mac substituting the cross output runs the same patched source
+  # a native build would compile.
+  patchedSrc = ix.patchedSrc {
     name = "btop";
     src = ix.btopSrc;
     patchDir = ./patches;
   };
 
-  # Fork updater (flake path only): bump btop-src and regenerate the patch
-  # series, so btop joins the registry-discovered `.#update` DAG.
-  passthru =
-    (old.passthru or {})
-    // lib.optionalAttrs (updateScriptWriter != null && repoPackages ? rebase-patches) {
-      updateScript =
-        ix.mkForkUpdater {
-          writeNushellApplication = updateScriptWriter;
-          inherit nix;
-          rebasePatches = repoPackages.rebase-patches;
-        } {
-          name = "btop";
-          input = "btop-src";
-        };
-    };
+  nativeBtop = btop.overrideAttrs (old: {
+    src = patchedSrc;
 
-  meta =
-    old.meta
-    // {
-      homepage = "https://github.com/aristocratos/btop";
+    # Fork updater (flake path only): bump btop-src and regenerate the patch
+    # series, so btop joins the registry-discovered `.#update` DAG.
+    passthru =
+      (old.passthru or {})
+      // lib.optionalAttrs (updateScriptWriter != null && repoPackages ? rebase-patches) {
+        updateScript =
+          ix.mkForkUpdater {
+            writeNushellApplication = updateScriptWriter;
+            inherit nix;
+            rebasePatches = repoPackages.rebase-patches;
+          } {
+            name = "btop";
+            input = "btop-src";
+          };
+      };
+
+    meta =
+      old.meta
+      // {
+        homepage = "https://github.com/aristocratos/btop";
+      };
+  });
+
+  # Linux->Darwin cross build (RFC 0009 lane; `cross = true` in package.nix).
+  # nixpkgs' own `pkgsCross.aarch64-darwin` cannot build this from Linux: the
+  # Darwin stdenv bootstraps from Apple binary blobs that only execute on
+  # Darwin, so the source-built SDK chain dies early (Csu-88 fails with
+  # `clang: command not found`; nixpkgs#405893 tracks Linux->Darwin cross as
+  # unfinished). Instead this drives btop's ordinary CMake build with the
+  # cross toolchain's standalone clang + macOS SDK lane (see
+  # lib/darwin/apple-sdk-toolchain.nix for why C++ executables cannot go
+  # through the zig wrappers the Rust lane uses). The toolchain file pins
+  # CMAKE_SYSTEM_NAME=Darwin, so btop's CMakeLists takes its APPLE branch
+  # (osx sources, the CoreFoundation/IOKit frameworks, IOReport for
+  # Apple-silicon GPU stats) exactly as on a native Mac build.
+  crossBtop = let
+    inherit (ix.cross) target;
+    toolchain = ix.appleSdkToolchain {
+      appleSdk = ix.macosSdk {inherit (ix) pkgs;};
+      inherit lib target;
+      inherit (ix) pkgs writeBashApplication;
     };
-})
+  in
+    stdenv.mkDerivation {
+      pname = "btop-${target}";
+      inherit (btop) version;
+      src = patchedSrc;
+
+      nativeBuildInputs = [
+        cmake
+        # Optional in upstream's CMakeLists; present so the man page is
+        # generated, matching the native nixpkgs build.
+        lowdown
+      ];
+
+      cmakeFlags = [
+        "-DCMAKE_TOOLCHAIN_FILE=${toolchain.standaloneCmakeToolchain}"
+        # Match the native nixpkgs Darwin build: LTO breaks btop on Darwin
+        # (nixpkgs#422218), and static linking is a musl/ELF affair.
+        (lib.cmakeBool "BTOP_LTO" false)
+        (lib.cmakeBool "BTOP_STATIC" false)
+      ];
+
+      # The output is a Mach-O arm64 binary; the Linux fixup's ELF strip
+      # cannot parse it and would only warn-and-skip, so skip it explicitly.
+      dontStrip = true;
+
+      # Same meta as the native build: `platforms` already spans linux (the
+      # cross build host) and darwin (the alias consumers), and `mainProgram`
+      # keeps `nix run` working through the Darwin alias.
+      inherit (nativeBtop) meta;
+    };
+in
+  if ix.cross.isCross or false
+  then crossBtop
+  else nativeBtop

--- a/packages/terminal/btop/package.nix
+++ b/packages/terminal/btop/package.nix
@@ -3,6 +3,11 @@
   packageSet = true;
   flake = true;
   overlay = false;
+  # Linux->Darwin cross lane (RFC 0009, #3584): CI cross-compiles the Mach-O
+  # arm64 binary with the apple-sdk cross toolchain (clang + macOS SDK) and aliases it into
+  # `packages.aarch64-darwin.btop`, so Macs substitute it from the cache
+  # instead of the darwin cache-push lane building it natively.
+  cross = true;
   # Joins `nix run .#update`: bump btop-src and regenerate the patch series via
   # passthru.updateScript (see default.nix / lib/fork-updater.nix).
   updateScript = true;


### PR DESCRIPTION
Closes #3584.

## What

`packages.aarch64-darwin.btop` is now the Linux-cross-built Mach-O arm64 derivation: `cross = true` in btop's `package.nix` puts it on the RFC 0009 cross lane, whose existing registry/alias machinery roots the Linux drv in `cachePushRoots.x86_64-linux`, aliases it over the Darwin namespace, and thereby drops btop from the native darwin cache-push lane (the `system == "aarch64-darwin"` eval filter). No mac builds btop anymore; Macs substitute the Linux-built closure (whose runtime closure is exactly one store path -- no Linux deps, no SDK reference).

## Why not nixpkgs pkgsCross (mechanism a)

Probed empirically on vin-compute-2/hil-compute-1 at our nixpkgs pin (`d407951`) and at master, with `config.allowUnsupportedSystem = true`. Dead at the Darwin SDK bootstrap, three different ways:

- `Csu-88.drv`: `bash: clang: command not found` (the cross bootstrap stdenv on Linux has no darwin-targeting clang; hello + btop root cause at the pin)
- `copyfile-230.0.1.0.1.drv`: compiled with host gcc, `fatal error: Availability.h: No such file or directory`
- `libsbuf-14.1.0.drv` (master, and the nix-output-monitor probe): `meson.build` not found under cross

Upstream tracks Linux->Darwin cross as an unfinished stretch goal (nixpkgs#405893, deferred past 26.05); no overlay-level fix exists because the whole libSystem/cctools/ld64-on-Linux layer is missing.

## Mechanism (b): apple-sdk toolchain, new standalone lane

btop is CMake/C++, not a cargo unit, so it cannot ride the zig wrappers the Rust lane uses:

- `zig c++` as a *linker* builds its bundled libc++ for the target and zig 0.16's Mach-O lane segfaults doing it (reproducibly, on two hosts);
- objects compiled against zig's libc++ headers are ABI-incompatible (`[abi:ne210100]` symbols) with the SDK's system libc++ a Mac binary must link.

`lib/darwin/apple-sdk-toolchain.nix` gains an additive standalone lane: plain clang/clang++ against the SDK's own libc++ headers (`-nostdinc++` + `c++/v1`), linked with `ld64.lld` against the SDK `.tbd` stubs -- the Xcode-native pairing -- exposed as `standaloneCmakeToolchain`. The existing zig/cc-rs lane is untouched: `cross-darwin-smoke` and `cross-darwin-web-monitor-smoke` still substitute from cache with unchanged drv hashes.

A new `cross-darwin-btop-smoke` check asserts the emitted binary is really Mach-O arm64 on x86_64-linux CI.

## nix-output-monitor: cross is infeasible, documented

nom is Haskell. The pkgsCross probe dies in the same SDK bootstrap (`libsbuf-14.1.0.drv`), and there is no mechanism-(b) analog for GHC: nixpkgs' GHC cross targets (riscv64, wasm, aarch64-linux) do not include Darwin, and a Darwin-targeting GHC would need exactly the missing cctools/ld64-on-Linux layer plus Template Haskell execution on the target. nom stays on the native darwin lane; details and receipts on #3584.

## Receipts

Built on hil-compute-1 (x86_64-linux):

```
$ nix build .#packages.x86_64-linux.btop-aarch64-apple-darwin
$ file result/bin/btop
Mach-O 64-bit arm64 executable, flags:<NOUNDEFS|DYLDLINK|TWOLEVEL|WEAK_DEFINES|BINDS_TO_WEAK|PIE>
$ nix path-info -r ./result
/nix/store/b07pwv4qdiw9pdqq6c5p27d7m7x212jf-btop-aarch64-apple-darwin-1.4.7   # closure = itself only
```

`nix eval .#packages.aarch64-darwin.btop.drvPath` resolves to the same cross drv (alias wired).

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cross-compile btop for aarch64-darwin from Linux using the apple-sdk toolchain
> - Adds a standalone C/C++ toolchain to [apple-sdk-toolchain.nix](https://github.com/indexable-inc/index/pull/3590/files#diff-280b8ec772b384638a8cf0c0343253ce69ad4920a97b562518ef17b33ba436d8) that wraps clang/clang++ with the macOS SDK sysroot and ld64.lld, exposing a CMake toolchain file via `standaloneCmakeToolchain`.
> - Refactors [btop/default.nix](https://github.com/indexable-inc/index/pull/3590/files#diff-383637721f4383c8a40bdf9b1a84b0bb1651a0df98b7063a6af22ff4f8d3c8ef) to use this toolchain in a CMake-based cross build when `ix.cross.isCross` is true, producing a Mach-O arm64 binary; native behavior is unchanged.
> - Sets `cross = true` in [package.nix](https://github.com/indexable-inc/index/pull/3590/files#diff-e4de028f6095f7b3d6ea4039ac24332bc21add194e8fb471bdf6ea1637cda40f) so the CI cross lane builds and aliases btop into `packages.aarch64-darwin.btop` without a native Darwin builder.
> - Adds a `cross-darwin-btop-smoke` check in [per-system.nix](https://github.com/indexable-inc/index/pull/3590/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) that asserts the cross-built binary is a Mach-O arm64 executable.
> - Documents in [doc/btop/overview.md](https://github.com/indexable-inc/index/pull/3590/files#diff-e6387b4cf82d5b9c5bb51fc4fb0258646e398b5f8e3071c2a348cbccb2e4884f) why `nom` cannot be cross-compiled this way and notes the darwin cache-push lane no longer builds btop natively.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fdec403.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->