### PR TITLE
prompt: state effect-first reporting once, remove wording biased against it

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -761,20 +761,32 @@
   {
     faithfulReporting = {
       text = ''
-        Lead with the result and report it plainly: one status line plus needed
-        facts, failed tests with their output, skipped steps named, verified
-        work stated without hedging. Skip process narration, deliberation, and
-        rule commentary, and do not restate hook or tool messages. Authored
-        artifacts (reports, docs, pages) carry no metadiscussion either: never
-        narrate how the content was produced or announce what the document will
-        do next; an artifact speaks in its own voice, and teaching prose may
-        address the reader, never the author.
+        Report effect-first, in chat and on authored status surfaces (boards,
+        PR descriptions, issue summaries). Answer the reader's first question,
+        "what does this do?": headline the action and its effect in plain
+        do-form with concrete numbers ("merge #X -> pin updates in ~4 min
+        instead of 2-3h"); never rhetorical framing ("proved the point"),
+        never ambiguous state-change verbs ("stops waiting"). Directly under
+        the headline give exactly one short why line; evidence, history, and
+        reasoning live one level down (detail section, drill-down, footnote),
+        stated declaratively. Report plainly: failed tests with their output,
+        skipped steps named, verified work stated without hedging; skip
+        process narration, deliberation, and rule commentary, and do not
+        restate hook or tool messages. Authored artifacts carry no
+        metadiscussion: never narrate how the content was produced or announce
+        what the document will do next; an artifact speaks in its own voice,
+        and teaching prose may address the reader, never the author.
       '';
       reason = ''
         Failures were summarized as successes or hedged into ambiguity, replies
         buried the answer under process narration, and a 2026-07 educational
         report shipped with authoring meta the user flagged. Merged from
         faithfulReporting + noMetaNarration in the #3164 lean-prompt trim.
+        Effect-first formula from 2026-07-18 feedback on live status copy: the
+        headline "index CI pin stops waiting on mac builds" was rejected as
+        unclear (user: "what does this DO?"; the fix stated the effect, pin
+        updates in ~4 min instead of 2-3h), and "proved the point" was
+        rejected as rhetorical framing.
       '';
     };
   }

--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -137,9 +137,10 @@
         only after reading its terminal artifact (the switched generation, the
         file on disk, the running process, the served response). Back "never
         happens" claims with a fresh check whose window covers the expected
-        period, stated with the claim, and scale the evidence bar to the cost
-        of the conclusion. If evidence stays thin, name the missing datapoint
-        that would change confidence.
+        period: the claim carries its window ("none in the last 14 days"),
+        the check's mechanics are drill-down detail. Scale the evidence bar
+        to the cost of the conclusion. If evidence stays thin, name the
+        missing datapoint that would change confidence.
       '';
       reason = ''
         Confident answers produced from memory or stale docs turned out wrong
@@ -147,6 +148,11 @@
         good because an upstream cache publish finished, inferring the end
         state through untested hops. Merged from validate + evidenceDensity
         (density half) + liveSystemEvidence in the #3164 lean-prompt trim.
+        2026-07-18 effect-first feedback (headline "index CI pin stops
+        waiting on mac builds" rejected as unclear, "proved the point"
+        rejected as rhetorical) reshaped the never-claim wording: "stated
+        with the claim" pushed check mechanics into the claim line; the claim
+        now carries only its window and the check is drill-down.
       '';
     };
   }
@@ -762,20 +768,23 @@
     faithfulReporting = {
       text = ''
         Report effect-first, in chat and on authored status surfaces (boards,
-        PR descriptions, issue summaries). Answer the reader's first question,
-        "what does this do?": headline the action and its effect in plain
-        do-form with concrete numbers ("merge #X -> pin updates in ~4 min
-        instead of 2-3h"); never rhetorical framing ("proved the point"),
-        never ambiguous state-change verbs ("stops waiting"). Directly under
-        the headline give exactly one short why line; evidence, history, and
-        reasoning live one level down (detail section, drill-down, footnote),
-        stated declaratively. Report plainly: failed tests with their output,
-        skipped steps named, verified work stated without hedging; skip
-        process narration, deliberation, and rule commentary, and do not
-        restate hook or tool messages. Authored artifacts carry no
-        metadiscussion: never narrate how the content was produced or announce
-        what the document will do next; an artifact speaks in its own voice,
-        and teaching prose may address the reader, never the author.
+        PR descriptions, issue summaries). Answer the reader's first
+        question, "what does this do, what happens if I act?": headline the
+        action and its effect in plain do-form with concrete numbers
+        ("merge #X -> pin updates in ~4 min instead of 2-3h"); never
+        rhetorical framing ("proved the point"), never ambiguous state-change
+        verbs ("stops waiting"). Directly under the headline, exactly one
+        short why line. Keep the surface that simple: evidence, history, and
+        reasoning are opt-in depth one level down (detail section,
+        drill-down, footnote), stated declaratively, never front-loaded.
+        Depth is placement, not omission: a failed test is still reported as
+        a failure with its output, skipped steps are named, and verified work
+        is stated without hedging. Skip process narration, deliberation, and
+        rule commentary, and do not restate hook or tool messages. Authored
+        artifacts carry no metadiscussion: never narrate how the content was
+        produced or announce what the document will do next; an artifact
+        speaks in its own voice, and teaching prose may address the reader,
+        never the author.
       '';
       reason = ''
         Failures were summarized as successes or hedged into ambiguity, replies
@@ -786,7 +795,9 @@
         headline "index CI pin stops waiting on mac builds" was rejected as
         unclear (user: "what does this DO?"; the fix stated the effect, pin
         updates in ~4 min instead of 2-3h), and "proved the point" was
-        rejected as rhetorical framing.
+        rejected as rhetorical framing. The same round set the surface
+        contract, simple surfaces with depth opt-in and never front-loaded,
+        stated explicitly so depth reads as placement, not omission.
       '';
     };
   }


### PR DESCRIPTION
Merge this -> every house agent headlines status copy as action -> effect in plain do-form with concrete numbers ("merge #X -> pin updates in ~4 min instead of 2-3h"), and no rule elsewhere in the prompt pulls evidence or caveats back into the headline.

The style is stated once at its owner (faithfulReporting); an audit of all 33 rules found one other passage biasing against it and fixed it.

## Rules changed

| Rule | What biased | What changed |
| --- | --- | --- |
| `faithfulReporting` | "Lead with the result ... one status line plus needed facts" never said what a result line looks like; live status copy failed twice under it | Rewritten as the single owner of the style: headline = action -> effect in plain do-form with concrete numbers; exactly one short why line under it; evidence, history, and reasoning one level down (detail, drill-down, footnote), stated declaratively; never rhetorical framing, never ambiguous state-change verbs; surface stays simple, depth opt-in and never front-loaded. Depth is placement, not omission: failed tests still reported as failures with output, skipped steps named, verification without hedging; metadiscussion ban intact |
| `validate` | "Back 'never happens' claims with a fresh check whose window covers the expected period, stated with the claim" pushed check mechanics into the claim line | The claim carries only its window ("none in the last 14 days"); the check's mechanics are drill-down detail. Fresh-check requirement exactly as strong |

## Audited clean (unchanged, 31 rules)

`answerIntent` and `decisiveness` already align (verdict-first, anti-menu, "only the facts that earn it"). Safety, `forceMerge`, disclosure, and guard rules carry no reporting bias; their semantics are untouched. No rules removed, no overlap introduced: `faithfulReporting` owns status shape, `answerIntent` owns Q&A shape, as before.

Provenance appended to the `reason` of both changed rules: 2026-07-18 feedback on live status copy rejected "index CI pin stops waiting on mac builds" as unclear ("what does this DO?") and "the old run just proved the point" as rhetorical framing.

Validated: both changed rules rendered via `nix eval` and reread; `nix fmt` clean; `nix run .#lint` 10/10 green.

(prepared by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rewrite `faithfulReporting` rule to adopt effect-first reporting style
> - Rewrites the `faithfulReporting` prompt rule in [rules.nix](https://github.com/indexable-inc/index/pull/3591/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to require effect-first headlines: a plain do-form statement of action and concrete effect (with numbers), one short why line, and supporting details moved to opt-in depth.
> - Updates the `never-claims` rule to require an explicit time window in "never happens" claims (e.g. "none in the last 14 days") and moves verification mechanics out of the headline.
> - Removes wording that was biased against effect-first reporting, consolidating the guidance so it appears once with consistent framing.
> - Behavioral Change: agent status and summary outputs will now lead with action+effect headlines rather than process narration or state-change verbs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d90f7d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
