### PR TITLE
plumb: array-style run references ${o[N][K]}; hero redesign

### DIFF
--- a/packages/plumb/cli/README.md
+++ b/packages/plumb/cli/README.md
@@ -1,35 +1,36 @@
-<p align="center"><img src="assets/hero.svg" width="720" alt="a pipeline whose every stream is tapped into a run value, whose variables feed a later command"></p>
+<p align="center"><img src="assets/hero.svg" width="760" alt="a typed pipeline decomposes into tee'd stages; the run becomes an addressable value whose streams feed a later command without re-running"></p>
 
 # plumb
 
-Ever run `cargo clippy | tail -n 5` and then wanted the 400 lines you just threw away? plumb is a shell where every run is a value: each pipe stage's stdout and stderr are captured (bounded, with exact byte counts), the whole run becomes an inspectable report, and outputs auto-bind to variables so later commands can reuse any earlier stream, including the intermediate pipe data, without re-running anything. It is a Rust library first (`plumb-core`), with a reedline REPL and a one-shot CLI on top, built for programs (LLM agents especially) that run commands and need what actually happened, not a scrollback.
+Ever run `cargo clippy | tail -n 5` and then wanted the 400 lines you just threw away? plumb is a shell where every run is a value. Each pipe stage's stdout and stderr are captured while they stream, the whole run becomes an inspectable report, and every stream stays addressable afterwards, so later commands reuse earlier output (including the bytes that flowed *between* pipe stages) without re-running anything. It is a Rust library first (`plumb-core`), with a reedline REPL and one-shot CLI on top, built for programs (LLM agents especially) that run commands and need what actually happened, not a scrollback.
 
 The syntax is a strict bash subset: everything plumb accepts pastes into bash unchanged and means the same thing there. Everything else is a loud parse error naming the construct, never a silent reinterpretation.
 
 ## Runs are values
 
 ```console
-plumb tmp> sh -c 'echo warn >&2; seq 1 10000' | tail -n 3
+plumb src> sh -c 'echo warn >&2; seq 1 10000' | tail -n 3
 9998
 9999
 10000
 [0] sh -c echo warn >&2; seq 1 10000  exit 0  11ms  out 48.9KB  err 5B
 [1] tail -n 3  exit 0  11ms  out 15B  err 0B
-run 3: exit 0  ${o3} ${e3} ${s3}
-plumb tmp> echo $o3_0 | head -n 1
+run 3: exit 0  ${o[3]} ${e[3]} ${s[3]}
+plumb src> echo ${o[3][0]} | head -n 1
 1
 ```
 
-Every run `N` binds, automatically:
+Every run stays addressable:
 
-| variable | value |
+| reference | value |
 | --- | --- |
-| `$oN` / `$eN` / `$sN` | final stdout / stderr / status |
-| `$oN_K` / `$eN_K` | stdout / stderr of pipe stage `K` (what stage `K+1` consumed) |
-| `$o` / `$e` / `$s` | same, for the most recent run |
+| `${o[7]}` / `${e[7]}` / `${s[7]}` | run 7's final stdout / stderr / status |
+| `${o[7][0]}` | what pipe stage 0 printed (exactly what stage 1 consumed) |
+| `${o[-1]}`, `${o[-1][-2]}` | negative indexes count back from the latest |
+| `$o` / `$e` / `$s` | the last run's stdout / stderr / status |
 | `$?` | last status, as in bash |
 
-`:runs` lists retained runs, `:json N` dumps a run's full report (argv after expansion, per-stage status, timing, byte counts, truncation flags), `:out N K` prints a captured stream raw. Captures are head+tail bounded (256KiB per stream by default) with exact totals, so a gigabyte through a pipe costs fixed memory and truncation is always marked, never silent.
+`:runs` lists retained runs, `:json 7` dumps a run's full report (argv after expansion, per-stage status, timing, byte counts, truncation flags), `:out 7 0` prints a captured stream raw. Captures are head+tail bounded (256KiB per stream by default) with exact byte totals, so a gigabyte through a pipe costs fixed memory, and truncation is always marked, never silent.
 
 ## Strict where bash is treacherous
 
@@ -47,14 +48,14 @@ Supported: pipes, `&&` `||` `;`, redirections (`>` `>>` `<` `2>` `2>&1` `&>` `>&
 ```rust
 let shell = plumb_core::Shell::new(plumb_core::Config::default())?;
 let report = shell.eval("cargo clippy 2>&1 | tail -n 5")?;
-report.status;                       // pipefail status
-report.pipelines[0].stages[0].stdout // everything tail consumed
+report.status;                        // pipefail status
+report.pipelines[0].stages[0].stdout  // everything tail consumed
     .render();
-shell.var("o1_0");                   // same thing, as a variable
-serde_json::to_string(&report)?;     // the whole run, machine-readable
+shell.eval("echo ${o[1][0]} | rg dead")?;  // reused; clippy never re-runs
+serde_json::to_string(&report)?;      // the whole run, machine-readable
 ```
 
-`Shell` is a cheap cloneable handle over shared state: concurrent evals from threads (`eval_detached`) or `&` background items see each other's variables, cwd, and run history; `wait` joins them. `exit` surfaces as `Error::ExitRequested` so the embedder decides what dying means.
+`Shell` is a cheap cloneable handle over shared state: concurrent evals from threads (`eval_detached`) or `&` background items see each other's variables, cwd, and run history; `wait` joins them. `exit` surfaces as `Error::ExitRequested` so the embedder decides what dying means. From Elixir, `plumb-ex` (unibind) exposes the same shell with reports as JSON.
 
 One-shot and script modes stream live and exit with the run's status; `--json` prints the report instead:
 
@@ -72,4 +73,4 @@ nix run github:indexable-inc/index#plumb
 cargo install --git https://github.com/indexable-inc/plumb
 ```
 
-The crates live in the [index monorepo](https://github.com/indexable-inc/index) under `packages/plumb/` (`plumb-syntax` parser, `plumb-core` library, `plumb` CLI); this repo is a read-only mirror.
+The crates live in the [index monorepo](https://github.com/indexable-inc/index) under `packages/plumb/` (`plumb-syntax` parser, `plumb-core` library, `plumb` CLI, `plumb-ex` Elixir NIF); this repo is a read-only mirror.

--- a/packages/plumb/cli/assets/hero.svg
+++ b/packages/plumb/cli/assets/hero.svg
@@ -1,22 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 240" role="img"
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 430" role="img"
      font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
   <style>
     svg { color: #1f2328; }
-    .muted  { fill: #656d76; }
-    .accent { fill: #8250df; }
+    .muted   { fill: #656d76; }
+    .accent  { fill: #8250df; }
     .accent-stroke { stroke: #8250df; }
-    .box    { stroke: currentColor; fill: none; rx: 6; }
-    text    { fill: currentColor; font-size: 14px; }
-    .mono   { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 13px; }
-    .small  { font-size: 11px; }
-    .edge   { stroke: currentColor; fill: none; marker-end: url(#arrow); }
-    .tap    { stroke: #8250df; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow-accent); }
+    .box     { stroke: currentColor; fill: none; rx: 8; }
+    text     { fill: currentColor; font-size: 14px; }
+    .mono    { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 13px; }
+    .cmd     { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 15px; }
+    .small   { font-size: 11px; }
+    .edge    { stroke: currentColor; stroke-width: 1.2; fill: none; marker-end: url(#arrow); }
+    .tap     { stroke: #8250df; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrow-accent); }
+    .decomp  { stroke: #656d76; fill: none; stroke-dasharray: 2 3; marker-end: url(#arrow-muted); }
     @media (prefers-color-scheme: dark) {
       svg { color: #e6edf3; }
       .muted  { fill: #8b949e; }
       .accent { fill: #a371f7; }
       .accent-stroke { stroke: #a371f7; }
       .tap    { stroke: #a371f7; }
+      .decomp { stroke: #8b949e; }
     }
   </style>
   <defs>
@@ -26,30 +29,48 @@
     <marker id="arrow-accent" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" class="accent"/>
     </marker>
+    <marker id="arrow-muted" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="muted"/>
+    </marker>
   </defs>
 
-  <!-- pipeline row -->
-  <rect class="box" x="30" y="40" width="150" height="40"/>
-  <text class="mono" x="105" y="65" text-anchor="middle">cargo clippy</text>
-  <line class="edge" x1="180" y1="60" x2="270" y2="60"/>
-  <rect class="box" x="270" y="40" width="120" height="40"/>
-  <text class="mono" x="330" y="65" text-anchor="middle">tail -n 5</text>
-  <line class="edge" x1="390" y1="60" x2="470" y2="60"/>
-  <text class="mono muted" x="478" y="65">stdout</text>
+  <!-- 1. what you type -->
+  <text class="cmd" x="40" y="36"><tspan class="accent">plumb&gt;</tspan> cargo clippy | tail -n 5</text>
+  <line class="decomp" x1="150" y1="48" x2="150" y2="84"/>
 
-  <!-- taps from every stream -->
-  <line class="tap" x1="105" y1="80" x2="105" y2="140"/>
-  <line class="tap" x1="225" y1="60" x2="225" y2="140"/>
-  <line class="tap" x1="330" y1="80" x2="330" y2="140"/>
+  <!-- 2. what runs -->
+  <rect class="box" x="40" y="88" width="160" height="42"/>
+  <text class="mono" x="120" y="114" text-anchor="middle">cargo clippy</text>
+  <line class="edge" x1="200" y1="109" x2="290" y2="109"/>
+  <rect class="box" x="290" y="88" width="110" height="42"/>
+  <text class="mono" x="345" y="114" text-anchor="middle">tail -n 5</text>
+  <line class="edge" x1="400" y1="109" x2="452" y2="109"/>
+  <text class="mono muted" x="460" y="114">the 5 lines you see</text>
 
-  <!-- the run-as-value box -->
-  <rect class="box accent-stroke" x="60" y="140" width="360" height="60"/>
-  <text class="accent" x="75" y="162">run 7 = a value</text>
-  <text class="mono" x="75" y="184">$o7_0 full clippy  $o7 last 5  $e7  $s7</text>
+  <!-- 3. every stream tee'd into the run value -->
+  <line class="tap" x1="90" y1="130" x2="90" y2="194"/>
+  <text class="small muted" x="98" y="164">stderr</text>
+  <line class="tap" x1="170" y1="130" x2="170" y2="194"/>
+  <text class="small muted" x="178" y="164">stdout</text>
+  <line class="tap" x1="345" y1="130" x2="345" y2="194"/>
+  <text class="small muted" x="353" y="164">stdout</text>
+  <text class="small muted" x="470" y="188">every stream is captured, exact byte counts,</text>
+  <text class="small muted" x="470" y="203">bounded memory</text>
 
-  <!-- reuse edge -->
-  <line class="edge" x1="420" y1="170" x2="500" y2="170"/>
-  <rect class="box" x="500" y="150" width="190" height="40"/>
-  <text class="mono" x="595" y="175" text-anchor="middle">echo $o7_0 | rg dead</text>
-  <text class="small muted" x="595" y="212" text-anchor="middle">re-use any stream later, without re-running</text>
+  <!-- 4. the run, kept as a value -->
+  <rect class="box accent-stroke" x="40" y="198" width="420" height="140"/>
+  <text class="accent" x="58" y="224" font-weight="600">run 7, kept as a value</text>
+  <text class="mono accent" x="58" y="254">${o[7][0]}</text>
+  <text class="mono muted" x="175" y="254">everything clippy printed</text>
+  <text class="mono accent" x="58" y="282">${o[7]}</text>
+  <text class="mono muted" x="175" y="282">the 5 lines tail kept</text>
+  <text class="mono accent" x="58" y="310">${e[7]}</text>
+  <text class="mono muted" x="130" y="310">stderr</text>
+  <text class="mono accent" x="240" y="310">${s[7]}</text>
+  <text class="mono muted" x="312" y="310">exit status</text>
+
+  <!-- 5. reuse without re-running -->
+  <line class="tap" x1="250" y1="338" x2="250" y2="374"/>
+  <text class="cmd" x="40" y="400"><tspan class="accent">plumb&gt;</tspan> echo ${o[7][0]} | rg dead</text>
+  <text class="small muted" x="360" y="400">grep the full clippy output later; nothing re-runs</text>
 </svg>

--- a/packages/plumb/cli/src/main.rs
+++ b/packages/plumb/cli/src/main.rs
@@ -17,8 +17,9 @@ use plumb_core::{Config, Error, Shell};
     about = "An inspectable bash-subset shell: every run is a value",
     long_about = "An inspectable bash-subset shell. Every run returns a report with per-stage \
                   argv, status, timing, and captured stdout/stderr (including what each pipe \
-                  stage fed the next). Outputs auto-bind to variables: $oN/$eN/$sN for run N, \
-                  $oN_K/$eN_K per stage, $o/$e/$s for the last run."
+                  stage fed the next). Runs stay addressable afterwards: ${o[N]}/${e[N]}/${s[N]} \
+                  for run N, ${o[N][K]} per pipe stage, negative indexes count from the latest, \
+                  and $o/$e/$s alias the last run."
 )]
 struct Args {
     /// Evaluate this source string and exit.

--- a/packages/plumb/cli/src/repl.rs
+++ b/packages/plumb/cli/src/repl.rs
@@ -53,7 +53,7 @@ pub fn run(shell: &Shell) -> ExitCode {
     };
     println!(
         "plumb: runs are values. `:runs` lists them, `:json N` dumps one, \
-         `$oN`/`$eN`/`$oN_K` reuse their output. ctrl-d exits."
+         `${{o[N]}}`/`${{e[N]}}`/`${{o[N][K]}}` reuse their output. ctrl-d exits."
     );
     loop {
         for report in shell.finished_background() {
@@ -169,7 +169,7 @@ fn summarize(report: &Report) {
         );
     }
     let id = report.id;
-    println!("run {id}: exit {}  ${{o{id}}} ${{e{id}}} ${{s{id}}}", report.status);
+    println!("run {id}: exit {}  ${{o[{id}]}} ${{e[{id}]}} ${{s[{id}]}}", report.status);
 }
 
 fn human_bytes(count: u64) -> String {

--- a/packages/plumb/core/src/engine.rs
+++ b/packages/plumb/core/src/engine.rs
@@ -186,7 +186,7 @@ fn open_sink(sink: &FileSink) -> Result<File, Error> {
 }
 
 /// Run one pipeline to completion. `first_stage_index` numbers the stages
-/// across the whole run for `$oN_K` addressing.
+/// across the whole run for `${o[N][K]}` addressing.
 pub fn run_pipeline(
     stages: Vec<StageSpec>,
     config: &EngineConfig,

--- a/packages/plumb/core/src/error.rs
+++ b/packages/plumb/core/src/error.rs
@@ -69,6 +69,14 @@ pub enum Error {
         message: String,
     },
 
+    /// An indexed run reference (dollar-brace `o[N]` form) could not
+    /// resolve.
+    #[snafu(display("run reference: {message}"))]
+    RunRef {
+        /// What failed to resolve.
+        message: String,
+    },
+
     /// A `$(...)` substitution produced more output than the configured
     /// budget; its value would have been silently wrong.
     #[snafu(display("command substitution output exceeded {limit} bytes"))]

--- a/packages/plumb/core/src/lib.rs
+++ b/packages/plumb/core/src/lib.rs
@@ -4,17 +4,20 @@
 //! `$VAR`, globs, `$(...)`, `&&`/`||`/`;`, `&`) and returns a [`Report`]:
 //! per-stage argv, status, timing, and bounded captures of every stream
 //! that flowed through the pipeline, including what each pipe stage fed the
-//! next. Outputs auto-bind to shell variables (`$oN`, `$eN`, `$sN`,
-//! `$oN_K`, `$eN_K`, and `$o`/`$e`/`$s` for the last run), so any earlier
-//! run's data, including intermediate pipe data, can feed later commands
-//! without re-running anything.
+//! next. Every run stays addressable afterwards: `${o[N]}` / `${e[N]}` /
+//! `${s[N]}` resolve run N's final stdout / stderr / status, `${o[N][K]}`
+//! resolves pipe stage K, negative indexes count from the latest, and
+//! `$o` / `$e` / `$s` alias the most recent run. Any earlier stream,
+//! including intermediate pipe data, can feed later commands without
+//! re-running anything.
 //!
 //! ```no_run
 //! let shell = plumb_core::Shell::new(plumb_core::Config::default())?;
 //! let report = shell.eval("cargo clippy 2>&1 | tail -n 5")?;
 //! assert_eq!(report.pipelines[0].stages.len(), 2);
-//! let full_clippy = shell.var("o1_0"); // everything tail consumed
-//! # let _ = full_clippy;
+//! // Everything tail consumed, reused without re-running clippy:
+//! let hits = shell.eval("echo ${o[1][0]} | rg dead")?;
+//! # let _ = hits;
 //! # Ok::<(), plumb_core::Error>(())
 //! ```
 //!

--- a/packages/plumb/core/src/report.rs
+++ b/packages/plumb/core/src/report.rs
@@ -94,7 +94,7 @@ impl Serialize for Capture {
 /// One pipeline stage after it ran.
 #[derive(Debug, Clone, Serialize)]
 pub struct Stage {
-    /// Index of the stage across the whole run (the `K` in `$oN_K`).
+    /// Index of the stage across the whole run (the `K` in `${o[N][K]}`).
     pub index: usize,
     /// The argv actually spawned, after expansion (empty for builtins that
     /// take no arguments? never: argv[0] is always present).
@@ -127,7 +127,7 @@ pub struct PipelineRun {
 /// evaluated.
 #[derive(Debug, Clone, Serialize)]
 pub struct Report {
-    /// Run id: the `N` in `$oN` / `$eN` / `$sN`.
+    /// Run id: the `N` in `${o[N]}` / `${e[N]}` / `${s[N]}`.
     pub id: u64,
     /// The source text that was evaluated.
     pub source: String,

--- a/packages/plumb/core/src/shell.rs
+++ b/packages/plumb/core/src/shell.rs
@@ -795,8 +795,10 @@ impl Shell {
                         }
                     }
                 }
-                Part::Var { name, .. } => {
-                    let value = if name == "?" {
+                Part::Var { name, indices, .. } => {
+                    let value = if !indices.is_empty() {
+                        self.run_ref(name, indices, report)?
+                    } else if name == "?" {
                         self.lock().last_status.to_string()
                     } else {
                         self.var(name).ok_or_else(|| Error::UnsetVar {
@@ -850,18 +852,88 @@ impl Shell {
         Ok(value.trim_end_matches('\n').to_owned())
     }
 
+    /// Resolve a `${o[run]}` / `${o[run][stage]}` reference. A non-negative
+    /// run index is a run id; a negative one counts back from the latest
+    /// (`-1` = latest). The run being evaluated participates once it has
+    /// stages, so `a | b; use ${o[1][0]}` works within one eval. The stage
+    /// index is a stage number as shown in summaries, negative counting
+    /// from the last stage.
+    fn run_ref(&self, name: &str, indices: &[i64], current: &Report) -> Result<String, Error> {
+        if !matches!(name, "o" | "e" | "s") {
+            return Err(Error::RunRef {
+                message: format!("`{name}` is not indexable; only ${{o[..]}}, ${{e[..]}}, ${{s[..]}}"),
+            });
+        }
+        let retained: Vec<Arc<Report>> = {
+            let state = self.lock();
+            state.runs.iter().cloned().collect()
+        };
+        let mut candidates: Vec<&Report> = retained.iter().map(Arc::as_ref).collect();
+        if current.stages().next().is_some() {
+            candidates.push(current);
+        }
+        let run_index = indices[0];
+        let run = if run_index < 0 {
+            let back = usize::try_from(-(run_index + 1)).map_err(|_| Error::RunRef {
+                message: format!("index {run_index} out of range"),
+            })?;
+            candidates
+                .len()
+                .checked_sub(back + 1)
+                .and_then(|position| candidates.get(position))
+        } else {
+            candidates
+                .iter()
+                .find(|report| i64::try_from(report.id) == Ok(run_index))
+        };
+        let Some(run) = run else {
+            return Err(Error::RunRef {
+                message: format!("run {run_index} is not retained"),
+            });
+        };
+        let stages: Vec<&Stage> = run.stages().collect();
+        let stage = match indices.get(1) {
+            None => stages.last().copied(),
+            Some(stage_index) if *stage_index < 0 => usize::try_from(-(stage_index + 1))
+                .ok()
+                .and_then(|back| stages.len().checked_sub(back + 1))
+                .and_then(|position| stages.get(position).copied()),
+            Some(stage_index) => stages
+                .iter()
+                .find(|stage| i64::try_from(stage.index) == Ok(*stage_index))
+                .copied(),
+        };
+        let Some(stage) = stage else {
+            return Err(Error::RunRef {
+                message: format!("run {} has no stage {}", run.id, indices[1]),
+            });
+        };
+        let value = match (name, indices.len()) {
+            // For the in-progress run, `status` is not final yet; the last
+            // pipeline's status is the honest answer for both cases.
+            ("s", 1) => run
+                .pipelines
+                .last()
+                .map_or(run.status, |pipeline| pipeline.status)
+                .to_string(),
+            ("s", _) => stage.status.to_string(),
+            ("o", _) => trimmed(&stage.stdout.render()),
+            (_, _) => trimmed(&stage.stderr.render()),
+        };
+        Ok(value)
+    }
+
     /// Commit a finished run: store the report and auto-bind its outputs.
     ///
-    /// Variables bound for run N: `$oN` / `$eN` (final stdout / stderr),
-    /// `$sN` (status), `$oN_K` / `$eN_K` per stage K, plus the unnumbered
-    /// aliases `$o` / `$e` / `$s` for the most recently finished run.
+    /// The run history itself is the addressable surface: `${o[N]}` /
+    /// `${e[N]}` / `${s[N]}` (and `[N][K]` per stage) resolve against it in
+    /// [`Self::run_ref`]. Only the unnumbered `$o` / `$e` / `$s` aliases
+    /// for the most recently finished run live in the variable map.
     fn commit(&self, report: &Report) {
         let arc = Arc::new(report.clone());
-        let id = arc.id;
-        let trim = |text: String| text.trim_end_matches('\n').to_owned();
-        let out = trim(arc.output());
-        let err = trim(
-            arc.pipelines
+        let out = trimmed(&arc.output());
+        let err = trimmed(
+            &arc.pipelines
                 .last()
                 .and_then(|p| p.stages.last())
                 .map(|s| s.stderr.render())
@@ -869,35 +941,21 @@ impl Shell {
         );
         let status = arc.status.to_string();
         let mut state = self.lock();
-        state.vars.insert(format!("o{id}"), out.clone());
-        state.vars.insert(format!("e{id}"), err.clone());
-        state.vars.insert(format!("s{id}"), status.clone());
         state.vars.insert("o".to_owned(), out);
         state.vars.insert("e".to_owned(), err);
         state.vars.insert("s".to_owned(), status);
-        for stage in arc.stages() {
-            state
-                .vars
-                .insert(format!("o{id}_{}", stage.index), trim(stage.stdout.render()));
-            state
-                .vars
-                .insert(format!("e{id}_{}", stage.index), trim(stage.stderr.render()));
-        }
         state.runs.push_back(arc);
         while state.runs.len() > self.inner.config.keep_runs {
-            if let Some(evicted) = state.runs.pop_front() {
-                let old = evicted.id;
-                state.vars.remove(&format!("o{old}"));
-                state.vars.remove(&format!("e{old}"));
-                state.vars.remove(&format!("s{old}"));
-                for stage in evicted.stages() {
-                    state.vars.remove(&format!("o{old}_{}", stage.index));
-                    state.vars.remove(&format!("e{old}_{}", stage.index));
-                }
-            }
+            state.runs.pop_front();
         }
         drop(state);
     }
+}
+
+/// Capture text with trailing newlines trimmed, the ergonomic form for
+/// variable-shaped reuse (mirrors `$(...)` trimming).
+fn trimmed(text: &str) -> String {
+    text.trim_end_matches('\n').to_owned()
 }
 
 /// A word after variable/substitution expansion, with the parallel glob

--- a/packages/plumb/core/src/tests.rs
+++ b/packages/plumb/core/src/tests.rs
@@ -25,11 +25,12 @@ fn pipeline_captures_every_stage() {
     assert_eq!(stages.len(), 2);
     assert_eq!(stages[0].stdout.render(), "hello\n");
     assert_eq!(stages[1].stdout.render(), "HELLO\n");
-    // Auto-bound variables, including the intermediate pipe data.
-    assert_eq!(sh.var("o1").as_deref(), Some("HELLO"));
-    assert_eq!(sh.var("o1_0").as_deref(), Some("hello"));
-    assert_eq!(sh.var("s1").as_deref(), Some("0"));
+    // The run is addressable afterwards, including intermediate pipe data.
     assert_eq!(sh.var("o").as_deref(), Some("HELLO"));
+    let reuse = sh
+        .eval("echo ${o[1][0]} then ${o[1]} exit ${s[1]}")
+        .expect("reuse");
+    assert_eq!(reuse.output(), "hello then HELLO exit 0\n");
 }
 
 #[test]
@@ -53,7 +54,9 @@ fn stderr_capture_and_merge() {
     let sh = shell();
     let report = sh.eval("sh -c 'echo oops >&2'").expect("eval");
     assert_eq!(report.pipelines[0].stages[0].stderr.render(), "oops\n");
-    assert_eq!(sh.var("e1").as_deref(), Some("oops"));
+    assert_eq!(sh.var("e").as_deref(), Some("oops"));
+    let reuse = sh.eval("echo saw:${e[1]}").expect("reuse");
+    assert_eq!(reuse.output(), "saw:oops\n");
 
     let merged = sh.eval("sh -c 'echo mixed >&2' 2>&1 | cat").expect("eval");
     let stages = &merged.pipelines[0].stages;
@@ -74,8 +77,9 @@ fn redirections_write_and_read_files() {
     sh.eval("echo second >> f.txt").expect("append");
     let report = sh.eval("cat < f.txt").expect("read");
     assert_eq!(report.output(), "first\nsecond\n");
-    // The redirected stream was still captured.
-    assert_eq!(sh.var("o1").as_deref(), Some("first"));
+    // The redirected stream was still captured and stays addressable.
+    let captured = sh.eval("echo ${o[1]}").expect("reuse");
+    assert_eq!(captured.output(), "first\n");
     std::fs::remove_dir_all(&dir).expect("cleanup");
 }
 
@@ -122,7 +126,7 @@ fn command_substitution_feeds_arguments() {
 fn auto_bound_variables_cross_runs() {
     let sh = shell();
     sh.eval("echo alpha | tr a-z A-Z").expect("first");
-    let report = sh.eval("echo $o1 and $o1_0").expect("second");
+    let report = sh.eval("echo ${o[1]} and ${o[1][0]}").expect("second");
     assert_eq!(report.output(), "ALPHA and alpha\n");
 }
 
@@ -196,7 +200,10 @@ fn background_runs_share_state_and_wait_joins() {
     let bg_id = report.background_started[0];
     let bg = sh.report(bg_id).expect("background report committed");
     assert_eq!(bg.output(), "bg-value\n");
-    assert_eq!(sh.var(&format!("o{bg_id}")).as_deref(), Some("bg-value"));
+    let reuse = sh
+        .eval(&format!("echo ${{o[{bg_id}]}}"))
+        .expect("background run addressable");
+    assert_eq!(reuse.output(), "bg-value\n");
 }
 
 #[test]
@@ -249,7 +256,7 @@ fn quoting_reaches_argv_intact() {
 }
 
 #[test]
-fn keep_runs_evicts_old_variables() {
+fn keep_runs_evicts_old_runs() {
     let sh = Shell::new(Config {
         keep_runs: 2,
         ..Config::default()
@@ -258,9 +265,32 @@ fn keep_runs_evicts_old_variables() {
     sh.eval("echo one").expect("run 1");
     sh.eval("echo two").expect("run 2");
     sh.eval("echo three").expect("run 3");
-    assert_eq!(sh.var("o1"), None, "run 1 evicted");
-    assert_eq!(sh.var("o3").as_deref(), Some("three"));
+    assert!(
+        matches!(sh.eval("echo ${o[1]}"), Err(Error::RunRef { .. })),
+        "run 1 evicted"
+    );
+    let ok = sh.eval("echo ${o[3]}").expect("run 3 retained");
+    assert_eq!(ok.output(), "three\n");
     assert_eq!(sh.reports().len(), 2);
+}
+
+#[test]
+fn same_eval_self_reference() {
+    let report = shell()
+        .eval("echo alpha | tr a-z A-Z; echo again=${o[1][0]}")
+        .expect("eval");
+    assert_eq!(report.output(), "again=alpha\n");
+}
+
+#[test]
+fn negative_run_references() {
+    let sh = shell();
+    sh.eval("echo newest").expect("run 1");
+    let previous = sh.eval("echo prev=${o[-1]}").expect("run 2");
+    assert_eq!(previous.output(), "prev=newest\n");
+    sh.eval("echo hi | tr a-z A-Z").expect("run 3");
+    let stage = sh.eval("echo ${o[-1][-2]}").expect("run 4");
+    assert_eq!(stage.output(), "hi\n");
 }
 
 #[test]

--- a/packages/plumb/ex/mix/test/plumb_test.exs
+++ b/packages/plumb/ex/mix/test/plumb_test.exs
@@ -1,6 +1,6 @@
 defmodule PlumbTest do
   # Not async: evals share one OS process's children; keep runs ordered so
-  # the auto-bound $oN ids in assertions stay deterministic per shell.
+  # the run ids in ${o[N]} assertions stay deterministic per shell.
   use ExUnit.Case, async: false
 
   defp eventually(fun, timeout_ms \\ 2_000) do
@@ -45,9 +45,9 @@ defmodule PlumbTest do
   test "auto-bound variables cross evals and are readable from Elixir" do
     {:ok, shell} = Plumb.Shell.new()
     {:ok, _} = Plumb.Shell.eval(shell, "echo alpha")
-    report = decode!(Plumb.Shell.eval(shell, "echo $o1-more"))
+    report = decode!(Plumb.Shell.eval(shell, "echo ${o[1]}-more"))
     assert final_stdout(report) == "alpha-more\n"
-    assert Plumb.Shell.var(shell, "o1") == "alpha"
+    assert Plumb.Shell.var(shell, "o") == "alpha"
     assert Plumb.Shell.var(shell, "does-not-exist") == nil
   end
 

--- a/packages/plumb/syntax/src/ast.rs
+++ b/packages/plumb/syntax/src/ast.rs
@@ -32,10 +32,14 @@ pub enum Part {
         /// True when the text originated inside quotes or a backslash escape.
         quoted: bool,
     },
-    /// `$NAME` / `${NAME}` / `$?` variable reference.
+    /// `$NAME` / `${NAME}` / `$?` variable reference, or an indexed run
+    /// reference `${o[7]}` / `${o[7][0]}` (braced form only).
     Var {
         /// Variable name (`?` for the last-status special).
         name: String,
+        /// Indexes from `${NAME[i]}` / `${NAME[i][j]}`; empty for a plain
+        /// reference. Negative values count back from the latest.
+        indices: Vec<i64>,
         /// Location of the reference in the source.
         span: Span,
     },

--- a/packages/plumb/syntax/src/parse.rs
+++ b/packages/plumb/syntax/src/parse.rs
@@ -482,6 +482,7 @@ impl Parser<'_> {
                         None | Some(' ' | '\t' | '\n' | ';' | '|' | '&' | '<' | '>' | '/') => {
                             acc.push_part(Part::Var {
                                 name: "HOME".to_owned(),
+                                indices: Vec::new(),
                                 span: Span {
                                     start,
                                     end: self.byte_pos(),
@@ -572,6 +573,67 @@ impl Parser<'_> {
         }
     }
 
+    /// The braced form after `${`: a plain name, optionally indexed as a
+    /// run reference (`${o[7]}`, `${o[7][0]}`, negative from the latest).
+    fn braced(&mut self, acc: &mut WordAcc, start: usize) -> Result<bool, ParseError> {
+        let name = self.ident_run();
+        if name.is_empty() || name.starts_with(|c: char| c.is_ascii_digit()) {
+            return self.fail_at(
+                start,
+                "unsupported parameter expansion: only a plain variable name in braces"
+                    .to_owned(),
+            );
+        }
+        let mut indices = Vec::new();
+        while self.peek() == Some('[') {
+            if indices.len() == 2 {
+                return self.fail_at(
+                    start,
+                    "run references take at most two indexes: ${o[run][stage]}".to_owned(),
+                );
+            }
+            self.pos += 1;
+            let negative = self.peek() == Some('-');
+            if negative {
+                self.pos += 1;
+            }
+            let mut digits = String::new();
+            while let Some(c) = self.peek() {
+                if c.is_ascii_digit() {
+                    digits.push(c);
+                    self.pos += 1;
+                } else {
+                    break;
+                }
+            }
+            let (Ok(magnitude), Some(']')) = (digits.parse::<i64>(), self.peek()) else {
+                return self.fail_at(
+                    start,
+                    "run reference indexes are integers: ${o[7]} or ${o[-1]}".to_owned(),
+                );
+            };
+            self.pos += 1;
+            indices.push(if negative { -magnitude } else { magnitude });
+        }
+        if self.peek() != Some('}') {
+            return self.fail_at(
+                start,
+                "unsupported parameter expansion: only a plain variable name in braces"
+                    .to_owned(),
+            );
+        }
+        self.pos += 1;
+        acc.push_part(Part::Var {
+            name,
+            indices,
+            span: Span {
+                start,
+                end: self.byte_pos(),
+            },
+        });
+        Ok(true)
+    }
+
     /// Consume a run of identifier characters (`[A-Za-z0-9_]*`).
     fn ident_run(&mut self) -> String {
         let mut name = String::new();
@@ -614,31 +676,13 @@ impl Parser<'_> {
             }
             Some('{') => {
                 self.pos += 2;
-                let name = self.ident_run();
-                let plain = self.peek() == Some('}')
-                    && !name.is_empty()
-                    && !name.starts_with(|c: char| c.is_ascii_digit());
-                if !plain {
-                    return self.fail_at(
-                        start,
-                        "unsupported parameter expansion: only a plain variable name in braces"
-                            .to_owned(),
-                    );
-                }
-                self.pos += 1;
-                acc.push_part(Part::Var {
-                    name,
-                    span: Span {
-                        start,
-                        end: self.byte_pos(),
-                    },
-                });
-                Ok(true)
+                self.braced(acc, start)
             }
             Some('?') => {
                 self.pos += 2;
                 acc.push_part(Part::Var {
                     name: "?".to_owned(),
+                    indices: Vec::new(),
                     span: Span {
                         start,
                         end: self.byte_pos(),
@@ -651,6 +695,7 @@ impl Parser<'_> {
                 let name = self.ident_run();
                 acc.push_part(Part::Var {
                     name,
+                    indices: Vec::new(),
                     span: Span {
                         start,
                         end: self.byte_pos(),
@@ -761,6 +806,48 @@ mod tests {
         assert_eq!(names, ["FOO", "BAR", "?"]);
     }
 
+    /// Each source must fail to parse with a message naming the construct.
+    fn assert_parse_errors(cases: &[(&str, &str)]) {
+        for (src, needle) in cases {
+            let error = parse(src).expect_err(src);
+            assert!(
+                error.message.contains(needle),
+                "{src:?}: {} should mention {needle:?}",
+                error.message
+            );
+        }
+    }
+
+    #[test]
+    fn run_references() {
+        let command = one_command("echo ${o[7]} ${e[7][0]} ${s[-1]}");
+        let refs: Vec<(&str, &[i64])> = command.words[1..]
+            .iter()
+            .map(|w| match &w.parts[0] {
+                Part::Var { name, indices, .. } => (name.as_str(), indices.as_slice()),
+                other => panic!("expected var, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            refs,
+            [
+                ("o", [7_i64].as_slice()),
+                ("e", [7_i64, 0].as_slice()),
+                ("s", [-1_i64].as_slice())
+            ]
+        );
+    }
+
+    #[test]
+    fn run_reference_errors() {
+        assert_parse_errors(&[
+            ("echo ${o[1][2][3]}", "at most two"),
+            ("echo ${o[x]}", "integers"),
+            ("echo ${o[1}", "integers"),
+            ("echo ${o[]}", "integers"),
+        ]);
+    }
+
     #[test]
     fn tilde_is_home() {
         let command = one_command("ls ~/src");
@@ -851,7 +938,7 @@ mod tests {
     #[test]
     fn unsupported_constructs_error_loudly() {
         let fancy_expansion = concat!("echo ${", "X:-default}");
-        for (src, needle) in [
+        assert_parse_errors(&[
             ("if true; then echo hi; fi", "keyword `if`"),
             ("for x in a b; do echo $x; done", "keyword `for`"),
             ("echo `date`", "backtick"),
@@ -866,14 +953,7 @@ mod tests {
             ("a |& b", "|&"),
             ("case x in esac", "keyword `case`"),
             ("diff <(sort a) <(sort b)", "process substitution"),
-        ] {
-            let error = parse(src).expect_err(src);
-            assert!(
-                error.message.contains(needle),
-                "{src:?}: {} should mention {needle:?}",
-                error.message
-            );
-        }
+        ]);
     }
 
     #[test]

--- a/packages/site/src/lib/updates/plumb-shell.svx
+++ b/packages/site/src/lib/updates/plumb-shell.svx
@@ -16,9 +16,9 @@ tags:
 `packages/plumb` is a bash-subset shell built library-first for LLM agents. Run
 `cargo clippy 2>&1 | tail -n 5` and the run comes back as a value: per-stage
 argv, status, timing, and bounded captures of every stream, including what each
-pipe stage fed the next. Outputs auto-bind to variables (`$o1_0` is everything
-`tail` consumed), so a later command can reuse any earlier stream without
-re-running it.
+pipe stage fed the next. Every stream stays addressable afterwards (`${o[1][0]}` is
+everything `tail` consumed, negative indexes count from the latest), so a
+later command can reuse any earlier stream without re-running it.
 
 Three crates: `plumb-syntax` (spanned parser; unsupported bash is a loud error,
 never a misparse), `plumb-core` (cloneable `Shell` over shared state, tee'd


### PR DESCRIPTION
Follow-up to #3579 / stacked on #3592 (its commits show in this diff until it merges; will be rebased onto main then). Addresses Andrew's review of the run-addressing syntax and the hero graphic.

**`${o[N][K]}` replaces `$oN_K`.** Runs are addressed through the run history itself, array-style:

- `${o[7]}` / `${e[7]}` / `${s[7]}`: run 7's final stdout / stderr / status
- `${o[7][0]}`: what pipe stage 0 printed (exactly what stage 1 consumed)
- `${o[-1]}`, `${o[-1][-2]}`: negative indexes count back from the latest
- the in-progress run participates once it has stages, so `a | b; use ${o[1][0]}` works within one eval
- flat `oN`/`eN`/`sN`/`oN_K` auto-variables are gone; only the `$o`/`$e`/`$s` aliases remain in the variable map

Braces are required for indexing on purpose: bare `$o[7]` in bash means `$o` + glob `[7]`, and plumb keeps that loud. `${o[7]}` is valid bash array syntax, so the shape is familiar; a resolution failure is a hard error (`Error::RunRef`), never empty expansion.

**Hero + README redesigned**: the graphic now walks the actual flow (typed `cargo clippy | tail -n 5`, decomposed pipeline with labeled stream taps, "run 7, kept as a value" with one row per addressable piece, reuse command with "nothing re-runs"), and the README examples all use the new addressing.

Validated: 47 crate tests, local clippy (org-fork lints pattern-checked), clone diff gate 0/822, repo lint 10/10, functional smoke of same-eval and negative references. plumb-ex ExUnit assertions updated to the new syntax.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add array-style run references `${o[N][K]}` to plumb shell and redesign hero
> - Replaces numbered auto-bound variables (`$o1`, `$o1_0`, etc.) with bracketed index syntax: `${o[N]}`, `${e[N]}`, `${s[N]}`, and `${o[N][K]}` for per-stage access; negative indices count back from the latest run.
> - Parser in [parse.rs](https://github.com/indexable-inc/index/pull/3593/files#diff-4e86a159f04929e761706e7a98e30545476b684c8d507cea38a3fadb7ae4f0af) gains a `braced` method that validates the new grammar and returns descriptive errors for malformed expressions.
> - A new `run_ref` method in [shell.rs](https://github.com/indexable-inc/index/pull/3593/files#diff-25dceb51aa6bcac5a8e77d4d7c746fea79d2cc39f63485251dae589435f90eef) resolves indexed references at expansion time; a `trimmed` helper centralises trailing-newline removal.
> - Adds `Error::RunRef` variant in [error.rs](https://github.com/indexable-inc/index/pull/3593/files#diff-e7b5ee4282d813fab8b174e785b5dc1336ed9641bca272ea79c708b4390de96a) for failures during run reference resolution.
> - Behavioral Change: `commit` no longer auto-binds numbered variables (`oN`, `eN`, `sN`, `oN_K`); existing scripts using those forms will break and must migrate to the bracketed syntax.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61d8c53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->