### PR TITLE
plumb: structured run paths ${runs[N].stages[K].field}

### DIFF
--- a/packages/plumb/cli/README.md
+++ b/packages/plumb/cli/README.md
@@ -27,6 +27,7 @@ Every run stays addressable:
 | `${o[7]}` / `${e[7]}` / `${s[7]}` | run 7's final stdout / stderr / status |
 | `${o[7][0]}` | what pipe stage 0 printed (exactly what stage 1 consumed) |
 | `${o[-1]}`, `${o[-1][-2]}` | negative indexes count back from the latest |
+| `${runs[7].stages[0].stdout}` | structured paths, field names matching the report JSON (`output`, `status`, `argv`, `duration_ms`, `stdout_bytes`, ...) |
 | `$o` / `$e` / `$s` | the last run's stdout / stderr / status |
 | `$?` | last status, as in bash |
 

--- a/packages/plumb/cli/src/main.rs
+++ b/packages/plumb/cli/src/main.rs
@@ -19,7 +19,8 @@ use plumb_core::{Config, Error, Shell};
                   argv, status, timing, and captured stdout/stderr (including what each pipe \
                   stage fed the next). Runs stay addressable afterwards: ${o[N]}/${e[N]}/${s[N]} \
                   for run N, ${o[N][K]} per pipe stage, negative indexes count from the latest, \
-                  and $o/$e/$s alias the last run."
+                  and $o/$e/$s alias the last run. Structured paths ${runs[N].stages[K].stdout} \
+                  mirror the report JSON field names."
 )]
 struct Args {
     /// Evaluate this source string and exit.

--- a/packages/plumb/core/src/shell.rs
+++ b/packages/plumb/core/src/shell.rs
@@ -8,8 +8,8 @@ use std::thread::JoinHandle;
 use std::time::Instant;
 
 use plumb_syntax::{
-    AndOr, Command as AstCommand, Connector, Part, Pipeline as AstPipeline, Program, RedirOp,
-    Word, parse,
+    AndOr, Command as AstCommand, Connector, Part, PathSeg, Pipeline as AstPipeline, Program,
+    RedirOp, Word, parse,
 };
 
 use crate::engine::{
@@ -795,9 +795,9 @@ impl Shell {
                         }
                     }
                 }
-                Part::Var { name, indices, .. } => {
-                    let value = if !indices.is_empty() {
-                        self.run_ref(name, indices, report)?
+                Part::Var { name, path, .. } => {
+                    let value = if !path.is_empty() {
+                        self.run_ref(name, path, report)?
                     } else if name == "?" {
                         self.lock().last_status.to_string()
                     } else {
@@ -852,18 +852,27 @@ impl Shell {
         Ok(value.trim_end_matches('\n').to_owned())
     }
 
-    /// Resolve a `${o[run]}` / `${o[run][stage]}` reference. A non-negative
-    /// run index is a run id; a negative one counts back from the latest
-    /// (`-1` = latest). The run being evaluated participates once it has
-    /// stages, so `a | b; use ${o[1][0]}` works within one eval. The stage
-    /// index is a stage number as shown in summaries, negative counting
-    /// from the last stage.
-    fn run_ref(&self, name: &str, indices: &[i64], current: &Report) -> Result<String, Error> {
-        if !matches!(name, "o" | "e" | "s") {
+    /// Resolve a run reference: the terse `${o[run]}` / `${o[run][stage]}`
+    /// shorthands and the structured `${runs[run]...}` paths whose field
+    /// names mirror the report JSON. A non-negative run index is a run id;
+    /// a negative one counts back from the latest (`-1` = latest). The run
+    /// being evaluated participates once it has stages, so
+    /// `a | b; use ${o[1][0]}` works within one eval. Stage indexes are the
+    /// numbers shown in summaries, negative counting from the last stage.
+    fn run_ref(&self, name: &str, path: &[PathSeg], current: &Report) -> Result<String, Error> {
+        let shorthand = matches!(name, "o" | "e" | "s");
+        if !shorthand && name != "runs" {
             return Err(Error::RunRef {
-                message: format!("`{name}` is not indexable; only ${{o[..]}}, ${{e[..]}}, ${{s[..]}}"),
+                message: format!(
+                    "`{name}` is not structured; use ${{o[..]}}, ${{e[..]}}, ${{s[..]}} or ${{runs[..]}} paths"
+                ),
             });
         }
+        let Some(PathSeg::Index(run_index)) = path.first() else {
+            return Err(Error::RunRef {
+                message: "select a run first: ${runs[7]...} or ${runs[-1]...}".to_owned(),
+            });
+        };
         let retained: Vec<Arc<Report>> = {
             let state = self.lock();
             state.runs.iter().cloned().collect()
@@ -872,19 +881,15 @@ impl Shell {
         if current.stages().next().is_some() {
             candidates.push(current);
         }
-        let run_index = indices[0];
-        let run = if run_index < 0 {
-            let back = usize::try_from(-(run_index + 1)).map_err(|_| Error::RunRef {
-                message: format!("index {run_index} out of range"),
-            })?;
-            candidates
-                .len()
-                .checked_sub(back + 1)
+        let run = if *run_index < 0 {
+            usize::try_from(-(run_index + 1))
+                .ok()
+                .and_then(|back| candidates.len().checked_sub(back + 1))
                 .and_then(|position| candidates.get(position))
         } else {
             candidates
                 .iter()
-                .find(|report| i64::try_from(report.id) == Ok(run_index))
+                .find(|report| i64::try_from(report.id) == Ok(*run_index))
         };
         let Some(run) = run else {
             return Err(Error::RunRef {
@@ -892,39 +897,51 @@ impl Shell {
             });
         };
         let stages: Vec<&Stage> = run.stages().collect();
-        let stage = match indices.get(1) {
-            None => stages.last().copied(),
-            Some(stage_index) if *stage_index < 0 => usize::try_from(-(stage_index + 1))
-                .ok()
-                .and_then(|back| stages.len().checked_sub(back + 1))
-                .and_then(|position| stages.get(position).copied()),
-            Some(stage_index) => stages
-                .iter()
-                .find(|stage| i64::try_from(stage.index) == Ok(*stage_index))
-                .copied(),
-        };
-        let Some(stage) = stage else {
-            return Err(Error::RunRef {
-                message: format!("run {} has no stage {}", run.id, indices[1]),
-            });
-        };
-        let value = match (name, indices.len()) {
-            // For the in-progress run, `status` is not final yet; the last
-            // pipeline's status is the honest answer for both cases.
-            ("s", 1) => run
-                .pipelines
-                .last()
-                .map_or(run.status, |pipeline| pipeline.status)
-                .to_string(),
-            ("s", _) => stage.status.to_string(),
-            ("o", _) => trimmed(&stage.stdout.render()),
-            (_, _) => trimmed(&stage.stderr.render()),
-        };
-        Ok(value)
+        if shorthand {
+            let stage_index = match &path[1..] {
+                [] => None,
+                [PathSeg::Index(stage_index)] => Some(*stage_index),
+                _ => {
+                    return Err(Error::RunRef {
+                        message: format!(
+                            "the `{name}` shorthand takes indexes only: ${{{name}[7]}} or ${{{name}[7][0]}}"
+                        ),
+                    });
+                }
+            };
+            let stage = select_stage(&stages, stage_index).ok_or_else(|| Error::RunRef {
+                message: format!("run {} has no stage {:?}", run.id, stage_index),
+            })?;
+            let value = match (name, stage_index) {
+                ("s", None) => pipeline_status(run).to_string(),
+                ("s", Some(_)) => stage.status.to_string(),
+                ("o", _) => trimmed(&stage.stdout.render()),
+                (_, _) => trimmed(&stage.stderr.render()),
+            };
+            return Ok(value);
+        }
+        match &path[1..] {
+            [] => Err(Error::RunRef {
+                message: "pick a run field: .output, .stderr, .status, .id, .source, .duration_ms, or .stages[K].<field>"
+                    .to_owned(),
+            }),
+            [PathSeg::Field(field)] if field != "stages" => run_leaf(run, &stages, field),
+            [PathSeg::Field(stages_field), PathSeg::Index(stage_index), PathSeg::Field(field)]
+                if stages_field == "stages" =>
+            {
+                let stage =
+                    select_stage(&stages, Some(*stage_index)).ok_or_else(|| Error::RunRef {
+                        message: format!("run {} has no stage {stage_index}", run.id),
+                    })?;
+                stage_leaf(stage, field)
+            }
+            _ => Err(Error::RunRef {
+                message: "unsupported path; shapes: ${runs[N].output} or ${runs[N].stages[K].stdout}"
+                    .to_owned(),
+            }),
+        }
     }
 
-    /// Commit a finished run: store the report and auto-bind its outputs.
-    ///
     /// The run history itself is the addressable surface: `${o[N]}` /
     /// `${e[N]}` / `${s[N]}` (and `[N][K]` per stage) resolve against it in
     /// [`Self::run_ref`]. Only the unnumbered `$o` / `$e` / `$s` aliases
@@ -950,6 +967,78 @@ impl Shell {
         }
         drop(state);
     }
+}
+
+/// Select a stage by summary index (negative from the end); `None` picks
+/// the final stage.
+fn select_stage<'stages>(
+    stages: &[&'stages Stage],
+    selector: Option<i64>,
+) -> Option<&'stages Stage> {
+    match selector {
+        None => stages.last().copied(),
+        Some(index) if index < 0 => usize::try_from(-(index + 1))
+            .ok()
+            .and_then(|back| stages.len().checked_sub(back + 1))
+            .and_then(|position| stages.get(position).copied()),
+        Some(index) => stages
+            .iter()
+            .find(|stage| i64::try_from(stage.index) == Ok(index))
+            .copied(),
+    }
+}
+
+/// The honest status for finished and in-progress runs alike: the last
+/// pipeline's status.
+fn pipeline_status(run: &Report) -> i32 {
+    run.pipelines
+        .last()
+        .map_or(run.status, |pipeline| pipeline.status)
+}
+
+/// A `${runs[N].<field>}` leaf.
+fn run_leaf(run: &Report, stages: &[&Stage], field: &str) -> Result<String, Error> {
+    let value = match field {
+        "output" => trimmed(&run.output()),
+        "stderr" => stages
+            .last()
+            .map(|stage| trimmed(&stage.stderr.render()))
+            .unwrap_or_default(),
+        "status" => pipeline_status(run).to_string(),
+        "id" => run.id.to_string(),
+        "source" => run.source.clone(),
+        "duration_ms" => run.duration_ms.to_string(),
+        _ => {
+            return Err(Error::RunRef {
+                message: format!(
+                    "unknown run field `{field}` (have: output, stderr, status, id, source, duration_ms, stages)"
+                ),
+            });
+        }
+    };
+    Ok(value)
+}
+
+/// A `${runs[N].stages[K].<field>}` leaf.
+fn stage_leaf(stage: &Stage, field: &str) -> Result<String, Error> {
+    let value = match field {
+        "stdout" => trimmed(&stage.stdout.render()),
+        "stderr" => trimmed(&stage.stderr.render()),
+        "status" => stage.status.to_string(),
+        "argv" => stage.argv.join(" "),
+        "duration_ms" => stage.duration_ms.to_string(),
+        "index" => stage.index.to_string(),
+        "stdout_bytes" => stage.stdout.total_bytes().to_string(),
+        "stderr_bytes" => stage.stderr.total_bytes().to_string(),
+        _ => {
+            return Err(Error::RunRef {
+                message: format!(
+                    "unknown stage field `{field}` (have: stdout, stderr, status, argv, duration_ms, index, stdout_bytes, stderr_bytes)"
+                ),
+            });
+        }
+    };
+    Ok(value)
 }
 
 /// Capture text with trailing newlines trimmed, the ergonomic form for

--- a/packages/plumb/core/src/tests.rs
+++ b/packages/plumb/core/src/tests.rs
@@ -283,6 +283,33 @@ fn same_eval_self_reference() {
 }
 
 #[test]
+fn structured_run_paths() {
+    let sh = shell();
+    sh.eval("echo alpha | tr a-z A-Z").expect("run 1");
+    let report = sh
+        .eval("echo ${runs[1].output} ${runs[1].stages[0].stdout} ${runs[1].status} ${runs[-1].stages[-1].argv}")
+        .expect("paths");
+    assert_eq!(report.output(), "ALPHA alpha 0 tr a-z A-Z\n");
+    let bytes = sh
+        .eval("echo ${runs[1].stages[0].stdout_bytes}")
+        .expect("bytes");
+    assert_eq!(bytes.output(), "6\n");
+    for src in [
+        "echo ${runs[1]}",
+        "echo ${runs[1].nope}",
+        "echo ${runs[1].stages[0].nope}",
+        "echo ${runs[1].stages[0]}",
+        "echo ${runs.output}",
+        "echo ${HOME[0]}",
+    ] {
+        assert!(
+            matches!(sh.eval(src), Err(Error::RunRef { .. })),
+            "{src} should be a run-reference error"
+        );
+    }
+}
+
+#[test]
 fn negative_run_references() {
     let sh = shell();
     sh.eval("echo newest").expect("run 1");

--- a/packages/plumb/syntax/src/ast.rs
+++ b/packages/plumb/syntax/src/ast.rs
@@ -32,14 +32,14 @@ pub enum Part {
         /// True when the text originated inside quotes or a backslash escape.
         quoted: bool,
     },
-    /// `$NAME` / `${NAME}` / `$?` variable reference, or an indexed run
-    /// reference `${o[7]}` / `${o[7][0]}` (braced form only).
+    /// `$NAME` / `${NAME}` / `$?` variable reference, or a run reference:
+    /// the terse `${o[7]}` / `${o[7][0]}` forms and the structured
+    /// `${runs[7].stages[0].stdout}` paths (braced form only).
     Var {
         /// Variable name (`?` for the last-status special).
         name: String,
-        /// Indexes from `${NAME[i]}` / `${NAME[i][j]}`; empty for a plain
-        /// reference. Negative values count back from the latest.
-        indices: Vec<i64>,
+        /// Path segments after the name; empty for a plain reference.
+        path: Vec<PathSeg>,
         /// Location of the reference in the source.
         span: Span,
     },
@@ -50,6 +50,15 @@ pub enum Part {
         /// Location of the substitution in the source.
         span: Span,
     },
+}
+
+/// One step of a run-reference path: `[7]` or `.stdout`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PathSeg {
+    /// `[i]`: negative values count back from the latest.
+    Index(i64),
+    /// `.name`
+    Field(String),
 }
 
 /// A single shell word: the concatenation of its parts.

--- a/packages/plumb/syntax/src/lib.rs
+++ b/packages/plumb/syntax/src/lib.rs
@@ -11,7 +11,7 @@ mod ast;
 mod parse;
 
 pub use ast::{
-    Assign, AndOr, AndOrTail, Command, Connector, Item, Part, Pipeline, Program, Redirect,
-    RedirOp, Span, Word,
+    AndOr, AndOrTail, Assign, Command, Connector, Item, Part, PathSeg, Pipeline, Program,
+    RedirOp, Redirect, Span, Word,
 };
 pub use parse::{parse, ParseError};

--- a/packages/plumb/syntax/src/parse.rs
+++ b/packages/plumb/syntax/src/parse.rs
@@ -5,8 +5,8 @@
 use snafu::Snafu;
 
 use crate::ast::{
-    AndOr, AndOrTail, Assign, Command, Connector, Item, Part, Pipeline, Program, RedirOp,
-    Redirect, Span, Word,
+    AndOr, AndOrTail, Assign, Command, Connector, Item, Part, PathSeg, Pipeline, Program,
+    RedirOp, Redirect, Span, Word,
 };
 
 /// Parse failure: an unsupported construct or malformed input, with the byte
@@ -482,7 +482,7 @@ impl Parser<'_> {
                         None | Some(' ' | '\t' | '\n' | ';' | '|' | '&' | '<' | '>' | '/') => {
                             acc.push_part(Part::Var {
                                 name: "HOME".to_owned(),
-                                indices: Vec::new(),
+                                path: Vec::new(),
                                 span: Span {
                                     start,
                                     end: self.byte_pos(),
@@ -584,36 +584,48 @@ impl Parser<'_> {
                     .to_owned(),
             );
         }
-        let mut indices = Vec::new();
-        while self.peek() == Some('[') {
-            if indices.len() == 2 {
-                return self.fail_at(
-                    start,
-                    "run references take at most two indexes: ${o[run][stage]}".to_owned(),
-                );
-            }
-            self.pos += 1;
-            let negative = self.peek() == Some('-');
-            if negative {
-                self.pos += 1;
-            }
-            let mut digits = String::new();
-            while let Some(c) = self.peek() {
-                if c.is_ascii_digit() {
-                    digits.push(c);
+        let mut path = Vec::new();
+        loop {
+            match self.peek() {
+                Some('[') => {
                     self.pos += 1;
-                } else {
-                    break;
+                    let negative = self.peek() == Some('-');
+                    if negative {
+                        self.pos += 1;
+                    }
+                    let mut digits = String::new();
+                    while let Some(c) = self.peek() {
+                        if c.is_ascii_digit() {
+                            digits.push(c);
+                            self.pos += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    let (Ok(magnitude), Some(']')) = (digits.parse::<i64>(), self.peek())
+                    else {
+                        return self.fail_at(
+                            start,
+                            "run reference indexes are integers: ${o[7]} or ${o[-1]}"
+                                .to_owned(),
+                        );
+                    };
+                    self.pos += 1;
+                    path.push(PathSeg::Index(if negative { -magnitude } else { magnitude }));
                 }
+                Some('.') => {
+                    self.pos += 1;
+                    let field = self.ident_run();
+                    if field.is_empty() {
+                        return self.fail_at(
+                            start,
+                            "expected a field name after `.` in a run reference".to_owned(),
+                        );
+                    }
+                    path.push(PathSeg::Field(field));
+                }
+                _ => break,
             }
-            let (Ok(magnitude), Some(']')) = (digits.parse::<i64>(), self.peek()) else {
-                return self.fail_at(
-                    start,
-                    "run reference indexes are integers: ${o[7]} or ${o[-1]}".to_owned(),
-                );
-            };
-            self.pos += 1;
-            indices.push(if negative { -magnitude } else { magnitude });
         }
         if self.peek() != Some('}') {
             return self.fail_at(
@@ -625,7 +637,7 @@ impl Parser<'_> {
         self.pos += 1;
         acc.push_part(Part::Var {
             name,
-            indices,
+            path,
             span: Span {
                 start,
                 end: self.byte_pos(),
@@ -682,7 +694,7 @@ impl Parser<'_> {
                 self.pos += 2;
                 acc.push_part(Part::Var {
                     name: "?".to_owned(),
-                    indices: Vec::new(),
+                    path: Vec::new(),
                     span: Span {
                         start,
                         end: self.byte_pos(),
@@ -695,7 +707,7 @@ impl Parser<'_> {
                 let name = self.ident_run();
                 acc.push_part(Part::Var {
                     name,
-                    indices: Vec::new(),
+                    path: Vec::new(),
                     span: Span {
                         start,
                         end: self.byte_pos(),
@@ -724,7 +736,7 @@ fn unquoted_literal(word: &Word) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse, Command, Connector, Part, RedirOp};
+    use super::{parse, Command, Connector, Part, PathSeg, RedirOp};
 
     fn one_command(src: &str) -> Command {
         let program = parse(src).expect("should parse");
@@ -821,28 +833,58 @@ mod tests {
     #[test]
     fn run_references() {
         let command = one_command("echo ${o[7]} ${e[7][0]} ${s[-1]}");
-        let refs: Vec<(&str, &[i64])> = command.words[1..]
+        let refs: Vec<(&str, Vec<PathSeg>)> = command.words[1..]
             .iter()
             .map(|w| match &w.parts[0] {
-                Part::Var { name, indices, .. } => (name.as_str(), indices.as_slice()),
+                Part::Var { name, path, .. } => (name.as_str(), path.clone()),
                 other => panic!("expected var, got {other:?}"),
             })
             .collect();
         assert_eq!(
             refs,
             [
-                ("o", [7_i64].as_slice()),
-                ("e", [7_i64, 0].as_slice()),
-                ("s", [-1_i64].as_slice())
+                ("o", vec![PathSeg::Index(7)]),
+                ("e", vec![PathSeg::Index(7), PathSeg::Index(0)]),
+                ("s", vec![PathSeg::Index(-1)])
             ]
         );
     }
 
     #[test]
+    fn structured_run_paths() {
+        let command = one_command("echo ${runs[7].stages[0].stdout} ${runs[-1].status}");
+        match &command.words[1].parts[0] {
+            Part::Var { name, path, .. } => {
+                assert_eq!(name, "runs");
+                assert_eq!(
+                    path,
+                    &vec![
+                        PathSeg::Index(7),
+                        PathSeg::Field("stages".to_owned()),
+                        PathSeg::Index(0),
+                        PathSeg::Field("stdout".to_owned())
+                    ]
+                );
+            }
+            other => panic!("expected var, got {other:?}"),
+        }
+        match &command.words[2].parts[0] {
+            Part::Var { name, path, .. } => {
+                assert_eq!(name, "runs");
+                assert_eq!(
+                    path,
+                    &vec![PathSeg::Index(-1), PathSeg::Field("status".to_owned())]
+                );
+            }
+            other => panic!("expected var, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn run_reference_errors() {
         assert_parse_errors(&[
-            ("echo ${o[1][2][3]}", "at most two"),
             ("echo ${o[x]}", "integers"),
+            ("echo ${runs[1].}", "field name"),
             ("echo ${o[1}", "integers"),
             ("echo ${o[]}", "integers"),
         ]);


### PR DESCRIPTION
Follow-up to #3593, from Andrew's structs idea (nushell prior art, minus the parts that bias models).

Structured run paths inside `${...}`, field names mirroring the report JSON one-to-one:

- `${runs[7].output}` `${runs[7].status}` `${runs[7].stderr}` `${runs[7].id}` `${runs[7].source}` `${runs[7].duration_ms}`
- `${runs[7].stages[0].stdout}` `.stderr` `.status` `.argv` `.duration_ms` `.index` `.stdout_bytes` `.stderr_bytes`
- negative indexes as everywhere (`${runs[-1].stages[-1].argv}`)

Design boundary on purpose: this is nushell's records idea applied to *addressing only*. Execution stays bash-shaped (pipes are bytes, `2>&1` is `2>&1`), so models never hit nushell-style redirection confusion; the structure they read here is the same structure `--json` and `Plumb.Shell.eval/2` already return. Terse `${o[N][K]}` shorthands remain for the common case. Wrong paths fail loudly with the valid field list in the message.

Validated: 49 crate tests (incl. path grammar, resolution, and error-shape cases), functional smoke, clippy clean, clone diff gate 0/271, lint 10/10.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured run reference paths `${runs[N].stages[K].field}` to plumb variable expansion
> - Extends the plumb variable expansion syntax to support structured paths like `${runs[N].stages[K].stdout}` and `${runs[N].<field>}`, mirroring the report JSON field names alongside the existing `$o`/`$e`/`$s` shorthands.
> - The parser ([parse.rs](https://github.com/indexable-inc/index/pull/3595/files#diff-4e86a159f04929e761706e7a98e30545476b684c8d507cea38a3fadb7ae4f0af)) replaces `indices: Vec<i64>` with `path: Vec<PathSeg>` (either `Index(i64)` or `Field(String)`) in the `Part::Var` AST node, removing the previous two-index cap.
> - The resolver ([shell.rs](https://github.com/indexable-inc/index/pull/3595/files#diff-25dceb51aa6bcac5a8e77d4d7c746fea79d2cc39f63485251dae589435f90eef)) adds `run_leaf` and `stage_leaf` helpers that return specific fields: `output`, `stderr`, `status`, `id`, `source`, `duration_ms`, `stdout`, `argv`, `index`, `stdout_bytes`, `stderr_bytes`.
> - Behavioral Change: shorthand `${o/e/s[N][K]}` forms now reject non-index path segments; malformed structured references (e.g. missing field name after `.`) return `RunRef` errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a335be1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->