### PR TITLE
plumb: per-stage wall timestamps and rusage cpu times

### DIFF
--- a/packages/plumb/cli/README.md
+++ b/packages/plumb/cli/README.md
@@ -27,7 +27,7 @@ Every run stays addressable:
 | `${o[7]}` / `${e[7]}` / `${s[7]}` | run 7's final stdout / stderr / status |
 | `${o[7][0]}` | what pipe stage 0 printed (exactly what stage 1 consumed) |
 | `${o[-1]}`, `${o[-1][-2]}` | negative indexes count back from the latest |
-| `${runs[7].stages[0].stdout}` | structured paths, field names matching the report JSON (`output`, `status`, `argv`, `duration_ms`, `stdout_bytes`, ...) |
+| `${runs[7].stages[0].stdout}` | structured paths, field names matching the report JSON (`output`, `status`, `argv`, `stdout_bytes`, `started_at_ms`/`ended_at_ms`, wall `duration_ms` and rusage `user_ms`/`sys_ms`, ...) |
 | `$o` / `$e` / `$s` | the last run's stdout / stderr / status |
 | `$?` | last status, as in bash |
 

--- a/packages/plumb/cli/src/repl.rs
+++ b/packages/plumb/cli/src/repl.rs
@@ -159,11 +159,13 @@ fn summarize(report: &Report) {
     }
     for stage in &stages {
         println!(
-            "[{}] {}  exit {}  {}ms  out {}  err {}",
+            "[{}] {}  exit {}  {}ms (cpu {}+{}ms)  out {}  err {}",
             stage.index,
             stage.argv.join(" "),
             stage.status,
             stage.duration_ms,
+            stage.user_ms,
+            stage.sys_ms,
             human_bytes(stage.stdout.total_bytes()),
             human_bytes(stage.stderr.total_bytes()),
         );

--- a/packages/plumb/core/src/engine.rs
+++ b/packages/plumb/core/src/engine.rs
@@ -9,7 +9,6 @@
 
 use std::fs::{File, OpenOptions};
 use std::io::{PipeReader, PipeWriter, Read, Write};
-use std::os::unix::process::ExitStatusExt;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::thread::JoinHandle;
@@ -171,6 +170,7 @@ struct Running {
     stderr: StageStream,
     stderr_merged: bool,
     spawned_at: Instant,
+    started_at_ms: u64,
 }
 
 fn open_sink(sink: &FileSink) -> Result<File, Error> {
@@ -232,6 +232,7 @@ pub fn run_pipeline(
                     stderr: StageStream::Ready(Capture::new(0)),
                     stderr_merged: false,
                     spawned_at: Instant::now(),
+                    started_at_ms: crate::report::now_ms(),
                 }
             }
             StageSpec::Quiet { status, argv } => Running {
@@ -243,6 +244,7 @@ pub fn run_pipeline(
                 stderr: StageStream::Ready(Capture::new(0)),
                 stderr_merged: false,
                 spawned_at: Instant::now(),
+                started_at_ms: crate::report::now_ms(),
             },
             StageSpec::External(spec) => spawn_external(
                 *spec,
@@ -257,15 +259,16 @@ pub fn run_pipeline(
     }
 
     let mut result_stages = Vec::with_capacity(count);
-    for (position, mut stage) in running.into_iter().enumerate() {
-        let status = match stage.child.as_mut() {
-            Some(child) => {
-                let exit = child.wait().context(IoSnafu)?;
-                exit.code()
-                    .or_else(|| exit.signal().map(|sig| 128 + sig))
-                    .unwrap_or(1)
-            }
-            None => stage.fixed_status,
+    for (position, stage) in running.into_iter().enumerate() {
+        let wait = match stage.child.as_ref() {
+            // Already reaped by wait4; dropping the Child afterwards is
+            // fine (std's Drop neither waits nor kills).
+            Some(child) => wait4_child(child)?,
+            None => WaitOutcome {
+                status: stage.fixed_status,
+                user_ms: 0,
+                sys_ms: 0,
+            },
         };
         let stdout = stage.stdout.finish();
         let stderr = stage.stderr.finish();
@@ -274,27 +277,35 @@ pub fn run_pipeline(
             index: first_stage_index + position,
             argv: stage.argv,
             builtin: stage.builtin,
-            status,
+            status: wait.status,
+            started_at_ms: stage.started_at_ms,
+            ended_at_ms: crate::report::now_ms(),
             duration_ms: crate::report::duration_millis(duration),
+            user_ms: wait.user_ms,
+            sys_ms: wait.sys_ms,
             stdout,
             stderr,
             stderr_merged: stage.stderr_merged,
         });
     }
 
-    // Pipefail, except a stage killed by SIGPIPE (141): that is the normal
-    // fate of an upstream whose reader finished (`yes | head`), and calling
-    // it a failure would fail almost every early-exiting pipeline.
-    let status = result_stages
-        .iter()
-        .rev()
-        .map(|stage| stage.status)
-        .find(|status| *status != 0 && *status != 128 + libc::SIGPIPE)
-        .unwrap_or(0);
+    let status = pipefail_status(&result_stages);
     Ok(PipelineRun {
         stages: result_stages,
         status,
     })
+}
+
+/// Pipefail, except a stage killed by SIGPIPE (141): that is the normal
+/// fate of an upstream whose reader finished (`yes | head`), and calling
+/// it a failure would fail almost every early-exiting pipeline.
+fn pipefail_status(stages: &[Stage]) -> i32 {
+    stages
+        .iter()
+        .rev()
+        .map(|stage| stage.status)
+        .find(|status| *status != 0 && *status != 128 + libc::SIGPIPE)
+        .unwrap_or(0)
 }
 
 fn spawn_external(
@@ -393,6 +404,7 @@ fn spawn_external(
             stderr: StageStream::spawn(err_reader, stderr_forward, config.capture_limit),
             stderr_merged: spec.stderr_to_stdout,
             spawned_at,
+            started_at_ms: crate::report::now_ms(),
         }),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             let mut stderr = Capture::new(config.capture_limit);
@@ -408,6 +420,7 @@ fn spawn_external(
                 stderr: StageStream::Ready(stderr),
                 stderr_merged: false,
                 spawned_at,
+                started_at_ms: crate::report::now_ms(),
             })
         }
         Err(error) => Err(Error::Io { source: error }),
@@ -429,4 +442,52 @@ fn restore_default_signals(command: &mut Command) {
             Ok(())
         });
     }
+}
+
+/// What `wait4` reports for a finished child.
+struct WaitOutcome {
+    status: i32,
+    user_ms: u64,
+    sys_ms: u64,
+}
+
+/// Timeval to whole milliseconds.
+fn timeval_millis(time: libc::timeval) -> u64 {
+    let seconds = u64::try_from(time.tv_sec).unwrap_or(0);
+    let micros = u64::try_from(time.tv_usec).unwrap_or(0);
+    seconds.saturating_mul(1000).saturating_add(micros / 1000)
+}
+
+/// Reap a child with `wait4(2)` so its rusage (user/kernel CPU time) comes
+/// back with the exit status; `Child::wait` would discard it.
+fn wait4_child(child: &Child) -> Result<WaitOutcome, Error> {
+    let pid = i32::try_from(child.id()).map_err(|_| Error::Io {
+        source: std::io::Error::other("pid out of i32 range"),
+    })?;
+    let mut status: libc::c_int = 0;
+    // SAFETY: plain wait4 on a pid we spawned; rusage is a plain-old-data
+    // out-parameter.
+    let mut rusage: libc::rusage = unsafe { std::mem::zeroed() };
+    loop {
+        let reaped = unsafe { libc::wait4(pid, &raw mut status, 0, &raw mut rusage) };
+        if reaped == pid {
+            break;
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return Err(Error::Io { source: error });
+        }
+    }
+    let exit = if libc::WIFEXITED(status) {
+        libc::WEXITSTATUS(status)
+    } else if libc::WIFSIGNALED(status) {
+        128 + libc::WTERMSIG(status)
+    } else {
+        1
+    };
+    Ok(WaitOutcome {
+        status: exit,
+        user_ms: timeval_millis(rusage.ru_utime),
+        sys_ms: timeval_millis(rusage.ru_stime),
+    })
 }

--- a/packages/plumb/core/src/report.rs
+++ b/packages/plumb/core/src/report.rs
@@ -103,8 +103,16 @@ pub struct Stage {
     pub builtin: bool,
     /// Exit status (128+signal for signal deaths, 127 for not found).
     pub status: i32,
+    /// Wall-clock start, unix epoch milliseconds.
+    pub started_at_ms: u64,
+    /// Wall-clock end, unix epoch milliseconds.
+    pub ended_at_ms: u64,
     /// Wall time of this stage in milliseconds.
     pub duration_ms: u64,
+    /// CPU time in user mode, milliseconds (rusage; 0 for builtins).
+    pub user_ms: u64,
+    /// CPU time in kernel mode, milliseconds (rusage; 0 for builtins).
+    pub sys_ms: u64,
     /// Captured stdout of this stage. For stage K, this is also exactly what
     /// stage K+1 received on stdin.
     pub stdout: Capture,
@@ -140,6 +148,10 @@ pub struct Report {
     pub substitutions: Vec<Self>,
     /// Run ids of `&` background items this run started.
     pub background_started: Vec<u64>,
+    /// Wall-clock start of the run, unix epoch milliseconds.
+    pub started_at_ms: u64,
+    /// Wall-clock end of the run, unix epoch milliseconds.
+    pub ended_at_ms: u64,
     /// Wall time of the whole run in milliseconds.
     pub duration_ms: u64,
     /// When the run aborted early (unset variable, failed glob, redirect
@@ -162,6 +174,14 @@ impl Report {
     pub fn stages(&self) -> impl Iterator<Item = &Stage> {
         self.pipelines.iter().flat_map(|p| p.stages.iter())
     }
+}
+
+/// Wall clock now, unix epoch milliseconds.
+#[must_use]
+pub fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, duration_millis)
 }
 
 /// Duration in whole milliseconds without a fallible narrowing conversion.

--- a/packages/plumb/core/src/shell.rs
+++ b/packages/plumb/core/src/shell.rs
@@ -284,6 +284,8 @@ impl Shell {
             pipelines: Vec::new(),
             substitutions: Vec::new(),
             background_started: Vec::new(),
+            started_at_ms: crate::report::now_ms(),
+            ended_at_ms: 0,
             duration_ms: 0,
             aborted: None,
         };
@@ -301,6 +303,7 @@ impl Shell {
             }
         }
         report.status = report.pipelines.last().map_or(0, |p| p.status);
+        report.ended_at_ms = crate::report::now_ms();
         report.duration_ms = crate::report::duration_millis(started.elapsed());
         if commit {
             self.commit(&report);
@@ -461,13 +464,18 @@ impl Shell {
                 let _ = std::io::stderr().write_all(message.as_bytes());
             }
         }
+        let now = crate::report::now_ms();
         report.pipelines.push(PipelineRun {
             stages: vec![Stage {
                 index: first_index,
                 argv,
                 builtin: true,
                 status,
+                started_at_ms: now,
+                ended_at_ms: now,
                 duration_ms: 0,
+                user_ms: 0,
+                sys_ms: 0,
                 stdout: Capture::new(0),
                 stderr,
                 stderr_merged: false,
@@ -1008,10 +1016,12 @@ fn run_leaf(run: &Report, stages: &[&Stage], field: &str) -> Result<String, Erro
         "id" => run.id.to_string(),
         "source" => run.source.clone(),
         "duration_ms" => run.duration_ms.to_string(),
+        "started_at_ms" => run.started_at_ms.to_string(),
+        "ended_at_ms" => run.ended_at_ms.to_string(),
         _ => {
             return Err(Error::RunRef {
                 message: format!(
-                    "unknown run field `{field}` (have: output, stderr, status, id, source, duration_ms, stages)"
+                    "unknown run field `{field}` (have: output, stderr, status, id, source, duration_ms, started_at_ms, ended_at_ms, stages)"
                 ),
             });
         }
@@ -1030,10 +1040,14 @@ fn stage_leaf(stage: &Stage, field: &str) -> Result<String, Error> {
         "index" => stage.index.to_string(),
         "stdout_bytes" => stage.stdout.total_bytes().to_string(),
         "stderr_bytes" => stage.stderr.total_bytes().to_string(),
+        "user_ms" => stage.user_ms.to_string(),
+        "sys_ms" => stage.sys_ms.to_string(),
+        "started_at_ms" => stage.started_at_ms.to_string(),
+        "ended_at_ms" => stage.ended_at_ms.to_string(),
         _ => {
             return Err(Error::RunRef {
                 message: format!(
-                    "unknown stage field `{field}` (have: stdout, stderr, status, argv, duration_ms, index, stdout_bytes, stderr_bytes)"
+                    "unknown stage field `{field}` (have: stdout, stderr, status, argv, duration_ms, index, stdout_bytes, stderr_bytes, user_ms, sys_ms, started_at_ms, ended_at_ms)"
                 ),
             });
         }

--- a/packages/plumb/core/src/tests.rs
+++ b/packages/plumb/core/src/tests.rs
@@ -310,6 +310,23 @@ fn structured_run_paths() {
 }
 
 #[test]
+fn timing_is_recorded() {
+    let before = crate::report::now_ms();
+    let sh = shell();
+    let report = sh
+        .eval("sh -c 'i=0; while [ $i -lt 100000 ]; do i=$((i+1)); done'")
+        .expect("busy loop");
+    let after = crate::report::now_ms();
+    assert!(report.started_at_ms >= before && report.ended_at_ms <= after);
+    assert!(report.started_at_ms <= report.ended_at_ms);
+    let stage = &report.pipelines[0].stages[0];
+    assert!(stage.started_at_ms >= before && stage.ended_at_ms <= after);
+    assert!(stage.user_ms >= 1, "busy loop burned user cpu: {}", stage.user_ms);
+    let path = sh.eval("echo ${runs[1].stages[0].user_ms}").expect("path");
+    assert_eq!(path.output().trim_end(), stage.user_ms.to_string());
+}
+
+#[test]
 fn negative_run_references() {
     let sh = shell();
     sh.eval("echo newest").expect("run 1");


### PR DESCRIPTION
Follow-up to #3595 (stacked; its commit shows here until it merges). From Andrew's request: runs and stages carry real timing.

- `started_at_ms` / `ended_at_ms` (unix epoch wall clock) on every run and every stage
- `user_ms` / `sys_ms` per stage from `wait4(2)` rusage: the engine reaps children with `wait4` instead of `waitpid`, so CPU accounting is free and on by default (no knob; zero cost)
- addressable like everything else: `${runs[1].stages[0].user_ms}`, and in the report JSON
- REPL stage summaries now read `exit 0  62ms (cpu 3+2ms)  out 1.2KB`

Validated: 50 crate tests incl. a busy-loop rusage assertion, functional smoke (`wall=62ms cpu=3+2ms`), clippy clean, clone diff gate PASS, lint 10/10.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-stage wall timestamps and rusage CPU times to plumb pipeline reports
> - Adds `started_at_ms`, `ended_at_ms`, `user_ms`, and `sys_ms` fields to the `Stage` struct in [report.rs](https://github.com/indexable-inc/index/pull/3596/files#diff-253603be3af78c8ff471f279c3cd89b641c4c4868372469ce64744fa3b9b5a25), and `started_at_ms`/`ended_at_ms` to the top-level `Report`.
> - Replaces `Child::wait` with a `wait4_child` routine in [engine.rs](https://github.com/indexable-inc/index/pull/3596/files#diff-a29a88c48efdd657a1ed1bfcdd512b182ccb85f104c35d48060577aa0074d4ff) that uses `wait4` to capture rusage-derived CPU times and maps signal deaths to `128+signal` exit status.
> - Exposes the new timing fields as readable structured paths (`${runs[N].started_at_ms}`, `${runs[N].stages[K].user_ms}`, etc.) in [shell.rs](https://github.com/indexable-inc/index/pull/3596/files#diff-25dceb51aa6bcac5a8e77d4d7c746fea79d2cc39f63485251dae589435f90eef).
> - REPL summary line in [repl.rs](https://github.com/indexable-inc/index/pull/3596/files#diff-0daa440fb01d1b4e99167a317c251c6f61b0eee0353bc011de890cdad94f73d0) now prints `(cpu {user_ms}+{sys_ms}ms)` alongside wall duration.
> - A new `timing_is_recorded` test validates that timestamps are within expected bounds and `user_ms` is captured correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73d5e64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->