### PR TITLE
plumb-ex: handle new RunRef error variant (fix main E0004)

### DIFF
--- a/packages/plumb/ex/src/lib.rs
+++ b/packages/plumb/ex/src/lib.rs
@@ -80,6 +80,7 @@ mod _plumb {
             | Error::GlobNoMatch { .. }
             | Error::BuiltinInPipeline { .. }
             | Error::BuiltinUsage { .. }
+            | Error::RunRef { .. }
             | Error::SubstitutionOverflow { .. } => PlumbError::Strict { message },
             Error::Redirect { .. } | Error::Io { .. } => PlumbError::Io { message },
             Error::ExitRequested { .. } => PlumbError::Exit { message },


### PR DESCRIPTION
#3593 added the `RunRef` variant to `plumb_core::Error` but did not extend the exhaustive `match` in plumb-ex's `convert`, so `plumb_ex` fails to compile on main (E0004, seen in flake-check run 29670951353). `RunRef` is a strict resolution failure like `UnsetVar`/`GlobNoMatch`, so it maps to `PlumbError::Strict`.

Validated: `cargo check -p plumb-ex` shows only the known local duplicate `nif_init` false-fail (E0428), no E0004; `cargo test -p plumb-syntax -p plumb-core` green; `nix run .#lint` 10/10.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle `plumb_core::Error::RunRef` in `_plumb.convert` by mapping it to `PlumbError::Strict`
> Adds a match arm for `plumb_core::Error::RunRef` in [lib.rs](https://github.com/indexable-inc/index/pull/3598/files#diff-116fd0d3b0f9df92954a05f565f9a86f40941db44af4462f71946c28ae661636), converting it to `PlumbError::Strict` using the error's string message. This fixes a non-exhaustive match compile error (E0004) introduced when the `RunRef` variant was added to `plumb_core::Error`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bcada15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->