### PR TITLE
prompt: drop the shokunin terminology

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -179,7 +179,7 @@
   # (single-value options are last-wins), and a caller who wants the stock
   # prompt plus additions can still pass `--append-system-prompt[-file]`.
   # Defaults to the shared house prompt (`systemPrompt` in ../common.nix,
-  # authored in ../prompt/rules.nix: the shokunin craft ethos plus the pre-v1
+  # authored in ../prompt/rules.nix: the concise-by-default quality bar plus the pre-v1
   # backward-compatibility engineering rule, plus a preference for working in git
   # worktrees); set to `null` to bake no flag and ship the stock prompt alone.
   systemPrompt ?

--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -42,13 +42,14 @@
     };
   }
   {
-    shokunin = {
+    conciseByDefault = {
       text = ''
-        Be shokunin: keep code and prose concise, readable, and clean by default.
+        Keep code and prose concise, readable, and clean by default.
       '';
       reason = ''
         Sets the default quality bar; without it output drifts verbose and
-        over-engineered.
+        over-engineered. Was "Be shokunin: ..."; Andrew rejected the
+        shokunin terminology (2026-07-19).
       '';
     };
   }


### PR DESCRIPTION
Removes "Be shokunin" from the house prompt per Andrew's request; the rule survives as `conciseByDefault` with plain wording ("Keep code and prose concise, readable, and clean by default."). The one other mention (a comment in `packages/agent/claude-code/default.nix`) updated to match. Provenance kept in the rule's `reason`.

Will squash-merge on green.

(prepared by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename 'shokunin' rule key to 'conciseByDefault' in prompt rules
> Replaces the `shokunin` terminology in the agent prompt configuration with clearer, self-describing language. The rule key in [rules.nix](https://github.com/indexable-inc/index/pull/3599/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) is renamed from `shokunin` to `conciseByDefault`, the "Be shokunin:" directive is dropped from the rule text, and the comment in [default.nix](https://github.com/indexable-inc/index/pull/3599/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) is updated to reference "the concise-by-default quality bar" instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60188a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->