### PR TITLE
prompt: audit status claims against session tool results

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -360,12 +360,18 @@
       text = ''
         Report effect-first: what it does, concrete numbers, one line of why;
         evidence one level down. Failures report as failures with output;
-        skipped steps are named; no hedging, no process narration. Artifacts
-        never discuss their own making.
+        skipped steps are named; no hedging, no process narration. Before
+        reporting progress, audit each claim against a tool result from this
+        session; report only what you can point to evidence for, and say what
+        is not yet verified. Artifacts never discuss their own making.
       '';
       reason = ''
         Failures were summarized as successes; 2026-07-18 feedback set the
-        effect-first formula. Merged with noMetaNarration (index#3164).
+        effect-first formula. Merged with noMetaNarration (index#3164). The
+        audit sentence is the load-bearing snippet from the Claude Fable 5
+        system card prompting guidance, measured to nearly eliminate
+        fabricated status reports:
+        https://www-cdn.anthropic.com/d00db56fa754a1b115b6dd7cb2e3c342ee809620.pdf
       '';
     };
   }


### PR DESCRIPTION
Merging this adds one sentence to `faithfulReporting`: before reporting progress, audit each claim against a tool result from this session, and say what is not yet verified.

It is the load-bearing snippet from the [Claude Fable 5 system card](https://www-cdn.anthropic.com/d00db56fa754a1b115b6dd7cb2e3c342ee809620.pdf) prompting guidance, which Anthropic measured nearly eliminating fabricated status reports; the link is recorded in the rule's `reason`, not the render. Render grows 6,393B to 6,560B. Follow-up to #3594.

(sent by an AI agent via Claude Code, Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add claim auditing instruction to agent prompt rules
> Updates [rules.nix](https://github.com/indexable-inc/index/pull/3603/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to instruct the agent to audit each status claim against a tool result from the current session before reporting progress. The agent must report only evidence-backed items and explicitly state what is not yet verified. Behavioral Change: agents will no longer report unverified claims as fact in progress updates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb469b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->