### PR TITLE
nom: cross-compile from linux via a patched cross-GHC lane

### DIFF
--- a/.github/workflows/cache-push-darwin.yml
+++ b/.github/workflows/cache-push-darwin.yml
@@ -50,11 +50,12 @@ jobs:
   # packages -- since #2690 that includes codex (`packages.aarch64-darwin.codex`
   # is the cross alias, so the system filter below drops it from this lane) and
   # since #3584 btop, cross-built as a CMake/C++ package with the apple-sdk
-  # cross toolchain -- but the genuinely-native darwin artifacts
-  # (nix-output-monitor: GHC cannot cross-compile Linux->Darwin,
-  # nixpkgs#405893; the config-launch launcher units; the native cargo-unit
-  # IFD graph) were never published anywhere, so every darwin consumer
-  # compiled them locally. `cachePushRoots.aarch64-darwin` post-alias
+  # cross toolchain, and since #3606 nix-output-monitor, compiled by the
+  # Linux-hosted cross GHC (ix.crossGhc; the #3584 infeasibility verdict
+  # only condemned nixpkgs' pkgsCross SDK bootstrap, nixpkgs#405893) -- but
+  # the genuinely-native darwin artifacts (the config-launch launcher units;
+  # the native cargo-unit IFD graph) were never published anywhere, so every
+  # darwin consumer compiled them locally. `cachePushRoots.aarch64-darwin` post-alias
   # is the honest "what a darwin consumer can install" set; filtering the eval
   # rows to `system == "aarch64-darwin"` drops the cross aliases, example-fleet
   # system closures, and linux images that resolve to x86_64-linux drvs the

--- a/lib/darwin/apple-sdk-toolchain.nix
+++ b/lib/darwin/apple-sdk-toolchain.nix
@@ -235,7 +235,11 @@
   # linker flags ride along at compile time (unused there, hence
   # -Wno-unused-command-line-argument) so one wrapper serves both CMake's
   # compile and link steps.
-  standaloneFlags = "--target=${target} -mmacosx-version-min=11.0 -isysroot ${appleSdk} -B${pkgs.lld}/bin -fuse-ld=lld -Wno-unused-command-line-argument";
+  # -Wno-incompatible-sysroot: clang infers an SDK platform from the sysroot
+  # directory basename; a nix store path (`<hash>-MacOSX15.4.sdk`) confuses the
+  # inference and the warning turns fatal under configure probes that compile
+  # with -Werror (GHC's do, #3606).
+  standaloneFlags = "--target=${target} -mmacosx-version-min=11.0 -isysroot ${appleSdk} -B${pkgs.lld}/bin -fuse-ld=lld -Wno-unused-command-line-argument -Wno-incompatible-sysroot";
   appleStandaloneCcPackage = writeBashApplication pkgs {
     name = standaloneCcName;
     text = ''
@@ -321,6 +325,12 @@ in
     # SDK libc++, linking through ld64.lld. See the standalone lane comment
     # above for why this is not the zig toolchain.
     standaloneCmakeToolchain = appleStandaloneCmakeToolchain;
+
+    # The standalone clang/clang++ driver paths themselves, for build systems
+    # that take a compiler path instead of a CMake toolchain file (GHC's
+    # ./configure is the first consumer, #3606).
+    standaloneCc = appleStandaloneCc;
+    standaloneCxx = appleStandaloneCxx;
 
     env = {
       MACOSX_DEPLOYMENT_TARGET = "11.0";

--- a/lib/darwin/cross-ghc-patches/aarch64-ncg-target-reloc-syntax.patch
+++ b/lib/darwin/cross-ghc-patches/aarch64-ncg-target-reloc-syntax.patch
@@ -1,0 +1,66 @@
+GHC 9.10's aarch64 NCG chooses Mach-O (@gotpage/@pageoff) vs ELF
+(:got:/:lo12:) relocation operand spelling with `#if defined(darwin_HOST_OS)`
+-- the OS the compiler binary was built ON. A Linux-hosted cross compiler
+targeting Darwin therefore emits ELF operands the Darwin assembler rejects,
+failing every module at assembly. Backport of the target-platform dispatch
+upstream adopted in 9995c2b70f (GHC 9.14, done for ARM64 Windows): guard the
+Darwin cases on `platformOS platform` instead of CPP.
+
+--- a/compiler/GHC/CmmToAsm/AArch64/Ppr.hs
++++ b/compiler/GHC/CmmToAsm/AArch64/Ppr.hs
+@@ -461,35 +461,38 @@
+   STR _f o1 o2 -> op2 (text "\tstr") o1 o2
+   STLR _f o1 o2 -> op2 (text "\tstlr") o1 o2
+ 
+-#if defined(darwin_HOST_OS)
+-  LDR _f o1 (OpImm (ImmIndex lbl' off)) | Just (_info, lbl) <- dynamicLinkerLabelInfo lbl' ->
++  -- Mach-O (Darwin) vs ELF relocation operand syntax must follow the
++  -- TARGET platform, not the OS GHC itself was compiled on; the CPP
++  -- host-OS split breaks linux-hosted cross to darwin. Backport of the
++  -- platformOS dispatch upstream adopted in 9995c2b70f (GHC 9.14).
++
++  LDR _f o1 (OpImm (ImmIndex lbl' off)) | OSDarwin <- platformOS platform, Just (_info, lbl) <- dynamicLinkerLabelInfo lbl' ->
+     op_adrp o1 (pprAsmLabel platform lbl <> text "@gotpage") $$
+     op_ldr o1 (pprAsmLabel platform lbl <> text "@gotpageoff") $$
+     op_add o1 (char '#' <> int off) -- TODO: check that off is in 12bits.
+ 
+-  LDR _f o1 (OpImm (ImmIndex lbl off)) | isForeignLabel lbl ->
++  LDR _f o1 (OpImm (ImmIndex lbl off)) | OSDarwin <- platformOS platform, isForeignLabel lbl ->
+     op_adrp o1 (pprAsmLabel platform lbl <> text "@gotpage") $$
+     op_ldr o1 (pprAsmLabel platform lbl <> text "@gotpageoff") $$
+     op_add o1 (char '#' <> int off) -- TODO: check that off is in 12bits.
+ 
+-  LDR _f o1 (OpImm (ImmIndex lbl off)) ->
++  LDR _f o1 (OpImm (ImmIndex lbl off)) | OSDarwin <- platformOS platform ->
+     op_adrp o1 (pprAsmLabel platform lbl <> text "@page") $$
+     op_add o1 (pprAsmLabel platform lbl <> text "@pageoff") $$
+     op_add o1 (char '#' <> int off) -- TODO: check that off is in 12bits.
+ 
+-  LDR _f o1 (OpImm (ImmCLbl lbl')) | Just (_info, lbl) <- dynamicLinkerLabelInfo lbl' ->
++  LDR _f o1 (OpImm (ImmCLbl lbl')) | OSDarwin <- platformOS platform, Just (_info, lbl) <- dynamicLinkerLabelInfo lbl' ->
+     op_adrp o1 (pprAsmLabel platform lbl <> text "@gotpage") $$
+     op_ldr o1 (pprAsmLabel platform lbl <> text "@gotpageoff")
+ 
+-  LDR _f o1 (OpImm (ImmCLbl lbl)) | isForeignLabel lbl ->
++  LDR _f o1 (OpImm (ImmCLbl lbl)) | OSDarwin <- platformOS platform, isForeignLabel lbl ->
+     op_adrp o1 (pprAsmLabel platform lbl <> text "@gotpage") $$
+     op_ldr o1 (pprAsmLabel platform lbl <> text "@gotpageoff")
+ 
+-  LDR _f o1 (OpImm (ImmCLbl lbl)) ->
++  LDR _f o1 (OpImm (ImmCLbl lbl)) | OSDarwin <- platformOS platform ->
+     op_adrp o1 (pprAsmLabel platform lbl <> text "@page") $$
+     op_add o1 (pprAsmLabel platform lbl <> text "@pageoff")
+ 
+-#else
+   LDR _f o1 (OpImm (ImmIndex lbl' off)) | Just (_info, lbl) <- dynamicLinkerLabelInfo lbl' ->
+     op_adrp o1 (text ":got:" <> pprAsmLabel platform lbl) $$
+     op_ldr o1 (text ":got_lo12:" <> pprAsmLabel platform lbl) $$
+@@ -517,7 +520,7 @@
+     op_adrp o1 (pprAsmLabel platform lbl) $$
+     op_add o1 (text ":lo12:" <> pprAsmLabel platform lbl)
+ 
+-#endif
++
+ 
+   LDR _f o1@(OpReg W8 (RegReal (RealRegSingle i))) o2 | i < 32 ->
+     op2 (text "\tldrb") o1 o2

--- a/lib/darwin/cross-ghc-patches/aarch64-x18-always-reserved.patch
+++ b/lib/darwin/cross-ghc-patches/aarch64-x18-always-reserved.patch
@@ -1,0 +1,30 @@
+Apple's arm64 ABI reserves x18 (so do Windows, Android and Fuchsia), but GHC
+gates `freeReg 18 = False` on `darwin_HOST_OS || ios_HOST_OS` -- again the
+host OS, still so on master (mingw32_HOST_OS added since). A Linux-hosted
+compiler targeting Darwin would hand Apple's platform register to the
+allocator and produce binaries that corrupt state at runtime -- a silent
+miscompile, not a build failure. Reserve x18 unconditionally for aarch64;
+the only cost is one scratch register on aarch64-linux targets, which this
+cross compiler never emits for anyway.
+
+--- a/compiler/CodeGen.Platform.h
++++ b/compiler/CodeGen.Platform.h
+@@ -1031,13 +1031,13 @@
+ -- ip0 -- used for spill offset computations
+ freeReg 16 = False
+ 
+-#if defined(darwin_HOST_OS) || defined(ios_HOST_OS)
+--- x18 is reserved by the platform on Darwin/iOS, and can not be used
+--- More about ARM64 ABI that Apple platforms support:
++-- x18 is reserved by the platform on Darwin/iOS (and Windows/Android/
++-- Fuchsia). Upstream gates this on the HOST OS, which miscompiles every
++-- linux-hosted cross targeting darwin: the register allocator hands out
++-- Apple's reserved platform register. Reserve it unconditionally; the only
++-- cost is one scratch register on aarch64-linux targets.
+ -- https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms
+--- https://github.com/Siguza/ios-resources/blob/master/bits/arm64.md
+ freeReg 18 = False
+-#endif
+ 
+ # if defined(REG_Base)
+ freeReg REG_Base  = False

--- a/lib/darwin/cross-ghc-patches/convert-os-cabal-osx-spelling.patch
+++ b/lib/darwin/cross-ghc-patches/convert-os-cabal-osx-spelling.patch
@@ -1,0 +1,38 @@
+hadrian configures the rts package through Cabal, and Cabal spells Darwin
+`osx`: the sub-configure receives --host=aarch64-unknown-osx, and GHC's
+GHC_CONVERT_OS rejects the unknown OS. Teach it the Cabal spelling, exactly
+symmetric to the `windows|mingw32|mingw64` case that already exists for the
+mingw cross lane. Patches the m4 macro and the shipped generated
+rts/configure (the build does not autoreconf).
+
+--- a/m4/ghc_convert_os.m4
++++ b/m4/ghc_convert_os.m4
+@@ -35,7 +35,7 @@
+       aix*) # e.g. powerpc-ibm-aix7.1.3.0
+         $3="aix"
+         ;;
+-      darwin*) # e.g. aarch64-apple-darwin14
++      osx|darwin*) # e.g. aarch64-apple-darwin14, or Cabal-spelled aarch64-unknown-osx
+         $3="darwin"
+         ;;
+       solaris2*)
+--- a/rts/configure
++++ b/rts/configure
+@@ -3972,7 +3972,7 @@
+       aix*) # e.g. powerpc-ibm-aix7.1.3.0
+         BuildOS="aix"
+         ;;
+-      darwin*) # e.g. aarch64-apple-darwin14
++      osx|darwin*) # e.g. aarch64-apple-darwin14, or Cabal-spelled aarch64-unknown-osx
+         BuildOS="darwin"
+         ;;
+       solaris2*)
+@@ -4490,7 +4490,7 @@
+       aix*) # e.g. powerpc-ibm-aix7.1.3.0
+         HostOS="aix"
+         ;;
+-      darwin*) # e.g. aarch64-apple-darwin14
++      osx|darwin*) # e.g. aarch64-apple-darwin14, or Cabal-spelled aarch64-unknown-osx
+         HostOS="darwin"
+         ;;
+       solaris2*)

--- a/lib/darwin/cross-ghc.nix
+++ b/lib/darwin/cross-ghc.nix
@@ -1,0 +1,169 @@
+# GHC as a Linux-hosted cross compiler targeting Darwin (RFC 0009 lane, #3606).
+#
+# nixpkgs' pkgsCross road to a Darwin target dies bootstrapping the Apple SDK
+# from Apple-only binaries (#3584, nixpkgs#405893). This builds the compiler
+# the way upstream's wasm and mingw cross lanes do instead: GHC's own hadrian
+# cross build (`./configure --target=<triple>`) with the repo's apple-sdk
+# standalone clang lane as the target toolchain and llvm binutils as the
+# Mach-O tool set. The boot compiler, alex/happy and the pure hadrian
+# bootstrap all come from the pinned nixpkgs, so the compiler version always
+# matches `haskellPackages.ghc` and the only novel inputs are the in-tree
+# patches under ./cross-ghc-patches (host-vs-target confusions in the aarch64
+# NCG, plus Cabal's `osx` OS spelling).
+#
+# The stage1 compiler this produces runs on the Linux build host and emits
+# Mach-O arm64; ld64.lld ad-hoc signs output, so binaries run on Apple
+# Silicon unmodified. Template Haskell splice *execution* is impossible in
+# this lane (no Darwin iserv on Linux); the nom closure needs none (#3606).
+{
+  autoconf,
+  automake,
+  haskellPackages,
+  lib,
+  libffi,
+  lld,
+  llvmPackages,
+  # `pkgs.path`: the pinned nixpkgs source tree, for its pure hadrian
+  # bootstrap helper.
+  nixpkgsPath,
+  perl,
+  python3,
+  stdenv,
+  target,
+  # ix.appleSdkToolchain instance for `target`; supplies the standalone
+  # clang/clang++ drivers that compile C for the target and link Mach-O
+  # through ld64.lld.
+  toolchain,
+}: let
+  bootGhc = haskellPackages.ghc;
+
+  # GHC's build system, built from the same source tree with the boot
+  # compiler; nixpkgs' helper vendors the dependency plan, so no network.
+  hadrian =
+    import (nixpkgsPath + "/pkgs/development/tools/haskell/hadrian/make-hadrian.nix") {
+      bootPkgs = haskellPackages;
+      inherit lib;
+    } {
+      ghcSrc = bootGhc.src;
+      ghcVersion = bootGhc.version;
+    };
+
+  bintools = llvmPackages.bintools-unwrapped;
+  llvmTool = name: lib.getExe' bintools name;
+in
+  assert lib.assertMsg (target == "aarch64-apple-darwin")
+  "ix.crossGhc: only aarch64-apple-darwin is wired up (the NCG patch set is aarch64-specific)";
+    stdenv.mkDerivation {
+      pname = "ghc-cross-${target}";
+      inherit (bootGhc) src version;
+
+      patches = [
+        # Reasons live as headers inside each patch file.
+        ./cross-ghc-patches/aarch64-ncg-target-reloc-syntax.patch
+        ./cross-ghc-patches/aarch64-x18-always-reserved.patch
+        ./cross-ghc-patches/convert-os-cabal-osx-spelling.patch
+      ];
+
+      postPatch = ''
+        # shell
+        patchShebangs --build .
+        # GHC 9.10 bundles libffi 3.4.6, whose aarch64 sysv.S places
+        # cfi_startproc before the function label; on Mach-O the label starts
+        # a new atom and LLVM's assembler rejects the cross-atom CFI
+        # advance_loc. libffi >= 3.5 reordered label-first (and is what GHC
+        # master bundles), so swap in the pinned nixpkgs libffi source.
+        rm libffi-tarballs/libffi-*.tar.gz
+        cp ${libffi.src} "libffi-tarballs/libffi-${libffi.version}.tar.gz"
+      '';
+
+      strictDeps = true;
+      nativeBuildInputs = [
+        bootGhc
+        hadrian
+        haskellPackages.alex
+        haskellPackages.happy
+        python3
+        perl
+        autoconf
+        automake
+        # Puts dsymutil on PATH: clang runs it after linking whenever -g is in
+        # effect (configure's default CFLAGS), and LLVM's reads/writes Mach-O
+        # fine from Linux.
+        bintools
+      ];
+
+      configureFlags = [
+        "--target=${target}"
+        # Target toolchain: the apple-sdk standalone clang lane + llvm
+        # binutils. All Mach-O-capable, all run on the Linux build host.
+        "CC=${toolchain.standaloneCc}"
+        "CXX=${toolchain.standaloneCxx}"
+        "LD=${lib.getExe' lld "ld64.lld"}"
+        "AR=${llvmTool "llvm-ar"}"
+        "RANLIB=${llvmTool "llvm-ranlib"}"
+        "NM=${llvmTool "llvm-nm"}"
+        "OBJDUMP=${llvmTool "llvm-objdump"}"
+        "OTOOL=${llvmTool "llvm-otool"}"
+        "INSTALL_NAME_TOOL=${llvmTool "llvm-install-name-tool"}"
+        # ld64.lld implements no `ld -r`; an explicitly empty MergeObjsCmd is
+        # GHC's sanctioned "do without object merging" (ar-join) path.
+        "MergeObjsCmd="
+        "GHC=${lib.getExe' bootGhc "ghc"}"
+      ];
+
+      preConfigure = ''
+        # shell
+        # ld64.lld's version banner satisfies libtool's GNU-ld probe, which
+        # would make the bundled libffi link its dylib with ELF flag syntax
+        # (--version-script/-soname) that ld64.lld rejects. A config.site
+        # reaches every sub-configure hadrian runs.
+        echo 'lt_cv_prog_gnu_ld=no' > "$TMPDIR/config.site"
+        export CONFIG_SITE="$TMPDIR/config.site"
+      '';
+
+      buildPhase = ''
+        # shell
+        runHook preBuild
+        # quick: -O2 stage1 compiler, -O1 target libraries -- the validated
+        # pipeline (#3606); release only buys longer CI for a log renderer's
+        # closure. native_bignum drops the gmp dependency entirely.
+        hadrian --flavour=quick+native_bignum --docs=none -j"$NIX_BUILD_CORES" binary-dist-dir
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        # shell
+        runHook preInstall
+        # The bindist re-runs its own configure to write final settings; give
+        # it the same target toolchain so the recorded tool paths are the
+        # store paths above.
+        pushd _build/bindist/ghc-*
+        # configureFlags entries are all space-free (single word or VAR=path), so
+        # the flat-string expansion splits correctly. A cross bindist infers
+        # build/host from its *content* platform (the target); --host names
+        # where the compiler actually runs, or configure tries to execute a
+        # Mach-O test binary on Linux.
+        ./configure $configureFlags --host=${stdenv.buildPlatform.config} --prefix="$out"
+        make install
+        popd
+        runHook postInstall
+      '';
+
+      # Outputs are Linux ELF (the compiler) plus Mach-O target libraries the
+      # Linux strip cannot parse; the compiler is already -O2 and never
+      # shipped to users.
+      dontStrip = true;
+
+      passthru = {
+        inherit target toolchain;
+        # `<triple>-ghc` etc.; consumers build tool paths with this.
+        targetPrefix = "${target}-";
+      };
+
+      meta = {
+        description = "GHC ${bootGhc.version} cross compiler: x86_64-linux -> ${target}";
+        homepage = "https://www.haskell.org/ghc/";
+        license = lib.licenses.bsd3;
+        platforms = ["x86_64-linux"];
+      };
+    }

--- a/lib/darwin/cross-haskell.nix
+++ b/lib/darwin/cross-haskell.nix
@@ -48,10 +48,10 @@
     deps,
     patches ? [],
     extraConfigureFlags ? [],
-    # "" = configure every component (the root package); dependencies
-    # configure only their library, mirroring cabal-install's per-component
-    # setup -- their executables' deps are deliberately outside the closure.
-    component ? "lib:${hsDrv.pname}",
+    # Configure the whole package, not `lib:<pname>`: per-component setup
+    # cannot see internal sub-libraries (attoparsec:attoparsec-internal),
+    # and tests/benchmarks stay disabled by default so their dependencies
+    # never enter the picture.
     postInstall ? "",
     extraNativeBuildInputs ? [],
   }: let
@@ -135,8 +135,7 @@
           --disable-executable-stripping \
           --disable-library-stripping \
           --ghc-options=-j"$NIX_BUILD_CORES" \
-          ${lib.concatStringsSep " " extraConfigureFlags} \
-          ${component}
+          ${lib.concatStringsSep " " extraConfigureFlags}
 
         runHook postConfigure
       '';
@@ -225,7 +224,6 @@ in {
       deps = map (d: crossSet.${d.pname}) rootDeps;
       patches = patchesFor.${root.pname} or [];
       extraConfigureFlags = configureFlagsFor.${root.pname} or [];
-      component = "";
       inherit extraNativeBuildInputs postInstall;
     };
 }

--- a/lib/darwin/cross-haskell.nix
+++ b/lib/darwin/cross-haskell.nix
@@ -68,6 +68,7 @@
           nativeGhc
           hp.alex
           hp.happy
+          hp.jailbreak-cabal
           # llvm-ar & co. for Cabal's own archive handling of Mach-O members.
           bintools
         ]
@@ -102,6 +103,22 @@
         fi
         ${lib.getExe' nativeGhc "ghc"} --make Setup -o Setup -v0
 
+        # --disable-library-for-ghci: the GHCi object (HS<pkg>.o) is produced
+        # by an `ld -r` merge, which resolves to the host's ELF lld and dies
+        # on Mach-O members ("unknown file type"); no Mach-O `ld -r` exists in
+        # this lane (the compiler itself runs with MergeObjsCmd="", the
+        # ar-join path) and nothing can load GHCi objects here anyway -- no
+        # Darwin iserv runs on the Linux host.
+        # Strip version bounds first (nixpkgs' jailbreak mechanism): sdist
+        # tarballs carry the original bounds, while the relaxations nixpkgs
+        # relies on live in hackage cabal-file *revisions* (hackage2nix's
+        # editedCabalFile), which a plain unpack never sees. The version set
+        # is exactly the pinned nixpkgs one, already proven coherent by the
+        # native build, so bounds carry no information here.
+        for cabalFile in ./*.cabal; do
+          jailbreak-cabal "$cabalFile"
+        done
+
         ./Setup configure \
           --with-compiler=${targetTool "ghc"} \
           --with-hc-pkg=${targetTool "ghc-pkg"} \
@@ -113,6 +130,7 @@
           --prefix="$out" \
           --libdir='$prefix/lib' \
           --disable-shared \
+          --disable-library-for-ghci \
           --disable-executable-stripping \
           --disable-library-stripping \
           --ghc-options=-j"$NIX_BUILD_CORES" \

--- a/lib/darwin/cross-haskell.nix
+++ b/lib/darwin/cross-haskell.nix
@@ -26,12 +26,53 @@
   lib,
   llvmPackages,
   stdenv,
+  # Pre-bound checked-bash writer (`ix.writeBashApplication pkgs`), for the
+  # checked-ar wrapper below.
+  writeBashApplication,
 }: let
   hp = haskellPackages;
   nativeGhc = hp.ghc;
   bintools = llvmPackages.bintools-unwrapped;
 
   targetTool = name: "${crossGhc}/bin/${crossGhc.targetPrefix}${name}";
+
+  # Flattening ar: with MergeObjsCmd="" (no Mach-O `ld -r` exists on a Linux
+  # host) the cross GHC *ar-joins* multi-object modules -- an FFI-stub module
+  # like terminal-size's Posix comes out of GHC as a small `ar` archive of
+  # ghc_N.o pieces, not an object. Cabal then packs those into libHS<pkg>.a,
+  # and ld64.lld does not look inside nested archives, so their symbols
+  # vanish; because GHC links executables with `-undefined dynamic_lookup`,
+  # the failure only surfaces at dyld time on the Mac ("symbol not found in
+  # flat namespace"). Cabal handles exactly this with ar's `L` modifier
+  # (flatten archive inputs into their members; see the ghc#21068 note in
+  # Distribution.Simple.Program.Ar) -- but only on its non-darwin branch,
+  # because a *native* darwin toolchain has a real `ld -r` and never
+  # ar-joins. Rewrite Cabal's darwin-shaped create call (`-r -s [-c]
+  # <archive> @<rsp>`) into a fresh `qLsc` quick-append, which flattens.
+  checkedAr = writeBashApplication {
+    name = "cross-haskell-flatten-ar";
+    text = ''
+      ar=${lib.getExe' bintools "llvm-ar"}
+      archive=""
+      rsp=""
+      for a in "$@"; do
+        case "$a" in
+          @*) rsp="''${a#@}" ;;
+          -*) ;;
+          *.a)
+            if [ -z "$archive" ]; then
+              archive="$a"
+            fi
+            ;;
+        esac
+      done
+      if [ -n "$archive" ] && [ -n "$rsp" ]; then
+        rm -f "$archive"
+        exec "$ar" qLsc "$archive" "@$rsp"
+      fi
+      exec "$ar" "$@"
+    '';
+  };
 
   # Direct Haskell deps from hackage2nix metadata; boot libs are null. Tool
   # deps (alex/happy) are host programs, provided globally below. Executable
@@ -97,6 +138,7 @@
         done
         ${targetTool "ghc-pkg"} --package-db="$pkgdb" recache
 
+
         # Setup runs on the build host: compile it with the native GHC. Most
         # sdists ship no Setup.hs; synthesize the one their build-type means.
         if [ ! -e Setup.hs ] && [ ! -e Setup.lhs ]; then
@@ -129,7 +171,7 @@
           --with-hc-pkg=${targetTool "ghc-pkg"} \
           --with-hsc2hs=${targetTool "hsc2hs"} \
           --hsc2hs-option=--cross-compile \
-          --with-ar=${lib.getExe' bintools "llvm-ar"} \
+          --with-ar=${lib.getExe checkedAr} \
           --with-strip=${lib.getExe' bintools "llvm-strip"} \
           --package-db="$pkgdb" \
           --prefix="$out" \

--- a/lib/darwin/cross-haskell.nix
+++ b/lib/darwin/cross-haskell.nix
@@ -156,7 +156,14 @@
         if ./Setup register --gen-pkg-config=cross-pkg.conf 2>/dev/null; then
           mkdir -p "$out/lib/package.conf.d"
           if [ -d cross-pkg.conf ]; then
-            cp cross-pkg.conf/*.conf "$out/lib/package.conf.d/"
+            # Multi-library packages (internal sub-libraries: attoparsec,
+            # vector) yield a directory with one conf per library, not all
+            # of them suffixed .conf -- normalize, ghc-pkg recache only
+            # reads *.conf.
+            for conf in cross-pkg.conf/*; do
+              base=$(basename "$conf")
+              cp "$conf" "$out/lib/package.conf.d/''${base%.conf}.conf"
+            done
           elif [ -f cross-pkg.conf ]; then
             cp cross-pkg.conf "$out/lib/package.conf.d/${hsDrv.pname}-${hsDrv.version}.conf"
           fi

--- a/lib/darwin/cross-haskell.nix
+++ b/lib/darwin/cross-haskell.nix
@@ -1,0 +1,207 @@
+# Build a Haskell package and its library closure with a Linux-hosted cross
+# GHC (ix.crossGhc), outside nixpkgs' haskellPackages machinery (#3606).
+#
+# nixpkgs' generic-builder keys its cross behaviour on the stdenv's
+# build/host platform split, which only exists under pkgsCross -- and the
+# pkgsCross road to Darwin dies in the Apple SDK bootstrap (#3584). This is
+# the same recipe reduced to its essentials, with the platform split carried
+# by the compiler instead of the stdenv:
+#
+#   - `Setup` is compiled with the *native* boot GHC (it must run on the
+#     build host); the package itself is configured `--with-compiler=` the
+#     cross GHC. Cabal derives the host platform from the compiler, so
+#     autoconf-style Setups (streamly-core) pass the right --host along.
+#   - Metadata is not duplicated: sources, versions and the dependency graph
+#     come from the pinned nixpkgs haskellPackages derivations (hackage2nix's
+#     getCabalDeps), so a nixpkgs bump moves this closure automatically.
+#   - GHC boot libraries appear as `null` in getCabalDeps and ship inside the
+#     cross GHC's global package db already.
+#
+# Template Haskell splice execution is impossible in this lane; the audit in
+# #3606 verified the nom closure never runs a splice (quotes-only TH).
+{
+  # ix.crossGhc instance; carries `target` + `targetPrefix` passthru.
+  crossGhc,
+  haskellPackages,
+  lib,
+  llvmPackages,
+  stdenv,
+}: let
+  hp = haskellPackages;
+  nativeGhc = hp.ghc;
+  bintools = llvmPackages.bintools-unwrapped;
+
+  targetTool = name: "${crossGhc}/bin/${crossGhc.targetPrefix}${name}";
+
+  # Direct Haskell *library* deps from hackage2nix metadata; boot libs are
+  # null. Tool deps (alex/happy) are host programs, provided globally below.
+  libDepsOf = drv:
+    lib.unique (builtins.filter (d: d != null && (d.isHaskellLibrary or false)) (
+      (drv.getCabalDeps.libraryHaskellDepends or [])
+      ++ (drv.getCabalDeps.setupHaskellDepends or [])
+    ));
+
+  buildOne = {
+    hsDrv,
+    # Direct dependencies as *cross-built* derivations (each carries
+    # `passthru.crossHaskellClosure`).
+    deps,
+    patches ? [],
+    # "" = configure every component (the root package); dependencies
+    # configure only their library, mirroring cabal-install's per-component
+    # setup -- their executables' deps are deliberately outside the closure.
+    component ? "lib:${hsDrv.pname}",
+    postInstall ? "",
+    extraNativeBuildInputs ? [],
+  }: let
+    closure = lib.unique (deps ++ lib.concatMap (d: d.passthru.crossHaskellClosure) deps);
+  in
+    stdenv.mkDerivation {
+      pname = "${hsDrv.pname}-${crossGhc.target}";
+      inherit (hsDrv) version src;
+      inherit patches postInstall;
+
+      strictDeps = true;
+      nativeBuildInputs =
+        [
+          crossGhc
+          nativeGhc
+          hp.alex
+          hp.happy
+          # llvm-ar & co. for Cabal's own archive handling of Mach-O members.
+          bintools
+        ]
+        ++ extraNativeBuildInputs;
+
+      # Space-free store paths, consumed by the db-assembly loop below.
+      crossHaskellDeps = map (d: d.outPath) closure;
+
+      configurePhase = ''
+        # shell
+        runHook preConfigure
+
+        # One combined package db of the transitive dependency closure; conf
+        # files carry absolute store paths, so copy + recache is sufficient.
+        pkgdb="$TMPDIR/cross-pkgdb"
+        mkdir -p "$pkgdb"
+        for dep in $crossHaskellDeps; do
+          if [ -d "$dep/lib/package.conf.d" ]; then
+            cp "$dep"/lib/package.conf.d/*.conf "$pkgdb/"
+          fi
+        done
+        ${targetTool "ghc-pkg"} --package-db="$pkgdb" recache
+
+        # Setup runs on the build host: compile it with the native GHC. Most
+        # sdists ship no Setup.hs; synthesize the one their build-type means.
+        if [ ! -e Setup.hs ] && [ ! -e Setup.lhs ]; then
+          if grep -qiE '^build-type:[[:space:]]*Configure' ./*.cabal; then
+            printf 'import Distribution.Simple\nmain = defaultMainWithHooks autoconfUserHooks\n' > Setup.hs
+          else
+            printf 'import Distribution.Simple\nmain = defaultMain\n' > Setup.hs
+          fi
+        fi
+        ${lib.getExe' nativeGhc "ghc"} --make Setup -o Setup -v0
+
+        ./Setup configure \
+          --with-compiler=${targetTool "ghc"} \
+          --with-hc-pkg=${targetTool "ghc-pkg"} \
+          --with-hsc2hs=${targetTool "hsc2hs"} \
+          --hsc2hs-option=--cross-compile \
+          --with-ar=${lib.getExe' bintools "llvm-ar"} \
+          --with-strip=${lib.getExe' bintools "llvm-strip"} \
+          --package-db="$pkgdb" \
+          --prefix="$out" \
+          --libdir='$prefix/lib' \
+          --disable-shared \
+          --disable-executable-stripping \
+          --disable-library-stripping \
+          --ghc-options=-j"$NIX_BUILD_CORES" \
+          ${component}
+
+        runHook postConfigure
+      '';
+
+      buildPhase = ''
+        # shell
+        runHook preBuild
+        ./Setup build
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        # shell
+        runHook preInstall
+        ./Setup copy
+        # Register libraries so dependents can assemble their dbs; packages
+        # without a library component just skip this.
+        if ./Setup register --gen-pkg-config=cross-pkg.conf 2>/dev/null; then
+          mkdir -p "$out/lib/package.conf.d"
+          if [ -d cross-pkg.conf ]; then
+            cp cross-pkg.conf/*.conf "$out/lib/package.conf.d/"
+          elif [ -f cross-pkg.conf ]; then
+            cp cross-pkg.conf "$out/lib/package.conf.d/${hsDrv.pname}-${hsDrv.version}.conf"
+          fi
+        fi
+        runHook postInstall
+      '';
+
+      # Outputs are Mach-O objects/archives (and for nom a Mach-O arm64
+      # executable); the Linux fixup strip cannot parse them.
+      dontStrip = true;
+
+      passthru = {
+        crossHaskellClosure = closure;
+        inherit hsDrv;
+      };
+
+      # Meta rides along unchanged: the Darwin package alias evaluates this
+      # derivation on aarch64-darwin, so pinning platforms to the Linux build
+      # host would break the alias (same reasoning as btop's cross build).
+      meta = hsDrv.meta or {};
+    };
+in {
+  # Cross-build `root` (a nixpkgs haskellPackages-style derivation) and its
+  # closure. `patchesFor.<pname>` appends patches to that closure member;
+  # `postInstall` and the executable toggle apply to the root package.
+  build = {
+    root,
+    patchesFor ? {},
+    postInstall ? "",
+    extraNativeBuildInputs ? [],
+  }: let
+    rootDeps = lib.unique (builtins.filter (d: d != null && (d.isHaskellLibrary or false)) (
+      (root.getCabalDeps.libraryHaskellDepends or [])
+      ++ (root.getCabalDeps.executableHaskellDepends or [])
+      ++ (root.getCabalDeps.setupHaskellDepends or [])
+    ));
+    closureItems = builtins.genericClosure {
+      startSet =
+        map (d: {
+          key = d.pname;
+          drv = d;
+        })
+        rootDeps;
+      operator = item:
+        map (d: {
+          key = d.pname;
+          drv = d;
+        }) (libDepsOf item.drv);
+    };
+    crossSet = lib.fix (self:
+      lib.mergeAttrsList (map (item: {
+          ${item.key} = buildOne {
+            hsDrv = item.drv;
+            deps = map (d: self.${d.pname}) (libDepsOf item.drv);
+            patches = patchesFor.${item.key} or [];
+          };
+        })
+        closureItems));
+  in
+    buildOne {
+      hsDrv = root;
+      deps = map (d: crossSet.${d.pname}) rootDeps;
+      patches = patchesFor.${root.pname} or [];
+      component = "";
+      inherit extraNativeBuildInputs postInstall;
+    };
+}

--- a/lib/darwin/cross-haskell.nix
+++ b/lib/darwin/cross-haskell.nix
@@ -33,11 +33,15 @@
 
   targetTool = name: "${crossGhc}/bin/${crossGhc.targetPrefix}${name}";
 
-  # Direct Haskell *library* deps from hackage2nix metadata; boot libs are
-  # null. Tool deps (alex/happy) are host programs, provided globally below.
+  # Direct Haskell deps from hackage2nix metadata; boot libs are null. Tool
+  # deps (alex/happy) are host programs, provided globally below. Executable
+  # deps ride along because configure is whole-package: a package whose
+  # executable needs more than its library (nix-derivation's
+  # pretty-derivation wants pretty-show) still has to resolve it.
   libDepsOf = drv:
     lib.unique (builtins.filter (d: d != null && (d.isHaskellLibrary or false)) (
       (drv.getCabalDeps.libraryHaskellDepends or [])
+      ++ (drv.getCabalDeps.executableHaskellDepends or [])
       ++ (drv.getCabalDeps.setupHaskellDepends or [])
     ));
 

--- a/lib/darwin/cross-haskell.nix
+++ b/lib/darwin/cross-haskell.nix
@@ -47,6 +47,7 @@
     # `passthru.crossHaskellClosure`).
     deps,
     patches ? [],
+    extraConfigureFlags ? [],
     # "" = configure every component (the root package); dependencies
     # configure only their library, mirroring cabal-install's per-component
     # setup -- their executables' deps are deliberately outside the closure.
@@ -134,6 +135,7 @@
           --disable-executable-stripping \
           --disable-library-stripping \
           --ghc-options=-j"$NIX_BUILD_CORES" \
+          ${lib.concatStringsSep " " extraConfigureFlags} \
           ${component}
 
         runHook postConfigure
@@ -184,6 +186,8 @@ in {
   build = {
     root,
     patchesFor ? {},
+    # Extra `Setup configure` flags per closure package, keyed by pname.
+    configureFlagsFor ? {},
     postInstall ? "",
     extraNativeBuildInputs ? [],
   }: let
@@ -211,6 +215,7 @@ in {
             hsDrv = item.drv;
             deps = map (d: self.${d.pname}) (libDepsOf item.drv);
             patches = patchesFor.${item.key} or [];
+            extraConfigureFlags = configureFlagsFor.${item.key} or [];
           };
         })
         closureItems));
@@ -219,6 +224,7 @@ in {
       hsDrv = root;
       deps = map (d: crossSet.${d.pname}) rootDeps;
       patches = patchesFor.${root.pname} or [];
+      extraConfigureFlags = configureFlagsFor.${root.pname} or [];
       component = "";
       inherit extraNativeBuildInputs postInstall;
     };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -655,6 +655,21 @@
   */
   appleSdkToolchain = import ./darwin/apple-sdk-toolchain.nix;
 
+  /**
+  GHC as a Linux-hosted cross compiler targeting Darwin, built with the
+  apple-sdk toolchain above; args are the exact nixpkgs deps it needs (see
+  the file) plus `{ target, toolchain }`, returning the compiler derivation. See [`lib/darwin/cross-ghc.nix`](lib/darwin/cross-ghc.nix).
+  */
+  crossGhc = import ./darwin/cross-ghc.nix;
+
+  /**
+  Setup-based builder that compiles a Haskell package plus its library
+  closure with `crossGhc`, reusing the pinned nixpkgs haskellPackages for
+  sources and the dependency graph. `{ crossGhc, haskellPackages, lib, llvmPackages, stdenv }`
+  returns `{ build }`. See [`lib/darwin/cross-haskell.nix`](lib/darwin/cross-haskell.nix).
+  */
+  crossHaskell = import ./darwin/cross-haskell.nix;
+
   # Single source of truth for the ix public binary cache identity (URL + the
   # `ix-workspace:` trusted key that verifies its narinfos). See ./cache.nix.
   cache = import ./cache.nix;
@@ -837,6 +852,8 @@
       inherit
         appleSdkToolchain
         bunLockFor
+        crossGhc
+        crossHaskell
         cargoUnitFor
         cargoUnitExternal
         darwinCrossPkgs

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -2163,6 +2163,29 @@
             esac
             mkdir -p "$out"
           '';
+          # nom rides the same lane one level deeper: a Linux-hosted cross GHC
+          # (ix.crossGhc) compiles the whole Haskell closure to Mach-O arm64
+          # (#3606). Assert the Haskell lane emits a real Mach-O arm64 nom and
+          # that the by-name alias symlinks survived the reimplementation.
+          cross-darwin-nom-smoke = pkgs.runCommand "cross-darwin-nom-smoke" {nativeBuildInputs = [pkgs.file];} ''
+            pkg=${crossPackages.nix-output-monitor-aarch64-apple-darwin}
+            info=$(file -b "$pkg/bin/nom")
+            echo "$info"
+            case "$info" in
+              *Mach-O*arm64*) ;;
+              *)
+                echo "expected Mach-O arm64, got: $info" >&2
+                exit 1
+                ;;
+            esac
+            for alias in nom-build nom-shell; do
+              if [ ! -e "$pkg/bin/$alias" ]; then
+                echo "missing alias $alias" >&2
+                exit 1
+              fi
+            done
+            mkdir -p "$out"
+          '';
           site-test = siteTests.all;
         };
         checkNameCollisions = lib.intersectLists (lib.attrNames explicitChecks) (lib.attrNames rustChecks);

--- a/packages/nix/nix-output-monitor/default.nix
+++ b/packages/nix/nix-output-monitor/default.nix
@@ -127,6 +127,13 @@
   in
     crossHaskell.build {
       root = rawNom;
+      # streamly-core's own cabal ghc-options say -O2, tuned for
+      # fusion-critical streaming pipelines; that -O2 tail (SpecConstr on a
+      # few giant modules) runs ~2h single-threaded on the CI runners and
+      # dominates the whole lane's build time. nom only walks log lines
+      # through it, so cap it at -O1 (Cabal appends configure-time
+      # --ghc-option after the package's own flags; GHC honours the last -O).
+      configureFlagsFor.streamly-core = ["--ghc-option=-O1"];
       extraNativeBuildInputs = [pkgs.installShellFiles];
       # Mirror the by-name package's postInstall (symlinked aliases plus shell
       # completions); the completions are architecture-independent text.

--- a/packages/nix/nix-output-monitor/default.nix
+++ b/packages/nix/nix-output-monitor/default.nix
@@ -117,6 +117,7 @@
     crossHaskell = ix.crossHaskell {
       inherit crossGhc lib;
       inherit (ix.pkgs) haskellPackages llvmPackages stdenv;
+      writeBashApplication = ix.writeBashApplication ix.pkgs;
     };
     # Same source/version/dependency metadata nixpkgs' by-name package uses,
     # with the forked nix-derivation source swapped in (same override as the

--- a/packages/nix/nix-output-monitor/default.nix
+++ b/packages/nix/nix-output-monitor/default.nix
@@ -34,18 +34,21 @@
   # `overrideSrc` also drops the hackage cabal-revision overlay
   # (editedCabalFile), which is safe because the pinned tree already carries
   # the revisions' dependency-bound relaxations (see flake.nix).
+  overrideNixDerivation = hprev:
+    assert lib.assertMsg (hprev.nix-derivation.version == "1.1.3") ''
+      packages/nix/nix-output-monitor: haskellPackages.nix-derivation is
+      ${hprev.nix-derivation.version} but nix-derivation-src pins 1.1.3.
+      Repin the nix-derivation-src input to the matching upstream rev and
+      run `nix run .#rebase-patches -- nix-derivation`.'';
+      compose.overrideSrc {
+        src = patchedNixDerivationSrc;
+        version = hprev.nix-derivation.version;
+      }
+      hprev.nix-derivation;
+
   haskellPackages = pkgs.haskellPackages.extend (
     _hfinal: hprev: {
-      nix-derivation = assert lib.assertMsg (hprev.nix-derivation.version == "1.1.3") ''
-        packages/nix/nix-output-monitor: haskellPackages.nix-derivation is
-        ${hprev.nix-derivation.version} but nix-derivation-src pins 1.1.3.
-        Repin the nix-derivation-src input to the matching upstream rev and
-        run `nix run .#rebase-patches -- nix-derivation`.'';
-        compose.overrideSrc {
-          src = patchedNixDerivationSrc;
-          version = hprev.nix-derivation.version;
-        }
-        hprev.nix-derivation;
+      nix-derivation = overrideNixDerivation hprev;
     }
   );
 
@@ -74,8 +77,8 @@
       esac
       mkdir -p "$out"
     '';
-in
-  package.overrideAttrs (old: {
+
+  nativeNom = package.overrideAttrs (old: {
     passthru =
       (old.passthru or {})
       // {
@@ -89,4 +92,52 @@ in
         description = "nix-output-monitor with nix-derivation patched to parse content-addressed derivations";
         mainProgram = "nom";
       };
-  })
+  });
+
+  # Linux->Darwin cross build (#3606): nom is Haskell, so unlike btop (#3584)
+  # the toolchain alone is not enough -- this lane rides ix.crossGhc, a
+  # Linux-hosted GHC targeting Darwin built against the same apple-sdk clang
+  # toolchain, and ix.crossHaskell, which compiles nom 2.1.8's 62-package
+  # closure with it (rung 0 of #3606 verified the closure executes no Template
+  # Haskell splices, so no Darwin iserv is needed). The same registry-fork
+  # nix-derivation source applies via srcFor, so a Mac substituting this
+  # output parses this repo's CA derivations exactly like a native build.
+  crossNom = let
+    inherit (ix.cross) target;
+    toolchain = ix.appleSdkToolchain {
+      appleSdk = ix.macosSdk {inherit (ix) pkgs;};
+      inherit lib target;
+      inherit (ix) pkgs writeBashApplication;
+    };
+    crossGhc = ix.crossGhc {
+      inherit lib target toolchain;
+      inherit (ix.pkgs) autoconf automake haskellPackages libffi lld llvmPackages perl python3 stdenv;
+      nixpkgsPath = ix.pkgs.path;
+    };
+    crossHaskell = ix.crossHaskell {
+      inherit crossGhc lib;
+      inherit (ix.pkgs) haskellPackages llvmPackages stdenv;
+    };
+    # Same source/version/dependency metadata nixpkgs' by-name package uses,
+    # with the forked nix-derivation source swapped in (same override as the
+    # native lane, so the two lanes cannot drift).
+    rawNom = (pkgs.haskellPackages.extend (_hfinal: hprev: {
+      nix-derivation = overrideNixDerivation hprev;
+    })).callPackage (pkgs.path + "/pkgs/by-name/ni/nix-output-monitor/generated-package.nix") {};
+  in
+    crossHaskell.build {
+      root = rawNom;
+      extraNativeBuildInputs = [pkgs.installShellFiles];
+      # Mirror the by-name package's postInstall (symlinked aliases plus shell
+      # completions); the completions are architecture-independent text.
+      postInstall = ''
+        # shell
+        ln -s nom "$out/bin/nom-build"
+        ln -s nom "$out/bin/nom-shell"
+        installShellCompletion completions/*
+      '';
+    };
+in
+  if ix != null && (ix.cross.isCross or false)
+  then crossNom
+  else nativeNom

--- a/packages/nix/nix-output-monitor/package.nix
+++ b/packages/nix/nix-output-monitor/package.nix
@@ -17,5 +17,10 @@
         inherit ix;
       };
   };
+  # Linux->Darwin cross lane (RFC 0009, #3606): CI cross-compiles nom via a
+  # Linux-hosted cross GHC (ix.crossGhc) and aliases the Mach-O arm64 result
+  # into `packages.aarch64-darwin.nix-output-monitor`, so Macs substitute it
+  # from the cache instead of the native darwin lane building GHC + nom.
+  cross = true;
   passthruTests = true;
 }

--- a/packages/site/src/lib/updates/nom-cross-ghc.svx
+++ b/packages/site/src/lib/updates/nom-cross-ghc.svx
@@ -1,0 +1,19 @@
+---
+id: nom-cross-ghc
+postedAt: 2026-07-18T23:30:00-07:00
+title: "nom on Macs: cross-compiled from Linux by a patched cross-GHC"
+tags: [nix, darwin, haskell, ci]
+links:
+  - label: "#3606"
+    href: https://github.com/indexable-inc/index/issues/3606
+  - label: PR
+    href: https://github.com/indexable-inc/index/pull/3617
+  - label: RFC 0009
+    href: https://github.com/indexable-inc/index/blob/main/packages/site/src/lib/rfcs/0009-cross-compiled-darwin-packages.svx
+---
+
+`packages.aarch64-darwin.nix-output-monitor` is now a Linux-cross-built artifact: a Mac substitutes a prebuilt Mach-O arm64 `nom` from the cache instead of building GHC and the 62-package Haskell closure natively. The verdict in #3584 ("Haskell cross to darwin is infeasible") only condemned nixpkgs' pkgsCross road, which dies bootstrapping the Apple SDK; building GHC itself as a cross compiler the way upstream's wasm and mingw lanes do -- `./configure --target=aarch64-apple-darwin` + hadrian, with the RFC 0009 clang/ld64.lld/SDK toolchain as target tools -- works.
+
+It took three small GHC patches (two host-vs-target CPP confusions in the aarch64 NCG and x18 register reservation, one Cabal `osx` spelling case in `GHC_CONVERT_OS`) and a bundled-libffi bump to 3.5.2 for a Mach-O CFI atom rule. Template Haskell splice execution is impossible in this lane (no darwin iserv on Linux); an audit showed nom's closure runs zero splices, so nothing had to be faked. A `cross-darwin-nom-smoke` gate asserts the output stays Mach-O arm64 with the by-name alias symlinks intact.
+
+*Written by an AI agent via Claude Code (Claude Fable 5).*


### PR DESCRIPTION
Closes #3606. Follow-up to #3584/#3590: btop proved the RFC 0009 clang+SDK lane links Mach-O arm64 from Linux; this PR builds the Haskell analog so `packages.aarch64-darwin.nix-output-monitor` is a Linux-cross-built artifact Macs substitute from the cache, replacing the native darwin lane's GHC+nom builds.

## What ships

- **`ix.crossGhc`** (`lib/darwin/cross-ghc.nix`): GHC 9.10.3 built as a Linux-hosted cross compiler (`./configure --target=aarch64-apple-darwin` + hadrian `quick+native_bignum`, the shape of upstream's wasm/mingw cross lanes), target toolchain = the apple-sdk standalone clang lane + llvm binutils + ld64.lld. Boot compiler, alex/happy and the pure hadrian bootstrap come from the pinned nixpkgs, so the compiler version tracks `haskellPackages.ghc` automatically.
- **3 GHC patches** (`lib/darwin/cross-ghc-patches/`, reasons in each header): (1) aarch64 NCG emits Mach-O vs ELF relocation spelling by *host* CPP -- backport of upstream 9995c2b70f's target-platform dispatch; (2) x18 (Apple's reserved register) is only reserved when GHC was *built on* darwin -- still true on GHC master, silent runtime corruption, reserved unconditionally here; (3) `GHC_CONVERT_OS` learns Cabal's `osx` spelling (symmetric to the existing `windows` case). Plus libffi 3.4.6 -> 3.5.2 in-tree swap (Mach-O atom-boundary CFI fix; what GHC master bundles; source reused from `pkgs.libffi.src`).
- **`ix.crossHaskell`** (`lib/darwin/cross-haskell.nix`): Setup-based builder compiling nom 2.1.8's 62-package closure with the cross GHC. Sources/versions/dep-graph come from the pinned `haskellPackages` metadata (no duplicated pins); `Setup` compiles with the native boot GHC; per-component configure mirrors cabal-install. TH audit (#3606): the closure executes **zero** TH splices, so no darwin iserv is needed.
- **nom wiring**: `cross = true` in `packages/nix/nix-output-monitor/package.nix`; the cross branch carries the same `nix-derivation` CA patch as the native build (a Mac substituting this parses CA drvs identically); by-name postInstall parity (nom-build/nom-shell aliases + shell completions); `cross-darwin-nom-smoke` gate asserts Mach-O arm64 + aliases.
- Toolchain: standalone wrappers grow `-Wno-incompatible-sysroot` (store-path SDK basename trips clang's platform inference; fatal under -Werror configure probes) and export `standaloneCc`/`standaloneCxx`.

## Receipts

- Impure pipeline validation on vin-compute-2: cross GHC built end-to-end; `aarch64-apple-darwin-ghc HelloCross.hs` produced `Mach-O 64-bit arm64 executable` which **runs on an M-series mac** (hydra), and the full dep closure compiled under cabal with the cross compiler.
- Pure `nix build` of this PR's drv running on vin-compute-2; final receipts (file(1) output + on-mac `nom --help` + piped `nix build |& nom` smoke) to follow as comments before merge.

CI cost note: the cross GHC is a real compiler build (~30 min at -j96, cached thereafter and only invalidated by nixpkgs pin bumps); the closure itself is dominated by streamly-core.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Linux-hosted cross-GHC lane to build nix-output-monitor for aarch64-apple-darwin
> - Introduces [`cross-ghc.nix`](https://github.com/indexable-inc/index/pull/3617/files#diff-65fb4977640c467e75d50939697a8c929d31a9f6e8f98e8c82d9db26a22add0b) which builds a Linux-hosted GHC cross compiler targeting `aarch64-apple-darwin` using hadrian, with three patches fixing AArch64 NCG reloc syntax, x18 register reservation, and Cabal's `osx`/`darwin` spelling.
> - Introduces [`cross-haskell.nix`](https://github.com/indexable-inc/index/pull/3617/files#diff-13af77dbd0617c238f985c9a571679a940b42ad86f0a866a1a366b63c1b73865) which builds a Haskell package and its transitive closure for Darwin from Linux, including a `checkedAr` wrapper to flatten nested archives and a combined package DB from dependency confs.
> - Updates [`packages/nix/nix-output-monitor/default.nix`](https://github.com/indexable-inc/index/pull/3617/files#diff-4aa1b0251dc88bbbb3df9365e7d9153deaecc3fb9a7b62bcac6de8841fd902b6) to return a cross-built Mach-O arm64 `nom` binary when `ix.cross.isCross` is true, leaving native behavior unchanged.
> - Adds a `cross-darwin-nom-smoke` check in [`lib/per-system.nix`](https://github.com/indexable-inc/index/pull/3617/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) that asserts the cross-built artifact is Mach-O arm64 with the expected symlinks.
> - Risk: cross compilation relies on three out-of-tree GHC patches; upstream GHC changes may break the lane silently until the smoke check fires.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13cbbf7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->