### PR TITLE
plumb-ex, tests: fix the four failures behind main's red Check

### DIFF
--- a/packages/plumb/core/src/engine.rs
+++ b/packages/plumb/core/src/engine.rs
@@ -453,8 +453,12 @@ struct WaitOutcome {
 
 /// Timeval to whole milliseconds.
 fn timeval_millis(time: libc::timeval) -> u64 {
-    let seconds = u64::try_from(time.tv_sec).unwrap_or(0);
-    let micros = u64::try_from(time.tv_usec).unwrap_or(0);
+    // Kernel-reported rusage times are non-negative; clamp defensively so a
+    // hostile value reads as zero instead of panicking mid-reap. After the
+    // clamp the conversion cannot fail: a non-negative signed value always
+    // fits in u64.
+    let seconds = u64::try_from(time.tv_sec.max(0)).expect("non-negative value fits in u64");
+    let micros = u64::try_from(time.tv_usec.max(0)).expect("non-negative value fits in u64");
     seconds.saturating_mul(1000).saturating_add(micros / 1000)
 }
 

--- a/packages/plumb/ex/mix/test/plumb_test.exs
+++ b/packages/plumb/ex/mix/test/plumb_test.exs
@@ -47,7 +47,9 @@ defmodule PlumbTest do
     {:ok, _} = Plumb.Shell.eval(shell, "echo alpha")
     report = decode!(Plumb.Shell.eval(shell, "echo ${o[1]}-more"))
     assert final_stdout(report) == "alpha-more\n"
-    assert Plumb.Shell.var(shell, "o") == "alpha"
+    # Bare $o is the most recently finished run (#3595); earlier runs stay
+    # addressable through ${o[N]}, exercised by the eval above.
+    assert Plumb.Shell.var(shell, "o") == "alpha-more"
     assert Plumb.Shell.var(shell, "does-not-exist") == nil
   end
 

--- a/packages/plumb/ex/src/lib.rs
+++ b/packages/plumb/ex/src/lib.rs
@@ -80,6 +80,7 @@ mod _plumb {
             | Error::GlobNoMatch { .. }
             | Error::BuiltinInPipeline { .. }
             | Error::BuiltinUsage { .. }
+            | Error::RunRef { .. }
             | Error::SubstitutionOverflow { .. } => PlumbError::Strict { message },
             Error::Redirect { .. } | Error::Io { .. } => PlumbError::Io { message },
             Error::ExitRequested { .. } => PlumbError::Exit { message },

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4371,13 +4371,16 @@
             exaSearchBaked = true;
           };
         in
-          # Without the kernel only the merge protections and the
-          # exa-superseded web pair remain: the stock shell/file/search tools
-          # are that agent's whole surface.
+          # Without the kernel only the merge protections, the unconditional
+          # bundled-skill denies (#3607) and the exa-superseded web pair
+          # remain: the stock shell/file/search tools are that agent's whole
+          # surface.
           overlay.claude.deniedToolPatterns
           == [
             "Bash(gh pr merge*--admin*)"
             "Bash(gh pr merge*--force*)"
+            "Skill(artifact-design)"
+            "Skill(dataviz)"
             "WebSearch"
             "WebFetch"
           ]


### PR DESCRIPTION
Main's required gate is red for four independent reasons; this PR carries all four fixes so one CI cycle restores green.

1. **plumb_ex E0004** (73c080d6): plumb-core grew `Error::RunRef` (#3593/#3595) after plumb-ex's exhaustive match landed (#3592). A failed run reference is a strict-mode refusal, so it maps to `PlumbError::Strict`.
2. **plumb_core clippy** (ffd7f2dd): the fork lint `fallible_int_fallback` denies the `u64::try_from(..).unwrap_or(0)` fallback #3596 introduced in `timeval_millis`; clamp the kernel-reported (non-negative by contract) timevals first, making the conversion infallible by construction.
3. **plumb-ex-run ExUnit** (e63f53b3): the binding test pinned pre-#3595 semantics where bare `o` kept the first eval's output; since #3595 bare `$o`/`$e`/`$s` alias the most recently finished run (documented on `Shell::commit`), with history addressable via `${o[N]}`. Assert the documented behavior. E0004 masked this until fix 1 let the suite run.
4. **ix-eval-tests / requiredGateRoots.eval** (679ed69a): 8d79809a added the unconditional `Skill(artifact-design)`/`Skill(dataviz)` denies (#3607) without updating the agent-policy gate's exact-equality list. Assert the current render; verified by pure eval against permissions.nix.

Each failure was attributed from the runner-side logs (`/var/log/ix-ci/runs/<merge>/Check`) of main run 29676685704 and this branch's runs 29675500058 / 29677652366 / 29677902923; fixes 1-3 additionally verified by building the plumb closure on hil-compute-3.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix four test and runtime failures blocking main's CI
> - Clamps `timeval` fields to non-negative in `timeval_millis` ([engine.rs](https://github.com/indexable-inc/index/pull/3619/files#diff-a29a88c48efdd657a1ed1bfcdd512b182ccb85f104c35d48060577aa0074d4ff)) and replaces silent `.unwrap_or(0)` with `.expect(...)` on clamped values.
> - Maps `plumb_core::Error::RunRef` to `PlumbError::Strict` in the error conversion in ([lib.rs](https://github.com/indexable-inc/index/pull/3619/files#diff-116fd0d3b0f9df92954a05f565f9a86f40941db44af4462f71946c28ae661636)) so `RunRef` errors now surface instead of being lost.
> - Updates bare variable `$o` test expectation to `"alpha-more"` (most recent run) in ([plumb_test.exs](https://github.com/indexable-inc/index/pull/3619/files#diff-46c30b92d2c248df6dd75118888bfa0c1f492a3015e1e13944f3b4aca3d7955b)).
> - Adds `Skill(artifact-design)` and `Skill(dataviz)` to `deniedToolPatterns` expectations in ([default.nix](https://github.com/indexable-inc/index/pull/3619/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a)).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 679ed69.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->