### PR TITLE
users: adopt the patched git in the andrewgazelka profile

### DIFF
--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -509,7 +509,7 @@ in {
       websocat # `curl` for WebSockets
 
       # Git and version control
-      git # the version control system itself
+      indexPkgs.git # git with the linked-worktree submodule alternates patch (packages/git, #3610); same pinned `index` input
       git-lfs # large-file storage extension for git
       gitoxide # pure-Rust git implementation (`gix`, used by the `gix clone` helper)
       libgit2 # C library implementing git core methods (linked against by other tools)
@@ -526,7 +526,7 @@ in {
       # each over the network. See scripts/git-wt-submodules.sh.
       (ix.writeBashApplication pkgs {
         name = "git-wt-submodules";
-        runtimeInputs = [git];
+        runtimeInputs = [indexPkgs.git];
         text = builtins.readFile (configRoot + "/scripts/git-wt-submodules.sh");
       })
 
@@ -1258,6 +1258,11 @@ in {
     # On darwin both resolve to the same derivation, so this is a no-op there.
     package = fishNoTests;
   };
+
+  # portable.nix (imported alongside this profile on hydra) enables
+  # programs.git, whose package defaults to nixpkgs git; align it with the
+  # patched home.packages entry so the profile holds one bin/git (#3610).
+  programs.git.package = indexPkgs.git;
 
   programs.yazi = {
     enable = true;


### PR DESCRIPTION
The profile git (workstation `home.packages` entry and `programs.git.package`, which portable.nix enables with the nixpkgs default) is now `packages/git` -- the linked-worktree submodule alternates build from #3612 -- so the git on PATH is the patched one.

Closes #3620

(PR authored by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch andrewgazelka workstation profile to use patched `indexPkgs.git`
> Updates [workstation.nix](https://github.com/indexable-inc/index/pull/3621/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962) to use `indexPkgs.git` (the Git build with the linked-worktree submodule alternates patch) in all three places: `home.packages`, the `git-wt-submodules` script's `runtimeInputs`, and `programs.git.package`. This ensures a consistent, patched Git binary is used across the profile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 316ebef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->