### PR TITLE
plans: eval trigger policy in 0023, memory-oriented world RFC 0024

### DIFF
--- a/packages/site/src/lib/plans/0023-evals-everywhere.svx
+++ b/packages/site/src/lib/plans/0023-evals-everywhere.svx
@@ -37,6 +37,22 @@ PR.
 2. Agent methods and harness changes (0020's gate).
 3. UI properties (0022's gate).
 
+## Triggering
+
+The lane runs exactly when it can change a decision:
+
+- A PR that touches a behavioral surface (prompt rules, skills, agent
+  definitions, harness code) runs the full eval lane on that PR, and the
+  baseline-vs-change comparison lands as the review artifact. Everything
+  else skips it.
+- A nightly cron run executes only when a behavioral surface changed
+  since the last recorded run, catching drift no PR diff names (model
+  and dependency bumps). Unchanged days cost nothing.
+
+Both paths record what they ran against (surface hash, model matrix), so
+"did evals cover this change" is answerable from the record rather than
+CI archaeology.
+
 ## Eval gate, applied to itself
 
 The paved road wins if plan-gated changes actually use it instead of

--- a/packages/site/src/lib/plans/0024-memory-oriented-world.svx
+++ b/packages/site/src/lib/plans/0024-memory-oriented-world.svx
@@ -1,0 +1,62 @@
+---
+id: 0024-memory-oriented-world
+number: '0024'
+title: One memory, queryable across the whole world
+status: Input wanted
+rfc: true
+authors: andrewgazelka
+created: '2026-07-18'
+updated: '2026-07-18'
+trackingIssue: null
+supersedes: null
+supersededBy: null
+scores:
+  ambition: { value: 8, why: 'one query language over memory, telemetry, and live system state' }
+  impact: { value: 7, why: 'cross-cutting questions about the fleet become queries instead of archaeology' }
+  effort: { value: 5, why: 'weave substrate is executed; the delta is adapters, projections, and a read surface' }
+  risk: { value: 4, why: 'rollups over noisy claims can mislead; projections are derived and cheap to fix' }
+  maturity: { value: 2, why: 'substrate landed in weave; no consumer rollup exists yet' }
+  leverage: { value: 8, why: 'every future dashboard or fleet question is a saved projection, not a subsystem' }
+  taste: { value: 7, why: 'deciding what becomes a claim and which rollups earn a surface is the judgment' }
+description: 'Agents write observations and claims into one Datalog memory (weave); consumers query the world instead of grepping hosts. Fleet rollups like "top things agents are irritated by, above a threshold" are saved projections, not features.'
+---
+
+## Summary
+
+Agents write observations and claims into one memory: weave, Datalog
+facts with provenance envelopes (weave#281, executed). Consumers then
+query the world instead of grepping hosts. "The world" is wider than
+what agents journal: pull and push adapters make live state facts by
+evaluation time (weave docs/weave-datalog-over-everything.html), so one
+query language spans memory, telemetry, and system state.
+
+## Motivation
+
+Cross-cutting questions ("what are agents most irritated by this week,
+across the cluster?") have no query today; the evidence is scattered
+over transcripts, issues, and per-host logs. Once every irritation,
+blocker, and gotcha is a stated claim with provenance, that question is
+a saved projection: group by subject, count distinct stating sessions,
+filter to current, apply a threshold, rank.
+
+## Detailed design
+
+- Substrate: weave agent memory plus the datalog-over-everything adapter
+  model for non-journal sources. Nothing here reopens those designs.
+- Consumer rollups are projections a consumer registers, not server
+  features. First dashboards: top irritations above a threshold,
+  recurring blockers, most-hit gotchas, per-repo friction.
+- ix-mcp stays the write choke point; the delta this plan owns is the
+  read surface where projections render for humans (site page or TUI
+  panel).
+- Plan 0021 (filesystem as database) becomes one adapter in this frame:
+  files are entities, xattrs components, its index a pull-through
+  source.
+
+## Open questions
+
+- Which rollups earn a rendered dashboard versus staying ad hoc queries?
+- Threshold semantics: absolute counts, distinct sessions, or
+  recency-decayed?
+
+Drafted by Claude Code (Fable); comments wanted, hence the RFC flag.

--- a/packages/site/src/lib/plans/0031-memory-oriented-world.svx
+++ b/packages/site/src/lib/plans/0031-memory-oriented-world.svx
@@ -1,6 +1,6 @@
 ---
-id: 0024-memory-oriented-world
-number: '0024'
+id: 0031-memory-oriented-world
+number: '0031'
 title: One memory, queryable across the whole world
 status: Input wanted
 rfc: true
@@ -52,6 +52,11 @@ filter to current, apply a threshold, rank.
 - Plan 0021 (filesystem as database) becomes one adapter in this frame:
   files are entities, xattrs components, its index a pull-through
   source.
+- Plans 0025 (agent gossip), 0026 (shared brain), 0028 (cross-agent
+  memory), and 0030 (knowledge graph) name write paths and stores; this
+  plan names the query substrate they can share: facts in Datalog,
+  rollups as saved projections. 0025's irritation clusters are the
+  first projection this plan wants rendered.
 
 ## Open questions
 


### PR DESCRIPTION
Extends plan 0023 (evals everywhere) with a trigger policy: a PR touching a behavioral surface (prompt rules, skills, agent definitions, harness) runs the full eval lane; a nightly cron run executes only when a surface changed since the last recorded run. Adds RFC plan 0024 (one memory, queryable across the whole world): weave Datalog memory plus datalog-over-everything adapters as the substrate, consumer rollups (top agent irritations across the cluster above a threshold, recurring blockers, per-repo friction) as saved projections, plan 0021 reframed as one adapter.

Closes #3623.

Authored by Claude Code (claude-fable-4.6).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add eval trigger policy to plan 0023 and introduce memory-oriented world RFC 0024
> - Adds a 'Triggering' section to [0023-evals-everywhere.svx](https://github.com/indexable-inc/index/pull/3625/files#diff-d1de6a7372a4ff0d0f36f205d091a4e7b4d42539c546226a09ec146958b783a7) specifying when the eval lane runs: PRs touching behavioral surfaces run full baseline-vs-change evals, non-surface PRs skip it, and a nightly cron runs only when behavioral surfaces have changed since the last run to catch model/dependency drift.
> - Adds a new RFC document [0031-memory-oriented-world.svx](https://github.com/indexable-inc/index/pull/3625/files#diff-7f1c9e255ce1ff7f5e6020c40a22ca212dd32a8131eff9700effaa8d5d60bf4f) proposing a unified queryable memory layer using weave Datalog with adapters for live state, consumer projections/rollups, and inter-plan relationships.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ffca75e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->