### PR TITLE
plans: 0032 web-search eval (claude vs exa) and 0033 agent truthfulness (rfc)

### DIFF
--- a/packages/site/src/lib/plans/0032-websearch-eval-claude-vs-exa.svx
+++ b/packages/site/src/lib/plans/0032-websearch-eval-claude-vs-exa.svx
@@ -1,0 +1,119 @@
+---
+id: 0032-websearch-eval-claude-vs-exa
+number: '0032'
+title: 'Web-search eval: Claude built-in WebSearch vs Exa'
+status: Input wanted
+rfc: true
+authors: andrewgazelka
+created: '2026-07-19'
+updated: '2026-07-19'
+trackingIssue: null
+supersedes: null
+supersededBy: null
+scores:
+  ambition: { value: 4, why: 'one eval suite over two backends the fleet already has wired up' }
+  impact: { value: 6, why: 'every research-heavy session inherits whichever backend the data picks' }
+  effort: { value: 5, why: 'task mining from transcripts, a grading rubric with a human-audit lane, N rollouts per backend' }
+  risk: { value: 2, why: 'worst case is a suite that confirms the current default; nothing breaks' }
+  maturity: { value: 1, why: 'unbuilt; the harness pattern exists in system-prompt-eval and the experiment skill' }
+  leverage: { value: 6, why: 'the suite reruns whenever either backend changes, and extends to any new search tool' }
+  taste: { value: 6, why: 'grading found-the-primary-source without an LLM judge rubber stamp is the hard part' }
+description: 'Our agents research constantly and use Exa MCP by default, a choice made without measured evidence. Vendor benchmarks conflict head-on and none test our workload. Build an eval from real session transcripts that runs Claude Code built-in WebSearch/WebFetch against the Exa MCP tools from identical fresh-context agents and grades primary-source hits, time-to-answer, tool calls, and claim-level correctness.'
+---
+
+## Summary
+
+Build a task suite from real research moments in our own session transcripts (upstream issue status, merged-PR archaeology, vendor and contact lookups, incident forensics) and run it against two backends: Claude Code's built-in WebSearch/WebFetch and the Exa MCP tools (`web_search_exa`, `web_fetch_exa`) our agents use today. Identical fresh-context agents, N rollouts per task per backend, graded on whether the load-bearing primary source was found, time-to-answer, tool calls used, and claim-level correctness audited against the fetched pages. Report per-task win rates. The output is a decision: switch defaults, keep both behind a router, or drop one.
+
+## Motivation
+
+Agents in this org research constantly: dependency intake checks upstream repos and advisories, incident forensics chases changelogs and issue threads, and upstream-status questions ("is this fixed, in what release") decide what we build versus wait for. We picked Exa as the default search backend without measured evidence, and the config has never been challenged by data.
+
+The two backends differ mechanically in ways that should matter for our workload. Claude Code's WebSearch is a server-side Anthropic tool backed by Brave's index; the model sees title and URL only, and WebFetch summarizes pages through a Haiku pass with a 125-character quote cap (documented by runtime inspection, see prior art). Exa search returns full text and highlights from a semantic index. For "find the exact PR that changed lock-update semantics" the verbatim-content difference plausibly dominates; for "what is the latest release" freshness of the underlying index plausibly dominates. We do not know, and the published numbers cannot tell us: every vendor wins its own benchmark (see prior art), and none of them test transcripts like ours.
+
+The cost question rides along: built-in WebSearch bills $10 per 1,000 searches plus tokens, Exa bills per request on our MCP plan. A backend that needs half the tool calls to find the primary source is cheaper even at a higher per-call price. Wrong-answer cost dwarfs both: a hallucinated-support citation that survives into a report costs an engineer-hour to unwind (plan 0033 documents one).
+
+## Prior art
+
+Static retrieval benchmarks measure the wrong layer for this question:
+
+- BEIR (arXiv:2104.08663): zero-shot retrieval over 18 fixed corpora, nDCG@10 over static relevance labels. No live index, no query reformulation loop, no answer synthesis.
+- MTEB retrieval (arXiv:2210.07316): embedding-model benchmark that folds BEIR in; measures encoders, not search APIs.
+
+Agentic browsing evals are closer in shape but use general-knowledge tasks, not engineering-workflow ones:
+
+- GAIA (arXiv:2311.12983): 466 assistant questions needing browsing and tool use; humans 92%, GPT-4 with plugins 15% at publication.
+- BrowseComp (arXiv:2504.12516, https://openai.com/index/browsecomp/): 1,266 hard-to-find-info questions; OpenAI Deep Research 51.5% where GPT-4o with browsing managed 1.9%; human trainers solved 29.2% inside a two-hour cap. The task style (entangled constraints, short verifiable answers) is a good template for our upstream-status questions.
+- SimpleQA (arXiv:2411.04368, https://openai.com/index/introducing-simpleqa/): 4,326 short fact questions with single indisputable answers; built as a closed-book factuality benchmark, now the de facto search-backend eval because vendors run it with a search harness attached.
+
+Vendor benchmarks exist and disagree with each other, which is itself the finding:
+
+- Exa's published claims: SimpleQA-graded search quality of Exa 89.77% vs Google 86.27%, Bing 85.41%, Brave 81.64% (https://exa.ai/bing-api-deprecation); a state-of-the-art claim with the caveat, stated in their own methodology, that competitor scores report "the highest number between our results and theirs" (https://exa.ai/blog/api-evals); eval philosophy at https://exa.ai/blog/evals-at-exa; open benchmark repo with the most coding-relevant suite found anywhere, WebCode, where Exa groundedness is 79.4 vs Brave 76.3 and Tavily 61.1 (https://github.com/exa-labs/benchmarks).
+- Perplexity's open harness (https://github.com/perplexity-ai/search_evals) ranks the same providers in a different order: SimpleQA Perplexity 0.930, Tavily 0.890, Brave 0.822, Exa 0.781. Exa is first on its own harness and last of four on Perplexity's. Harness design (query generation model, snippet vs full-text feeding, grader) dominates the outcome, which is the strongest argument for running our own on our own tasks.
+
+On the Claude side there is no published quality benchmark from Anthropic, only tool documentation (https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool: versions, domain filters, $10 per 1,000 searches, citations always on). What is known comes from runtime inspection: Claude Code's WebSearch discards everything but title and URL, WebFetch pipes pages through Haiku summarization with a 125-character quote cap, and the backing index is Brave's (https://mikhail.io/2025/10/claude-code-web-tools/, https://trevorfox.com/2026/04/how-claude-code-search-actually-works/). One small independent eval (https://github.com/andresfortunato/raw-web-search) found built-in WebSearch strong on general factual coverage (96% vs 72% against raw extraction) and weak exactly where our workload lives: verbatim code and API docs, where Haiku paraphrasing mangles content, and URL extraction (roughly 100% vs 50% fetch success). Third-party API comparisons (https://rhumb.dev/blog/exa-vs-tavily-vs-serper-vs-brave-search) are qualitative scorecards, no Claude-builtin lane.
+
+Nothing published compares Claude Code's built-in search against Exa on engineering-agent tasks. The ground is genuinely open.
+
+## Detailed design
+
+### Task suite
+
+Mine tasks from real transcripts (the fleet history archive is searchable; plan 0027 makes per-session provenance easier later). Candidate task families, each with a known, human-verified answer key:
+
+- Upstream issue status: "what is the current status of NixOS/nix issue 7730" (the correct answer requires finding both the open issue and merged PR #13437; plan 0033 uses this same pair for a different grading axis).
+- Merged-PR archaeology: "find the merged PR that changed lock-update semantics in Nix".
+- Vendor and contact lookups: the rep for an account, the billing contact, a company's current pricing page.
+- Incident root-cause: "what changed in dependency X between versions A and B that could cause symptom S".
+- Release-status: "is fix Y in any released version of Z".
+
+Target 20 to 40 tasks. Each task record: the prompt, the load-bearing primary source URL (the artifact, not a blog about it), acceptable equivalent sources, and the answer key as checkable claims.
+
+### Harness
+
+The experiment skill pattern with `tui.harness.Claude` (`packages/tui/tui-py/python/tui/harness.py`): fresh-context Claude Code sessions, live-visible on the dashboard. Two lanes differing only in tool config: one with built-in WebSearch/WebFetch allowed and Exa MCP absent, one with Exa MCP tools and built-ins denied. Same model, same system prompt, same task text. N rollouts per task per lane (start with N=5; widen where win rates are close). Session transcripts are the grading input.
+
+### Grading
+
+Per rollout:
+
+- Found the load-bearing primary source: y/n, checked by URL match (plus the equivalents list) against fetched URLs in the transcript.
+- Time-to-answer: wall clock from task start to final answer.
+- Tool calls used: count of search plus fetch calls.
+- Claim-level correctness: decompose the final answer into claims, audit each against the pages the session actually fetched. A claim the fetched pages do not support is a hallucinated-support citation and fails the rollout regardless of whether it happens to be true. LLM-graded with a human audit lane on a sample (the Exa and Perplexity harness disagreement above is what unaudited LLM grading buys).
+
+Report per-task win rates per metric, not aggregate vibes: a backend can win contact lookups and lose PR archaeology, and the router decision below needs exactly that shape.
+
+## Decision criteria
+
+Stated before the data comes in:
+
+- Switch defaults to built-in WebSearch if it wins primary-source rate on a clear majority of task families and is not worse on hallucinated-support rate.
+- Keep both behind a router if each backend wins some task family by a wide margin (say 20+ points of win rate) and the family is predictable from the task text; the router is then a one-line rule in the prompt, not new machinery.
+- Drop the loser if one backend wins or ties every family; the config and its per-call spend go away.
+- If hallucinated-support rates differ materially, that metric vetoes the others: we would take slower and fewer answers over confident wrong citations.
+
+## Drawbacks
+
+- Answer keys rot: upstream status changes, contacts move. Volatile tasks need a checked-at date and periodic re-keying, or the suite silently grades against stale truth.
+- Two lanes cannot be perfectly identical: tool descriptions themselves steer agent behavior, so some difference is tool-prompt quality, not index quality. That confound is real but it is also fair: agents consume the tool through its description.
+- N=5 over 30 tasks and 2 lanes is 300 sessions; at a few minutes each this is an afternoon of compute and a nontrivial search bill. Fine for a one-shot decision, worth budgeting before it becomes a recurring CI lane.
+
+## Alternatives
+
+- Adopt a published benchmark (SimpleQA with a search harness) instead of mining our transcripts: cheaper, but it measures general trivia, and the vendor disagreement shows the harness would decide the result anyway.
+- A/B in production by routing live sessions: real workload, but uncontrolled tasks, no answer keys, and failed research costs real engineering time.
+- Trust the mechanism analysis and skip the eval: the documented title-plus-URL and quote-cap limits suggest Exa wins code-shaped tasks, but "plausibly dominates" is the phrase this plan exists to delete.
+
+## Unresolved questions
+
+- Does WebFetch vs `web_fetch_exa` get evaluated as part of the search lane or as a separate axis? A backend could win search and lose fetch.
+- How to price the comparison honestly: per-call list price, or measured tokens plus calls per solved task?
+- Do we include mgrep/semantic code search tasks, or scope strictly to web? (Plan 0019 owns internal search trust.)
+- Is the router decision stable across models, or does it need a rerun when the default model changes? Plan 0023 would make the rerun cheap.
+
+## Future possibilities
+
+The suite generalizes to any new search backend in an afternoon: add a lane, rerun, read the per-family table. If the claim-level grading lane works, it is the same machinery plan 0033 needs for its truthfulness eval, and the two suites should share a grader.
+
+Drafted by an AI agent via Claude Code; comments wanted, hence the RFC flag.

--- a/packages/site/src/lib/plans/0033-agent-truthfulness-claim-audit.svx
+++ b/packages/site/src/lib/plans/0033-agent-truthfulness-claim-audit.svx
@@ -1,0 +1,119 @@
+---
+id: 0033-agent-truthfulness-claim-audit
+number: '0033'
+title: 'Agent truthfulness: decomposed claims, per-claim provenance, and an audit eval'
+status: Input wanted
+rfc: true
+authors: andrewgazelka
+created: '2026-07-19'
+updated: '2026-07-19'
+trackingIssue: null
+supersedes: null
+supersededBy: null
+scores:
+  ambition: { value: 5, why: 'a reporting contract for every agent surface, enforced by rules and measured by an eval' }
+  impact: { value: 7, why: 'a wrong-altitude summary sent the user back to re-verify upstream state by hand' }
+  effort: { value: 4, why: 'rules text, a claim-audit pass, and an eval suite; no new infrastructure' }
+  risk: { value: 3, why: 'worst case is heavier reports and provenance tags readers skim past' }
+  maturity: { value: 2, why: 'faithfulReporting already has an audit sentence; nothing enforces decomposition or provenance' }
+  leverage: { value: 7, why: 'every status report, upstream-status answer, and handoff inherits the contract' }
+  taste: { value: 6, why: 'the judgment is which claims deserve decomposition without turning prose into a form' }
+description: 'Agents compress verified facts, stale recall, and inference into one confident sentence. This plan separates them: every factual claim in a report maps to a tool result or is marked unverified, volatile state carries a checked-at timestamp, and claims with sub-claims of different truth values are stated separately. An eval with known-answer upstream-status questions measures whether the rules change works.'
+---
+
+## Summary
+
+Make agent reports decomposable into auditable claims. Three contract changes: a claim-audit pass before any report (every factual claim maps to a tool result from the current session or is marked unverified), per-claim provenance (checked now, recalled, or inferred, with timestamps on volatile state), and a decomposition rule (sub-claims with different truth values are never merged into one verdict). Delivery is a rules change in `packages/agent/prompt/rules.nix`, and the gate for adopting it is an eval with known-answer questions whose correct answers require splitting a claim.
+
+## Motivation: a real miss, 2026-07-19
+
+An agent (Claude Opus 4.5 via Claude Code) summarized the state of Nix sparse lock files:
+
+> #7730 (sparse lock files - parent lock stores a pointer to the child's flake.lock instead of copying its nodes) is the proper fix and is still open, years on. There's no released Nix where the parent just defers to index/flake.lock.
+
+What verification found afterwards (2026-07-19): NixOS/nix#7730 (since retitled "Reuse input lock files") is indeed still open, and its body says "Status: Not implemented yet", with a sparseNodes migration plan posted Nov 2025. But the summary omitted load-bearing context. NixOS/nix PR #13437 ("lockFlake(): When updating a lock, respect the input's lock file", edolstra) merged 2025-07-10 and shipped in Nix 2.31 (backported to a 2.30.x point release), and it is the exact mechanism the workflow under discussion (`nix flake update <input>` copying the child's pins) relies on.
+
+The claim collapsed two questions into one verdict:
+
+- Eval-time deferral (the parent lock stores a pointer, #7730): not implemented.
+- Update-time respect (updating an input copies the child's locked pins, #13437): implemented and released.
+
+So the user reasonably asked "has this been implemented yet" and could not tell which half was true. The verdict was right at one altitude and wrong at the altitude the user was operating at. Diagnosis: a compressed claim synthesized from search-result snippets, without separating adjacent facts and without stating which sub-claim each citation supports.
+
+The same session had a second failure mode. Two PR watcher processes died silently (a known pre-fix MCP build bug), and the agent initially trusted that a watcher existed instead of verifying liveness. Later it reported a PR as blocked while the user believed it had landed, because the two of them had checked state at different times and neither statement carried a timestamp.
+
+The general problem: agents make compressed claims that mix verified facts, stale facts, and inference, all in the same confident register. The reader has no way to tell which words are load-bearing.
+
+## Detailed design
+
+Five mechanisms, evaluated independently. The first three are the reporting contract; the last two are how it ships and how it is measured.
+
+### a. Claim-audit pass before reporting
+
+Before a report goes out, every factual claim in it must map to a tool result from the current session. A claim with no backing tool result is either cut or explicitly marked unverified. The `faithfulReporting` rule already contains this sentence (sourced from the Claude Fable 5 system card guidance, where it measurably reduced fabricated status reports). The case study shows the audit alone is not sufficient: every sentence in the quoted claim did map to a tool result (search snippets mentioning #7730), and the report was still misleading. The audit catches fabrication; it does not catch compression. It stays, and the next two mechanisms cover what it misses.
+
+### b. Per-claim provenance with timestamps
+
+Three provenance classes, distinguished in the report:
+
+- Checked at source now: the agent fetched the artifact this session (the issue body, the PR state, the CI log).
+- Recalled: from memory files or training data, not re-checked.
+- Inferred: derived from other claims, not observed.
+
+Volatile state (PR status, CI status, issue status, deploy state) always carries when it was checked. "Blocked as of 14:32Z" and "landed, checked 13:10Z" can both be true; "blocked" and "landed" without timestamps read as a contradiction, which is precisely the watcher disagreement from the case study. Liveness claims are provenance-class checked-now by definition: "a watcher exists" is only reportable after probing the watcher, never from remembering that one was started.
+
+### c. Decomposition rule
+
+When a claim has sub-claims with different truth values, state them separately, never as one merged verdict. The 7730 answer under this rule reads: "Eval-time deferral (#7730): not implemented, issue still open. Update-time respect (#13437): merged 2025-07-10, released in Nix 2.31." Each half cites the artifact that supports it. The rule triggers on a cheap test: if a yes/no question about the claim has the answer "yes for X, no for Y", the claim must be split. Most claims do not need this; the skill is noticing the ones that do, which is why the eval below exists.
+
+### d. An eval that measures splitting
+
+Seed tasks with known-answer upstream-status questions where the correct answer requires decomposition, modeled on the 7730/13437 pair: an issue that is open while an adjacent PR shipped the workflow-relevant half, a feature flag that is merged but not in any release, a CVE fixed on main but not backported. Grading, per rollout: did the agent state the halves separately (y/n), did each half cite the right artifact (y/n), did volatile state carry a timestamp (y/n). Run with the experiment skill and `tui.harness.Claude` (`packages/tui/tui-py/python/tui/harness.py`), N fresh-context rollouts per task, baseline rules vs changed rules, report pass rates per task. Plan 0023 (evals as the gate for behavioral change) is the discipline this slots into; plan 0032 builds the adjacent search-backend suite and shares the harness pattern.
+
+### e. Delivery: rules change validated by prompt-eval
+
+The mechanisms land as edits to `packages/agent/prompt/rules.nix` (the `faithfulReporting` and `validate` rules are the anchors), validated with the prompt-eval approach: baseline vs changed prompt, N fresh sessions on the eval suite from (d), adopt only on a measured win. No harness code changes are required for (a) through (c); they are prompt-level contracts. If prompt-level enforcement proves too weak, a structured report format (claims as data, prose rendered from them) is the escalation, noted under future possibilities.
+
+## Why the existing rules were not enough
+
+The house rules already say "Never guess what you can check: verify load-bearing facts at the strongest source" (`validate`) and "audit each claim against a tool result from this session; report only what you can point to evidence for" (`faithfulReporting`). Both gate the wrong thing for this failure. `validate` gates acting on unverified facts; the agent did verify that #7730 was open. `faithfulReporting` gates claims with no evidence; every clause had evidence. Neither rule constrains the altitude of a summary: which adjacent facts may be merged, which citation supports which clause, and when a timestamp is part of the claim. The miss was in synthesis, after verification and before reporting, and that step currently has no rule.
+
+## Success criteria
+
+- On the eval suite from (d), the changed rules beat baseline on split-rate and per-claim citation accuracy, with at least a repeat of the 7730/13437 shape answered correctly in a majority of rollouts where baseline fails it.
+- Volatile-state claims in real session reports carry checked-at timestamps (spot-audited from history, plan 0027 makes this samplable).
+- No regression in report length beyond a small constant factor; provenance is a tag, never a paragraph.
+- Zero recurrence of the watcher-liveness shape: existence claims about monitors backed by a liveness probe in the same session.
+
+## Drawbacks
+
+- Provenance tags add friction to every report; over-applied, they read as hedging and train readers to skim. The rule must scope to factual claims about external state, never to code the agent just wrote.
+- Decomposition can be overdone: a report that splits every sentence into sub-claims is worse to read than the compressed one was to trust. The trigger test in (c) is the guard.
+- Prompt-level contracts decay; without the eval in (d) re-run on rule changes, this regresses silently.
+
+## Alternatives
+
+- Do nothing: the existing audit sentence keeps catching fabrication and keeps missing compression; the next 7730-shaped miss is a matter of time.
+- Structured claims-as-data reports from day one: strongest enforcement, but a large harness change, and the case study does not yet justify it over prose contracts.
+- Post-hoc verifier agent that fact-checks reports before delivery: catches misses but doubles latency on every report, and the verifier has the same compression incentives.
+
+## Prior art
+
+- `faithfulReporting` in `packages/agent/prompt/rules.nix`: the claim-audit sentence and its measured effect on fabricated reports, per the Claude Fable 5 system card guidance.
+- FActScore (arXiv:2305.14251): factuality scoring by decomposing long-form output into atomic claims and verifying each one independently; the same move mechanism (c) asks the agent to perform on itself.
+- SAFE, "Long-form factuality in large language models" (arXiv:2403.18802): claim decomposition plus per-claim search-backed verification, evidence that per-claim grading is tractable at scale.
+- Plan 0023 (evals as the gate for behavioral change): the adopt-only-on-measured-win discipline that (d) and (e) follow.
+- Plan 0027 (session provenance): commit-level provenance; this plan is claim-level provenance inside a single report.
+
+## Unresolved questions
+
+- Where does the claim-audit pass live: a sentence in the rules, a pre-report checklist in the harness, or a Stop-hook gate that samples reports?
+- What is the timestamp convention: absolute UTC, session-relative, or both? Volatile-state comparisons across agents need a shared clock.
+- Does provenance apply to chat replies or only to durable artifacts (reports, issues, PR bodies)? Chat is where the 7730 miss happened, and chat is also where tags cost the most.
+- How large does the eval suite in (d) need to be before a pass-rate difference is decision-grade? Plan 0023 has the same open question.
+
+## Future possibilities
+
+If prompt-level contracts hold, the same decomposition makes reports machine-checkable: claims as structured data with provenance and timestamps, prose rendered from them, and the claim-audit pass becomes a mechanical diff between claims and the session's tool results. That is also the natural attestation shape for plan 0030's claim graph.
+
+Drafted by an AI agent via Claude Code; comments wanted, hence the RFC flag.


### PR DESCRIPTION
Two RFC-status plans.

**Plan 0032** (packages/site/src/lib/plans/0032-websearch-eval-claude-vs-exa.svx): an eval comparing Claude Code's built-in WebSearch/WebFetch against the Exa MCP tools our agents default to, on a task suite mined from real session transcripts (upstream issue status, merged-PR archaeology, vendor lookups, incident forensics). Prior-art research found no neutral head-to-head for this question, and vendor benchmarks that contradict each other (Exa self-reports 89.77% SimpleQA and first place; Perplexity's open harness ranks Exa last of four at 0.781), which is the argument for running our own suite with pre-stated decision criteria.

**Plan 0033** (packages/site/src/lib/plans/0033-agent-truthfulness-claim-audit.svx): mechanisms for more reliable factual claims, built around a verified 2026-07-19 miss where a summary of NixOS/nix#7730 vs PR #13437 merged two sub-claims with different truth values into one verdict. Proposes a claim-audit pass, per-claim provenance with timestamps on volatile state, a decomposition rule, an eval to measure splitting, and delivery via packages/agent/prompt/rules.nix validated with prompt-eval.

(PR authored by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add RFC plans for web-search eval and agent truthfulness claim audit
> - Adds [0032-websearch-eval-claude-vs-exa.svx](https://github.com/indexable-inc/index/pull/3628/files#diff-041145417e49f20d8d10c1f5d80f24ea692e261135a304447534f42f4638c098), an RFC proposing an eval suite to compare Claude Code's built-in WebSearch/WebFetch against Exa MCP tools using tasks mined from session transcripts.
> - Adds [0033-agent-truthfulness-claim-audit.svx](https://github.com/indexable-inc/index/pull/3628/files#diff-1f175e903771a75d4f330d4c973ed40bd96e5bca9e700741a189bf20f020296b), an RFC proposing a claim-audit pass for agents that attaches per-claim provenance and timestamps, and decomposes mixed-truth claims, with an eval to measure effectiveness.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dacbf29.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->