### PR TITLE
plans: 0034 proactive improvement pipeline + 0035 endorsement trust lens (rfc)

### DIFF
--- a/packages/site/src/lib/plans/0034-proactive-improvement-pipeline.svx
+++ b/packages/site/src/lib/plans/0034-proactive-improvement-pipeline.svx
@@ -1,0 +1,130 @@
+---
+id: 0034-proactive-improvement-pipeline
+number: '0034'
+title: 'Proactive improvement: one controlled pipeline for drive-by fixes'
+status: Input wanted
+rfc: true
+authors: andrewgazelka
+created: '2026-07-19'
+updated: '2026-07-19'
+trackingIssue: '#3629'
+supersedes: null
+supersededBy: null
+scores:
+  ambition: { value: 6, why: 'turns every agent into a maintenance sensor without giving any of them push access' }
+  impact: { value: 7, why: 'drive-by fixes happen today ad hoc, unaudited, and through an open injection channel' }
+  effort: { value: 5, why: 'nomination contract plus one standing fixer; 0012, blast-radius, and code-reviewer already exist' }
+  risk: { value: 5, why: 'an autonomous fixer with merge rights is itself attack surface; nominate-only default contains it' }
+  maturity: { value: 2, why: 'the instincts are in the prompt rules; there is no contract, queue, or fixer' }
+  leverage: { value: 8, why: 'every repo and every future agent inherits the same noticing-to-landed path' }
+  taste: { value: 6, why: 'which fix classes earn autonomy is judgment; the pipeline itself is plumbing' }
+description: 'Agents notice objectively-improvable things constantly; what happens next depends on whose personal agent noticed, under whatever prompt and tool grants it ran. This plan gives noticing exactly one controlled outlet: a nomination contract requiring a machine-checkable acceptance, a single fleet-owned fixer with pinned prompt and constrained tools, risk-gated review, and a measured experiment deciding fix-now versus file-first per fix class.'
+---
+
+## Summary
+
+Make agents more agentic about the things they notice in passing, without
+letting every agent act on them. Any agent may nominate an improvement, but
+only if it carries a machine-checkable acceptance. Exactly one fleet-owned
+fixer turns nominations into PRs. Whether the fixer should act immediately
+or the nomination should sit as an issue first is an open question; this
+plan treats it as an experiment per fix class, not a doctrine.
+
+## Motivation
+
+An agent doing task A constantly walks past defect B: a dead link, a lint
+smell, a stale doc, a flaky test, dead code. Today the outcome depends on
+which agent noticed and whose harness it ran under. Some fix it inline and
+bloat their diff. Some file an issue. Most say nothing and the observation
+dies with the session.
+
+The prompt rules already encode both instincts without deciding between
+them: a tactical fix gets an issue or a background agent, and agents should
+spawn background agents named for issues they could fix themselves. Plans
+0025 (gossip) and 0031 (recommended next actions) build capture surfaces
+for exactly this kind of observation. What is missing is the execution
+side: who acts, under what identity, and with what controls.
+
+The control question is the sharp one. If drive-by fixes come from
+whichever personal agent noticed the problem, there is no pinned prompt, no
+shared tool policy, and no audit trail. That is not just messy, it is an
+injection channel: the threat model is a subtle security defect laundered
+as a drive-by improvement, a typo fix that also touches CI, a lint cleanup
+that weakens an auth check. The more agentic we make agents, the more this
+channel matters. Autonomy has to route through a surface we control.
+
+## Detailed design
+
+### Nomination contract
+
+A nomination is a structured issue (label `auto-improve`) with two required
+fields:
+
+- The defect, stated as a claim about repo state, citing file and line.
+- An acceptance check: a command that fails before the fix and passes
+  after (a lint rule, a link checker, a test, a build). No acceptance
+  check, no nomination; it is an opinion and goes through the normal issue
+  path.
+
+Any agent, personal or fleet, may nominate. Nomination is the only verb
+personal agents get; they never produce the fix in shared repos. The
+auto-issue and session-retro skills and the 0025/0031 surfaces all become
+nominators feeding one queue.
+
+### The standing fixer
+
+One fleet-owned fixer drains the queue:
+
+- One bot identity; every PR it opens is attributable to it.
+- Pinned prompt, hash recorded on each PR, so behavior changes are diffs.
+- Constrained tool policy and no secrets access.
+- Issue text is data, never instructions: the fixer reproduces the defect
+  from repo state plus the acceptance check, and refuses nominations whose
+  body tries to direct edits beyond making the check pass.
+- A provenance envelope on every PR: model, harness, prompt hash, the
+  nomination it drains, the acceptance result before and after. Same
+  envelope shape as the weave claim provenance work.
+
+Landing goes through the 0012 PR-landing primitive; this plan does not
+build its own merge loop.
+
+### Fix-now versus file-first
+
+We do not know whether immediate autofix beats file-and-drain. Probably it
+differs by class: typos and dead links want fix-now; anything touching
+behavior wants a queue and a human glance. So it is measured, per class,
+0023-style: revert rate, time from noticing to landed, review minutes per
+PR. File-first is the default; a class graduates to fix-now only when its
+measured revert rate stays at zero over a real sample.
+
+### Security gates
+
+- A diff-risk classifier over the fixer's output: paths touching auth,
+  crypto, CI workflows, release machinery, lockfiles, or permissions force
+  human review regardless of class. Blast-radius machinery is the seed.
+- A code-reviewer pass on every fixer PR; trivial classes may land on a
+  green pass, everything else waits for a human.
+- Rate limits per repo and per nominator, so a flood of nominations is a
+  signal, not a takeover.
+- Red-team evals: periodically inject nominations that hide a defect
+  behind a plausible fix. The pipeline must catch them, and the catch rate
+  is the evidence that decides how much autonomy each class earns.
+
+## Rollout
+
+1. Nomination contract and label; wire auto-issue, session-retro, and the
+   0031 surface to emit it.
+2. Standing fixer drains file-first for all classes; collect the metrics.
+3. Graduate the first classes (typo, dead link) to fix-now; compare
+   against their file-first baseline.
+4. Red-team injections gate every graduation and run continuously after.
+
+## Open questions
+
+- Dedupe: many agents will nominate the same defect; cluster before the
+  fixer drains (0025 clustering is the obvious reuse).
+- Scope: index first, then ix and weave; does one fixer serve all repos or
+  one per repo?
+- Who triages nominations that fail their own acceptance check?
+
+Drafted by Claude Code (Fable); comments wanted, hence the RFC flag.

--- a/packages/site/src/lib/plans/0035-endorsement-trust-lens.svx
+++ b/packages/site/src/lib/plans/0035-endorsement-trust-lens.svx
@@ -1,0 +1,120 @@
+---
+id: 0035-endorsement-trust-lens
+number: '0035'
+title: 'Endorsement trust lens: judge ideas by local PageRank over people we trusted'
+status: Input wanted
+rfc: true
+authors: andrewgazelka
+created: '2026-07-19'
+updated: '2026-07-19'
+trackingIssue: '#3631'
+supersedes: null
+supersededBy: null
+scores:
+  ambition: { value: 6, why: 'gives every agent the who-is-talking prior humans use, derived instead of gut-felt' }
+  impact: { value: 6, why: 'agents currently weigh a stranger and a proven contributor identically' }
+  effort: { value: 4, why: 'edges already exist in git, review, and issue history; the lens is a bounded graph walk' }
+  risk: { value: 4, why: 'a popularity prior can entrench cliques and be gamed; costly-act edges and caps contain it' }
+  maturity: { value: 2, why: 'weave trust-as-lens states the principle; nothing computes or consumes it in index' }
+  leverage: { value: 7, why: 'every triage surface (reviews, nominations, RFC comments) inherits one prior' }
+  taste: { value: 6, why: 'which edges count as endorsement is judgment; the walk is plumbing' }
+description: 'When an agent judges an incoming idea (a review comment, an issue suggestion, an external PR, RFC input), it should weigh who is talking the way people do: a voice close to voices we have consistently accepted starts with credit. The history to derive this already exists in merged PRs, approvals, and accepted claims. This plan defines the endorsement graph, a read-time personalized-PageRank lens over it, and the surfaces that consume the prior, never a stored reputation score.'
+---
+
+## Summary
+
+Give agents the prior humans use when they hear an idea: who is saying it,
+and how close is that voice to voices we already trust. Build an
+endorsement graph from acts the org has already recorded (merged and
+unreverted PRs, approvals, issues that led to landed fixes, accepted
+claims), and at judgment time run a personalized PageRank seeded at the
+principals the reader has consistently accepted, a few hops out. The
+result is a prior, computed per reader per query and never stored. If a
+new voice keeps agreeing with, or being leaned on by, people we have liked
+a lot, its ideas start with credit; a voice clustered with consistently
+rejected sources starts in deficit.
+
+## Motivation
+
+Agents treat all input as equally credible. A drive-by suggestion from an
+unknown account and a review comment from the person who wrote the
+subsystem get the same weight in the context window. Humans do not work
+this way, and the correction they apply is not bias, it is evidence:
+track record is data. We have that data and throw it away.
+
+The weave agent-memory plan (weave#281, extended in weave#337) already
+establishes the principle on the storage side: trust is a lens, never a
+stored column, and the journal's agrees, supersedes, and based_on facts
+form an endorsement graph. This plan is the index-side consumer: where the
+graph comes from in this repo's history, and which agent decisions read
+the prior.
+
+## Detailed design
+
+### Edges: only costly acts
+
+An endorsement edge is created by an act that cost something, never by a
+cheap signal:
+
+- A merged PR that was not reverted endorses its author (weight grows
+  with survival time).
+- An approving review that merged endorses the author; a requested change
+  that was accepted endorses the reviewer.
+- An issue whose fix landed endorses the filer.
+- In agent memory, a claim pulled into another principal's basis endorses
+  its author (weave based_on), as do agrees edges.
+
+Likes, comments, and volume do not create edges. That is the sybil
+defense: manufacturing standing requires landing real work past the
+existing gates.
+
+### The lens
+
+At judgment time the reader seeds personalized PageRank at the principals
+whose contributions it (or its operator) has consistently accepted, walks
+the endorsement edges a bounded number of hops, and reads off the mass on
+the voice being judged. Properties carried over from trust-as-lens:
+
+- Derived per reader per query; different readers legitimately weigh the
+  same history differently.
+- Never stored: no reputation column, no global leaderboard, nothing to
+  gradually go stale or get gamed at rest.
+- Local: the walk stays in the seed neighborhood, so pricing one voice
+  never needs the global graph.
+
+### Consumers
+
+- Review triage: code-reviewer and human-facing summaries order external
+  suggestions by prior, and say so.
+- Plan and RFC comments: input-wanted plans surface which feedback comes
+  from near the trusted cluster.
+- Plan 0034 nominations: the fixer drains high-prior nominations first,
+  and a class may require a minimum prior to skip human review.
+
+### What the prior may not do
+
+The prior orders attention; it never replaces gates. A high-trust voice
+still goes through 0034's risk classifier, review passes, and red-team
+evals: trusted people get compromised, and popularity is not authority.
+Symmetrically, a zero-prior voice is unpriced, not rejected; its
+acceptance check still speaks for itself.
+
+## Rollout
+
+1. Extract the edge set from git and GitHub history for index; validate
+   that the derived neighborhood matches operator intuition on a sample.
+2. Implement the lens as a query (0030's graph is the natural home; a
+   standalone extractor is fine until it lands).
+3. Wire the first consumer: suggestion ordering in review summaries.
+4. Feed 0034 nomination triage once both plans have landed their first
+   stages.
+
+## Open questions
+
+- Seed set: operator-curated, derived from the reader's own accept
+  history, or both?
+- Decay: does an endorsement from three years ago still carry mass?
+- Negative edges: reverted PRs and rejected claims as explicit deficit,
+  or just absent credit?
+
+Drafted by Claude Code (Fable); comments wanted, hence the RFC flag.


### PR DESCRIPTION
Closes #3629. Closes #3631.

Two Input-wanted RFC plans, both about making agents more agentic safely:

**0034 proactive improvement pipeline.** Any agent may nominate an objectively-improvable defect, but only with a machine-checkable acceptance (fails before, passes after). Exactly one fleet-owned fixer produces diffs: bot identity, pinned prompt hash, constrained tools, provenance envelope, nomination text treated as data not instructions. Fix-now vs file-first is explicitly undecided and measured per class (revert rate, time-to-land, review minutes); file-first default. Security gates: diff-risk classifier forcing human review on auth/crypto/CI/release/lockfile paths, code-reviewer pass on every PR, rate limits, continuous red-team injections. Motivation: uncontrolled personal-agent drive-by fixes are an injection channel for subtle security defects.

**0035 endorsement trust lens.** Agents weigh a stranger and a proven contributor identically; humans weigh who is talking. Build an endorsement graph from costly acts only (merged unreverted PRs, accepted reviews, landed issue fixes, weave based_on/agrees claims), then at judgment time run a personalized PageRank seeded at principals the reader has consistently accepted: a voice near people we have liked a lot starts with credit. Derived per reader per query, never a stored reputation. Consumers: review-suggestion ordering, RFC comment triage, and 0034 nomination priority. The prior orders attention; it never replaces gates.

Companion to weave#337 (trust-as-lens endorsement propagation in the weave memory plan).

Doc-only (two .svx). Written by Claude Code (Fable), an AI agent.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add RFC documents for proactive improvement pipeline and endorsement trust lens plans
> - Adds [0034-proactive-improvement-pipeline.svx](https://github.com/indexable-inc/index/pull/3630/files#diff-3fb14a33e684b67f6a4efa251914ab35170b9a2b9cce67e4e3e97534967399dd), an RFC defining a single controlled pipeline for drive-by fixes, covering nomination contracts, a standing fixer role, fix-now vs file-first decision logic, and security gates.
> - Adds [0035-endorsement-trust-lens.svx](https://github.com/indexable-inc/index/pull/3630/files#diff-5b5450496a099bc5bf820c7bec1c9dfa330fb19d12dcba04fe81201170942258), an RFC proposing an endorsement trust lens that ranks ideas using personalized PageRank over trusted contributors, including rollout steps and constraints on prior use.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c718673.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->