### PR TITLE
claude-code-rainbow: POC byte-patch pipeline for a customized Claude Code binary

### DIFF
--- a/packages/agent/claude-code-debug/default.nix
+++ b/packages/agent/claude-code-debug/default.nix
@@ -1,0 +1,47 @@
+# claude-code-debug: launch Claude Code with Bun's inspector bound so a JS
+# debugger can attach to the LIVE process (breakpoints, scope variables, a REPL
+# evaluated in the paused frame, heap snapshots).
+#
+# Claude Code is a `bun build --compile` standalone binary, but the embedded Bun
+# runtime still honors the `BUN_INSPECT` env var: set it to `host:port/path` and
+# the inspector binds a WebSocket once the runtime starts. The catch is that the
+# TUI takes the alternate screen and swallows Bun's own "Inspect in browser: ..."
+# banner (printed to stderr), so this wrapper prints the connect URL ITSELF
+# before handing the terminal to the real binary.
+{
+  ix,
+  lib,
+  writeNushellApplication,
+  repoPackages ? {},
+}: let
+  claude-code =
+    repoPackages.claude-code
+      or (throw "claude-code-debug: needs the claude-code sibling (flake package set only)");
+  # The unwrapped upstream binary (unmodified, still Anthropic-signed, so it runs
+  # as-is). Debugging the raw binary keeps the house system-prompt/MCP wrapper out
+  # of the picture while inspecting internals.
+  claudeBin = "${claude-code}/libexec/Claude Code";
+in
+  writeNushellApplication {
+    name = "claude-debug";
+    meta.description = "Launch Claude Code under the Bun inspector for live JS debugging";
+    text = ''
+      # nu
+      def main [
+        --host: string = "127.0.0.1" # inspector bind host
+        --port: int = 9229           # inspector bind port
+      ] {
+        let ep = $"($host):($port)/claude"
+        print "Bun inspector for Claude Code:"
+        print $"  websocket: ws://($ep)"
+        print $"  browser:   https://debug.bun.sh/#($ep)"
+        print "  attach VS Code / Chrome DevTools to the websocket above"
+        print ""
+        # BUN_INSPECT binds the inspector; DISABLE_UPDATES keeps the store binary
+        # from trying to self-update. The TUI inherits this terminal.
+        with-env { BUN_INSPECT: $ep, DISABLE_UPDATES: "1" } {
+          run-external "${claudeBin}"
+        }
+      }
+    '';
+  }

--- a/packages/agent/claude-code-debug/package.nix
+++ b/packages/agent/claude-code-debug/package.nix
@@ -1,0 +1,7 @@
+{
+  id = "claude-code-debug";
+  packageSet = true;
+  flake = true;
+  # Debug helper, not something to shadow anything in nixpkgs.
+  overlay = false;
+}

--- a/packages/agent/claude-code-rainbow-live/claude-rainbow.py
+++ b/packages/agent/claude-code-rainbow-live/claude-rainbow.py
@@ -1,0 +1,138 @@
+"""claude-rainbow: launch Claude Code and inject a looping rainbow animation.
+
+No binary edits. We attach to the stock Claude Code binary's Bun inspector
+(BUN_INSPECT) over the WebKit Inspector Protocol and evaluate a payload that:
+
+  * wraps process.stdout.write to remap every truecolor SGR escape
+    (ESC[38;2;R;G;Bm) to a hue that rotates over time, and
+  * captures the last full frame Ink writes and re-emits it recolored on a
+    timer. Ink diffs its output and skips writing identical frames, so a timer
+    alone cannot animate an idle screen; replaying the captured frame does.
+
+The launcher runs Claude on the real terminal and drives injection from a
+background thread once the inspector port is up.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import socket
+import struct
+import subprocess
+import sys
+import threading
+import time
+
+# The rainbow payload, evaluated once inside Claude's runtime.
+PAYLOAD = r"""
+(function(){
+  if(globalThis.__rbw)return"already";
+  const so=process.stdout,orig=so.write.bind(so);
+  function hsv(h){h=((h%1)+1)%1;let i=Math.floor(h*6),f=h*6-i,q=1-f,r,g,b;
+   switch(i%6){case 0:r=1;g=f;b=0;break;case 1:r=q;g=1;b=0;break;case 2:r=0;g=1;b=f;break;
+   case 3:r=0;g=q;b=1;break;case 4:r=f;g=0;b=1;break;default:r=1;g=0;b=q;}
+   return[Math.round(r*255),Math.round(g*255),Math.round(b*255)];}
+  function paint(str,t){return str.replace(/\x1b\[38;2;(\d+);(\d+);(\d+)m/g,function(_,r,gg,b){
+    let base=((+r)+2*(+gg)+3*(+b))/(6*255);let c=hsv(base+t);
+    return "\x1b[38;2;"+c[0]+";"+c[1]+";"+c[2]+"m";});}
+  let t=0;globalThis.__frame=null;
+  so.write=function(ch){let rest=Array.prototype.slice.call(arguments,1);
+    try{let str=typeof ch==="string"?ch:ch.toString("utf8");
+      if(str.length>300&&str.indexOf("\x1b[")>=0)globalThis.__frame=str;
+      return orig.apply(null,[paint(str,t)].concat(rest));}
+    catch(e){return orig.apply(null,arguments);}};
+  let oc=so.columns;try{so.columns=oc-1;so.emit("resize");}catch(e){}
+  setTimeout(function(){try{so.columns=oc;so.emit("resize");}catch(e){}},60);
+  globalThis.__rbw=setInterval(function(){t=(t+0.04)%1;
+    if(globalThis.__frame){try{orig(paint(globalThis.__frame,t));}catch(e){}}},90);
+  return"rainbow-animating";
+})()
+"""
+
+
+def _ws_connect(host: str, port: int, path: str) -> socket.socket:
+    sock = socket.create_connection((host, port), timeout=5)
+    key = base64.b64encode(os.urandom(16)).decode()
+    sock.sendall(
+        (
+            f"GET /{path} HTTP/1.1\r\nHost: {host}:{port}\r\n"
+            "Upgrade: websocket\r\nConnection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\n\r\n"
+        ).encode()
+    )
+    buf = b""
+    while b"\r\n\r\n" not in buf:
+        buf += sock.recv(1)
+    return sock
+
+
+def _ws_send(sock: socket.socket, obj: dict[str, object]) -> None:
+    data = json.dumps(obj).encode()
+    header = bytearray([0x81])
+    n = len(data)
+    mask = os.urandom(4)
+    if n < 126:
+        header.append(0x80 | n)
+    elif n < 65536:
+        header.append(0x80 | 126)
+        header += struct.pack(">H", n)
+    else:
+        header.append(0x80 | 127)
+        header += struct.pack(">Q", n)
+    header += mask
+    sock.sendall(bytes(header) + bytes(b ^ mask[i % 4] for i, b in enumerate(data)))
+
+
+def _inject(host: str, port: int, path: str, deadline: float) -> None:
+    while time.time() < deadline:
+        try:
+            sock = _ws_connect(host, port, path)
+        except OSError:
+            time.sleep(0.3)
+            continue
+        _ws_send(sock, {"id": 0, "method": "Runtime.enable"})
+        _ws_send(
+            sock,
+            {
+                "id": 1,
+                "method": "Runtime.evaluate",
+                "params": {"expression": PAYLOAD, "returnByValue": True},
+            },
+        )
+        time.sleep(0.2)
+        sock.close()
+        return
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Claude Code with a looping rainbow")
+    parser.add_argument("--claude-bin", required=True)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=9229)
+    args, rest = parser.parse_known_args()
+
+    endpoint = f"{args.host}:{args.port}/claude"
+    env = dict(os.environ)
+    env["BUN_INSPECT"] = endpoint
+    env["DISABLE_UPDATES"] = "1"
+
+    # Inject once the inspector port comes up (after the TUI starts).
+    threading.Thread(
+        target=_inject,
+        args=(args.host, args.port, "claude", time.time() + 20),
+        daemon=True,
+    ).start()
+
+    proc = subprocess.Popen([args.claude_bin, *rest], env=env)
+    try:
+        return proc.wait()
+    except KeyboardInterrupt:
+        proc.terminate()
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/agent/claude-code-rainbow-live/default.nix
+++ b/packages/agent/claude-code-rainbow-live/default.nix
@@ -1,0 +1,25 @@
+# claude-code-rainbow-live: launch Claude Code with a LOOPING rainbow animation,
+# injected at runtime over the Bun inspector (no binary edits, no recompile).
+#
+# Byte-patching can only swap static color constants (one key = one flat color)
+# and cannot animate. This attaches to the stock binary's inspector and evaluates
+# a payload that hooks process.stdout.write to rotate truecolor escapes over time,
+# re-emitting the last captured frame on a timer (Ink diffs identical frames, so a
+# timer alone will not repaint an idle screen; replaying the frame does).
+{
+  ix,
+  lib,
+  repoPackages ? {},
+}: let
+  claude-code =
+    repoPackages.claude-code
+      or (throw "claude-code-rainbow-live: needs the claude-code sibling (flake package set only)");
+  claudeBin = "${claude-code}/libexec/Claude Code";
+in
+  ix.writePythonApplication ix.pkgs {
+    name = "claude-rainbow";
+    src = ./claude-rainbow.py;
+    # Bake the stock binary as the launch target; a user --claude-bin still wins.
+    args = ["--claude-bin" claudeBin];
+    meta.description = "Claude Code with a runtime-injected looping rainbow animation";
+  }

--- a/packages/agent/claude-code-rainbow-live/package.nix
+++ b/packages/agent/claude-code-rainbow-live/package.nix
@@ -1,0 +1,6 @@
+{
+  id = "claude-code-rainbow-live";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+}

--- a/packages/agent/claude-code-rainbow/default.nix
+++ b/packages/agent/claude-code-rainbow/default.nix
@@ -1,0 +1,175 @@
+# claude-code-rainbow: proof that we can produce a *visibly customized* Claude
+# Code binary through a chain of independently-cacheable Nix derivations, one
+# per "mapping" (patch), without recompiling Bun.
+#
+# WHY this works at all (the load-bearing fact): Claude Code ships as a prebuilt
+# Bun single-file executable with the minified app JS embedded as text inside
+# the Mach-O/ELF, plus a trailer Bun appends. Bun does NOT fatally integrity-
+# check that bundle, so an EQUAL-LENGTH, in-place byte swap leaves every offset
+# (and the trailer) intact and the CLI still runs. We never rebuild Bun; we just
+# rewrite bytes. See ./patch-binary.py for the two gates every rule must pass
+# (equal length + a pinned occurrence count that fails loudly on version drift).
+#
+# Each mapping is its OWN `runCommand` derivation, folded so mapping N+1 consumes
+# mapping N's output. That way every layer caches independently: editing the
+# color map does not invalidate the banner layer.
+{
+  lib,
+  ix,
+  stdenv,
+  fetchurl,
+  runCommand,
+  python3,
+  autoPatchelfHook,
+  darwin,
+}: let
+  # Single source of truth for the pin: reuse the stock package's manifest so
+  # the rainbow build tracks the exact same version/hash Anthropic shipped.
+  manifest = lib.importJSON ../claude-code/manifest.json;
+  inherit (manifest) version;
+  inherit (stdenv.hostPlatform) system;
+  target =
+    manifest.platforms.${system}
+      or (throw "claude-code-rainbow: no prebuilt binary for ${system}");
+
+  # The raw Bun binary, fetched directly (same bytes as the stock package's
+  # `nativeBinary`). Depending on the fetch rather than the wrapped
+  # `claude-code` package keeps each mapping derivation tiny: its only input is
+  # the binary itself, nothing else in the wrapper closure.
+  nativeBinary = fetchurl {
+    urls = [
+      "https://downloads.claude.ai/claude-code-releases/${version}/${target.slug}/claude"
+      "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${version}/${target.slug}/claude"
+    ];
+    inherit (target) hash;
+  };
+
+  patcher = ./patch-binary.py;
+
+  # One cacheable derivation per mapping. `input` is a store path to a single
+  # binary file (the fetched binary, or the previous mapping's output); `$out`
+  # is likewise a single patched binary file. `dontStrip`/`dontFixup` because
+  # stripping rewrites the file length and corrupts the Bun trailer.
+  applyMapping = {
+    name,
+    mapping,
+    input,
+  }:
+    runCommand "claude-code-rainbow-${name}"
+    {
+      nativeBuildInputs = [python3];
+      dontStrip = true;
+      dontFixup = true;
+    }
+    ''
+      python3 ${patcher} ${input} ${mapping} $out
+    '';
+
+  # The rainbow chain. Order is irrelevant to correctness (finds and replaces
+  # are disjoint), but the fold makes the caching layers explicit:
+  #   nativeBinary -> banner -> colors -> final
+  mappings = [
+    {
+      name = "banner";
+      mapping = ./mappings/banner.json;
+    }
+    {
+      name = "colors";
+      mapping = ./mappings/colors.json;
+    }
+  ];
+
+  patched =
+    lib.foldl'
+    (input: m:
+      applyMapping {
+        inherit (m) name mapping;
+        inherit input;
+      })
+    nativeBinary
+    mappings;
+in
+  # Same unfree binary as the stock package, so wrap identically:
+  # `allowVendoredUnfree` strips `meta.license` so the per-system flake package
+  # set (evaluated without `allowUnfree`) can still build this.
+  ix.allowVendoredUnfree (stdenv.mkDerivation (finalAttrs: {
+    pname = "claude-code-rainbow";
+    inherit version;
+
+    dontUnpack = true;
+    # Stripping corrupts the Bun trailer; keep the patched bytes verbatim.
+    dontStrip = true;
+    strictDeps = true;
+
+    # Any byte change invalidates the upstream Developer-ID signature, and
+    # Apple Silicon SIGKILLs a Mach-O whose CodeDirectory hashes no longer
+    # match. `autoSignDarwinBinariesHook` re-signs the patched binary ad-hoc
+    # during fixup (dropping the now-meaningless hardened-runtime + Developer-ID
+    # signature), which is what makes the patched CLI runnable again.
+    nativeBuildInputs =
+      lib.optional stdenv.hostPlatform.isElf autoPatchelfHook
+      ++ lib.optional stdenv.hostPlatform.isDarwin darwin.autoSignDarwinBinariesHook;
+
+    installPhase = ''
+      runHook preInstall
+      install -D -m755 ${patched} $out/bin/claude
+      runHook postInstall
+    '';
+
+    # Proof gate: the patched binary must still run AND must actually contain
+    # the rainbow bytes (new banner present, old banner gone, a rainbow hex
+    # present). Runs natively; the prebuilt CLI only needs DISABLE_UPDATES=1 to
+    # print its version offline.
+    doInstallCheck = true;
+    # Proof gate. The byte-level grep proof runs everywhere (in-sandbox): the
+    # rainbow banner must be present, the stock banner gone, and a rainbow hex
+    # present. The runtime `--version` smoke runs in-check on Linux, where the
+    # raw patched binary needs no signature. On darwin we skip the in-sandbox
+    # exec: AMFI refuses to launch a Mach-O that was ad-hoc re-signed inside
+    # this same sandboxed build (SIGTRAP), even though the signature is valid
+    # and the binary runs fine outside the sandbox. Runtime is proven
+    # out-of-band there (see the report / `nix run .#claude-code-rainbow`).
+    installCheckPhase =
+      ''
+        runHook preInstallCheck
+
+        echo "== rainbow byte proof =="
+        new=$(grep -c "Rainbow!!! Claude Code" "$out/bin/claude" || true)
+        old=$(grep -c "Welcome to Claude Code" "$out/bin/claude" || true)
+        hex=$(grep -c "#ff7f00" "$out/bin/claude" || true)
+        echo "new banner count: $new"
+        echo "old banner count: $old"
+        echo "rainbow hex #ff7f00 count: $hex"
+        [ "$new" -ge 1 ] || { echo "FAIL: new rainbow banner not present" >&2; exit 1; }
+        [ "$old" -eq 0 ] || { echo "FAIL: original banner bytes still present ($old)" >&2; exit 1; }
+        [ "$hex" -ge 1 ] || { echo "FAIL: rainbow hex not present" >&2; exit 1; }
+      ''
+      + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+        echo "== version smoke =="
+        DISABLE_UPDATES=1 $out/bin/claude --version
+      ''
+      + lib.optionalString stdenv.hostPlatform.isDarwin ''
+        echo "== version smoke: skipped in darwin sandbox =="
+        echo "AMFI blocks exec of a just-ad-hoc-signed Mach-O inside the build"
+        echo "sandbox; run 'DISABLE_UPDATES=1 result/bin/claude --version' after build."
+      ''
+      + ''
+        runHook postInstallCheck
+      '';
+
+    passthru = {
+      # Each mapping layer, exposed so the derivation graph is inspectable.
+      inherit nativeBinary;
+      rainbowLayers = patched;
+    };
+
+    meta = {
+      description = "Claude Code with a visibly rainbow'd banner and theme, patched via equal-length byte swaps";
+      homepage = "https://www.anthropic.com/claude-code";
+      # Stripped by `ix.allowVendoredUnfree` above; kept honest here.
+      license = lib.licenses.unfree;
+      mainProgram = "claude";
+      platforms = builtins.attrNames manifest.platforms;
+      sourceProvenance = [lib.sourceTypes.binaryNativeCode];
+    };
+  }))

--- a/packages/agent/claude-code-rainbow/default.nix
+++ b/packages/agent/claude-code-rainbow/default.nix
@@ -136,13 +136,13 @@ in
         echo "== rainbow byte proof =="
         new=$(grep -c "Rainbow!!! Claude Code" "$out/bin/claude" || true)
         old=$(grep -c "Welcome to Claude Code" "$out/bin/claude" || true)
-        hex=$(grep -c "#ff7f00" "$out/bin/claude" || true)
+        hex=$(grep -c "rgb(255,20,255)" "$out/bin/claude" || true)
         echo "new banner count: $new"
         echo "old banner count: $old"
-        echo "rainbow hex #ff7f00 count: $hex"
+        echo "rainbow rgb count: $hex"
         [ "$new" -ge 1 ] || { echo "FAIL: new rainbow banner not present" >&2; exit 1; }
         [ "$old" -eq 0 ] || { echo "FAIL: original banner bytes still present ($old)" >&2; exit 1; }
-        [ "$hex" -ge 1 ] || { echo "FAIL: rainbow hex not present" >&2; exit 1; }
+        [ "$hex" -ge 1 ] || { echo "FAIL: rainbow rgb not present" >&2; exit 1; }
       ''
       + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
         echo "== version smoke =="

--- a/packages/agent/claude-code-rainbow/mappings/banner.json
+++ b/packages/agent/claude-code-rainbow/mappings/banner.json
@@ -1,0 +1,7 @@
+[
+  {
+    "find": "Welcome to Claude Code",
+    "replace": "Rainbow!!! Claude Code",
+    "expect": 10
+  }
+]

--- a/packages/agent/claude-code-rainbow/mappings/colors.json
+++ b/packages/agent/claude-code-rainbow/mappings/colors.json
@@ -1,8 +1,10 @@
 [
-  { "find": "#e2e8f0", "replace": "#ff0000", "expect": 61 },
-  { "find": "#64748b", "replace": "#ff7f00", "expect": 61 },
-  { "find": "#334155", "replace": "#00ff00", "expect": 40 },
-  { "find": "#475569", "replace": "#0000ff", "expect": 38 },
-  { "find": "#0f172a", "replace": "#8b00ff", "expect": 24 },
-  { "find": "#1a1a19", "replace": "#00ffff", "expect": 16 }
+  { "find": "rgb(215,119,87)",  "replace": "rgb(255,20,255)",  "expect": 9 },
+  { "find": "rgb(245,149,117)", "replace": "rgb(255,120,255)", "expect": 2 },
+  { "find": "rgb(87,105,247)",  "replace": "rgb(20,255,120)",  "expect": 5 },
+  { "find": "rgb(0,102,102)",   "replace": "rgb(0,255,255)",   "expect": 2 },
+  { "find": "rgb(71,130,200)",  "replace": "rgb(255,120,20)",  "expect": 5 },
+  { "find": "rgb(255,0,135)",   "replace": "rgb(255,255,0)",   "expect": 2 },
+  { "find": "rgb(153,153,153)", "replace": "rgb(255,100,255)", "expect": 5 },
+  { "find": "rgb(135,0,255)",   "replace": "rgb(255,0,100)",   "expect": 9 }
 ]

--- a/packages/agent/claude-code-rainbow/mappings/colors.json
+++ b/packages/agent/claude-code-rainbow/mappings/colors.json
@@ -1,0 +1,8 @@
+[
+  { "find": "#e2e8f0", "replace": "#ff0000", "expect": 61 },
+  { "find": "#64748b", "replace": "#ff7f00", "expect": 61 },
+  { "find": "#334155", "replace": "#00ff00", "expect": 40 },
+  { "find": "#475569", "replace": "#0000ff", "expect": 38 },
+  { "find": "#0f172a", "replace": "#8b00ff", "expect": 24 },
+  { "find": "#1a1a19", "replace": "#00ffff", "expect": 16 }
+]

--- a/packages/agent/claude-code-rainbow/package.nix
+++ b/packages/agent/claude-code-rainbow/package.nix
@@ -1,0 +1,9 @@
+{
+  id = "claude-code-rainbow";
+  packageSet = true;
+  flake = true;
+  # Flake-output + index package set only, deliberately NOT a nixpkgs overlay:
+  # this is a POC wrapper of the same unfree binary, not something that should
+  # shadow anything in `pkgs`.
+  overlay = false;
+}

--- a/packages/agent/claude-code-rainbow/patch-binary.py
+++ b/packages/agent/claude-code-rainbow/patch-binary.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Equal-length, count-gated byte patcher for the Claude Code Bun binary.
+
+The load-bearing idea behind the whole "rainbow" chain lives here:
+
+  * Claude Code ships as a prebuilt Bun single-file executable: a Mach-O/ELF
+    with the minified app JS embedded as text inside it, plus a trailer Bun
+    appends. Rewriting the file length (or stripping it) corrupts that trailer
+    and the CLI aborts. But an EQUAL-LENGTH, in-place byte swap leaves every
+    offset intact, so Bun still loads and runs. That is why every rule asserts
+    len(find) == len(replace).
+
+  * The `expect` count is the version-robustness gate. We hard-code how many
+    times each `find` string must occur in the stock binary. If Anthropic ships
+    a build where a string appears a different number of times, the swap might
+    land in the wrong place (or miss), so we FAIL LOUDLY instead of silently
+    emitting a subtly-wrong binary. Bump `expect` deliberately when the pin
+    moves, having re-counted against the new stock binary.
+
+Usage: patch-binary.py <input-binary> <mapping.json> <output-binary>
+  mapping.json = [{"find": "...", "replace": "...", "expect": N}, ...]
+Deterministic: no randomness, rules applied in file order.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        sys.stderr.write(
+            "usage: patch-binary.py <input> <mapping.json> <output>\n"
+        )
+        return 2
+
+    input_path, mapping_path, output_path = sys.argv[1:4]
+
+    with Path(mapping_path).open(encoding="ascii") as fh:
+        rules = json.load(fh)
+
+    with Path(input_path).open("rb") as fh:
+        data = fh.read()
+
+    for i, rule in enumerate(rules):
+        find = rule["find"].encode("utf-8")
+        replace = rule["replace"].encode("utf-8")
+        expect = int(rule["expect"])
+
+        # Gate 1: equal length keeps every downstream offset (and the Bun
+        # trailer) byte-identical, which is the only reason patching is safe.
+        if len(find) != len(replace):
+            sys.stderr.write(
+                f"rule {i}: LENGTH MISMATCH: find={rule['find']!r} "
+                f"({len(find)}B) != replace={rule['replace']!r} "
+                f"({len(replace)}B)\n"
+            )
+            return 1
+
+        # Gate 2: observed occurrence count must match the pinned expectation,
+        # or the stock binary drifted and we must not guess.
+        found = data.count(find)
+        if found != expect:
+            sys.stderr.write(
+                f"rule {i}: COUNT DRIFT for {rule['find']!r}: "
+                f"expected {expect}, found {found}. The pinned binary changed; "
+                f"re-count and update `expect` before trusting this swap.\n"
+            )
+            return 1
+
+        data = data.replace(find, replace)
+        sys.stdout.write(
+            f"rule {i}: {rule['find']!r} -> {rule['replace']!r} "
+            f"({found} occurrence(s), {len(find)}B each)\n"
+        )
+
+    with Path(output_path).open("wb") as fh:
+        fh.write(data)
+
+    sys.stdout.write(f"wrote {len(data)} bytes to {output_path}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

A proof-of-concept pipeline that produces a **visibly customized ("rainbow") Claude Code binary** through a chain of independently-cacheable Nix derivations, one per patch ("mapping"), **without recompiling Bun**.

## Why it works (the load-bearing fact)

Claude Code ships as a prebuilt Bun single-file executable with the minified app JS embedded as text. Bun does **not** fatally integrity-check that bundle, so an **equal-length, in-place byte swap** leaves every offset and the Bun trailer intact and the CLI still runs. We never rebuild Bun; we rewrite bytes.

## Shape

- `patch-binary.py`: deterministic patcher with two gates per rule: `len(find) == len(replace)` (keeps offsets/trailer valid) and a pinned occurrence `expect` count that **fails loudly on version drift** instead of mis-patching.
- Each mapping is its own `runCommand` derivation, folded so `nativeBinary -> banner -> colors -> final`; editing colors does not invalidate the banner layer.
- `default.nix`: fetches the same pinned binary as the stock package, folds the mappings, re-signs ad-hoc on darwin (`autoSignDarwinBinariesHook`, because any byte change voids the Developer-ID signature and Apple Silicon SIGKILLs a mismatched Mach-O), and gates on an install check.

## Proof (aarch64-darwin)

```
$ nix build .#claude-code-rainbow            # green
$ DISABLE_UPDATES=1 result/bin/claude --version
2.1.206 (Claude Code)
$ grep -ac 'Rainbow!!! Claude Code' result/bin/claude   # 6
$ grep -ac 'Welcome to Claude Code' result/bin/claude    # 0
$ grep -ac '#ff7f00' result/bin/claude                   # 61
```

## Scope / caveats

- POC. Equal-length byte swaps only, so a true animated gradient (a length-changing code edit) is out of scope; that needs the extract-bundle -> SWC-transform -> Bun-recompile path.
- Patches an unfree vendored binary; kept out of the nixpkgs overlay on purpose.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add byte-patch pipeline and inspector-based injection tools for a customized Claude Code binary
> - Introduces [`claude-code-rainbow`](https://github.com/indexable-inc/index/pull/3636/files#diff-9027e5033039736c7d8446fd58e053e5970f96fa544e3a5cf2443bc3173bbc90), a Nix package that fetches the upstream Claude Code binary and applies equal-length byte-swap patches via [`patch-binary.py`](https://github.com/indexable-inc/index/pull/3636/files#diff-21a9dd3287ecf622e51094df257158a870e0cbbd55f5808801e4f3c2eeb5331f), replacing the welcome banner and theme color literals with rainbow-themed values.
> - The patcher validates that each rule's find/replace strings are equal length and that occurrence counts match pinned expectations, failing the build on any drift.
> - Adds [`claude-code-rainbow-live`](https://github.com/indexable-inc/index/pull/3636/files#diff-ebbbcda5fb19c082ef9c0d2f977f8286cb269bd5494278622cc55aa7b1a2fb7f), a Python-based runtime alternative that launches Claude Code with Bun's inspector enabled and injects a JS payload over WebSocket to hook `process.stdout` for rainbow color animation, without modifying the binary.
> - Adds [`claude-code-debug`](https://github.com/indexable-inc/index/pull/3636/files#diff-a0fe8725121f590eea67a08c7b89579312cbdbbe2251e54ed749656d4035648a), a Nushell wrapper that launches the unmodified Claude Code binary with `BUN_INSPECT` set and prints the WebSocket and browser debug URLs.
> - Risk: the byte-patch approach is fragile — upstream binary changes will break pinned occurrence counts and invalidate the patch rules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cea888a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

---

## Update: `claude-code-debug` (live JS debugging)

New sibling flake package `claude-code-debug` -> `claude-debug`. It sets `BUN_INSPECT` on the stock Claude Code binary so a JS debugger attaches to the **live process** (breakpoints, scope variables, a REPL in the paused frame, heap snapshots). This is the dynamic way to find the exact theme color / string a UI element uses, instead of grepping the minified bundle.

Why a wrapper: Claude Code is a `bun build --compile` standalone, but the embedded Bun runtime still honors `BUN_INSPECT=host:port/path`; the TUI's alt-screen swallows Bun's own "Inspect in browser" banner, so the wrapper prints the connect URLs first.

```
$ claude-debug --port 9229
Bun inspector for Claude Code:
  websocket: ws://127.0.0.1:9229/claude
  browser:   https://debug.bun.sh/#127.0.0.1:9229/claude
  attach VS Code / Chrome DevTools to the websocket above
# ... Claude TUI launches; inspector bound (verified: LISTEN on the port under a pty)
```

Known limitation (v1): does not forward flag-shaped args to `claude` (nushell's strict parser intercepts them); the launcher runs `claude` with defaults, which is the launch-and-attach case.