### PR TITLE
plans: plan 0038 a better nix, rebuilt from scratch (rfc)

### DIFF
--- a/packages/site/src/lib/plans/0038-better-nix.svx
+++ b/packages/site/src/lib/plans/0038-better-nix.svx
@@ -1,0 +1,440 @@
+---
+id: 0038-better-nix
+number: '0038'
+title: 'A better Nix: what a from-scratch rebuild keeps, what it sheds, and how effects would look'
+status: Input wanted
+rfc: true
+authors: andrewgazelka
+created: '2026-07-19'
+updated: '2026-07-19'
+trackingIssue: null
+supersedes: null
+supersededBy: null
+scores:
+  ambition: { value: 9, why: 'a design position on replacing the tool every build in the company runs through' }
+  impact: { value: 8, why: 'the fork patches, eval OOMs, lock confusion, and CA races we carry all trace to accidents named here' }
+  effort: { value: 7, why: 'the document is cheap; the prototypes it commissions are bounded but land in nox and the fork series' }
+  risk: { value: 6, why: 'rebuild specs rot into wishlists; the migration section pins this one to strangler steps we already run' }
+  maturity: { value: 3, why: 'nox evaluates real Nix and the fork carries the pain patches, but nothing is designed as effects yet' }
+  leverage: { value: 9, why: 'a fix in the core lands once instead of once per fetcher, per lock format, per lint rule' }
+  taste: { value: 8, why: 'deciding which invariants are load-bearing and which are scar tissue is the entire job' }
+description: 'Nix''s core model is right and its accretions are not. This RFC separates the two: the invariants a rebuild must keep, the documented accidents it sheds (flattened locks, eager source copies, the untyped language, the fetcher zoo, half-adopted content addressing), a clean-slate sketch, and a concrete answer to how effects would look: every impurity Nix expresses today as a mode or a hash-checked loophole becomes a typed capability with a handler the scheduler can see. Grounded in our fork patch series, our CI eval OOMs, and nox, our in-house Rust implementation.'
+---
+
+## Summary
+
+Rebuilt from scratch, Nix keeps its store model and sheds its accretions.
+This RFC names both lists, then answers the question that motivated it:
+what would effects look like. The position: every impurity that today's
+Nix expresses as a global mode or a loophole (`--impure`, fixed-output
+derivations, import-from-derivation, sandbox exceptions) becomes a typed
+capability, declared in the function's type and discharged by a handler
+the store and scheduler can see. That change is also what unlocks the
+build-system cell Nix cannot reach today. Build Systems a la Carte places
+Nix at suspending scheduler plus deep constructive traces, the cell that
+requires task determinism and cannot support early cutoff; typed effects
+are machine-checkable determinism evidence, which lets proved-pure
+subgraphs move to plain constructive traces and cut off early. The rest
+of the sketch (sparse locks, lazy sources, one fetcher interface, a
+CA-only store, first-class remote execution) follows from taking the 2006
+thesis model seriously and deleting what was accreted instead of designed.
+Migration is honest about gravity: forks-in-place win short term and we
+already run one; nox is our strangler-fig frontend; the first prototypes
+are small and listed at the end.
+
+## Motivation: the pain is local
+
+We are not collecting other people's complaints. We carry the patches.
+
+- Our Nix fork has an open PR to make `nix flake check` use the eval
+  cache ([indexable-inc/nix#1](https://github.com/indexable-inc/nix/pull/1)),
+  because upstream populates the cache on check but never consults it
+  ([NixOS/nix#4279](https://github.com/NixOS/nix/issues/4279), open since
+  2020).
+- We patched the fork so `github:` inputs that request submodules fall
+  back to `git+https`
+  ([index#3626](https://github.com/indexable-inc/index/issues/3626)),
+  because the tarball fetcher silently drops them
+  ([NixOS/nix#14982](https://github.com/NixOS/nix/issues/14982)).
+- Whole-tree eval regularly OOMs our CI; flake-check memory blowups have
+  their own recurring incident shape in our runbooks, and slow eval was a
+  founding reason for [nox](https://github.com/indexable-inc/nox), our
+  Rust implementation of Nix.
+- We run content-addressed derivations in CI and have hit realisation
+  registration races upstream also documents
+  ([NixOS/nix#15649](https://github.com/NixOS/nix/issues/15649)).
+- Our lint bans `with` and `rec` outright, we package
+  [typenix](https://github.com/ryanrasti/typenix) and nox-lsp into the
+  workstation profile, and plan 0033's case study is two adjacent
+  lock-file facts (issue [#7730](https://github.com/NixOS/nix/issues/7730)
+  open, PR [#13437](https://github.com/NixOS/nix/pull/13437) shipped) that
+  a careful reader could not tell apart. Tooling this heavy around a
+  language is a type system filed as separate purchases.
+
+When a user carries this many patches, lint rules, and reimplementation
+experiments, the interesting question stops being which bug to fix next
+and becomes: what is the fixed point? What would this tool be if the model
+were kept and the accidents were not?
+
+## What Nix got right
+
+A rebuild that loses any of these is a different, worse tool. From
+Dolstra's 2006 thesis
+([The Purely Functional Software Deployment Model](https://edolstra.github.io/pubs/phd-thesis.pdf)):
+
+- The immutable, content-addressed store. Artifacts named by hash,
+  never mutated in place, shared structurally.
+- The derivation as a pure function of its inputs. Same inputs, same
+  output, no ambient state. Everything else (caching, substitution,
+  reproducibility claims) is downstream of this.
+- Hermetic builds. The sandbox makes the purity claim enforceable
+  instead of aspirational.
+- Rollback and generations. Because nothing is mutated, every
+  configuration that ever worked is still there.
+- One language for configuration and packaging. The thing that composes
+  a system and the thing that builds a package are the same thing; Guix
+  kept this property when it swapped the language for Scheme, which is
+  evidence the property matters independently of the language.
+- Binary cache substitution keyed by input hashes. A cache hit is a
+  proof you do not need to build, and the key derives from the same
+  hashes that name the store paths.
+
+## The accidents a rebuild sheds
+
+### Locks: flattened, and only half reused
+
+A parent flake's lock inlines every transitive input as a flattened node
+graph. The fix has been designed in public for three years:
+[NixOS/nix#7730](https://github.com/NixOS/nix/issues/7730) ("Reuse input
+lock files") is labeled idea approved and its body still says "Not
+implemented yet"; a `sparseNodes` migration plan with a four-phase
+rollout was posted in November 2025. What did ship is the update-time
+half: [#13437](https://github.com/NixOS/nix/pull/13437) (merged 2025-07-10,
+released in Nix 2.31) makes `nix flake update <input>` copy the child's
+locked pins. Eval-time deferral, where the parent lock is a pointer and
+the child's lock is authoritative, exists nowhere released. Add the
+relative-path input warts and the result is a lock format everyone
+regenerates and nobody can read. In a rebuild, locks are tree-shaped from
+day one: each flake's lock is authoritative for its subtree, the parent
+stores a reference plus a hash, and flattening is at most a cache.
+
+### Sources: eager copies, and lazy trees stalled on determinism
+
+Evaluating a flake copies the whole source tree into the store before a
+single derivation needs it. The fix, lazy trees, has been implemented
+twice and released once, by a downstream: upstream's lazy trees v2
+([NixOS/nix#13225](https://github.com/NixOS/nix/pull/13225)) has been open
+since May 2025, stalled on a real objection. Roberth's review: "Using
+randomness or even fingerprints for placeholders makes the language
+non-deterministic and impure," with rope-structured strings and lazily
+computed substring hashes as the proposed way out (see also his design
+space in [#10689](https://github.com/NixOS/nix/issues/10689)). Meanwhile
+Determinate Nix ships lazy trees enabled by default and claims 3x wall
+time and 20x disk reductions on eval-heavy workflows. Both sides are
+right, which is the indictment: the released architecture forces a choice
+between eager copies and entropy in the evaluator. A rebuild makes
+virtual paths the only path type, with deterministic identity (the
+rope-string direction), so laziness is not a mode. The eval cache gaps
+compound this: `nix flake check` populates but does not consult the cache
+([#4279](https://github.com/NixOS/nix/issues/4279)), and since ~2.21 dirty
+trees are never cached at all because the fingerprint requires reading
+the whole tree, which is exactly what laziness was supposed to avoid.
+
+### The language: dynamic at a scale where dynamic stopped working
+
+Nixpkgs is a few million lines of untyped, lazily evaluated code whose
+errors arrive as strings at force time, far from the mistake. The
+ecosystem's response is a shadow type system: thufschmitt's
+[tix](https://github.com/thufschmitt/tix) research line, typenix, our
+nox-lsp, Nickel as a whole
+([nickel-lang.org](https://nickel-lang.org), gradual types plus lazy
+contracts, at 1.17 as of June 2026), and our own `codex/nickel-migration`
+experiment branch. Inside the language, `with` destroys static scope
+resolution and `rec` invites anonymous recursion; our lint bans both,
+which means we already program in a restricted dialect and enforce it
+with a linter that upstream users do not have. PureNix's self-assessment
+is the honest data point on bolting types on afterward: "PureNix is not a
+complete typed replacement for Nix," because nixpkgs idioms
+(`callPackage` reflection, overlays, fixed-points over 80k attributes)
+resist retrofitted types. A rebuild starts gradually typed: inferred row
+types inside, contracts at module boundaries, and string contexts (the
+current invisible dependency-tracking effect smuggled through string
+values) replaced by explicit staged references, which is what Guix
+G-expressions have done since 2017.
+
+### Fetchers: one name, several capability matrices
+
+`github:archive/tarball` and `git+https` are presented as two spellings
+of the same input and disagree on submodules
+([#14982](https://github.com/NixOS/nix/issues/14982): silently ignored;
+[#13571](https://github.com/NixOS/nix/issues/13571): a flake with
+`inputs.self.submodules = true` errors when used as a `github:` input),
+on `export-ignore` handling, and on hashing (tarball NAR vs git tree),
+so the same commit can produce different store paths depending on the
+scheme that fetched it. Our fork's answer (index#3626, fall back to
+`git+https` when submodules are requested) is a patch over a design gap:
+capabilities are implicit per scheme. A rebuild has one fetcher
+interface with a declared capability matrix (submodules, lfs, filters,
+shallowness) and one canonical tree encoding hashed one way, so two
+fetchers that claim the same source cannot disagree about its identity.
+
+### The store: content addressing, half-adopted for a decade
+
+The intensional, fully content-addressed store was in the 2006 thesis
+and in [RFC 17](https://github.com/NixOS/rfcs/pull/17);
+[RFC 62](https://github.com/NixOS/rfcs/pull/62) was accepted in January
+2022 explicitly as an experiment, and in 2026 `ca-derivations` is still
+experimental, with the stabilisation issue
+([#4087](https://github.com/NixOS/nix/issues/4087)) open since 2020.
+The half-adoption has sharp edges we have personally cut ourselves on:
+realisations are registered with a one-realisation-per-output invariant
+that nondeterministic builds violate
+([#15649](https://github.com/NixOS/nix/issues/15649)), deep realisations
+were found unsound for cross-store sharing and removed entirely in
+February 2026 ([#15289](https://github.com/NixOS/nix/pull/15289)), and
+our own CI has hit concurrent realisation registration races. The daemon
+protocol underneath is ossified enough that Lix is building a Cap'n
+Proto RPC layer to escape it. A rebuild is CA-only: input addressing
+becomes the cache key layer instead of the store identity layer,
+realisations merge monotonically, and a nondeterministic build is not a
+registration conflict, it is a typed effect (below).
+
+## The clean-slate sketch
+
+- A typed, lazily evaluated configuration language with gradual types.
+  Inference inside, contracts at boundaries, errors carrying provenance
+  instead of strings. Nickel is the closest existing artifact.
+- Tree-lazy sources everywhere. A source is a content-addressed virtual
+  tree; bytes materialize when a derivation forces them. Deterministic
+  virtual identity per the rope-string and lazy-hashing direction, no
+  placeholder entropy.
+- Sparse, tree-shaped locks. Each unit's lock is authoritative for its
+  subtree; parents hold references. Compatible in spirit with the
+  `sparseNodes` plan on #7730 so a migration path to upstream exists.
+- One fetcher interface with a declared capability matrix and one
+  canonical hash per tree. Scheme choice can change transport, never
+  identity.
+- CA derivations as the only mode. Early cutoff falls out: when a
+  rebuilt input produces byte-identical output, downstream is skipped,
+  the thing Bazel and Buck2 get from digest-keyed action caches.
+- Remote execution and scheduling first-class in the build graph, the
+  Buck2 posture (it speaks Bazel's remote execution API against
+  EngFlow, BuildBarn, BuildBuddy) rather than `ssh://` push-pull
+  bolted on. Dynamic dependencies get a bounded escape hatch like Buck2's
+  `dynamic_output` instead of IFD's unbounded one.
+
+## Effects: impurity as typed capabilities
+
+The question this RFC exists to answer. Today every impurity is a mode,
+a flag, or a loophole, and none of them appear in any type:
+
+- `--impure` flips the whole evaluation.
+- A fixed-output derivation may do anything on the network as long as
+  the output hash matches; the capability is invisible at the call site.
+- Import-from-derivation suspends evaluation on an arbitrary build; the
+  cost exists but no interface admits it.
+- `__noChroot` and sandbox exceptions relax hermeticity per derivation,
+  discoverable only by grepping.
+
+A rebuilt Nix types these as algebraic effects, in the Unison sense
+(abilities in the arrow: `Nat ->{Store, Abort} Nat`) or the Koka sense
+(row-polymorphic effect types, `a -> <div,exn> b`, fully inferred).
+OCaml 5 is the cautionary entry: it shipped effect handlers as runtime
+machinery with no typing, and an unhandled effect is a runtime error,
+which is `--impure` with extra steps. Sketch, in illustrative syntax:
+
+```text
+# pure by construction: no effect row, the default
+drv    : BuildSpec -> Drv
+
+# a fixed-output fetch is a network capability with an expected digest
+fetch  : { url : Url, digest : Digest } -> {Net} Src
+
+# IFD is a staged-eval effect; the suspension is visible and schedulable
+stage  : Drv -> {Stage} Val
+
+# host introspection is granted at the entry point, not read ambiently
+env    : Key -> {Host} Str
+```
+
+What each of today's escapes becomes:
+
+- Fixed-output derivations become `{Net}` with an expected digest. The
+  handler is the substituter chain: a cache can answer the effect
+  without touching the network, and an auditor can enumerate every
+  network-capable node in a closure by reading types.
+- IFD becomes `{Stage}`. The scheduler sees the suspension point
+  explicitly, which is the suspending scheduler from Build Systems a la
+  Carte reified into the interface instead of implemented as a blocking
+  hack inside eval. Cost becomes visible: a flake whose evaluation
+  stages ten builds says so in its signature.
+- Sandbox relaxations become declared capabilities on the derivation
+  (`{Net}`, `{HostPath /dev/kvm}`), auditable at the boundary, and the
+  cache policy can key on them: outputs of `{Net}`-capable builds can
+  be treated as claims requiring attestation rather than proofs.
+- Nondeterminism stops being a store corruption. A build observed to
+  produce differing outputs is an unhandled `{NonDet}` effect with a
+  policy decision (pin one realisation, or mark the node), instead of
+  the current "Trying to register a realisation but we already have
+  another one" failure.
+
+The payoff is bigger than hygiene. Build Systems a la Carte (Mokhov,
+Mitchell, Peyton Jones, ICFP 2018) classifies build systems by scheduler
+and rebuilder, and puts Nix at suspending scheduler plus deep
+constructive traces, the cell that requires deterministic tasks and
+"cannot support early cutoff." The paper's coveted empty cell, suspending
+scheduler plus plain constructive traces (their "Cloud Shake"), needs to
+know which tasks are trustworthy. An effect row is exactly that
+knowledge, checked by a compiler instead of asserted by a sandbox:
+proved-pure subgraphs get constructive traces and early cutoff, effectful
+nodes keep deep traces and their capability discipline. Guix's
+G-expressions (Courtès, GPCE 2017) already demonstrate the staging half
+of this design in production; what no deployed system has is the
+capability half.
+
+## Migration reality
+
+Nobody adopts a from-scratch Nix because its design is better. Nixpkgs
+is the moat: twenty years and 80k packages that any replacement must
+evaluate, byte-for-byte, before it is anything more than a language demo.
+So the short term belongs to forks-in-place, and the field agrees: Lix
+(forked from CppNix 2.18, now versioning the language and extracting
+flakes into a plugin), Determinate (tracking upstream, lazy trees and
+parallel eval shipped, flakes declared stable), and our own
+indexable-inc/nix patch series are all the same strategy at different
+scales. Fork economics are real but capped: a fork inherits the
+architecture, so it can ship eval caches and fetcher fallbacks and
+cannot ship typed effects.
+
+The strangler-fig paths out, in increasing ambition:
+
+1. Replace the store under the existing frontend. Snix (the active fork
+   of tvix, [snix.dev](https://snix.dev)) is furthest here: its blake3
+   content-addressed castore, nar-bridge, and FUSE layer already speak
+   enough nix-daemon protocol to sit under CppNix as a read-only lower
+   store. Its licensing prompted our exp-nixoxide side experiment, so
+   the store-swap path has two candidate implementations.
+2. Replace the frontend over the existing ecosystem. This is nox: a
+   Rust implementation that accepts `nix` CLI invocations unchanged,
+   evaluates nixpkgs, diffs derivation output against CppNix for
+   equality, and is remote-first. Drop-in compatibility is the
+   strangler boundary; the effects design would land behind it.
+3. New language compiling to derivations. The Nickel and typenix
+   direction: keep the store and the drv format, replace the surface.
+   Cheapest to try, and PureNix's experience says the types must be
+   load-bearing from the start or nixpkgs idioms will reject them.
+
+What we would validate first, in order: derivation-equality at nixpkgs
+scale (nox and snix-eval-jobs both already diff against CppNix, keep
+that bar), lock semantics aligned with the #7730 `sparseNodes` plan so
+we do not invent a third lock format, then an effects-typed derivation
+interface as a nox crate to learn whether capability rows survive
+contact with real nixpkgs idioms.
+
+## Success criteria and first prototypes
+
+- An effect inventory of our own tree: count and classify every FOD,
+  IFD site, `--impure` invocation, and sandbox exception in index and
+  ix. If the capability vocabulary cannot cover our own usage, the
+  design is wrong before it meets nixpkgs.
+- nox evaluates index's flake through virtual paths with no whole-tree
+  store copy, measured against CppNix on the workloads that OOM our CI
+  today: peak RSS and wall time, before and after.
+- A sparse-lock prototype behind our fork: index's flattened transitive
+  lock becomes a tree with each input authoritative for its subtree;
+  success is a lock diff a human can review.
+- One CA realisation race from our CI history reproduced, then shown
+  impossible under monotone realisation merge.
+- The effects sketch written as a real interface in a nox crate, with
+  the four escapes above expressed as capabilities, even if no builder
+  enforces them yet.
+
+## Drawbacks
+
+- A rebuild spec is a standing invitation to stop patching the fork and
+  start dreaming; the fork series pays rent today and must not slow.
+- Effect rows could Haskell-ify a language whose users mostly write
+  config. Gradual typing is the mitigation, and it is unproven at
+  nixpkgs scale; PureNix is evidence against optimism here.
+- The ecosystem is already trifurcating (Lix froze flakes, Determinate
+  stabilized them, upstream has #7730 approved and unbuilt). A fourth
+  position costs credibility unless it ships through an existing
+  strangler boundary, which is why everything above lands via nox or
+  the fork.
+
+## Alternatives
+
+- Do nothing beyond the fork. Viable indefinitely, and it caps us at
+  fixes the architecture permits: no typed effects, no early cutoff,
+  locks and fetchers patched one wart at a time.
+- Adopt Determinate Nix. Buys lazy trees and parallel eval today;
+  costs following a commercial downstream's pace, and the language,
+  lock, and effects problems remain untouched.
+- Back snix as the whole future rather than the store layer. The store
+  is its mature third; eval is close but the build layer is explicitly
+  not a nix-build replacement yet, and licensing is why exp-nixoxide
+  exists.
+- Nickel as frontend only, no core rebuild. Fixes the language and
+  nothing else; locks, fetchers, and the store keep their accidents.
+
+## Prior art
+
+- [Dolstra, The Purely Functional Software Deployment Model (2006)](https://edolstra.github.io/pubs/phd-thesis.pdf)
+  and [RFC 17](https://github.com/NixOS/rfcs/pull/17): the intensional
+  model this RFC asks to finish.
+- [Build Systems a la Carte (ICFP 2018)](https://www.microsoft.com/en-us/research/wp-content/uploads/2018/03/build-systems-a-la-carte.pdf):
+  the scheduler-rebuilder taxonomy used throughout.
+- [Guix G-expressions](https://guix.gnu.org/manual/en/html_node/G_002dExpressions.html):
+  typed staging over the same store model, in production since 2017.
+- [Lix](https://lix.systems/about/), [Determinate Nix](https://determinate.systems/blog/determinate-nix-30/),
+  [Snix](https://snix.dev): the three live rebuild-adjacent strategies.
+- [Nickel](https://nickel-lang.org) and [tf-ncl](https://github.com/nickel-lang/tf-ncl);
+  [PureNix](https://github.com/purenix-org/purenix); Dhall: typed
+  config prior art, including the negative results.
+- [Buck2 remote execution](https://buck2.build/docs/users/remote_execution/)
+  and [dynamic dependencies](https://buck2.build/docs/rule_authors/dynamic_dependencies/):
+  the build-graph comparison target.
+- Koka, Eff, OCaml 5 effect handlers, Unison abilities: the effect
+  system design space, from fully inferred rows to untyped runtime
+  handlers.
+- roberth's determinism line: the
+  [#13225 review](https://github.com/NixOS/nix/pull/13225), lazy path
+  semantics in [#10689](https://github.com/NixOS/nix/issues/10689), and
+  the rope-string direction this sketch adopts.
+- In-house: [nox](https://github.com/indexable-inc/nox),
+  exp-nixoxide, the indexable-inc/nix patch series, plan 0033 (whose
+  case study is the #7730/#13437 lock split), and plan 0010 (the fork
+  patch discipline any of this ships through).
+
+## Unresolved questions
+
+- Effect granularity: is a coarse row (`Net`, `Stage`, `Host`,
+  `NonDet`) enough, or do capabilities need parameters (`Net` with a
+  host allowlist, `HostPath` with a path) to be worth checking?
+- Where are effects checked: in the evaluator's type system, at the
+  derivation boundary by the store, or both? The store must enforce
+  what the compiler claims or the types are decorative.
+- Do string contexts get types, or get replaced by explicit staged
+  references? Guix says replacement works; nixpkgs compatibility says
+  contexts must at least be emulated.
+- How closely should the sparse-lock prototype track upstream's
+  `sparseNodes` plan, given it may ship someday and Determinate lists
+  sparse locks on its roadmap too?
+- Is gradual typing actually strong enough for `callPackage`-style
+  reflection, or does the compatibility frontend need to treat nixpkgs
+  as a dynamically typed foreign world forever?
+
+## Future possibilities
+
+Typed effects make cache policy programmable: a closure's trust level
+derives from its capability rows, which is the natural attestation
+substrate for plan 0030's claim graph and for blast-radius decisions in
+CI. Observability gets provenance for free: nox already streams live
+eval and build state over CRDT, and an effect row tells the stream what
+kind of node it is watching. And the Cloud Shake cell, constructive
+traces with early cutoff over a suspending scheduler, stops being a
+paper's empty square: it is what the scheduler does to every subgraph
+the type system can prove pure.
+
+Drafted by an AI agent via Claude Code (Claude Opus 4.5); comments
+wanted, hence the RFC flag.


### PR DESCRIPTION
Plan 0036: an RFC on what Nix would look like rebuilt from scratch, and how effects would look.

Adds `packages/site/src/lib/plans/0036-better-nix.svx` (status: Input wanted, rfc: true).

Contents:
- What Nix got right that a rebuild must keep: CA immutable store, derivations as pure functions, hermetic builds, generations, one language, hash-keyed substitution.
- The accidents it sheds, grounded in upstream issues and our own fork patches: flattened locks (NixOS/nix#7730 approved but unimplemented vs #13437 shipped in 2.31), eager source copies and lazy-trees v2 stalled on determinism (NixOS/nix#13225, roberth's rope-string direction), eval cache gaps (NixOS/nix#4279, our fork PR indexable-inc/nix#1), the untyped language (our lint bans with/rec; typenix and nox-lsp on workstations), fetcher capability divergence (NixOS/nix#14982, #13571, our index#3626 fallback), and half-adopted CA derivations (RFC 062 experimental since 2022, realisation races we hit in CI).
- The effects answer the title asks for: --impure, fixed-output derivations, IFD, and sandbox exceptions become typed capabilities with handlers (Unison abilities / Koka rows as prior art; OCaml 5 as the untyped cautionary), which is also the determinism evidence that unlocks the Build Systems a la Carte "Cloud Shake" cell (early cutoff) that Nix's deep-constructive-traces cell forbids.
- Migration reality: forks-in-place (Lix, Determinate, our patch series) short term, strangler-fig via snix store or nox frontend, and five small prototypes with success criteria.

Validation: repo lint suite passes locally (10/10 tasks); site build checked before merge.

(PR authored by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add RFC plan 0038 for a from-scratch Nix rebuild
> Adds a new plan document [0038-better-nix.svx](https://github.com/indexable-inc/index/pull/3641/files#diff-cd41e9e954049a78528355e854d90b940f36021bb8223298a5e67b87953712de) proposing a ground-up redesign of Nix. The RFC covers typed effects, sparse locks, lazy sources, a CA-only store, a unified fetcher interface, and a revised remote execution model, along with migration strategy, success criteria, drawbacks, alternatives, and unresolved questions. Status is set to 'Input wanted'.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a539136.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->