### PR TITLE
forks: require an intent entry for every fork patch

### DIFF
--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -77,7 +77,10 @@
 #                                 a commit message; appended after the PR body.
 #                    A patch with no entry defaults to `hold` with an "unclassified"
 #                    reason (fail-safe: an unclassified patch is never sent upstream
-#                    automatically). `upstream-sync` treats a repo whose
+#                    automatically) -- but for a fork that declares any intent, the
+#                    `patch-dag-<name>` check fails a patch with no entry, so the
+#                    fallback only backstops forks with no `patches` attrset at all.
+#                    `upstream-sync` treats a repo whose
 #                    `upstreamPolicy.aiPrsAllowed == false` as `never` regardless of
 #                    the per-patch mark, so a banned repo cannot leak a PR.
 #
@@ -146,6 +149,10 @@
         "0002-nix-expose-stable-application-package.patch" = {
           upstream = "never";
           reason = "Required to install the stable app from Zed's own flake, but Zed's contribution policy rejects autonomous-agent submissions.";
+        };
+        "0003-editor-navigate-directly-to-a-single-reference.patch" = {
+          upstream = "never";
+          reason = "General editor behavior fix (indexable-inc/index#2976), but Zed's contribution policy rejects autonomous-agent submissions.";
         };
       };
     }
@@ -545,6 +552,16 @@
         "0021-libstore-enforce-derivation-no-progress-deadlines.patch" = {
           upstream = "hold";
           reason = "Fleet CI policy for indexable-inc/index#3317. Validate the process-aware deadline before proposing a general Nix interface; humans submit Nix patches upstream per NixOS/nix#15984.";
+        };
+        # 0022: a paused (backpressured) substitution download neither reads
+        # its socket nor advances CURLOPT_LOW_SPEED_TIME, so a peer half-close
+        # parked the transfer forever -- nix-daemon children stranded in
+        # CLOSE-WAIT wedged CI slots for hours. The worker loop now polls
+        # paused transfers and fails them as transient curl errors, so
+        # download-attempts still applies.
+        "0022-libstore-fail-paused-downloads-on-peer-half-close-or.patch" = {
+          upstream = "hold";
+          reason = "Fails paused downloads on peer half-close or stall past stalled-download-timeout instead of parking forever (indexable-inc/index#3559). Hold: humans submit Nix patches upstream per NixOS/nix#15984.";
         };
         # 0023: forge archive inputs (github:/gitlab:/sourcehut:) requesting
         # submodules or LFS are constructed as the equivalent git+https input

--- a/packages/rebase-patches/dag-check.nu
+++ b/packages/rebase-patches/dag-check.nu
@@ -9,8 +9,11 @@
 #   (c) dag.json is in sync: regenerating from scratch yields identical bytes,
 #       and the NNNN order is a valid topological order of the DAG.
 #   (d) the hand-written upstreaming intent (lib/fork-packages.nix `patches`)
-#       is coherent with the series: every intent key names a real patch file
-#       (a rebase can renumber/rename patches and orphan intent silently),
+#       is coherent with the series, in both directions: every intent key
+#       names a real patch file (a rebase can renumber/rename patches and
+#       orphan intent silently), and -- when the fork declares intent at
+#       all -- every patch file has an intent entry, so a new patch cannot
+#       silently ride the registry's hold/unclassified fallback,
 #   (e) every patch states WHY it exists in its commit-message body. The body
 #       is the reason of record (one fact, one home): it rides the `git am` /
 #       rebase / `format-patch` round-trip, so it reaches upstream reviewers,
@@ -88,14 +91,28 @@ def main [src_dir: string, patch_dir: string, expected_base: string, intent_json
     $failed = true
   }
 
-  # (d) intent coherence: keys must name real patch files (a rebase renumbers
-  # names and would orphan intent silently).
+  # (d) intent coherence, both directions. Keys must name real patch files (a
+  # rebase renumbers names and would orphan intent silently), and every patch
+  # must carry an intent entry: without the mirror check, a new patch falls
+  # back to the registry's fail-safe default (hold / "unclassified") and its
+  # upstream stance never gets written down (index#3637). Forks that declare
+  # no intent pass an empty record and stay exempt (mkForkChecks defaults to
+  # `{}` for them).
   let intent = ($intent_json | from json)
   let names = ($patches | get name)
-  for key in ($intent | columns) {
+  let intent_keys = ($intent | columns)
+  for key in $intent_keys {
     if $key not-in $names {
       print $"patch-dag check: lib/fork-packages.nix intent references nonexistent patch ($key) \(renamed by a rebase?\); update the intent key."
       $failed = true
+    }
+  }
+  if not ($intent_keys | is-empty) {
+    for name in $names {
+      if $name not-in $intent_keys {
+        print $"patch-dag check: ($name) has no entry in the fork's `patches` intent attrset \(lib/fork-packages.nix\); declare its upstream stance + reason instead of riding the hold/unclassified default."
+        $failed = true
+      }
     }
   }
 

--- a/packages/site/src/lib/updates/fork-intent-registry-complete.svx
+++ b/packages/site/src/lib/updates/fork-intent-registry-complete.svx
@@ -1,0 +1,15 @@
+---
+id: fork-intent-registry-complete
+postedAt: 2026-07-19T12:00:00-07:00
+title: "every fork patch must now declare its upstreaming stance"
+tags: [nix, fork, ci]
+links:
+  - label: issue 3637
+    href: https://github.com/indexable-inc/index/issues/3637
+  - label: dag-check.nu
+    href: https://github.com/indexable-inc/index/blob/main/packages/rebase-patches/dag-check.nu
+---
+
+The fork registry (`lib/fork-packages.nix`) keys per-patch upstreaming intent by exact patch file name, and a patch with no entry falls back to `hold` with an "unclassified" reason. Fail-safe for the outward act, but silent: two series files had quietly accumulated no entry at all -- the nix fork's `0022-libstore-fail-paused-downloads-on-peer-half-close-or.patch` (index#3637) and zed's `0003-editor-navigate-directly-to-a-single-reference.patch` -- so their stances were never written down anywhere a human would review.
+
+Both entries exist now, and the `patch-dag-<name>` check enforces the invariant in the direction it was missing. It already failed intent keys naming nonexistent patch files (the rebase-rename case); it now also fails any series patch with no intent entry, whenever the fork declares intent at all. Forks with no `patches` attrset keep the empty-record default, so downstream consumers of `mkForkChecks` are unaffected.


### PR DESCRIPTION
The fork registry (`lib/fork-packages.nix`) keys per-patch upstreaming intent by exact patch file name; a patch with no entry silently defaults to `hold` / "unclassified". Two series files had no entry at all:

- nix `0022-libstore-fail-paused-downloads-on-peer-half-close-or.patch` — marked `hold` (all nix patches are hold per NixOS/nix#15984), reason derived from the commit body: fails paused downloads on peer half-close or stall past stalled-download-timeout instead of parking forever (index#3559).
- zed `0003-editor-navigate-directly-to-a-single-reference.patch` — marked `never` like its siblings (Zed rejects autonomous-agent submissions), found by the new guard.

The guard: `dag-check.nu`'s intent-coherence check (d) already failed intent keys naming nonexistent patch files; it now also fails any series patch with no intent entry, whenever the fork declares intent at all. Forks with no `patches` attrset keep the empty-record exemption, so downstream `mkForkChecks` consumers are unaffected. The change is a small mirror loop, so it went in rather than being deferred.

Verified: with the guard committed and the entries absent, `patch-dag-zed` fails with the new message; with the entries added, the checks pass.

Closes #3637

(authored by an AI agent via Claude Code, Claude Opus 4.6)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require an intent entry for every patch in fork package declarations
> - Updates [`dag-check.nu`](https://github.com/indexable-inc/index/pull/3643/files#diff-3b8436d65230cc36c31cb65c97b9fee6efca12622c1403356f02a8ffb0b0bd32) to fail when a fork declares any intent entries but one or more patch files lack a corresponding entry, emitting a specific diagnostic message.
> - Adds explicit intent entries in [`fork-packages.nix`](https://github.com/indexable-inc/index/pull/3643/files#diff-35e5ff5b02c2dcd32c93fd770ad2194f9fcbfc9f35fdcbd56821891b6e7452f4) for two previously uncovered patches: one under the Zed fork (`upstream = "never"`) and one under the Nix fork (`upstream = "hold"`).
> - Adds a site update post documenting that all fork patches must declare an upstreaming stance.
> - Behavioral Change: forks that declare partial intent records will now fail the DAG check until all patches have entries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d493bac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->