### PR TITLE
nix fmt: drop Alejandra's promotional output

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -2270,7 +2270,26 @@ in {
   # so they key identically in both views.
   ciChecks = catalogFor rustPackageTestSets.sharded // forkChecks;
 
-  formatter = pkgs.alejandra;
+  # `nix fmt` runs alejandra directly on the paths it is given. A single `-q`
+  # (`--quiet`) drops alejandra's informational chatter -- the
+  # "Congratulations! Your code complies with the Alejandra style." success
+  # line and the rotating "Special thanks ... for being a sponsor of
+  # Alejandra" promo -- while still surfacing genuine formatting/parse errors
+  # (a second `-q` would suppress those too, which we do not want). The
+  # lint-fix `nix` lane above already runs `alejandra --quiet`; this wraps the
+  # interactive `nix fmt` entrypoint the same way. A makeWrapper wrapper (not a
+  # hand-rolled shell script, per no-write-shell-application) over the cached
+  # `pkgs.alejandra` store path, so there is nothing extra to rebuild.
+  formatter = pkgs.symlinkJoin {
+    name = "alejandra-quiet";
+    paths = [pkgs.alejandra];
+    nativeBuildInputs = [pkgs.makeWrapper];
+    postBuild = ''
+      # shell
+      wrapProgram $out/bin/alejandra --add-flags --quiet
+    '';
+    meta.mainProgram = "alejandra";
+  };
 
   # Per-TU content-addressed kernel build (kbuild-unit, #3411), exposed under
   # `legacyPackages` so `nix build .#kernel-unit.vmlinux` resolves while the

--- a/packages/site/src/lib/updates/nix-fmt-quiet.svx
+++ b/packages/site/src/lib/updates/nix-fmt-quiet.svx
@@ -1,0 +1,13 @@
+---
+id: nix-fmt-quiet
+postedAt: 2026-07-19T09:00:00-07:00
+title: "nix fmt drops Alejandra's promo output"
+tags: [nix, tooling, formatter]
+links:
+  - label: formatter
+    href: https://github.com/indexable-inc/index/blob/main/lib/per-system.nix
+---
+
+Running `nix fmt` used to end with Alejandra's marketing: a "Congratulations! Your code complies with the Alejandra style." line and a rotating "Special thanks to <sponsor> for being a sponsor of Alejandra" plug on every invocation. That noise is gone. The `formatter` flake output now wraps `pkgs.alejandra` with a single `-q` (`--quiet`) flag, which Alejandra treats as "hide informational messages".
+
+Real output survives. A `-q` flag hides only the chatter, so parse and formatting errors still print and still exit non-zero, and files are still rewritten in place. A second `-q` would also swallow errors, so the wrapper stops at one. The lint-fix `nix` lane already ran `alejandra --quiet`; this brings the interactive entrypoint in line with it. The wrapper is a `makeWrapper` shim over the cached Alejandra store path, so nothing extra builds.


### PR DESCRIPTION
## What

`nix fmt` in this repo runs `pkgs.alejandra` directly (`lib/per-system.nix`, the `formatter` flake output). Alejandra ends every invocation with promotional noise:

- `Congratulations! Your code complies with the Alejandra style.`
- `👏 Special thanks to <sponsor> for being a sponsor of Alejandra!` (rotating, e.g. mercury.com)
- `Success! N file was formatted.`

This wraps the `formatter` output with a single `-q` (`--quiet`) flag, which alejandra documents as "hide informational messages". The promo/congratulations/sponsor chatter is gone; **genuine output stays**: parse and formatting errors still print and still exit non-zero (a second `-q` would suppress those too, so the wrapper stops at one), and files are still reformatted in place.

The lint-fix `nix` lane already ran `alejandra --quiet`; this brings the interactive `nix fmt` entrypoint in line with it.

## How

A `makeWrapper`/`symlinkJoin` shim over the cached `pkgs.alejandra` store path (not a hand-rolled shell script, per the `no-write-shell-application` astlog rule), adding `--add-flags --quiet`. Nothing extra rebuilds.

## Before / after

Before (`nix fmt` on a mis-formatted file):
```
Checking style in 1 file using 18 threads.
Formatted: /tmp/bad.nix
Success! 1 file was formatted.
👏 Special thanks to https://mercury.com for being a sponsor of Alejandra!
```
Before (already-clean file): also prints `Congratulations! Your code complies with the Alejandra style.` + sponsor line.

After:
```
<no formatter output>   # file still reformatted, exit 0
```
After (syntax error) still reports and exits 1:
```
Failed! 1 error found at:
- /tmp/err.nix: unexpected TOKEN_SEMICOLON at 6..7, wanted any of [...]
```

`nix run .#lint` passes (exit 0).

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress Alejandra's promotional output when running `nix fmt`
> Wraps the `alejandra` formatter with `makeWrapper` in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/3644/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) to pass `--quiet` by default, suppressing informational/promotional messages while still surfacing formatting errors. Also adds a site update post documenting the change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64e1ad4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->