### PR TITLE
prompt: subagent tools are never a superset of yours

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -285,6 +285,27 @@
     };
   }
   {
+    subagentToolSubset = {
+      topics = ["tooling"];
+      text = ''
+        Treat a subagent's toolset as never a superset of yours: if you
+        cannot run shell commands, assume your children cannot either.
+        Nothing tells an agent what tools its children get, so an agent
+        lacking a capability delegates hoping the child has it; the child
+        inherits the same limits, reasons the same way, and the recursion
+        spawns agents that burn tokens doing no work. Some agent types do
+        attach extra tools, but decide as if none do: when you lack the
+        tools for a task, fail fast and name the missing tool instead of
+        spawning.
+      '';
+      reason = ''
+        A parent without exec tools recursively spawned relay agents that
+        inherited the same gap: roughly 30k tokens of pure coordination
+        and no real work.
+      '';
+    };
+  }
+  {
     wallTime = {
       topics = ["workflow" "agency"];
       text = ''

--- a/packages/site/src/lib/updates/prompt-subagent-tool-subset.svx
+++ b/packages/site/src/lib/updates/prompt-subagent-tool-subset.svx
@@ -1,0 +1,13 @@
+---
+id: prompt-subagent-tool-subset
+postedAt: 2026-07-19T12:00:00-07:00
+title: "House prompt: subagent tools are never a superset of yours"
+tags: [agent, prompt]
+links:
+  - label: rules
+    href: https://github.com/indexable-inc/index/blob/main/packages/agent/prompt/rules.nix
+---
+
+The house prompt gains a `subagentToolSubset` rule: treat a subagent's toolset as never a superset of your own. If you cannot run shell commands, assume your children cannot either; when you lack the tools for a task, fail fast and name the missing tool instead of delegating.
+
+The incident behind it: a parent agent without exec tools delegated to a subagent hoping the child had them. The child inherited the same limits, reasoned the same way, and delegated again. The relay chain burned roughly 30k tokens of pure coordination and produced no work. Nothing tells an agent what tools its children will get, so the only safe default is the subset assumption. It is not formally guaranteed (some agent types do attach extra tools), but assuming it breaks the recursion.


### PR DESCRIPTION
## What

Adds a `subagentToolSubset` rule to the house prompt (`packages/agent/prompt/rules.nix`, topic `tooling`): treat a subagent's toolset as never a superset of your own. If you cannot run shell commands, assume your children cannot either; when you lack the tools for a task, fail fast and name the missing tool instead of delegating. The subset property is not formally guaranteed (some agent types do attach extra tools), but the rule says to decide as if it were.

## Why

Nothing tells an agent what tools its children will have, so an agent that lacks a capability tends to delegate hoping the child has it. The child inherits the same limits and reasons the same way, and this recurses into unbounded spawning. Incident: a parent agent without exec tools recursively spawned relay agents, burning roughly 30k tokens of pure coordination while doing no real work.

Site page: `packages/site/src/lib/updates/prompt-subagent-tool-subset.svx`

(authored by an AI agent via Claude Code, Claude Fable 5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `subagentToolSubset` rule to agent prompt to fail fast on missing tools
> Adds a new rule to [rules.nix](https://github.com/indexable-inc/index/pull/3648/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) instructing agents to assume subagents do not have a superset of the parent agent's tools. When a required tool is missing, the agent should name the missing tool and fail immediately rather than spawning a subagent that will recurse and burn tokens. Also adds a [site update post](https://github.com/indexable-inc/index/pull/3648/files#diff-1ff588fa475a8bbdde16478d4effef5370b3f023d0c57f20ea992e5bc7b7af83) describing the rule and the incident that motivated it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68e9fc2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->