### PR TITLE
hooks: drop the pre-commit lint run

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-# Repo pre-commit hook. Activated via .envrc setting core.hooksPath.
-# Runs the same lint app contributors should run manually.
-set -euo pipefail
-exec nix run .#lint

--- a/packages/site/src/lib/updates/drop-precommit-lint.svx
+++ b/packages/site/src/lib/updates/drop-precommit-lint.svx
@@ -1,0 +1,23 @@
+---
+id: drop-precommit-lint
+postedAt: "2026-07-19T08:20:00-07:00"
+title: "commits stop running the whole lint suite locally"
+links:
+  - label: "the hook removal"
+    href: "https://github.com/indexable-inc/index/pull/3627"
+tags:
+  - ci
+  - workflow
+---
+
+`.githooks/pre-commit` was `exec nix run .#lint`: every commit re-ran the
+entire lint suite on the committer's machine, minutes per commit on a
+laptop, serially, before CI ran the identical suite again on fleet
+hardware. Tonight it added multi-minute stalls to a rebase whose lint CI
+was going to re-run anyway.
+
+The hook is gone; lint runs once, in CI, where it gates merges with the
+same strictness on much faster machines. `nix run .#lint` remains available
+for anyone who wants the check before pushing. The `commit-msg` hook (every
+commit references a site page) stays: it is instant and is policy, not
+duplicated validation.


### PR DESCRIPTION
Every commit re-ran `nix run .#lint` (the whole suite) on the committer's machine, minutes per commit on a laptop, before flake-check ran the identical suite as the merge gate. Lint once, in CI. `nix run .#lint` stays for opt-in local runs; the instant commit-msg site-page policy hook stays.

Tonight's cost datapoint: a rebase commit stalled multiple minutes in the local hook while its CI was going to relint anyway.

(prepared by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop the pre-commit lint hook and add a site update announcing the change
> - Removes [.githooks/pre-commit](https://github.com/indexable-inc/index/pull/3653/files#diff-87320095d7c4f39eed5d8f3866b512eb910e4eec8e7926faaeef6a53ab786fcb), which ran `nix run .#lint` on every commit.
> - Adds a site update page at [drop-precommit-lint.svx](https://github.com/indexable-inc/index/pull/3653/files#diff-dfcf78c43d0d63eea47cc7951e43bf072570391437049f40c9e4cfc008aaa708) noting that lint now runs in CI and that the commit-msg hook remains.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2dbfc50.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->