### PR TITLE
nix fork: relative path flake inputs defer to the child's own flake.lock

### DIFF
--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -573,6 +573,20 @@
           upstream = "hold";
           reason = "Implements roberth's implicit git+https switch from NixOS/nix#14982 (also fixes NixOS/nix#13571; indexable-inc/index#3626). Hold: humans submit Nix patches upstream per NixOS/nix#15984.";
         };
+        # 0024: the child's own flake.lock is authoritative for the subtree of
+        # a relative path flake input (the child lives in the parent's tree,
+        # so its fetch is free and its content is already pinned). Scoped
+        # first step of roberth's approved sparseNodes plan (NixOS/nix#7730,
+        # Nov 2025, unimplemented upstream); lock format untouched, so the
+        # patch drops cleanly when upstream ships the real migration. Also
+        # carries the kept-flake relative-input refetch of the open upstream
+        # PR NixOS/nix#15982 (bug NixOS/nix#14762), which the deferral needs
+        # for nested relative inputs. Extends the merged update-time child
+        # lock respect of NixOS/nix#13437 to every lock computation.
+        "0024-libflake-defer-to-the-child-lock-for-relative-path-f.patch" = {
+          upstream = "hold";
+          reason = "Eval/lock-time sparse lock semantics for relative path inputs, the scoped start of the sparseNodes plan (NixOS/nix#7730; indexable-inc/index#3627). Hold: humans submit Nix patches upstream per NixOS/nix#15984, and the sparseNodes migration should land via the upstream plan, not a cold fork PR.";
+        };
       };
     }
     {

--- a/packages/nix/nix/patches/0024-libflake-defer-to-the-child-lock-for-relative-path-f.patch
+++ b/packages/nix/nix/patches/0024-libflake-defer-to-the-child-lock-for-relative-path-f.patch
@@ -1,0 +1,157 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew.gazelka@gmail.com>
+Date: Sun, 19 Jul 2026 02:18:44 -0700
+Subject: [PATCH] libflake: defer to the child lock for relative path flake
+ inputs
+
+A relative path flake input (type "path" with a relative path, per the
+`parent` lock field from NixOS/nix#10089) lives inside the parent's own
+source tree: the parent's pin already fixes the child's content, and
+fetching the child is virtually free. Upstream nonetheless copies the
+child's entire lock subtree into the parent's flake.lock and, because
+the input's flakeref never changes (e.g. `path:./index`), the "keep
+existing input" shortcut in computeLocks() reuses those copied nodes
+forever. When the child's own flake.nix and flake.lock move (a
+submodule bump), the parent silently evaluates with stale transitive
+pins, and a child that gained a new input fails hard with "function
+'outputs' called without required argument '<name>'" until a manual
+`nix flake update <input>`. Both failure modes hit production on
+2026-07-19 in the workstation config consuming index at `path:./index`.
+
+Fix: treat the child's own lock file as authoritative for the subtree
+of a relative path flake input. computeLocks() now skips the keep
+shortcut for such inputs and re-locks them through the fresh-input
+path, which reads the child's flake.nix and recurses with the child's
+own flake.lock as the old node, exactly as `nix flake update <input>`
+would. The child's non-relative transitive inputs are still kept
+lazily from its lock, so nothing new is fetched. When the child is
+unchanged this reproduces byte-identical nodes, so in-sync lock files
+do not churn; when it changed, the parent refreshes on the next
+lock-writing operation and read-only operations use the refreshed
+lock in memory. Kept non-relative flakes whose lock subtree contains
+a relative input are refetched (pinned, cached) so the relative path
+resolves against the right source tree; without this, deferral would
+resolve the path against the parent's tree, the bug class of
+NixOS/nix#14762 (fix modeled on the open PR NixOS/nix#15982).
+
+This is the scoped first step of the approved sparseNodes migration
+plan (roberth, NixOS/nix#7730, Nov 2025), which upstream has not
+implemented ("Status: Not implemented yet"). roberth calls relative
+path inputs the natural start: "fetching a relative path flake is
+virtually instantaneous, so we don't have to cache (duplicate)", and
+calls the semantics change "a breaking fix" (stale duplicates were
+never a behavior worth preserving). The lock file format is untouched
+(no sparseNodes field), so this patch drops cleanly when upstream
+ships the real migration. Update-time respect of the child lock
+(NixOS/nix#13437) is already in this base; this extends it to every
+lock computation. The upstream test FIXME for exactly this propagation
+in tests/functional/flakes/relative-paths-lockfile.sh becomes a hard
+assertion, with new coverage for the added-input production failure
+and for lock byte-stability.
+
+Refs indexable-inc/index#3627
+
+diff --git a/src/libflake/flake.cc b/src/libflake/flake.cc
+index 752cbcfb1..250a34cf4 100644
+--- a/src/libflake/flake.cc
++++ b/src/libflake/flake.cc
+@@ -629,7 +629,21 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
+                             if (auto oldLock3 = std::get_if<0>(&*oldLock2))
+                                 oldLock = *oldLock3;
+ 
+-                    if (oldLock && oldLock->originalRef.canonicalize() == input.ref->canonicalize()
++                    /* Sparse lock semantics for relative path flake inputs
++                       (NixOS/nix#7730): such an input lives inside the
++                       parent's own source tree, so the parent's pin already
++                       fixes its content and fetching it is virtually free.
++                       The copy of its transitive locks in our lock file is
++                       therefore not authoritative; the child's own flake.nix
++                       and flake.lock are. Skip the "keep existing input"
++                       shortcut and re-lock the subtree from the child on
++                       every operation. If the child is unchanged this
++                       reproduces the exact same nodes, so in-sync lock files
++                       stay byte-identical. */
++                    auto deferToChildLock = input.isFlake && input.ref->input.isRelative();
++
++                    if (oldLock && !deferToChildLock
++                        && oldLock->originalRef.canonicalize() == input.ref->canonicalize()
+                         && oldLock->parentInputAttrPath == overriddenParentPath && !hasCliOverride) {
+                         debug("keeping existing input '%s'", inputAttrPathS);
+ 
+@@ -657,6 +671,20 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
+                                those. */
+                             for (auto & i : oldLock->inputs) {
+                                 if (auto lockedNode = std::get_if<0>(&i.second)) {
++                                    /* A kept flake whose lock subtree contains
++                                       a relative path flake input cannot be
++                                       handled lazily: resolving that input
++                                       needs the kept flake's real source tree
++                                       rather than the parent's
++                                       (NixOS/nix#14762), and the child-lock
++                                       deferral above needs the child's actual
++                                       flake.nix and flake.lock. Refetch the
++                                       kept flake; its lockedRef is pinned, so
++                                       this is cached and deterministic. */
++                                    if ((*lockedNode)->isFlake && (*lockedNode)->lockedRef.input.isRelative()) {
++                                        mustRefetch = true;
++                                        break;
++                                    }
+                                     fakeInputs.emplace(
+                                         i.first,
+                                         FlakeInput{
+diff --git a/tests/functional/flakes/relative-paths-lockfile.sh b/tests/functional/flakes/relative-paths-lockfile.sh
+index 662c9329c..001e46a14 100644
+--- a/tests/functional/flakes/relative-paths-lockfile.sh
++++ b/tests/functional/flakes/relative-paths-lockfile.sh
+@@ -66,10 +66,46 @@ nix flake update --flake "path:$subflake" --override-input dep "$depFlakeB"
+ 
+ [[ $(nix eval "path:$subflake#y") = 12 ]]
+ 
+-# Expect that changes to sub/flake.lock are propagated to the root flake.
+-# FIXME: doesn't work at the moment #7730
+-[[ $(nix eval "$rootFlake#y") = 6 ]] || true
++# Changes to sub/flake.lock are propagated to the root flake (#7730):
++# the child's own lock file is authoritative for the subtree of a
++# relative path input. A read-only evaluation must already see the new
++# pin without modifying the parent's lock on disk.
++cp "$rootFlake/flake.lock" "$TEST_ROOT/lock-before"
++[[ $(nix eval --no-write-lock-file "$rootFlake#y") = 6 ]]
++cmp "$TEST_ROOT/lock-before" "$rootFlake/flake.lock"
+ 
+-# This will force refresh flake.lock with changes from sub/flake.lock
+-nix flake update --flake "$rootFlake"
++# A lock-writing evaluation refreshes the stale copied nodes in the
++# parent's lock, with no manual `nix flake update` needed.
+ [[ $(nix eval "$rootFlake#y") = 6 ]]
++
++# With the child unchanged, further evaluations must leave the parent
++# lock byte-identical (no churn on every operation).
++cp "$rootFlake/flake.lock" "$TEST_ROOT/lock-stable"
++[[ $(nix eval "$rootFlake#y") = 6 ]]
++cmp "$TEST_ROOT/lock-stable" "$rootFlake/flake.lock"
++
++# `nix flake update` on an already in-sync lock is a no-op.
++nix flake update --flake "$rootFlake"
++cmp "$TEST_ROOT/lock-stable" "$rootFlake/flake.lock"
++[[ $(nix eval "$rootFlake#y") = 6 ]]
++
++# A NEW input added to the child's flake.nix and flake.lock must become
++# visible to the parent without a manual update of the parent's lock.
++# Previously this failed with "function 'outputs' called without
++# required argument 'dep2'" (indexable-inc/index#3627).
++cat > "$subflake/flake.nix" <<EOF
++{
++  inputs.dep.url = "path:$depFlakeA";
++  inputs.dep2.url = "path:$depFlakeB";
++  outputs = { self, dep, dep2 }: {
++    y = dep.x + dep2.x;
++  };
++}
++EOF
++nix flake lock "path:$subflake"
++[[ $(nix eval "$rootFlake#y") = 13 ]]
++
++# And the refreshed parent lock is again stable.
++cp "$rootFlake/flake.lock" "$TEST_ROOT/lock-stable2"
++[[ $(nix eval "$rootFlake#y") = 13 ]]
++cmp "$TEST_ROOT/lock-stable2" "$rootFlake/flake.lock"

--- a/packages/nix/nix/patches/dag.json
+++ b/packages/nix/nix/patches/dag.json
@@ -105,6 +105,10 @@
       "deps": [
         "0013-libfetchers-opt-in-incremental-fetching-of-forge-inp.patch"
       ]
+    },
+    {
+      "patch": "0024-libflake-defer-to-the-child-lock-for-relative-path-f.patch",
+      "deps": []
     }
   ]
 }

--- a/packages/site/src/lib/updates/nix-sparse-locks-relative-inputs.svx
+++ b/packages/site/src/lib/updates/nix-sparse-locks-relative-inputs.svx
@@ -1,0 +1,21 @@
+---
+id: nix-sparse-locks-relative-inputs
+postedAt: 2026-07-19T12:30:00-07:00
+title: "nix fork: relative path flake inputs defer to the child's own flake.lock"
+tags: [nix, fork, flakes]
+links:
+  - label: index#3627
+    href: https://github.com/indexable-inc/index/issues/3627
+  - label: sparseNodes plan (NixOS/nix#7730)
+    href: https://github.com/NixOS/nix/issues/7730
+  - label: patch 0024
+    href: https://github.com/indexable-inc/index/blob/main/packages/nix/nix/patches/0024-libflake-defer-to-the-child-lock-for-relative-path-f.patch
+---
+
+Nix patch 0024 makes the child's own `flake.lock` authoritative for the subtree of a relative path flake input (`path:./index` style, including submodule-backed ones). Upstream copies the child's entire lock subtree into the parent's lock and, because a relative flakeref never changes, reuses the copy forever: after a submodule bump the parent silently evaluates with stale transitive pins, and a child that gained a new input fails with `function 'outputs' called without required argument '<name>'` until a manual `nix flake update <input>`. Both modes hit the workstation config (which consumes index at `./index`) on 2026-07-19.
+
+The patched `computeLocks()` re-locks relative path inputs from the child on every lock computation, exactly as `nix flake update <input>` would. The child lives in the parent's tree, so the read is free and its content is already pinned; its non-relative transitive inputs are still taken lazily from its lock file. An unchanged child reproduces byte-identical parent locks, so in-sync repositories see no churn; a changed child refreshes the parent lock on the next lock-writing operation, and read-only operations use the refreshed lock in memory. Non-path inputs are untouched.
+
+This is the scoped first step of roberth's approved sparseNodes migration plan on NixOS/nix#7730, which has no upstream implementation yet. The lock file format is unchanged (no `sparseNodes` field), so the patch drops cleanly when upstream ships the real migration. The change also carries the kept-flake refetch fix from the open upstream PR NixOS/nix#15982 so nested relative inputs resolve against the right source tree.
+
+*Written by Claude Code, an AI coding agent.*


### PR DESCRIPTION
Implements eval/lock-time sparse lock semantics for relative path flake inputs in the nix fork (patch 0024): `computeLocks()` now treats the child's own `flake.lock` as authoritative for the subtree of a relative path flake input (`path:./index` style, including submodule-backed ones), re-locking it from the child on every lock computation exactly as `nix flake update <input>` would.

Why this scope: the full sparseNodes migration (lock format change, phased rollout) is upstream's multi-year path per roberth's approved plan on NixOS/nix#7730 (Nov 2025, "Status: Not implemented yet"). The plan itself singles out relative path inputs as the free case: "fetching a relative path flake is virtually instantaneous, so we don't have to cache (duplicate)". This patch takes exactly that slice, leaves the lock format untouched (no `sparseNodes` field), and drops cleanly when upstream ships the real migration.

Semantics decision: always on, no setting. The only observable change for in-sync locks is none (an unchanged child reproduces byte-identical parent locks, covered by new test assertions); for out-of-sync locks the stale copies refresh, which roberth calls "a breaking fix" and users would call a bugfix. The refresh writes the parent lock only on operations that may already write locks today (same class as flake.nix gaining an input not yet locked); read-only operations use the refreshed lock in memory via the existing `--no-write-lock-file` path.

Production failure fixed (2026-07-19): after a submodule bump added the `git-src` input to index, the workstation config failed with `function 'outputs' called without required argument 'git-src'` until a manual `nix flake update index`; a bump that only moved a child pin silently kept the stale pin.

Also carries the kept-flake relative-input refetch from the open upstream PR NixOS/nix#15982 (bug NixOS/nix#14762): without it, deferral would resolve a nested relative input against the wrong source tree. Extends merged NixOS/nix#13437 (update-time child lock respect, already in the 2.34.7 base) to every lock computation.

Tests: the upstream FIXME in `tests/functional/flakes/relative-paths-lockfile.sh` for exactly this propagation ("doesn't work at the moment #7730") becomes a hard assertion, plus new coverage for the added-input failure, read-only propagation, lock byte-stability (no churn), and `nix flake update` idempotence.

Upstream intent: hold. Humans submit nix patches upstream per NixOS/nix#15984; the sparseNodes migration should land via the upstream plan, not a cold fork PR.

Closes #3627

(PR authored by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer relative path flake inputs to the child's own flake.lock during lock computation
> - Adds [0024-libflake-defer-to-the-child-lock-for-relative-path-f.patch](https://github.com/indexable-inc/index/pull/3657/files#diff-022ac8f53eae415ac20a702f4cb14d7f772c4cdb6300243d9af9f86617f6f2cc) to the nix fork, registered in [dag.json](https://github.com/indexable-inc/index/pull/3657/files#diff-bb8cabe3c8aca5a21a04124e99377308810f2ffd5701104ed528dd747207dc2d) and [fork-packages.nix](https://github.com/indexable-inc/index/pull/3657/files#diff-35e5ff5b02c2dcd32c93fd770ad2194f9fcbfc9f35fdcbd56821891b6e7452f4).
> - Patches `libflake.lockFlake` to skip the "keep existing input" fast-path for relative path inputs, re-locking them via the fresh-input path so the child's `flake.lock` is treated as authoritative.
> - Also forces a refetch when a kept flake's lock subtree contains a relative path input, ensuring nested relative inputs resolve against the correct source tree.
> - Adds a site post in [nix-sparse-locks-relative-inputs.svx](https://github.com/indexable-inc/index/pull/3657/files#diff-26be4dbae1dd65dbab027b360d9c61fae76398214877b54e60e54b692944adff) describing the change and its relation to the sparse locks roadmap.
> - Behavioral Change: relative path flake inputs no longer reuse stale copied lock nodes; parent locks are refreshed when child `flake.lock` changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c6df99.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->