### PR TITLE
nix fork: vendor lazy trees as an off-by-default lazy-trees setting

### DIFF
--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -620,6 +620,42 @@
           upstream = "hold";
           reason = "Eval/lock-time sparse lock semantics for relative path inputs, the scoped start of the sparseNodes plan (NixOS/nix#7730; indexable-inc/index#3627). Hold: humans submit Nix patches upstream per NixOS/nix#15984, and the sparseNodes migration should land via the upstream plan, not a cold fork PR.";
         };
+        # 0025-0028: lazy trees (indexable-inc/index#3645), vendored as the
+        # variant upstream actually merged to master (NixOS/nix#15711 plus its
+        # two post-merge fixes), not the closed lazy-trees-v2 PR
+        # (NixOS/nix#13225) and not Determinate's random-virtual-path
+        # implementation: roberth rejected randomness/fingerprint placeholders
+        # as impure (path equality and ordering must stay observably
+        # identical; his rope-string lazy-hashing alternative is unbuilt), and
+        # #13225 was closed 2026-07-16 pointing at #15711 as the mergeable
+        # subset. Determinate's own v2.35.1 tree has dropped the
+        # random-path implementation and rides the same mechanism. All four
+        # are already on upstream master; drop when the base reaches 2.35+.
+        "0025-libexpr-Add-a-way-to-collect-string-context-from-Val.patch" = {
+          upstream = "hold";
+          reason = "Backports upstream 569ee752c (prerequisite of NixOS/nix#15711, merged to master 2026-04-27); drop when the base reaches a release containing it (2.35+).";
+        };
+        "0026-Don-t-copy-flakes-to-the-store-unnecessarily.patch" = {
+          upstream = "hold";
+          reason = "Backports upstream 891ef140b (NixOS/nix#15711, merged to master 2026-04-27); drop when the base reaches a release containing it (2.35+).";
+        };
+        "0027-libexpr-Make-hash-mismatches-while-copying-lazy-path.patch" = {
+          upstream = "hold";
+          reason = "Backports upstream 8ffda0826 (NixOS/nix#15950, post-merge fix to #15711); drop when the base reaches a release containing it (2.35+).";
+        };
+        "0028-libexpr-Handle-lazy-paths-in-builtins.storePath-bett.patch" = {
+          upstream = "hold";
+          reason = "Backports upstream 933f3140b (NixOS/nix#16078, post-merge fix to #15711); drop when the base reaches a release containing it (2.35+).";
+        };
+        # 0029: our divergence from upstream master, which enables lazy
+        # mounting unconditionally. The off-by-default `lazy-trees` setting
+        # keeps the fork byte-identical to eager evaluation unless opted in;
+        # flipping the fleet on is a separate decision with its own drv-hash
+        # and eval-result equivalence sweeps (indexable-inc/index#3645).
+        "0029-libexpr-gate-lazy-input-mounting-behind-an-off-by-de.patch" = {
+          upstream = "hold";
+          reason = "Fork policy gate for the 0025-0028 backports (indexable-inc/index#3645): upstream ships the behavior unconditionally, we default it off pending fleet-wide equivalence sweeps. Retire together with the backports when the base reaches 2.35+.";
+        };
       };
     }
     {
@@ -725,8 +761,7 @@
         "0001-tokenizer-accept-underscore-digit-separators-in-nume.patch" = {
           upstream = "hold";
           reason = "Lexes a dialect only index's patched nix accepts (packages/nix/nix/patches/0014); upstream rnix should not take it before the Nix language change lands upstream.";
-        };
-      };
+        };      };
     }
   ];
 }

--- a/packages/nix/nix/default.nix
+++ b/packages/nix/nix/default.nix
@@ -22,7 +22,11 @@
 # build-observability series (patches 0003..0009): behind an experimental
 # feature of that name, every active build/substitution goal writes a JSON
 # status file under `<nixStateDir>/status/`, readable daemonlessly via the
-# new `nix store builds [--json]` command. The fork's
+# new `nix store builds [--json]` command. Patches 0025-0029 carry the lazy
+# trees backport (NixOS/nix#15711 plus its post-merge fixes) behind an
+# off-by-default `lazy-trees` eval setting: flake inputs mount at their
+# content-addressed store paths and only materialize when forced
+# (indexable-inc/index#3645). The fork's
 # `codex/flake-check-eval-cache` branch (draft PR indexable-inc/nix#1) is
 # deliberately excluded: it is self-declared WIP, untested, and incomplete.
 let

--- a/packages/nix/nix/patches/0025-libexpr-Add-a-way-to-collect-string-context-from-Val.patch
+++ b/packages/nix/nix/patches/0025-libexpr-Add-a-way-to-collect-string-context-from-Val.patch
@@ -1,0 +1,121 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sergei Zimmerman <sergei@zimmerman.foo>
+Date: Sun, 19 Apr 2026 03:20:34 +0300
+Subject: [PATCH] libexpr: Add a way to collect string context from
+ ValuePrinter
+
+Backport of a prerequisite refactor for lazy flake input mounting
+(NixOS/nix#15711, merged to upstream master 2026-04-27): printing a
+value, which is the default output mode of `nix eval`, must be able to
+report the string context it printed so the caller can materialize any
+lazy store paths that escaped into the output. printValue() and
+ValuePrinter gain an optional NixStringContext out parameter. No caller
+passes it yet, so this commit has no behavior change on its own; the
+next commit in the series uses it.
+
+Refs indexable-inc/index#3645
+
+(cherry picked from commit 569ee752c341db5de5fa63962d01f6a5d4cb995e)
+
+Assisted-by: Claude <noreply@anthropic.com>
+
+diff --git a/src/libexpr/include/nix/expr/print.hh b/src/libexpr/include/nix/expr/print.hh
+index 229f715..8e6d0f9 100644
+--- a/src/libexpr/include/nix/expr/print.hh
++++ b/src/libexpr/include/nix/expr/print.hh
+@@ -10,6 +10,7 @@
+ #include <iostream>
+ 
+ #include "nix/util/fmt.hh"
++#include "nix/expr/value/context.hh"
+ #include "nix/expr/print-options.hh"
+ 
+ namespace nix {
+@@ -64,7 +65,12 @@ bool isReservedKeyword(const std::string_view str);
+  */
+ std::ostream & printIdentifier(std::ostream & o, std::string_view s);
+ 
+-void printValue(EvalState & state, std::ostream & str, Value & v, PrintOptions options = PrintOptions{});
++void printValue(
++    EvalState & state,
++    std::ostream & str,
++    Value & v,
++    PrintOptions options = PrintOptions{},
++    NixStringContext * context = nullptr);
+ 
+ /**
+  * A partially-applied form of `printValue` which can be formatted using `<<`
+@@ -77,12 +83,15 @@ private:
+     EvalState & state;
+     Value & value;
+     PrintOptions options;
++    NixStringContext * context;
+ 
+ public:
+-    ValuePrinter(EvalState & state, Value & value, PrintOptions options = PrintOptions{})
++    ValuePrinter(
++        EvalState & state, Value & value, PrintOptions options = PrintOptions{}, NixStringContext * context = nullptr)
+         : state(state)
+         , value(value)
+         , options(options)
++        , context(context)
+     {
+     }
+ };
+diff --git a/src/libexpr/print.cc b/src/libexpr/print.cc
+index f2f62a6..0c95ae6 100644
+--- a/src/libexpr/print.cc
++++ b/src/libexpr/print.cc
+@@ -162,6 +162,7 @@ private:
+     std::ostream & output;
+     EvalState & state;
+     PrintOptions options;
++    NixStringContext * context;
+     std::optional<ValuesSeen> seen;
+     size_t totalAttrsPrinted = 0;
+     size_t totalListItemsPrinted = 0;
+@@ -577,9 +578,12 @@ private:
+                 printBool(v);
+                 break;
+ 
+-            case nString:
++            case nString: {
+                 printString(v);
++                if (context)
++                    copyContext(v, *context);
+                 break;
++            }
+ 
+             case nPath:
+                 printPath(v);
+@@ -632,10 +636,11 @@ private:
+     }
+ 
+ public:
+-    Printer(std::ostream & output, EvalState & state, PrintOptions options)
++    Printer(std::ostream & output, EvalState & state, PrintOptions options, NixStringContext * context)
+         : output(output)
+         , state(state)
+         , options(options)
++        , context(context)
+     {
+     }
+ 
+@@ -656,14 +661,14 @@ public:
+     }
+ };
+ 
+-void printValue(EvalState & state, std::ostream & output, Value & v, PrintOptions options)
++void printValue(EvalState & state, std::ostream & output, Value & v, PrintOptions options, NixStringContext * context)
+ {
+-    Printer(output, state, options).print(v);
++    Printer(output, state, options, context).print(v);
+ }
+ 
+ std::ostream & operator<<(std::ostream & output, const ValuePrinter & printer)
+ {
+-    printValue(printer.state, output, printer.value, printer.options);
++    printValue(printer.state, output, printer.value, printer.options, printer.context);
+     return output;
+ }
+ 

--- a/packages/nix/nix/patches/0026-Don-t-copy-flakes-to-the-store-unnecessarily.patch
+++ b/packages/nix/nix/patches/0026-Don-t-copy-flakes-to-the-store-unnecessarily.patch
@@ -1,0 +1,563 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sergei Zimmerman <sergei@zimmerman.foo>
+Date: Sun, 19 Apr 2026 03:46:58 +0300
+Subject: [PATCH] Don't copy flakes to the store unnecessarily
+
+Backport of the lazy trees mechanism that upstream actually merged
+(NixOS/nix#15711, merged to master 2026-04-27 as c2acffee566, after our
+2.34.7 base branched from master on 2026-03-02), vendored per
+indexable-inc/index#3645 as the biggest known eval-cost lever for
+flake-heavy workloads: evaluating a flake no longer copies every input
+tree into the store first.
+
+Mechanism: mountInput() computes the store path and narHash of an input
+with FetchMode::DryRun and mounts the input's source accessor at that
+store path in storeFS instead of copying. The store object is
+materialized on demand by the new EvalState::ensureLazyPathCopied() and
+ensureLazyPathsCopied(), called from every site that needs a real store
+object: derivationStrict inputSrcs, builtins.storePath, builtins.toFile
+references, builtins.exec, IFD string realisation, installable string
+coercion, app resolution, and the printed or written outputs of nix
+eval and nix-instantiate. builtins.getFlake gains a backwards
+compatibility lookup so a store-path flakeref whose string context was
+discarded still resolves through the storeFS mount. nix flake metadata
+no longer forces a copy of the flake tree. Because the store path is
+still derived from the dry-run NAR hash, paths, hashes, and lock files
+are byte identical to eager mode by construction.
+
+Source selection: indexable-inc/index#3645 names two candidate sources,
+both examined.
+- NixOS/nix#13225 (edolstra, "Lazy trees v2") mounts inputs at random
+  virtual store paths and devirtualizes (copies to the content-addressed
+  location, rewriting strings) when a derivation forces them. It was
+  closed unmerged on 2026-07-16; xokdvium: "the best we could achieve
+  without the generally contended topic of exposing entropy in the
+  language has been done in #15711. Some of the stuff from here has been
+  merged, modulo the StorePath::random() bits."
+- DeterminateSystems/nix shipped lazy trees to Determinate Nix users via
+  staged rollouts since 3.8.0, which is why the issue calls it the more
+  battle-tested source. But as of their v2.35.1, whose merge base with
+  upstream master is exactly our base commit 2c6d06e93, their tree no
+  longer contains the random-virtual-path implementation (no lazy-trees
+  or devirtualize symbols remain): they ride the same upstream mechanism
+  this commit backports. #15711 itself says it "repurposes a slightly
+  less lazy (but also more deterministic) approach than determinate nix
+  has taken" and takes its getFlake compatibility hack from detnix.
+
+Upstream pushback, which is why a later commit in this series gates the
+behavior off by default:
+- roberth, reviewing #13225: "Using randomness or even fingerprints for
+  placeholders makes the language non-deterministic and impure." Path
+  equality and ordering must remain observably identical to eager
+  evaluation. His preferred design, rope-structured strings with lazily
+  computed fixed-length substrings (lazy hashing), has not been built
+  yet by anyone. This backport sidesteps the randomness objection (the
+  mounted path IS the final content-addressed path, hashed up front) at
+  the cost of still hashing every input once.
+- The toString wrinkle: a derivation built from a store path string
+  whose context was discarded was always unsound, but lazy mounting
+  changes when it surfaces. The referenced path may not exist on disk
+  until something forces the copy, so evaluations that worked by
+  accident (the eager copy happened to exist) can fail with a missing
+  store path. #13225 handled this with a new devirtualize-without-
+  reference context type plus a warning; #15711 instead keeps real
+  paths, forces the copy at the sites listed above, and adds the
+  getFlake compatibility lookup.
+
+Adaptations to the 2.34.7 base:
+- the base predates the getFlake nPath variant from upstream master and
+  the SourcePath lockFlake() overload that upstream's compatibility
+  lookup resolves mounted refs with, so the lookup instead materializes
+  the mounted store object (ensureLazyPathCopied) and falls through to
+  the unchanged path-input flow: same user-visible behavior, eager only
+  for this discarded-context corner case;
+- EvalSettings::isReadOnly() does not exist in 2.34.7 (it arrived with
+  the unrelated libexpr-c use-after-free fix d5f162d1166); the base's
+  readOnlyMode reference is used directly;
+- the flakes.sh assertion that the nix flake metadata --json .path
+  exists on disk is dropped, exactly as upstream dropped it.
+
+This commit alone leaves lazy mounting enabled unconditionally, matching
+upstream master; a later commit in the series adds the off-by-default
+lazy-trees setting per the fork policy in indexable-inc/index#3645.
+
+Refs indexable-inc/index#3645
+
+(cherry picked from commit 891ef140b8564a7848a3d75976e172c3e15ec14b)
+
+Assisted-by: Claude <noreply@anthropic.com>
+
+diff --git a/src/libcmd/installable-value.cc b/src/libcmd/installable-value.cc
+index 3a167af..92811c1 100644
+--- a/src/libcmd/installable-value.cc
++++ b/src/libcmd/installable-value.cc
+@@ -54,8 +54,11 @@ InstallableValue::trySinglePathToDerivedPaths(Value & v, const PosIdx pos, std::
+     }
+ 
+     else if (v.type() == nString) {
++        auto path = state->coerceToSingleDerivedPath(pos, v, errorCtx);
++        if (auto o = std::get_if<SingleDerivedPath::Opaque>(&path.raw()))
++            state->ensureLazyPathCopied(o->path);
+         return {{
+-            .path = DerivedPath::fromSingle(state->coerceToSingleDerivedPath(pos, v, errorCtx)),
++            .path = DerivedPath::fromSingle(path),
+             .info = make_ref<ExtraPathInfo>(),
+         }};
+     }
+diff --git a/src/libexpr/include/nix/expr/eval.hh b/src/libexpr/include/nix/expr/eval.hh
+index bea6161..9de0f23 100644
+--- a/src/libexpr/include/nix/expr/eval.hh
++++ b/src/libexpr/include/nix/expr/eval.hh
+@@ -728,6 +728,26 @@ public:
+     std::optional<std::string> tryAttrsToString(
+         const PosIdx pos, Value & v, NixStringContext & context, bool coerceMore = false, bool copyToStore = true);
+ 
++    enum class CopyLazyPaths : bool {
++        PreserveLazy = false,
++        Copy = true,
++    };
++
++    /**
++     * For efficiency reasons, some store paths (as seen by the evaluator) in
++     * the storeFS at their content-addressed locations don't get copied to the
++     * store eagerly. This saves on needless I/O and possibly IPC if all the
++     * evaluator does is just evaluate nix expressions from those locations.
++     * This function copies such store objects to the store if they aren't already valid.
++     */
++    void ensureLazyPathCopied(const StorePath & path);
++
++    /**
++     * Ensure that all NixStringContextElem::Opaque context elements get fetched
++     * to the store.
++     */
++    void ensureLazyPathsCopied(const NixStringContext & context);
++
+     /**
+      * String coercion.
+      *
+@@ -1031,9 +1051,14 @@ public:
+ 
+     /**
+      * Coerce `v` to a path and realise it, i.e. build anything in the value's string context using `realiseContext()`.
++     * @param copyLazyPaths When encountering a lazy path (i.e. a string with Opaque context that's also "mounted" on
++     * the storeFS), fetch the store path to the store.
+      */
+     SourcePath realisePath(
+-        const PosIdx pos, Value & v, std::optional<SymlinkResolution> resolveSymlinks = SymlinkResolution::Full);
++        const PosIdx pos,
++        Value & v,
++        std::optional<SymlinkResolution> resolveSymlinks = SymlinkResolution::Full,
++        CopyLazyPaths copyLazyPaths = CopyLazyPaths::PreserveLazy);
+ 
+     /**
+      * Realise the given string with context, and return the string with outputs instead of downstream output
+diff --git a/src/libexpr/include/nix/expr/print-ambiguous.hh b/src/libexpr/include/nix/expr/print-ambiguous.hh
+index 7e44a6b..07fcc33 100644
+--- a/src/libexpr/include/nix/expr/print-ambiguous.hh
++++ b/src/libexpr/include/nix/expr/print-ambiguous.hh
+@@ -17,6 +17,12 @@ class EvalState;
+  *
+  * See: https://github.com/NixOS/nix/issues/9730
+  */
+-void printAmbiguous(EvalState & state, Value & v, std::ostream & str, std::set<const void *> * seen, size_t depth = 0);
++void printAmbiguous(
++    EvalState & state,
++    Value & v,
++    std::ostream & str,
++    std::set<const void *> * seen,
++    NixStringContext * context = nullptr,
++    size_t depth = 0);
+ 
+ } // namespace nix
+diff --git a/src/libexpr/paths.cc b/src/libexpr/paths.cc
+index 08c2a45..002dd63 100644
+--- a/src/libexpr/paths.cc
++++ b/src/libexpr/paths.cc
+@@ -20,10 +20,55 @@ SourcePath EvalState::storePath(const StorePath & path)
+     return {rootFS, CanonPath{store->printStorePath(path)}};
+ }
+ 
++void EvalState::ensureLazyPathCopied(const StorePath & path)
++{
++    if (settings.readOnlyMode)
++        return;
++
++    auto mount = storeFS->getMount(CanonPath(store->printStorePath(path)));
++    if (!mount)
++        return;
++
++    /* TODO: We could memoise this in-memory if necessary. */
++    auto storePath = fetchToStore(
++        fetchSettings,
++        *store,
++        SourcePath{ref(mount)},
++        /* Force a copy. mountInput does a dryRun to just calculate the storePath and narHash. */
++        FetchMode::Copy,
++        path.name());
++
++    /* Catch hash mismatches more loudly. This is more likely caused by unsound
++       caching of different accessor types that fetch the same repo with
++       the same git revision, but with different kinds of accessors (think
++       tarball-based fetchers vs local/remote git accessors). */
++    if (storePath != path) {
++        panic(fmt(
++            "hashed store path computed by the evaluator ('%1%') does not match what was computed when copying to the store ('%2%'), this is a bug",
++            store->printStorePath(path),
++            store->printStorePath(storePath)));
++    }
++}
++
++void EvalState::ensureLazyPathsCopied(const NixStringContext & context)
++{
++    for (const auto & c : context)
++        if (auto * o = std::get_if<NixStringContextElem::Opaque>(&c.raw))
++            /* TODO: This could be done in parallel. */
++            ensureLazyPathCopied(o->path);
++}
++
+ StorePath
+ EvalState::mountInput(fetchers::Input & input, const fetchers::Input & originalInput, ref<SourceAccessor> accessor)
+ {
+-    auto [storePath, narHash] = fetchToStore2(fetchSettings, *store, accessor, FetchMode::Copy, input.getName());
++    /* To mount the input, dryRun is sufficient. We still compute the narHash (to check for mismatches) and the store
++       path to figure out where to mount it. TODO: This could be relaxed in the future by making outPath and narHash
++       lazier. Good code that doesn't do `toString ./.` or otherwise inspects the outPath string and only uses it for
++       doing relative imports does not even require computing the store path. That is a big invasive change though and
++       would require having a special "LazyStorePathString" thunk. narHash also doesn't need to be computed eagerly in
++       case it's not actually specified (like during local development with a dirty tree) - in that case narHash could
++       also become a lazy app/thunk that shares the state with the storePath delayed computation. */
++    auto [storePath, narHash] = fetchToStore2(fetchSettings, *store, accessor, FetchMode::DryRun, input.getName());
+ 
+     allowPath(storePath); // FIXME: should just whitelist the entire virtual store
+ 
+diff --git a/src/libexpr/primops.cc b/src/libexpr/primops.cc
+index 3fb31fb..386faa0 100644
+--- a/src/libexpr/primops.cc
++++ b/src/libexpr/primops.cc
+@@ -10,6 +10,7 @@
+ #include "nix/store/names.hh"
+ #include "nix/store/path-references.hh"
+ #include "nix/store/store-api.hh"
++#include "nix/util/mounted-source-accessor.hh"
+ #include "nix/util/util.hh"
+ #include "nix/util/os-string.hh"
+ #include "nix/util/processes.hh"
+@@ -63,7 +64,7 @@ std::string EvalState::realiseString(Value & s, StorePathSet * storePathsOutMayb
+     nix::NixStringContext stringContext;
+     auto rawStr = coerceToString(pos, s, stringContext, "while realising a string").toOwned();
+     auto rewrites = realiseContext(stringContext, storePathsOutMaybe, isIFD);
+-
++    ensureLazyPathsCopied(stringContext);
+     return nix::rewriteStrings(rawStr, rewrites);
+ }
+ 
+@@ -88,7 +89,11 @@ StringMap EvalState::realiseContext(const NixStringContext & context, StorePathS
+                     ensureValid(b.drvPath->getBaseStorePath());
+                 },
+                 [&](const NixStringContextElem::Opaque & o) {
+-                    ensureValid(o.path);
++                    /* If the path happens to be mounted on the storeFS, that means it's lazy path string and would get
++                       copied to the store on-demand (when referenced in a derivation). The string is equal to final
++                       store path where the store object would end up (the path is hashed before mounting). */
++                    if (!storeFS->getMount(CanonPath(store->printStorePath(o.path))))
++                        ensureValid(o.path);
+                     if (maybePathsOut)
+                         maybePathsOut->emplace(o.path);
+                 },
+@@ -158,7 +163,8 @@ StringMap EvalState::realiseContext(const NixStringContext & context, StorePathS
+     return res;
+ }
+ 
+-SourcePath EvalState::realisePath(const PosIdx pos, Value & v, std::optional<SymlinkResolution> resolveSymlinks)
++SourcePath EvalState::realisePath(
++    const PosIdx pos, Value & v, std::optional<SymlinkResolution> resolveSymlinks, CopyLazyPaths copyLazyPaths)
+ {
+     NixStringContext context;
+ 
+@@ -167,6 +173,8 @@ SourcePath EvalState::realisePath(const PosIdx pos, Value & v, std::optional<Sym
+     try {
+         if (!context.empty() && path.accessor == rootFS) {
+             auto rewrites = realiseContext(context);
++            if (copyLazyPaths == CopyLazyPaths::Copy)
++                ensureLazyPathsCopied(context);
+             path = {path.accessor, CanonPath(rewriteStrings(path.path.abs(), rewrites))};
+         }
+         return resolveSymlinks ? path.resolveSymlinks(*resolveSymlinks) : path;
+@@ -441,10 +449,11 @@ static RegisterPrimOp primop_import(
+ /* !!! Should we pass the Pos or the file name too? */
+ extern "C" typedef void (*ValueInitializer)(EvalState & state, Value & v);
+ 
+-/* Load a ValueInitializer from a DSO and return whatever it initializes */
++/* Load a ValueInitializer from a DSO and return whatever it initializes. FIXME: This doesn't
++   work with chroot stores. */
+ void prim_importNative(EvalState & state, const PosIdx pos, Value ** args, Value & v)
+ {
+-    auto path = state.realisePath(pos, *args[0]);
++    auto path = state.realisePath(pos, *args[0], SymlinkResolution::Full, EvalState::CopyLazyPaths::Copy);
+ 
+     std::string sym(
+         state.forceStringNoCtx(*args[1], pos, "while evaluating the second argument passed to builtins.importNative"));
+@@ -471,7 +480,7 @@ void prim_importNative(EvalState & state, const PosIdx pos, Value ** args, Value
+     /* We don't dlclose because v may be a primop referencing a function in the shared object file */
+ }
+ 
+-/* Execute a program and parse its output */
++/* Execute a program and parse its output. FIXME: This doesn't work with chroot stores. */
+ void prim_exec(EvalState & state, const PosIdx pos, Value ** args, Value & v)
+ {
+     state.forceList(*args[0], pos, "while evaluating the first argument passed to builtins.exec");
+@@ -509,6 +518,7 @@ void prim_exec(EvalState & state, const PosIdx pos, Value ** args, Value & v)
+             .debugThrow();
+     }
+ 
++    state.ensureLazyPathsCopied(context);
+     auto output = runProgram(program, true, toOsStrings(std::move(commandArgs)));
+     Expr * parsed;
+     try {
+@@ -1726,7 +1736,10 @@ static void derivationStrictInternal(EvalState & state, std::string_view drvName
+                 [&](const NixStringContextElem::Built & b) {
+                     drv.inputDrvs.ensureSlot(*b.drvPath).value.insert(b.output);
+                 },
+-                [&](const NixStringContextElem::Opaque & o) { drv.inputSrcs.insert(o.path); },
++                [&](const NixStringContextElem::Opaque & o) {
++                    state.ensureLazyPathCopied(o.path);
++                    drv.inputSrcs.insert(o.path);
++                },
+             },
+             c.raw);
+     }
+@@ -1930,6 +1943,10 @@ static void prim_storePath(EvalState & state, const PosIdx pos, Value ** args, V
+     auto path =
+         state.coerceToPath(pos, *args[0], context, "while evaluating the first argument passed to 'builtins.storePath'")
+             .path;
++    /* Here we are leaving the realm of the rootFS accessor and must actually fetch to the store.
++       TODO: This could probably get optimised to avoid the fetching altogether to short-circuit when the path
++       is already mounted on storeFS. */
++    state.ensureLazyPathsCopied(context);
+     /* Resolve symlinks in ‘path’, unless ‘path’ itself is a symlink
+        directly in the store.  The latter condition is necessary so
+        e.g. nix-push does the right thing. */
+@@ -2666,9 +2683,10 @@ static void prim_toFile(EvalState & state, const PosIdx pos, Value ** args, Valu
+     StorePathSet refs;
+ 
+     for (auto c : context) {
+-        if (auto p = std::get_if<NixStringContextElem::Opaque>(&c.raw))
++        if (auto p = std::get_if<NixStringContextElem::Opaque>(&c.raw)) {
++            state.ensureLazyPathCopied(p->path);
+             refs.insert(p->path);
+-        else
++        } else
+             state
+                 .error<EvalError>(
+                     "files created by %1% may not reference derivations, but %2% references %3%",
+diff --git a/src/libexpr/print-ambiguous.cc b/src/libexpr/print-ambiguous.cc
+index ed91cad..b0a5224 100644
+--- a/src/libexpr/print-ambiguous.cc
++++ b/src/libexpr/print-ambiguous.cc
+@@ -7,7 +7,13 @@
+ namespace nix {
+ 
+ // See: https://github.com/NixOS/nix/issues/9730
+-void printAmbiguous(EvalState & state, Value & v, std::ostream & str, std::set<const void *> * seen, size_t depth)
++void printAmbiguous(
++    EvalState & state,
++    Value & v,
++    std::ostream & str,
++    std::set<const void *> * seen,
++    NixStringContext * context,
++    size_t depth)
+ {
+     checkInterrupt();
+ 
+@@ -22,6 +28,8 @@ void printAmbiguous(EvalState & state, Value & v, std::ostream & str, std::set<c
+         break;
+     case nString:
+         printLiteralString(str, v.string_view());
++        if (context)
++            copyContext(v, *context);
+         break;
+     case nPath:
+         str << v.path().to_string(); // !!! escaping?
+@@ -36,7 +44,7 @@ void printAmbiguous(EvalState & state, Value & v, std::ostream & str, std::set<c
+             str << "{ ";
+             for (auto & i : v.attrs()->lexicographicOrder(state.symbols)) {
+                 str << state.symbols[i->name] << " = ";
+-                printAmbiguous(state, *i->value, str, seen, depth + 1);
++                printAmbiguous(state, *i->value, str, seen, context, depth + 1);
+                 str << "; ";
+             }
+             str << "}";
+@@ -52,7 +60,7 @@ void printAmbiguous(EvalState & state, Value & v, std::ostream & str, std::set<c
+             str << "[ ";
+             for (auto v2 : v.listView()) {
+                 if (v2)
+-                    printAmbiguous(state, *v2, str, seen, depth + 1);
++                    printAmbiguous(state, *v2, str, seen, context, depth + 1);
+                 else
+                     str << "(nullptr)";
+                 str << " ";
+diff --git a/src/libflake/flake-primops.cc b/src/libflake/flake-primops.cc
+index 4b84c08..a2d7593 100644
+--- a/src/libflake/flake-primops.cc
++++ b/src/libflake/flake-primops.cc
+@@ -29,6 +29,7 @@
+ #include "nix/util/source-path.hh"
+ #include "nix/util/types.hh"
+ #include "nix/util/util.hh"
++#include "nix/store/store-api.hh"
+ 
+ namespace nix::flake::primops {
+ 
+@@ -44,6 +45,19 @@ PrimOp getFlake(const Settings & settings)
+                 flakeRefS,
+                 state.positions[pos]);
+ 
++        /* Backwards compatibility: since flakes used to be copied to the store eagerly, some users
++           relied on being able to do builtins.getFlake on a flakeref with discarded string context.
++           If such a ref points at a lazily mounted (not yet materialized) store path, force the copy
++           so the path-input fetch below can read it from disk. Upstream resolves these refs directly
++           through the storeFS mount via a SourcePath lockFlake() overload; that overload builds on
++           the getFlake-on-paths refactor which is not in this base, so materializing and falling
++           through to the unchanged path-input flow is the minimal equivalent. */
++        if (auto sourcePath = flakeRef.input.getSourcePath();
++            flakeRef.input.getType() == "path" && sourcePath && state.store->isInStore(sourcePath->string())) {
++            auto [storePath, subPath] = state.store->toStorePath(sourcePath->string());
++            state.ensureLazyPathCopied(storePath);
++        }
++
+         callFlake(
+             state,
+             lockFlake(
+diff --git a/src/nix/app.cc b/src/nix/app.cc
+index 634db04..167ffd8 100644
+--- a/src/nix/app.cc
++++ b/src/nix/app.cc
+@@ -95,6 +95,8 @@ UnresolvedApp InstallableValue::toApp(EvalState & state)
+                     c.raw));
+         }
+ 
++        state.ensureLazyPathsCopied(context);
++
+         return UnresolvedApp{App{
+             .context = std::move(context2),
+             .program = program,
+diff --git a/src/nix/eval.cc b/src/nix/eval.cc
+index f41d98f..69eb3ae 100644
+--- a/src/nix/eval.cc
++++ b/src/nix/eval.cc
+@@ -83,10 +83,10 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
+ 
+             [&](this const auto & recurse, Value & v, const PosIdx pos, const std::filesystem::path & path) -> void {
+                 state->forceValue(v, pos);
+-                if (v.type() == nString)
+-                    // FIXME: disallow strings with contexts?
++                if (v.type() == nString) {
++                    copyContext(v, context);
+                     writeFile(path, v.string_view());
+-                else if (v.type() == nAttrs) {
++                } else if (v.type() == nAttrs) {
+                     [[maybe_unused]] bool directoryCreated = std::filesystem::create_directory(path);
+                     // Directory should not already exist
+                     assert(directoryCreated);
+@@ -110,9 +110,8 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
+ 
+         else if (raw) {
+             logger->stop();
+-            writeFull(
+-                getStandardOutput(),
+-                *state->coerceToString(noPos, *v, context, "while generating the eval command output"));
++            auto string = state->coerceToString(noPos, *v, context, "while generating the eval command output");
++            writeFull(getStandardOutput(), *string);
+         }
+ 
+         else if (json) {
+@@ -120,8 +119,11 @@ struct CmdEval : MixJSON, InstallableValueCommand, MixReadOnlyOption
+         }
+ 
+         else {
+-            logger->cout("%s", ValuePrinter(*state, *v, PrintOptions{.force = true, .derivationPaths = true}));
++            ValuePrinter printer(*state, *v, PrintOptions{.force = true, .derivationPaths = true}, &context);
++            logger->cout("%s", printer);
+         }
++
++        state->ensureLazyPathsCopied(context);
+     }
+ };
+ 
+diff --git a/src/nix/flake.cc b/src/nix/flake.cc
+index df2a3a9..3c4533e 100644
+--- a/src/nix/flake.cc
++++ b/src/nix/flake.cc
+@@ -7,6 +7,7 @@
+ #include "nix/expr/get-drvs.hh"
+ #include "nix/util/os-string.hh"
+ #include "nix/util/signals.hh"
++#include "nix/util/mounted-source-accessor.hh"
+ #include "nix/store/store-open.hh"
+ #include "nix/store/derivations.hh"
+ #include "nix/store/outputs-spec.hh"
+@@ -217,8 +218,10 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
+         auto lockedFlake = lockFlake();
+         auto & flake = lockedFlake.flake;
+ 
+-        // Currently, all flakes are in the Nix store via the rootFS accessor.
+-        auto storePath = store->printStorePath(store->toStorePath(flake.path.path.abs()).first);
++        /* Flakes do not get copied to the store, but are instead mounted at
++           their expected store paths in storeFS. Querying metadata does not
++           force copying to the store, as one would expect. */
++        auto storePath = store->toStorePath(flake.path.path.abs()).first;
+ 
+         if (json) {
+             nlohmann::json j;
+@@ -240,7 +243,7 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
+                 j["revCount"] = *revCount;
+             if (auto lastModified = flake.lockedRef.input.getLastModified())
+                 j["lastModified"] = *lastModified;
+-            j["path"] = storePath;
++            j["path"] = store->printStorePath(storePath);
+             j["locks"] = lockedFlake.lockFile.toJSON().first;
+             if (auto fingerprint = lockedFlake.getFingerprint(*store, fetchSettings))
+                 j["fingerprint"] = fingerprint->to_string(HashFormat::Base16, false);
+@@ -251,7 +254,7 @@ struct CmdFlakeMetadata : FlakeCommand, MixJSON
+                 logger->cout(ANSI_BOLD "Locked URL:" ANSI_NORMAL "    %s", flake.lockedRef.to_string());
+             if (flake.description)
+                 logger->cout(ANSI_BOLD "Description:" ANSI_NORMAL "   %s", *flake.description);
+-            logger->cout(ANSI_BOLD "Path:" ANSI_NORMAL "          %s", storePath);
++            logger->cout(ANSI_BOLD "Path:" ANSI_NORMAL "          %s", store->printStorePath(storePath));
+             if (auto rev = flake.lockedRef.input.getRev())
+                 logger->cout(ANSI_BOLD "Revision:" ANSI_NORMAL "      %s", rev->to_string(HashFormat::Base16, false));
+             if (auto dirtyRev = fetchers::maybeGetStrAttr(flake.lockedRef.toAttrs(), "dirtyRev"))
+diff --git a/src/nix/nix-instantiate/nix-instantiate.cc b/src/nix/nix-instantiate/nix-instantiate.cc
+index 82838e2..ec08fdd 100644
+--- a/src/nix/nix-instantiate/nix-instantiate.cc
++++ b/src/nix/nix-instantiate/nix-instantiate.cc
+@@ -68,7 +68,7 @@ void processExpr(
+                 if (strict)
+                     state.forceValueDeep(vRes);
+                 std::set<const void *> seen;
+-                printAmbiguous(state, vRes, std::cout, &seen);
++                printAmbiguous(state, vRes, std::cout, &seen, &context);
+                 std::cout << std::endl;
+             }
+         } else {
+@@ -96,6 +96,8 @@ void processExpr(
+                 std::cout << fmt("%s%s\n", drvPathS, (outputName != "out" ? "!" + outputName : ""));
+             }
+         }
++
++        state.ensureLazyPathsCopied(context);
+     }
+ }
+ 
+diff --git a/tests/functional/flakes/flakes.sh b/tests/functional/flakes/flakes.sh
+index 8d95f61..fec80cc 100755
+--- a/tests/functional/flakes/flakes.sh
++++ b/tests/functional/flakes/flakes.sh
+@@ -69,7 +69,6 @@ nix flake metadata "$flake1Dir" | grepQuiet 'URL:.*flake1.*'
+ # Test 'nix flake metadata --json'.
+ json=$(nix flake metadata flake1 --json | jq .)
+ [[ $(echo "$json" | jq -r .description) = 'Bla bla' ]]
+-[[ -d $(echo "$json" | jq -r .path) ]]
+ [[ $(echo "$json" | jq -r .lastModified) = $(git -C "$flake1Dir" log -n1 --format=%ct) ]]
+ hash1=$(echo "$json" | jq -r .revision)
+ [[ -n $(echo "$json" | jq -r .fingerprint) ]]

--- a/packages/nix/nix/patches/0027-libexpr-Make-hash-mismatches-while-copying-lazy-path.patch
+++ b/packages/nix/nix/patches/0027-libexpr-Make-hash-mismatches-while-copying-lazy-path.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sergei Zimmerman <sergei@zimmerman.foo>
+Date: Mon, 1 Jun 2026 21:34:02 +0300
+Subject: [PATCH] libexpr: Make hash mismatches while copying lazy paths to the
+ store a proper error
+
+Backport of the first post-merge fix to NixOS/nix#15711 (upstream
+NixOS/nix#15950): when a dirty source tree is modified while nix is
+evaluating from it, the on-demand copy hashes differently from the
+mount-time dry-run hash. That is a user-triggerable condition (the
+upstream author hit it himself), so fail with a proper Error (exit code
+102, the same class as NAR hash mismatches) instead of panic(), which
+aborts the whole process. Vendored together with the lazy mounting
+backport so our series carries upstream's known fixes for it.
+
+Refs indexable-inc/index#3645
+
+(cherry picked from commit 8ffda0826d3b850b67b2e1ab48088a7a50ac80c5)
+
+Assisted-by: Claude <noreply@anthropic.com>
+
+diff --git a/src/libexpr/paths.cc b/src/libexpr/paths.cc
+index 002dd63..acd9ad3 100644
+--- a/src/libexpr/paths.cc
++++ b/src/libexpr/paths.cc
+@@ -38,15 +38,15 @@ void EvalState::ensureLazyPathCopied(const StorePath & path)
+         FetchMode::Copy,
+         path.name());
+ 
+-    /* Catch hash mismatches more loudly. This is more likely caused by unsound
+-       caching of different accessor types that fetch the same repo with
+-       the same git revision, but with different kinds of accessors (think
+-       tarball-based fetchers vs local/remote git accessors). */
++    /* This can happen if the source gets modified by another process while we are evaluaing
++       from it. Alternatively, the caching might be unsound and fetcher cache is poisoned somehow.
++       See https://github.com/NixOS/nix/issues/14317. */
+     if (storePath != path) {
+-        panic(fmt(
+-            "hashed store path computed by the evaluator ('%1%') does not match what was computed when copying to the store ('%2%'), this is a bug",
++        throw Error(
++            (unsigned int) 102,
++            "store path ('%1%') was hashed to avoid a full copy at first, but upon reading it again, the contents have changed ('%2%'), so we can not proceed. Make sure files do not change during evaluation",
+             store->printStorePath(path),
+-            store->printStorePath(storePath)));
++            store->printStorePath(storePath));
+     }
+ }
+ 

--- a/packages/nix/nix/patches/0028-libexpr-Handle-lazy-paths-in-builtins.storePath-bett.patch
+++ b/packages/nix/nix/patches/0028-libexpr-Handle-lazy-paths-in-builtins.storePath-bett.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sergei Zimmerman <sergei@zimmerman.foo>
+Date: Mon, 29 Jun 2026 02:39:57 +0300
+Subject: [PATCH] libexpr: Handle lazy paths in builtins.storePath better
+
+Backport of the second post-merge fix to NixOS/nix#15711 (upstream
+NixOS/nix#16078): builtins.storePath on a lazy (mounted but not yet
+materialized) store path failed with "no substituter that can build it"
+because the path went through nix::canonPath() and store validity
+checks outside the rootFS accessor. Funnel symlink resolution through
+the accessor and skip ensurePath() for mounted paths. Upstream hit this
+in the wild through flake-compat's `builtins.storePath src` pattern
+while building the nix.dev manual. Vendored together with the lazy
+mounting backport so our series carries upstream's known fixes for it.
+
+Refs indexable-inc/index#3645
+
+(cherry picked from commit 933f3140b1e73de2b909902b0e251c7da4031607)
+
+Assisted-by: Claude <noreply@anthropic.com>
+
+diff --git a/src/libexpr/primops.cc b/src/libexpr/primops.cc
+index 386faa0..8336248 100644
+--- a/src/libexpr/primops.cc
++++ b/src/libexpr/primops.cc
+@@ -1940,25 +1940,21 @@ static void prim_storePath(EvalState & state, const PosIdx pos, Value ** args, V
+             .debugThrow();
+ 
+     NixStringContext context;
+-    auto path =
+-        state.coerceToPath(pos, *args[0], context, "while evaluating the first argument passed to 'builtins.storePath'")
+-            .path;
+-    /* Here we are leaving the realm of the rootFS accessor and must actually fetch to the store.
+-       TODO: This could probably get optimised to avoid the fetching altogether to short-circuit when the path
+-       is already mounted on storeFS. */
+-    state.ensureLazyPathsCopied(context);
++    SourcePath sourcePath = state.coerceToPath(
++        pos, *args[0], context, "while evaluating the first argument passed to 'builtins.storePath'");
++
+     /* Resolve symlinks in ‘path’, unless ‘path’ itself is a symlink
+        directly in the store.  The latter condition is necessary so
+        e.g. nix-push does the right thing. */
+-    if (!state.store->isStorePath(path.abs()))
+-        path = CanonPath(canonPath(path.abs(), true).string());
+-    if (!state.store->isInStore(path.abs()))
+-        state.error<EvalError>("path '%1%' is not in the Nix store", path).atPos(pos).debugThrow();
+-    auto path2 = state.store->toStorePath(path.abs()).first;
+-    if (!settings.readOnlyMode)
+-        state.store->ensurePath(path2);
+-    context.insert(NixStringContextElem::Opaque{.path = path2});
+-    v.mkString(path.abs(), context, state.mem);
++    if (!state.store->isStorePath(sourcePath.path.abs()))
++        sourcePath = sourcePath.resolveSymlinks(SymlinkResolution::Full);
++    if (!state.store->isInStore(sourcePath.path.abs()))
++        state.error<EvalError>("path '%1%' is not in the Nix store", sourcePath).atPos(pos).debugThrow();
++    auto storePath = state.store->toStorePath(sourcePath.path.abs()).first;
++    if (!state.storeFS->getMount(CanonPath(state.store->printStorePath(storePath))) && !settings.readOnlyMode)
++        state.store->ensurePath(storePath);
++    context.insert(NixStringContextElem::Opaque{.path = storePath});
++    v.mkString(sourcePath.path.abs(), context, state.mem);
+ }
+ 
+ static RegisterPrimOp primop_storePath({

--- a/packages/nix/nix/patches/0029-libexpr-gate-lazy-input-mounting-behind-an-off-by-de.patch
+++ b/packages/nix/nix/patches/0029-libexpr-gate-lazy-input-mounting-behind-an-off-by-de.patch
@@ -1,0 +1,145 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew@ix.dev>
+Date: Sun, 19 Jul 2026 02:14:50 -0700
+Subject: [PATCH] libexpr: gate lazy input mounting behind an off-by-default
+ lazy-trees setting
+
+Upstream master enables lazy input mounting unconditionally. Our fork
+keeps the mechanism but defaults it off, per indexable-inc/index#3645:
+roberth's determinism review of NixOS/nix#13225 (randomness or
+fingerprints as placeholders make the language non-deterministic and
+impure; path equality and ordering must remain observably identical;
+his rope-string lazy-hashing alternative remains unbuilt) plus the
+toString-without-context wrinkle mean that flipping the fleet to lazy
+evaluation is a separate decision with its own drv-hash and eval-result
+equivalence sweeps. This patch only makes the capability available
+behind the new EvalSettings boolean `lazy-trees`.
+
+With lazy-trees = false, the default:
+- mountInput() copies eagerly (FetchMode::Copy), exactly like the
+  2.34.7 base;
+- ensureLazyPathCopied()/ensureLazyPathsCopied() return immediately,
+  since everything was already copied at mount time;
+- realiseContext() and builtins.storePath keep the eager ensureValid()
+  and ensurePath() calls even for mounted paths (inputs are mounted on
+  storeFS in both modes, so checking mount presence alone would skip
+  validity checks the base performed);
+- the getFlake discarded-context compatibility lookup is inert, because
+  the materialization it relies on is itself gated (with eager copying
+  the store path is physically present and the base code path already
+  handled it).
+
+Off means off: the only deltas against the base are behavior-neutral
+refactors, verified by byte-identical drvPaths on index's own attrs
+(indexable-inc/index#3645 records the validation).
+
+With lazy-trees = true, inputs mount at their final content-addressed
+store paths (hashed via dry run at mount time, so paths, hashes, and
+lock files match eager mode by construction) and materialize only when
+something forces them.
+
+Refs indexable-inc/index#3645
+
+Assisted-by: Claude <noreply@anthropic.com>
+
+diff --git a/src/libexpr/include/nix/expr/eval-settings.hh b/src/libexpr/include/nix/expr/eval-settings.hh
+index d9dba95..c787475 100644
+--- a/src/libexpr/include/nix/expr/eval-settings.hh
++++ b/src/libexpr/include/nix/expr/eval-settings.hh
+@@ -296,6 +296,34 @@ struct EvalSettings : Config
+             Intermediate results are not cached.
+         )"};
+ 
++    Setting<bool> lazyTrees{
++        this,
++        false,
++        "lazy-trees",
++        R"(
++            If set to true, flake inputs are not copied to the Nix store
++            eagerly. Instead the evaluator computes the store path and NAR
++            hash of each input up front (so paths, hashes and lock files
++            are byte-identical to eager mode) and mounts the input's
++            source tree at that store path inside the evaluator. The
++            store object is only materialized on demand, when something
++            actually forces it: instantiating a derivation that
++            references the path, `builtins.storePath`, IFD, and similar.
++
++            This avoids the per-evaluation cost of copying whole source
++            trees (such as large monorepo checkouts) into the store.
++
++            Strings that carry a lazy store path but whose context has
++            been discarded (for example via `builtins.toString` on a
++            path followed by `builtins.unsafeDiscardStringContext`, or
++            other context-dropping tricks) refer to a path that may not
++            exist on disk until something forces the copy. Such
++            derivations were always unsound; with lazy trees the failure
++            can surface earlier, as a missing store path at build time.
++
++            This is off by default for now.
++        )"};
++
+     Setting<bool> ignoreExceptionsDuringTry{
+         this,
+         false,
+diff --git a/src/libexpr/paths.cc b/src/libexpr/paths.cc
+index acd9ad3..a4316c8 100644
+--- a/src/libexpr/paths.cc
++++ b/src/libexpr/paths.cc
+@@ -22,6 +22,13 @@ SourcePath EvalState::storePath(const StorePath & path)
+ 
+ void EvalState::ensureLazyPathCopied(const StorePath & path)
+ {
++    /* With lazy-trees disabled every input was copied to the store when
++       it was mounted, so there is nothing left to materialize. Returning
++       early keeps the disabled mode byte-for-byte identical to the
++       behavior before this patch series. */
++    if (!settings.lazyTrees)
++        return;
++
+     if (settings.readOnlyMode)
+         return;
+ 
+@@ -61,14 +68,17 @@ void EvalState::ensureLazyPathsCopied(const NixStringContext & context)
+ StorePath
+ EvalState::mountInput(fetchers::Input & input, const fetchers::Input & originalInput, ref<SourceAccessor> accessor)
+ {
+-    /* To mount the input, dryRun is sufficient. We still compute the narHash (to check for mismatches) and the store
+-       path to figure out where to mount it. TODO: This could be relaxed in the future by making outPath and narHash
++    /* With lazy-trees enabled, dryRun is sufficient to mount the input.
++       We still compute the narHash (to check for mismatches) and the store
++       path to figure out where to mount it, so paths, hashes and lock files
++       do not depend on the setting. TODO: This could be relaxed in the future by making outPath and narHash
+        lazier. Good code that doesn't do `toString ./.` or otherwise inspects the outPath string and only uses it for
+        doing relative imports does not even require computing the store path. That is a big invasive change though and
+        would require having a special "LazyStorePathString" thunk. narHash also doesn't need to be computed eagerly in
+        case it's not actually specified (like during local development with a dirty tree) - in that case narHash could
+        also become a lazy app/thunk that shares the state with the storePath delayed computation. */
+-    auto [storePath, narHash] = fetchToStore2(fetchSettings, *store, accessor, FetchMode::DryRun, input.getName());
++    auto [storePath, narHash] = fetchToStore2(
++        fetchSettings, *store, accessor, settings.lazyTrees ? FetchMode::DryRun : FetchMode::Copy, input.getName());
+ 
+     allowPath(storePath); // FIXME: should just whitelist the entire virtual store
+ 
+diff --git a/src/libexpr/primops.cc b/src/libexpr/primops.cc
+index 8336248..3f7dc8a 100644
+--- a/src/libexpr/primops.cc
++++ b/src/libexpr/primops.cc
+@@ -92,7 +92,7 @@ StringMap EvalState::realiseContext(const NixStringContext & context, StorePathS
+                     /* If the path happens to be mounted on the storeFS, that means it's lazy path string and would get
+                        copied to the store on-demand (when referenced in a derivation). The string is equal to final
+                        store path where the store object would end up (the path is hashed before mounting). */
+-                    if (!storeFS->getMount(CanonPath(store->printStorePath(o.path))))
++                    if (!settings.lazyTrees || !storeFS->getMount(CanonPath(store->printStorePath(o.path))))
+                         ensureValid(o.path);
+                     if (maybePathsOut)
+                         maybePathsOut->emplace(o.path);
+@@ -1951,7 +1951,8 @@ static void prim_storePath(EvalState & state, const PosIdx pos, Value ** args, V
+     if (!state.store->isInStore(sourcePath.path.abs()))
+         state.error<EvalError>("path '%1%' is not in the Nix store", sourcePath).atPos(pos).debugThrow();
+     auto storePath = state.store->toStorePath(sourcePath.path.abs()).first;
+-    if (!state.storeFS->getMount(CanonPath(state.store->printStorePath(storePath))) && !settings.readOnlyMode)
++    if (!(state.settings.lazyTrees && state.storeFS->getMount(CanonPath(state.store->printStorePath(storePath))))
++        && !settings.readOnlyMode)
+         state.store->ensurePath(storePath);
+     context.insert(NixStringContextElem::Opaque{.path = storePath});
+     v.mkString(sourcePath.path.abs(), context, state.mem);

--- a/packages/nix/nix/patches/dag.json
+++ b/packages/nix/nix/patches/dag.json
@@ -109,6 +109,32 @@
     {
       "patch": "0024-libflake-defer-to-the-child-lock-for-relative-path-f.patch",
       "deps": []
+    },
+    {
+      "patch": "0025-libexpr-Add-a-way-to-collect-string-context-from-Val.patch",
+      "deps": []
+    },
+    {
+      "patch": "0026-Don-t-copy-flakes-to-the-store-unnecessarily.patch",
+      "deps": []
+    },
+    {
+      "patch": "0027-libexpr-Make-hash-mismatches-while-copying-lazy-path.patch",
+      "deps": [
+        "0026-Don-t-copy-flakes-to-the-store-unnecessarily.patch"
+      ]
+    },
+    {
+      "patch": "0028-libexpr-Handle-lazy-paths-in-builtins.storePath-bett.patch",
+      "deps": [
+        "0026-Don-t-copy-flakes-to-the-store-unnecessarily.patch"
+      ]
+    },
+    {
+      "patch": "0029-libexpr-gate-lazy-input-mounting-behind-an-off-by-de.patch",
+      "deps": [
+        "0028-libexpr-Handle-lazy-paths-in-builtins.storePath-bett.patch"
+      ]
     }
   ]
 }

--- a/packages/site/src/lib/updates/nix-fork-lazy-trees-setting.svx
+++ b/packages/site/src/lib/updates/nix-fork-lazy-trees-setting.svx
@@ -1,0 +1,24 @@
+---
+id: nix-fork-lazy-trees-setting
+postedAt: 2026-07-19T12:00:00-07:00
+title: "nix fork: lazy trees vendored as an off-by-default `lazy-trees` setting"
+tags: [nix, fork, performance, flakes]
+links:
+  - label: patches 0025-0029
+    href: https://github.com/indexable-inc/index/tree/main/packages/nix/nix/patches
+  - label: NixOS/nix#15711
+    href: https://github.com/NixOS/nix/pull/15711
+  - label: NixOS/nix#13225
+    href: https://github.com/NixOS/nix/pull/13225
+---
+
+The fork's nix now carries lazy trees: with `lazy-trees = true`, flake inputs are no longer copied into `/nix/store` at evaluation time. `mountInput()` computes each input's store path and NAR hash with a dry run, mounts the input's source tree at that path inside the evaluator, and only materializes the store object when something forces it (instantiating a derivation that references the path, `builtins.storePath`, IFD, `nix eval` output that leaks the path). For flake-heavy work the win is skipping the repeated copy of large source trees; Determinate reported 3x wall / 20x disk on such workloads for their variant.
+
+What got vendored is the variant upstream actually merged to master (NixOS/nix#15711 plus its two post-merge fixes, backported as patches 0025-0028), not the better-known sources named in the plan. Both were examined:
+
+- edolstra's lazy-trees-v2 (NixOS/nix#13225) mounts inputs at random virtual store paths and devirtualizes on demand. roberth blocked it: "Using randomness or even fingerprints for placeholders makes the language non-deterministic and impure." Path equality and ordering must remain observably identical to eager evaluation; his preferred alternative, rope-structured strings with lazily computed fixed-length substrings (lazy hashing), has not been built by anyone. The PR was closed on 2026-07-16 pointing at #15711 as the mergeable subset, "modulo the `StorePath::random()` bits".
+- Determinate's fork shipped lazy trees to their users via staged rollouts since Determinate Nix 3.8.0, and was the preferred source going in. But their current tree (v2.35.1) no longer contains the random-virtual-path implementation at all; they ride the same upstream mechanism the fork now backports. #15711 describes itself as "a slightly less lazy (but also more deterministic) approach than determinate nix has taken": it still hashes every input once, so the mounted path is the real content-addressed store path and paths, hashes, and lock files are byte-identical to eager mode by construction.
+
+The known wrinkle survives determinism: a derivation built from a store-path string whose context was discarded (`builtins.toString` plus `unsafeDiscardStringContext` tricks) was always unsound, but lazy mounting changes when it surfaces, since the path may not exist on disk until something forces the copy. #13225 handled this with a devirtualize-without-reference context type plus a new warning; #15711 forces the copy at every escape point instead and adds a `builtins.getFlake` compatibility lookup for discarded-context store paths.
+
+Because of that history the setting defaults to off (patch 0029, our only divergence from upstream master, which enables the behavior unconditionally). Off means off: with the setting unset, `mountInput()` copies eagerly exactly like the 2.34.7 base, and the drvPath of index's own attrs is byte-identical to the previous fork build. Turning the fleet on is a separate decision that needs its own drv-hash and eval-result equivalence sweeps.


### PR DESCRIPTION
Implements #3645: vendor lazy trees into the nix fork as an off-by-default `lazy-trees` setting (patches 0025-0029 on the 2.34.7 base; renumbered from 0024-0028 after rebasing over the relative-path lockfile patch that landed on main as 0024).

## Source chosen

Both sources named in the issue were compared against our base:

- **NixOS/nix#13225** (edolstra, lazy-trees-v2): single stale commit from 2025-05, closed unmerged on 2026-07-16. xokdvium's closing comment: the mergeable subset already landed via #15711, "modulo the `StorePath::random()` bits".
- **DeterminateSystems/nix**: battle-tested via staged rollouts since Determinate Nix 3.8.0, and the preferred source going in. But their current tree (v2.35.1, merge-base with upstream master is exactly our base commit 2c6d06e93) no longer contains the random-virtual-path implementation at all; they now ride the mechanism upstream merged.

What both point at is **NixOS/nix#15711** ("Don't copy flakes to the store unnecessarily", merged to master 2026-04-27, not in our 2.34.7 base which branched 2026-03-02). This PR backports it (patches 0025-0026) plus its two post-merge fixes NixOS/nix#15950 and NixOS/nix#16078 (patches 0027-0028), and adds our one divergence from upstream master: patch 0029 gates the behavior behind `lazy-trees`, default **off** (upstream enables it unconditionally). Its prerequisite #14050 is already in our base; per the upstream-first directive nothing already shipped in 2.34.7 (e.g. NixOS/nix#13437 lock semantics) is duplicated.

## Pushback (documented in patch bodies and the site update page)

- roberth on #13225: "Using randomness or even fingerprints for placeholders makes the language non-deterministic and impure"; path equality and ordering must remain observably identical; his rope-string lazy-hashing alternative remains unbuilt. The vendored variant sidesteps the randomness objection (inputs mount at their real content-addressed paths, hashed up front) at the cost of still hashing each input once.
- The toString-without-context wrinkle: derivations built from context-discarded store path strings were always unsound; lazy mounting changes when that surfaces. #13225 added a devirtualize-without-reference context type plus a warning; #15711 forces the copy at every escape point and adds a getFlake compatibility lookup instead.
- Because of both, the setting stays off by default. Flipping it on fleet-wide is explicitly out of scope and needs its own drv-hash and eval-result equivalence sweeps.

## Validation

- Patched nix builds: `nix-2.34.7+ix.p28.h8e2b146de21c2fc14557` (aarch64-darwin), `patched-src-nix` gate green, dag regenerated (28 nodes).
- OFF no-regression gate: `nix eval` of `packages.aarch64-darwin.mcp.drvPath` on a pinned index rev is byte-identical across p23 baseline, p28 with the setting off, and p28 with it on: `/nix/store/9fibcmllh2yhrq5w7ldlwcia6f1nw6rv-ix-mcp.drv`.
- ON actually engages: `nix flake metadata` on a fresh throwaway commit computes the source store path without materializing it (`path-info` reports the path invalid), while OFF copies it eagerly (52M for the index tree). The `lazy-trees` setting shows in `nix config show` with default `false`.
- Timing (honest report): on the index mcp drvPath eval, cold 8.0s off vs 9.5s on, warm 6.5s vs 6.6s, on a heavily loaded host. No wall-clock win on this attr: the index tree copy is only about 1.5s on APFS, and lazy mode pays per-read accessor overhead during eval. The win here is the skipped 52M store copy per fresh tree (and it compounds for CI-style many-fresh-revisions workloads); Determinate's 3x wall / 20x disk numbers come from flake-heavy workloads with much larger trees.
- Test suites: patched `nix-expr-tests`, `nix-fetchers-tests`, `nix-flake-tests`, `nix-store-tests`, and `nix-functional-tests` components building; results reported on this PR before merge.

Upstream policy: all five patches are marked `hold`; `aiPrsAllowed = false` for nix (NixOS/nix#15984), a human submits upstream if ever. Patches 0025-0028 retire when the base reaches 2.35+.

Closes #3645

(PR authored by an AI agent via Claude Code, Claude Opus 4.5)
