### PR TITLE
agent: add visual-explainers skill

### DIFF
--- a/packages/agent/skills/visual-explainers/SKILL.md
+++ b/packages/agent/skills/visual-explainers/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: visual-explainers
+description: "Build interactive visual explanations: single-file HTML explorables, system diagrams, and data charts where the reader learns by doing. Use whenever asked to visualize something, explain a system or mechanism visually, build an interactive or explorable explainer, diagram a pipeline or protocol, or chart data. Encodes the house philosophy: the visualization is the explanation, no decorative animation, progressive disclosure, one accent color, a single self-contained HTML file in vanilla JS."
+---
+
+## Visual explainers
+
+Make rich, simple, beautiful visualizations. The goal is that the reader walks
+away with a deep understanding of the system, gained by interacting with it,
+explained in plain words. Everything below serves that.
+
+## The visualization is the explanation
+
+The reader learns by doing (edit, click, toggle, drag), not by watching. If the
+page would teach the same thing as a static screenshot of itself, it is a
+diagram with extra steps; add the interaction that makes the reader's action
+the lesson.
+
+Every moving pixel must satisfy one of two tests: the reader caused it, or it
+encodes causality in the system being explained (pipeline stages lighting in
+the order they actually fire after the reader hits save). Delete everything
+else: entrance transitions, pulse loops, parallax, hover shimmer, animated
+gradients. No animation for animation's sake.
+
+## Progressive disclosure
+
+Overview first. One idea per view. Details on demand: clicking a node, stage,
+or mark reveals its explanation in place, next to the thing it explains. Never
+dump all annotations at once; a page where every label is visible up front has
+already spent the reader's attention before they act.
+
+Include a counterexample or contrast when it deepens understanding: show the
+world without the mechanism. A "full reload" button next to an HMR pipeline
+demonstrates exactly the state loss HMR prevents, and teaches more than a
+paragraph saying so.
+
+## Deep but simple
+
+Plain words, short sentences. Use real payloads, real file contents, and real
+values from the actual system under discussion, never lorem ipsum or `foo`.
+The test of success is prediction, not recall: after using the page, the
+reader should be able to say what the system would do in a case the page never
+showed.
+
+## Visual system
+
+- Dark-friendly. One accent color, plus at most one or two semantic colors
+  (error red, success green) used only for their meaning.
+- Generous whitespace. Monospace for code and data tokens.
+- No chart junk, no gradients as decoration, no drop shadows doing nothing.
+
+## Form
+
+Default to a single self-contained HTML file the user can open locally: inline
+CSS and JS, no build step, no CDN fetches. Vanilla JS unless the task genuinely
+demands more. State lives in a few plain variables; a render function reflects
+it. This keeps the artifact portable, diffable, and editable by the reader.
+
+## Data charts
+
+When the task is an actual data chart rather than a system explainer:
+
+- Honest axes: bar charts start at zero; never truncate an axis to manufacture
+  drama; label units.
+- Direct labeling over legends: put the series name at the end of its line.
+- Accessible contrast for every mark and label, in dark and light.
+- Interaction still earns its place: a tooltip that shows the exact value, a
+  toggle that isolates one series. Nothing autoplays.
+
+## Worked example: the target shape
+
+"How Svelte HMR works": the reader edits a fake `Button.svelte` in a textarea,
+clicks the rendered counter a few times to build up state, then hits save. The
+pipeline stages (watcher, compile, patch, re-render) light in causal order,
+each clickable for an in-place explanation of what it just did, and the counter
+keeps its value. A "full reload" button beside it wipes the counter,
+demonstrating the state loss HMR exists to prevent. Every element of that page
+follows a rule above: interaction builds the state the lesson needs, motion
+encodes causal order, disclosure is per-stage on click, and the contrast
+button is the counterexample.
+
+## Before shipping
+
+- Remove any motion the reader did not cause and the system does not explain.
+- Confirm the page opens from `file://` with the network disabled.
+- Read every annotation: is anything visible before the reader needs it?
+- Replace any placeholder data that survived with values from the real system.

--- a/packages/site/src/lib/updates/visual-explainers-skill.svx
+++ b/packages/site/src/lib/updates/visual-explainers-skill.svx
@@ -1,0 +1,15 @@
+---
+id: visual-explainers-skill
+postedAt: 2026-07-19T12:00:00-07:00
+title: "`visual-explainers` skill: interactive, explanation-first visualization"
+tags: [agent, skills]
+links:
+  - label: visual-explainers skill
+    href: https://github.com/indexable-inc/index/blob/main/packages/agent/skills/visual-explainers/SKILL.md
+  - label: "#3660"
+    href: https://github.com/indexable-inc/index/issues/3660
+---
+
+Agents now carry a house skill for building visualizations. The Claude-bundled `dataviz` skill was invocation-blocked in #3607 because it injected Anthropic's own chart styling; `visual-explainers` fills the gap with a different philosophy. The visualization is the explanation: the reader learns by doing, every moving pixel is either caused by the reader or encodes causality in the system being explained, and decorative motion gets deleted.
+
+The skill also fixes the artifact shape: overview first with details on demand (click a stage to reveal its explanation in place), a counterexample when it deepens understanding, one accent color on a dark-friendly page, real payloads instead of lorem ipsum, and a single self-contained HTML file in vanilla JS that opens from `file://` with the network off. The name is not `dataviz` because `Skill(dataviz)` stays hard-denied in agent policy, and a scoped deny blocks invocation by name no matter which skill carries it.


### PR DESCRIPTION
Adds `packages/agent/skills/visual-explainers/SKILL.md`, a house skill for building visualizations, plus its site-updates entry.

Philosophy the skill encodes:

- The visualization is the explanation: the reader learns by editing, clicking, and toggling, not by watching. Every moving pixel is either reader-caused or encodes causality in the system being explained; decorative motion is deleted.
- Progressive disclosure: overview first, one idea per view, per-element explanations revealed in place on click, never all annotations at once. A counterexample (the world without the mechanism) when it deepens understanding.
- Deep but simple: plain words, short sentences, real payloads from the actual system.
- Simple visual system: dark-friendly, one accent color plus semantic colors only, monospace for tokens, no chart junk.
- Default artifact: one self-contained HTML file in vanilla JS that works from `file://` offline.
- Data charts: honest zero-based axes, direct labels over legends, accessible contrast.

Named `visual-explainers`, not `dataviz`: the Claude-bundled `dataviz` skill was invocation-blocked in #3607 via a `Skill(dataviz)` deny in `packages/agent/policy/permissions.nix` (gated in `tests/default.nix`), and a scoped deny blocks invocation by name regardless of which skill carries it, so a repo skill reusing the name would list but never run.

Skills under `packages/agent/skills/` are auto-discovered by `lib/skills.nix`, so the directory is the only wiring. `nix run .#lint` passes locally.

Fixes #3660

Sent by an AI agent via Claude Code on Andrew's behalf.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add visual-explainers skill with documentation and site update post
> - Adds [SKILL.md](https://github.com/indexable-inc/index/pull/3661/files#diff-3d254f5916b3278718cc3b1cf320884ea598a3df730e4fe4c28c11a03ba7cd56) defining the `visual-explainers` skill, covering interaction/motion guidelines, progressive disclosure, visual system constraints, data chart principles, a worked example, and a pre-ship checklist.
> - Adds a [site update post](https://github.com/indexable-inc/index/pull/3661/files#diff-2a408085e228e6fa677f0ef0a11a82ddb745d111871420a765dc73dd29e4e17e) announcing the skill with links to the skill doc and rationale.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7165273.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->