### PR TITLE
nix fork: wire the sparse-locks functional test into passthru.tests

### DIFF
--- a/packages/nix/nix/default.nix
+++ b/packages/nix/nix/default.nix
@@ -307,6 +307,10 @@ let
     testDaemon = package.components.nix-cli;
   };
   buildStatus = focusedFunctionalTest {name = "build-status";};
+  # Patch 0024 regression coverage: the upstream relative-paths lock file
+  # test now asserts sparse child-lock semantics (stale copied nodes refresh
+  # from the child's own flake.lock; in-sync locks stay byte-identical).
+  sparseLocks = focusedFunctionalTest {name = "relative-paths-lockfile";};
 in
   package.overrideAttrs (old: {
     passthru =
@@ -320,7 +324,7 @@ in
         tests =
           (old.passthru.tests or old.tests or {})
           // lib.optionalAttrs (!isCross) {
-            inherit autoGcInterrupt buildStatus daemonSignal smoke;
+            inherit autoGcInterrupt buildStatus daemonSignal smoke sparseLocks;
           };
       }
       // lib.optionalAttrs (updateScriptWriter != null) {


### PR DESCRIPTION
Follow-up to #3657 (patch 0024, issue #3627): the amend adding passthru.tests.sparseLocks (a focused run of the rewritten relative-paths-lockfile.sh) raced an automerge of the original commit and never reached main. This PR carries just that wiring. Validated: the focused test and the whole flakes suite ran green on aarch64-linux against the patched build. (PR authored by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire sparse-locks functional test into nix fork's `passthru.tests`
> Adds a `sparseLocks` test binding in [default.nix](https://github.com/indexable-inc/index/pull/3664/files#diff-4332ad9feb37626c0ac4a68155597b10c261c0e0460cfcbca84f88d3d6125c6e) using `focusedFunctionalTest { name = "relative-paths-lockfile"; }` to cover upstream relative-paths lock file behavior. The test is included in `passthru.tests` alongside existing tests when not cross-compiling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d9f302.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->