### PR TITLE
agent: remove bundled dataviz skill via skillOverrides

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -284,7 +284,7 @@
     # Anthropic style guidelines we do not want steering output. Denying the
     # bare name also drops the companion `artifact-design` skill from the
     # skills listing (verified 2026-07, index#3607); the sibling `dataviz`
-    # skill is invocation-blocked in policy/permissions.nix.
+    # skill is removed via `skillOverrides` in houseSettingsDefaults below.
     Artifact = false;
     AskUserQuestion = false;
     DesignSync = false;
@@ -349,6 +349,18 @@
     fileCheckpointingEnabled = false;
     autoUpdatesChannel = "latest";
     skipAutoPermissionPrompt = true;
+    # Remove the Claude-bundled `dataviz` skill outright: it injects
+    # Anthropic's own chart-style guidance with no benefit to this harness,
+    # and before this override it sat permission-denied yet still listed,
+    # spending context on a skill that could never run. `"off"` both drops
+    # the skill from the listing and refuses invocation ("disabled for model
+    # invocation in skillOverrides settings"), and both hold under
+    # `--dangerously-skip-permissions` (probed headlessly on 2.1.206,
+    # index#3659; the older prompt-path stub where user/project
+    # `skillOverrides` was ignored no longer reproduces). The sibling
+    # `artifact-design` skill needs no row here: denying the bare Artifact
+    # tool in defaultSystemTools above already delists it (index#3607).
+    skillOverrides.dataviz = "off";
     # House statusline (./statusline.nu): context bar, model, effort, and the
     # running CLI version with an update marker against Anthropic's `latest`
     # release pointer. The house effortLevel also rides argv as the script's

--- a/packages/agent/policy/permissions.nix
+++ b/packages/agent/policy/permissions.nix
@@ -108,18 +108,17 @@
   ];
 
   # Claude-bundled skills that inject Anthropic's own style guidance with no
-  # real benefit to this harness. The CLI cannot strip a bundled skill from
-  # the listing, but a scoped deny hard-blocks invocation (verified 2026-07,
-  # index#3607: `Skill(dataviz)` deny rejects the call; `artifact-design`
-  # additionally vanishes from the listing once the Artifact tool itself is
-  # denied in the wrapper's tool table). These denies HOLD under
-  # `--dangerously-skip-permissions` (probed 2026-07: tool absent, skill
-  # delisted, invocation denied under bypass), like every deny; bypass skips
-  # prompts, not deny rules. Unconditional: unlike the kernel-superseded rows
-  # these have no non-kernel fallback role.
+  # real benefit to this harness. `artifact-design` vanishes from the listing
+  # once the Artifact tool itself is denied in the wrapper's tool table, and
+  # this scoped deny hard-blocks any blind invocation (verified 2026-07,
+  # index#3607). It HOLDS under `--dangerously-skip-permissions` (probed
+  # 2026-07), like every deny; bypass skips prompts, not deny rules.
+  # Unconditional: unlike the kernel-superseded rows it has no non-kernel
+  # fallback role. The sibling `dataviz` skill needs no deny: the wrapper
+  # removes it outright via `skillOverrides` in claude-code/default.nix
+  # (index#3659), which both delists it and refuses invocation.
   claudeBundledSkillDenies = [
     "Skill(artifact-design)"
-    "Skill(dataviz)"
   ];
 in {
   claude = {

--- a/packages/site/src/lib/updates/remove-dataviz-skill.svx
+++ b/packages/site/src/lib/updates/remove-dataviz-skill.svx
@@ -1,0 +1,32 @@
+---
+id: remove-dataviz-skill
+postedAt: "2026-07-19T12:30:00-07:00"
+title: "the bundled dataviz skill is gone, not just blocked"
+links:
+  - label: "the issue"
+    href: "https://github.com/indexable-inc/index/issues/3659"
+  - label: "the original deny"
+    href: "https://github.com/indexable-inc/index/issues/3607"
+tags:
+  - agents
+---
+
+Claude Code ships a bundled `dataviz` skill that injects Anthropic's own
+chart-style guidance. We never wanted it steering output, so #3607 denied
+it with `Skill(dataviz)` -- which blocked invocation but left the skill in
+every session's listing, spending context on a skill that could never run.
+At the time that was the only lever: the CLI had no way to delist a
+bundled skill.
+
+It does now. `skillOverrides` (CLI v2.1.129+, our pin is 2.1.206) accepts
+`"dataviz": "off"`, which removes the skill from the listing and refuses
+invocation outright, and holds under `--dangerously-skip-permissions`.
+Probed headlessly against 2.1.206 before switching: the earlier release
+where user- and project-level `skillOverrides` were silently ignored no
+longer reproduces.
+
+The override now rides the claude-code house settings defaults, and the
+redundant `Skill(dataviz)` deny is gone from agent policy. Wrapped
+sessions simply never see the skill. `artifact-design`, the other bundled
+design skill, is unchanged: denying the bare Artifact tool already
+delists it.

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4372,15 +4372,15 @@
           };
         in
           # Without the kernel only the merge protections, the unconditional
-          # bundled-skill denies (#3607) and the exa-superseded web pair
+          # bundled-skill deny (#3607) and the exa-superseded web pair
           # remain: the stock shell/file/search tools are that agent's whole
-          # surface.
+          # surface. `dataviz` carries no deny: the claude-code wrapper
+          # removes it via `skillOverrides` instead (#3659).
           overlay.claude.deniedToolPatterns
           == [
             "Bash(gh pr merge*--admin*)"
             "Bash(gh pr merge*--force*)"
             "Skill(artifact-design)"
-            "Skill(dataviz)"
             "WebSearch"
             "WebFetch"
           ]


### PR DESCRIPTION
The bundled `dataviz` skill was deny-listed (#3607): invocation blocked, but the skill stayed in every session's listing. The CLI has since gained `skillOverrides`, so the wrapper can remove it outright.

What changed:
- `packages/agent/claude-code/default.nix`: house settings default `skillOverrides.dataviz = "off"`.
- `packages/agent/policy/permissions.nix`: drop the now-redundant `Skill(dataviz)` deny (the `artifact-design` deny stays; that skill is delisted by the bare Artifact tool deny).
- `tests/default.nix`: update the expected overlay deny list.
- `packages/site/src/lib/updates/remove-dataviz-skill.svx`: site update entry.

Verified by headless probes against the pinned 2.1.206 before writing the change: the override delists the skill and refuses invocation ("Skill dataviz is disabled for model invocation in skillOverrides settings") in flag, project, and user settings layers, and both hold under `--dangerously-skip-permissions`. Locally: `nix run .#lint` green, `nix build .#claude-code` (install checks) green, and the policy eval matches the updated test expectation.

Closes #3659

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove bundled dataviz skill via `skillOverrides` instead of policy deny
> - Sets `houseSettingsDefaults.skillOverrides.dataviz` to `"off"` in [default.nix](https://github.com/indexable-inc/index/pull/3665/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8), causing the skill to be delisted and refused at the wrapper level.
> - Removes `Skill(dataviz)` from the `claudeBundledSkillDenies` list in [permissions.nix](https://github.com/indexable-inc/index/pull/3665/files#diff-c9733b1461e1c4084b3b81090b51274bf4a156b58a7110dfb75a5d40bef2df1d) since the wrapper now handles the block.
> - Updates test expectations in [tests/default.nix](https://github.com/indexable-inc/index/pull/3665/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) to assert `Skill(dataviz)` is absent from `deniedToolPatterns`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dffcd31.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->