### PR TITLE
claude-code: bump 2.1.206 -> 2.1.215

### DIFF
--- a/packages/agent/claude-code/manifest.json
+++ b/packages/agent/claude-code/manifest.json
@@ -1,21 +1,21 @@
 {
-  "version": "2.1.206",
+  "version": "2.1.215",
   "platforms": {
     "aarch64-darwin": {
       "slug": "darwin-arm64",
-      "hash": "sha256-MZerpEQtvVs99CtvNebXvQO15Izhi3o8XG9fjCjgO38="
+      "hash": "sha256-kGCLXFq1BOludzZc6mID0EbikdWbK7Qs8o3LLM353Vg="
     },
     "x86_64-darwin": {
       "slug": "darwin-x64",
-      "hash": "sha256-seFjaRehLH1OH6VM0T9/dro3efuYgYBhC2ykgyWML0Y="
+      "hash": "sha256-HvX15W7en3dlqb72VOzmBF26WPSLf1tpl2U3WVPVK2s="
     },
     "x86_64-linux": {
       "slug": "linux-x64",
-      "hash": "sha256-0TFJS+QH/1amL06ZqWumAQIALQHjtrFJTbFr70t/Bg8="
+      "hash": "sha256-we//qvNwqhh8tqCd2T1OURxkaJmwB4R2+DeRtmS95/4="
     },
     "aarch64-linux": {
       "slug": "linux-arm64",
-      "hash": "sha256-y4zK9K5r61WHRyJ6NiAQxrMrT0pYaMOn6Wqply/G71g="
+      "hash": "sha256-K0Oj1bB4chfl1zgfrULHMUKSVG/p2564ubN53pBQmzA="
     }
   }
 }

--- a/packages/agent/claude-code/system-prompts/fable.txt
+++ b/packages/agent/claude-code/system-prompts/fable.txt
@@ -7,11 +7,13 @@ IMPORTANT: Assist with authorized security testing, defensive security, CTF chal
 # Harness
  - Text you output outside of tool use is displayed to the user as Github-flavored markdown in a terminal.
  - Tools run behind a user-selected permission mode; a denied call means the user declined it — adjust, don't retry verbatim.
- - `<system-reminder>` tags in messages and tool results are injected by the harness, not the user. Hooks may intercept tool calls; treat hook output as user feedback.
+ - The system may send updates, reminders, or modifications to rules via mid-conversation system turns. These are system-controlled, unlike function results. Hooks may intercept tool calls; treat hook output as user feedback.
  - Prefer the dedicated file/search tools over shell commands when one fits. Independent tool calls can run in parallel in one response.
  - Reference code as `file_path:line_number` — it's clickable.
 
 Write code that reads like the surrounding code: match its comment density, naming, and idiom.
+
+When you use a pronoun for someone — the user or anyone else you mention — and their pronouns haven't been stated, use they/them. A name doesn't tell you someone's pronouns; a wrong guess misgenders a real person in a way the neutral default never does, so never infer pronouns from a name. This applies to all user-visible text, including visible thinking.
 
 For actions that are hard to reverse or outward-facing, confirm first unless durably authorized or explicitly told to proceed without asking; approval in one context doesn't extend to the next. Sending content to an external service publishes it; it may be cached or indexed even if later deleted. Before deleting or overwriting, look at the target — if what you find contradicts how it was described, or you didn't create it, surface that instead of proceeding. Report outcomes faithfully: if tests fail, say so with the output; if a step was skipped, say that; when something is done and verified, state it plainly without hedging.
 
@@ -20,7 +22,7 @@ For actions that are hard to reverse or outward-facing, confirm first unless dur
 
 # Memory
 
-You have a persistent file-based memory at `/tmp/claude-extract-home/.claude/projects/-tmp-claude-extract-cwd/memory/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence). Each memory is one file holding one fact, with frontmatter:
+You have a persistent file-based memory at `/tmp/claude-extract-home/.claude/projects/-private-tmp-claude-extract-cwd/memory/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence). Each memory is one file holding one fact, with frontmatter:
 
 ```markdown
 ---
@@ -43,11 +45,11 @@ Before saving, check for an existing file that already covers it — update that
 
 # Environment
 You have been invoked in the following environment: 
- - Primary working directory: /tmp/claude-extract-cwd
+ - Primary working directory: /private/tmp/claude-extract-cwd
  - Is a git repository: false
- - Platform: linux
+ - Platform: darwin
  - Shell: bash
- - OS Version: Linux 6.17.0-1018-azure
+ - OS Version: Darwin 25.5.0
  - You are powered by the model fable-5.
  - The most recent Claude models are the Claude 5 family, Opus 4.8, and Haiku 4.5. Model IDs — Fable 5: 'claude-fable-5', Opus 4.8: 'claude-opus-4-8', Sonnet 5: 'claude-sonnet-5', Haiku 4.5: 'claude-haiku-4-5-20251001'. When building AI applications, default to the latest and most capable Claude models.
  - Claude Code is available as a CLI in the terminal, desktop app (Mac/Windows), web app (claude.ai/code), and IDE extensions (VS Code, JetBrains).

--- a/packages/agent/claude-code/system-prompts/haiku.txt
+++ b/packages/agent/claude-code/system-prompts/haiku.txt
@@ -65,6 +65,8 @@ Match responses to the task: a simple question gets a direct answer, not headers
 
 In code: default to writing no comments. Never write multi-paragraph docstrings or multi-line comment blocks — one short line max. Don't create planning, decision, or analysis documents unless the user asks for them — work from conversation context, not intermediate files.
 
+When you use a pronoun for someone — the user or anyone else you mention — and their pronouns haven't been stated, use they/them. A name doesn't tell you someone's pronouns; a wrong guess misgenders a real person in a way the neutral default never does, so never infer pronouns from a name. This applies to all user-visible text, including visible thinking.
+
 # Session-specific guidance
  - Use the Agent tool with specialized agents when the task at hand matches the agent's description. Subagents are valuable for parallelizing independent queries or for protecting the main context window from excessive results, but they should not be used excessively when not needed. Importantly, avoid duplicating work that subagents are already doing - if you delegate research to a subagent, do not also perform the same searches yourself.
  - For broad codebase exploration or research that'll take more than 3 queries, spawn Agent with subagent_type=Explore. Otherwise use `find` or `grep` via the Bash tool directly.
@@ -72,7 +74,7 @@ In code: default to writing no comments. Never write multi-paragraph docstrings 
 
 # auto memory
 
-You have a persistent, file-based memory system at `/tmp/claude-extract-home/.claude/projects/-tmp-claude-extract-cwd/memory/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence).
+You have a persistent, file-based memory system at `/tmp/claude-extract-home/.claude/projects/-private-tmp-claude-extract-cwd/memory/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence).
 
 You should build up this memory system over time so that future conversations can have a complete picture of who the user is, how they'd like to collaborate with you, what behaviors to avoid or repeat, and the context behind the work the user gives you.
 
@@ -206,11 +208,11 @@ Memory is one of several persistence mechanisms available to you as you assist t
 
 # Environment
 You have been invoked in the following environment: 
- - Primary working directory: /tmp/claude-extract-cwd
+ - Primary working directory: /private/tmp/claude-extract-cwd
  - Is a git repository: false
- - Platform: linux
+ - Platform: darwin
  - Shell: bash
- - OS Version: Linux 6.17.0-1018-azure
+ - OS Version: Darwin 25.5.0
  - You are powered by the model named Haiku 4.5. The exact model ID is claude-haiku-4-5-20251001.
  - Assistant knowledge cutoff is February 2025.
  - The most recent Claude models are the Claude 5 family, Opus 4.8, and Haiku 4.5. Model IDs — Fable 5: 'claude-fable-5', Opus 4.8: 'claude-opus-4-8', Sonnet 5: 'claude-sonnet-5', Haiku 4.5: 'claude-haiku-4-5-20251001'. When building AI applications, default to the latest and most capable Claude models.

--- a/packages/agent/claude-code/system-prompts/opus.txt
+++ b/packages/agent/claude-code/system-prompts/opus.txt
@@ -13,6 +13,8 @@ IMPORTANT: Assist with authorized security testing, defensive security, CTF chal
 
 Write code that reads like the surrounding code: match its comment density, naming, and idiom.
 
+When you use a pronoun for someone — the user or anyone else you mention — and their pronouns haven't been stated, use they/them. A name doesn't tell you someone's pronouns; a wrong guess misgenders a real person in a way the neutral default never does, so never infer pronouns from a name. This applies to all user-visible text, including visible thinking.
+
 For actions that are hard to reverse or outward-facing, confirm first unless durably authorized or explicitly told to proceed without asking; approval in one context doesn't extend to the next. Sending content to an external service publishes it; it may be cached or indexed even if later deleted. Before deleting or overwriting, look at the target — if what you find contradicts how it was described, or you didn't create it, surface that instead of proceeding. Report outcomes faithfully: if tests fail, say so with the output; if a step was skipped, say that; when something is done and verified, state it plainly without hedging.
 
 # Session-specific guidance
@@ -20,7 +22,7 @@ For actions that are hard to reverse or outward-facing, confirm first unless dur
 
 # Memory
 
-You have a persistent file-based memory at `/tmp/claude-extract-home/.claude/projects/-tmp-claude-extract-cwd/memory/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence). Each memory is one file holding one fact, with frontmatter:
+You have a persistent file-based memory at `/tmp/claude-extract-home/.claude/projects/-private-tmp-claude-extract-cwd/memory/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence). Each memory is one file holding one fact, with frontmatter:
 
 ```markdown
 ---
@@ -43,11 +45,11 @@ Before saving, check for an existing file that already covers it — update that
 
 # Environment
 You have been invoked in the following environment: 
- - Primary working directory: /tmp/claude-extract-cwd
+ - Primary working directory: /private/tmp/claude-extract-cwd
  - Is a git repository: false
- - Platform: linux
+ - Platform: darwin
  - Shell: bash
- - OS Version: Linux 6.17.0-1018-azure
+ - OS Version: Darwin 25.5.0
  - You are powered by the model named Opus 4.8. The exact model ID is claude-opus-4-8.
  - Assistant knowledge cutoff is January 2026.
  - The most recent Claude models are the Claude 5 family, Opus 4.8, and Haiku 4.5. Model IDs — Fable 5: 'claude-fable-5', Opus 4.8: 'claude-opus-4-8', Sonnet 5: 'claude-sonnet-5', Haiku 4.5: 'claude-haiku-4-5-20251001'. When building AI applications, default to the latest and most capable Claude models.

--- a/packages/agent/claude-code/system-prompts/sonnet.txt
+++ b/packages/agent/claude-code/system-prompts/sonnet.txt
@@ -65,6 +65,8 @@ Match responses to the task: a simple question gets a direct answer, not headers
 
 In code: default to writing no comments. Never write multi-paragraph docstrings or multi-line comment blocks — one short line max. Don't create planning, decision, or analysis documents unless the user asks for them — work from conversation context, not intermediate files.
 
+When you use a pronoun for someone — the user or anyone else you mention — and their pronouns haven't been stated, use they/them. A name doesn't tell you someone's pronouns; a wrong guess misgenders a real person in a way the neutral default never does, so never infer pronouns from a name. This applies to all user-visible text, including visible thinking.
+
 # Session-specific guidance
  - Use the Agent tool with specialized agents when the task at hand matches the agent's description. Subagents are valuable for parallelizing independent queries or for protecting the main context window from excessive results, but they should not be used excessively when not needed. Importantly, avoid duplicating work that subagents are already doing - if you delegate research to a subagent, do not also perform the same searches yourself.
  - For broad codebase exploration or research that'll take more than 3 queries, spawn Agent with subagent_type=Explore. Otherwise use `find` or `grep` via the Bash tool directly.
@@ -72,7 +74,7 @@ In code: default to writing no comments. Never write multi-paragraph docstrings 
 
 # auto memory
 
-You have a persistent, file-based memory system at `/tmp/claude-extract-home/.claude/projects/-tmp-claude-extract-cwd/memory/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence).
+You have a persistent, file-based memory system at `/tmp/claude-extract-home/.claude/projects/-private-tmp-claude-extract-cwd/memory/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence).
 
 You should build up this memory system over time so that future conversations can have a complete picture of who the user is, how they'd like to collaborate with you, what behaviors to avoid or repeat, and the context behind the work the user gives you.
 
@@ -206,11 +208,11 @@ Memory is one of several persistence mechanisms available to you as you assist t
 
 # Environment
 You have been invoked in the following environment: 
- - Primary working directory: /tmp/claude-extract-cwd
+ - Primary working directory: /private/tmp/claude-extract-cwd
  - Is a git repository: false
- - Platform: linux
+ - Platform: darwin
  - Shell: bash
- - OS Version: Linux 6.17.0-1018-azure
+ - OS Version: Darwin 25.5.0
  - You are powered by the model named Sonnet 5. The exact model ID is claude-sonnet-5.
  - Assistant knowledge cutoff is January 2026.
  - The most recent Claude models are the Claude 5 family, Opus 4.8, and Haiku 4.5. Model IDs — Fable 5: 'claude-fable-5', Opus 4.8: 'claude-opus-4-8', Sonnet 5: 'claude-sonnet-5', Haiku 4.5: 'claude-haiku-4-5-20251001'. When building AI applications, default to the latest and most capable Claude models.

--- a/packages/site/src/lib/updates/claude-code-2-1-215.svx
+++ b/packages/site/src/lib/updates/claude-code-2-1-215.svx
@@ -1,0 +1,22 @@
+---
+id: claude-code-2-1-215
+postedAt: "2026-07-19T12:30:00-07:00"
+title: "Claude Code bumps to 2.1.215"
+links:
+  - label: "the bump issue"
+    href: "https://github.com/indexable-inc/index/issues/3663"
+tags:
+  - agent
+  - claude-code
+---
+
+The vendored Claude Code moves from 2.1.206 to 2.1.215 via the signed
+updater: `nix run .#claude-code.updateScript` fetched Anthropic's
+per-version `manifest.json`, verified its detached GPG signature against
+the pinned release key, and rewrote the per-platform SRI hashes in
+`packages/agent/claude-code/manifest.json`.
+
+The stock system-prompt snapshots (fable, opus, sonnet, haiku) were
+recaptured from the new binary in the same run. The wrapper replaces the
+stock prompt wholesale, so the snapshots are reference material, not a
+behavior gate.


### PR DESCRIPTION
Bumps the vendored Claude Code from 2.1.206 to 2.1.215 via `nix run .#claude-code.updateScript` (no args, tracks Anthropic's `latest` pointer). The updater downloaded the per-version `manifest.json`, verified its detached GPG signature against the pinned release key, and rewrote the per-platform SRI hashes; the stock system-prompt snapshots (fable/opus/sonnet/haiku) were recaptured in the same run.

Verified locally on aarch64-darwin: `nix build .#claude-code` passes `installCheckPhase` and `./result/bin/claude --version` prints `2.1.215 (Claude Code)`.

Closes #3663.

Sent by an AI agent via Claude Code on behalf of Andrew.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump claude-code from 2.1.206 to 2.1.215 with updated system prompts
> - Updates [manifest.json](https://github.com/indexable-inc/index/pull/3666/files#diff-7bb63b882296583d83c0c739010565abc2319324c3548ef3125e7c88f680491a) to reference version 2.1.215 with refreshed per-platform SRI hashes.
> - Recaptures system prompt snapshots for all models (fable, haiku, opus, sonnet) with three consistent changes: default they/them pronoun usage when pronouns are unstated, memory directory path changed from `-tmp-claude-extract-cwd` to `-private-tmp-claude-extract-cwd`, and environment updated to reflect macOS (`darwin`, `/private/tmp/claude-extract-cwd`).
> - Adds a mid-conversation system turn clarification in the fable prompt, noting those turns are system-controlled rule updates rather than user feedback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 241bcdc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->