### PR TITLE
kbuild-unit: cache root, snapshot repro pins, dep trim (P3 PR C, #3413)

### DIFF
--- a/lib/kernel/kbuild-unit.nix
+++ b/lib/kernel/kbuild-unit.nix
@@ -181,16 +181,26 @@ only to make the plan's inputs body-independent.
   # subprocesses need, so the helper reads its own environment. KBUILD_UNIT_*
   # stays out: those carry plan-only shim store paths, and a snapshot that
   # shifts with shim tweaks would re-execute every unit.
-  linkEnvVarPattern = "^(KBUILD_[A-Za-z0-9_]+|CONFIG_SHELL|CC|LD|NM|AR|OBJCOPY|OBJDUMP|READELF|STRIP|PAHOLE|RESOLVE_BTFIDS|SRCARCH|ARCH|srctree|objtree|LINUXINCLUDE|NOSTDINC_FLAGS|LDFLAGS_vmlinux|CFLAGS_vmlinux|KALLSYMS[A-Za-z0-9_]*|MAKE|HOSTCC)$";
   linkEnvDump = writeBashApplication {
     name = "kbuild-unit-link-env-dump";
+    runtimeInputs = [pkgs.coreutils];
     text = ''
       # shell
-      compgen -A export | LC_ALL=C sort | grep -E '${linkEnvVarPattern}' \
-        | grep -vE '^KBUILD_UNIT_' \
-        | while IFS= read -r name; do
-            printf 'export %s=%q\n' "$name" "''${!name}"
-          done
+      # Prefix expansion, not compgen: writeBashApplication's bash builds
+      # without programmable completion. Every variable in this fresh
+      # process came from the environ, so "is set" is "is exported".
+      names=()
+      for name in "''${!KBUILD_@}" "''${!KALLSYMS@}" \
+        CONFIG_SHELL CC LD NM AR OBJCOPY OBJDUMP READELF STRIP PAHOLE \
+        RESOLVE_BTFIDS SRCARCH ARCH srctree objtree LINUXINCLUDE \
+        NOSTDINC_FLAGS LDFLAGS_vmlinux CFLAGS_vmlinux MAKE HOSTCC; do
+        [ -n "''${!name+x}" ] || continue
+        case $name in KBUILD_UNIT_*) continue ;; esac
+        names+=("$name")
+      done
+      while IFS= read -r name; do
+        printf 'export %s=%q\n' "$name" "''${!name}"
+      done < <(printf '%s\n' "''${names[@]}" | LC_ALL=C sort -u)
     '';
   };
 
@@ -364,6 +374,12 @@ only to make the plan's inputs body-independent.
         installPhase = ''
           # shell
           runHook preInstall
+          # The link-env dump is written mid-link by the helper call patched
+          # into link-vmlinux.sh at configure time, whose failures are muted
+          # for unit replays; catch a plan-side regression loudly before an
+          # empty dump ships in the snapshot and breaks the link unit's
+          # replay.
+          test -s .kbuild-unit-link-env
           mkdir -p $out
           ${
             # Under skeleton the plan's vmlinux and .ko files are stub garbage;

--- a/lib/kernel/kbuild-unit.nix
+++ b/lib/kernel/kbuild-unit.nix
@@ -33,6 +33,28 @@ with its generated ksymtab source, `Module.symvers` with each module's
 `.mod.c`), and every final `.ko` link; `modulesEquivalence` byte-compares
 each unit-built module against the reference build's (#3413).
 
+Sharing over the fleet cache rides `cachePushRoot` (#3413): one linkFarm
+whose runtime closure spans every unit output plus the IFD artifacts
+(plan, rendered units.nix, snapshot, skeleton). Building that root on a
+CI dispatcher enqueues ONE obligation whose recursive closure the cache
+drainer publishes -- NARs and CA realisations -- so other hosts
+substitute units instead of rebuilding, while the mass unit build itself
+runs with the per-derivation post-build hook disabled (one hook enqueue
+per unit serialized 3.6k-unit builds to a crawl under queue
+backpressure; see #3413).
+
+Plan reruns must reproduce the snapshot bit-identically or every unit
+re-executes at defconfig scale, so the plan pins down every observed
+nondeterminism carrier: the build tree always unpacks to a fixed
+directory name (DWARF comp_dir and the vdso build-id record the absolute
+build path; a name that shifted with the src derivation made the
+embedded vdso diverge from the reference's), snapshotted host tools
+under tools/ are stripped of debug info (tools/build compiles with -g,
+and objtool's .debug_line_str differed across otherwise identical plan
+builds), and the link-env dump is emitted by one bash helper with sorted
+names and printf %q quoting instead of whichever shell CONFIG_SHELL
+resolves to (its `export -p` quoting style flipped between runs).
+
 Each unit's build tree is scoped to the sources its .cmd recorded (#3412):
 compile units see their .c plus tracked headers as per-file store paths,
 the link unit adds the script-read Makefile and header trees, and archive
@@ -101,6 +123,19 @@ only to make the plan's inputs body-independent.
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -frandom-seed=kbuild-unit"
   '';
 
+  # DWARF comp_dir, the vdso build-id, and objtool's .debug_line_str all
+  # record the absolute build tree path, and parts of that DWARF flow into
+  # unit inputs (the vdso .so embedded via the generated vdso-image-*.c) and
+  # the snapshot (host tools, vdso .so.dbg). Unpack to one fixed name --
+  # matching the `kbuild-tree` unit replays build in -- so those bytes agree
+  # between the plan (whose src name varies by strategy: skeletonTree vs
+  # srcTree), the reference build, and every plan rerun (#3413).
+  pinBuildTreeName = ''
+    # shell
+    mv "$sourceRoot" kbuild-tree
+    sourceRoot=kbuild-tree
+  '';
+
   buildVmlinuxAndModules = ''
     # shell
     runHook preBuild
@@ -135,6 +170,28 @@ only to make the plan's inputs body-independent.
   planCcShim = writeBashApplication {
     name = "gcc";
     text = builtins.readFile ./kbuild-plan-cc.sh;
+  };
+
+  # Deterministic emitter for the `.kbuild-unit-link-env` dump. The dump used
+  # to be `export -p` output, whose quoting style belongs to whichever shell
+  # CONFIG_SHELL resolves to and flipped across plan builds (#3413 PR A),
+  # shifting the snapshot CA and re-executing every unit. One bash helper
+  # with LC_ALL=C-sorted names and printf %q quoting owns the format instead.
+  # Inherited env is the interface: link-vmlinux.sh exports what its
+  # subprocesses need, so the helper reads its own environment. KBUILD_UNIT_*
+  # stays out: those carry plan-only shim store paths, and a snapshot that
+  # shifts with shim tweaks would re-execute every unit.
+  linkEnvVarPattern = "^(KBUILD_[A-Za-z0-9_]+|CONFIG_SHELL|CC|LD|NM|AR|OBJCOPY|OBJDUMP|READELF|STRIP|PAHOLE|RESOLVE_BTFIDS|SRCARCH|ARCH|srctree|objtree|LINUXINCLUDE|NOSTDINC_FLAGS|LDFLAGS_vmlinux|CFLAGS_vmlinux|KALLSYMS[A-Za-z0-9_]*|MAKE|HOSTCC)$";
+  linkEnvDump = writeBashApplication {
+    name = "kbuild-unit-link-env-dump";
+    text = ''
+      # shell
+      compgen -A export | LC_ALL=C sort | grep -E '${linkEnvVarPattern}' \
+        | grep -vE '^KBUILD_UNIT_' \
+        | while IFS= read -r name; do
+            printf 'export %s=%q\n' "$name" "''${!name}"
+          done
+    '';
   };
 
   # Skeleton-only linker shim: `--defsym`s the linker-script-referenced
@@ -259,11 +316,14 @@ only to make the plan's inputs body-independent.
         pname = "kbuild-unit-plan";
         version = configTarget;
         src = planSrc;
-        nativeBuildInputs = kbuildInputs ++ [nixKbuildUnit];
+        nativeBuildInputs = kbuildInputs ++ [nixKbuildUnit linkEnvDump];
         env = reproEnv // planShimEnv;
-        # Unit replays must see identical bits: no strip / patchelf over the
-        # reference vmlinux or the snapshotted host tools.
+        # Unit replays must see identical bits: no fixup strip / patchelf over
+        # the reference vmlinux or the snapshot (the targeted host-tool strip
+        # in installPhase is deliberate; fixup would also rewrite outputs the
+        # gates byte-compare).
         dontFixup = true;
+        postUnpack = pinBuildTreeName;
         # The sed below inserts a brace group after line 1; substituteInPlace
         # only replaces, and the script has no stable anchor string to
         # replace, while sed's `1a` address cannot stop matching.
@@ -287,16 +347,16 @@ only to make the plan's inputs body-independent.
           # rendered link unit can replay it (CC/LD/LINUXINCLUDE/KBUILD_* for
           # the in-script init/version-timestamp.o compile and postlink make).
           # The dump is build-created and not unit-owned, so harvest sweeps it
-          # into the generated snapshot on its own. `export -p` because make
-          # runs the script under $(CONFIG_SHELL). The KBUILD_UNIT_* shim
-          # vars match the KBUILD_ prefix but must stay out: they carry
-          # plan-only store paths, and a snapshot that shifts with shim
-          # tweaks would re-execute every unit.
+          # into the generated snapshot on its own. The helper (see
+          # linkEnvDump above) owns the selection and the canonical quoting;
+          # it is called by bare name so the patched script -- itself a
+          # snapshot member -- carries no store path.
           # `|| :` and the muted stderr keep unit replays quiet: there the
-          # dump target is a store symlink from the generated snapshot, the
-          # rewrite fails by design, and the sourced snapshot env is already
-          # identical to what the dump would produce.
-          sed -i '1a { export -p | grep -E "^(declare -x |export )(KBUILD_[A-Za-z0-9_]+|CONFIG_SHELL|CC|LD|NM|AR|OBJCOPY|OBJDUMP|READELF|STRIP|PAHOLE|RESOLVE_BTFIDS|SRCARCH|ARCH|srctree|objtree|LINUXINCLUDE|NOSTDINC_FLAGS|LDFLAGS_vmlinux|CFLAGS_vmlinux|KALLSYMS[A-Za-z0-9_]*|MAKE|HOSTCC)=" | grep -vE "^(declare -x |export )KBUILD_UNIT_" > .kbuild-unit-link-env; } 2>/dev/null || :' scripts/link-vmlinux.sh
+          # helper is off PATH and the dump target is a store symlink from
+          # the generated snapshot, the redump fails by design, and the
+          # sourced snapshot env is already identical to what the dump would
+          # produce.
+          sed -i '1a { kbuild-unit-link-env-dump > .kbuild-unit-link-env; } 2>/dev/null || :' scripts/link-vmlinux.sh
           make ${configTarget}
           runHook postConfigure
         '';
@@ -315,6 +375,18 @@ only to make the plan's inputs body-independent.
             --srctree ${planSrc} \
             --generated-out $out/generated \
             > $out/plan.json
+          # tools/build compiles host tools with -g, and their DWARF varies
+          # with the build path when the sandbox is off (#3413 PR A: objtool
+          # differed only in .debug_line_str across identical-source plan
+          # builds, re-executing every unit). The snapshot only needs the
+          # tools to run, so drop the debug sections deterministically.
+          if [ -d $out/generated/tools ]; then
+            find $out/generated/tools -type f | while IFS= read -r tool; do
+              if [ "$(head -c4 "$tool" | od -An -tx1 | tr -d ' ')" = 7f454c46 ]; then
+                strip --strip-debug "$tool"
+              fi
+            done
+          fi
           runHook postInstall
         '';
       }
@@ -331,6 +403,7 @@ only to make the plan's inputs body-independent.
         nativeBuildInputs = kbuildInputs;
         env = reproEnv;
         dontFixup = true;
+        postUnpack = pinBuildTreeName;
         configurePhase = ''
           # shell
           runHook preConfigure
@@ -381,6 +454,42 @@ only to make the plan's inputs body-independent.
       extraEnv = reproEnv;
     };
 
+    # The fleet cache lane's aggregation root (#3413): unit outputs are
+    # build-time deps of vmlinux, so pushing any final artifact would never
+    # publish the per-TU objects; this farm carries every unit output plus
+    # the eval-time IFD artifacts (plan, rendered units.nix, snapshot,
+    # skeleton) in one runtime closure. Build it on a CI dispatcher and the
+    # post-build hook enqueues ONE obligation whose recursive closure the
+    # drainer publishes -- NARs and the CA realisations another host needs to
+    # substitute instead of rebuild. The mass unit build itself must run with
+    # the per-derivation hook disabled (`--option post-build-hook ''` as a
+    # trusted user): at 3.6k units the per-drv enqueue serialized the whole
+    # build under queue backpressure (#3413 PR A).
+    cachePushRoot = pkgs.linkFarm "kbuild-unit-cache-root" (
+      [
+        {
+          name = "units";
+          path = imported.allUnits;
+        }
+        {
+          name = "units-nix";
+          path = unitsNix;
+        }
+        {
+          name = "generated";
+          path = generatedSnapshot;
+        }
+        {
+          name = "plan";
+          path = plan;
+        }
+      ]
+      ++ lib.optional (planStrategy == "skeleton") {
+        name = "skeleton";
+        path = skeletonTree;
+      }
+    );
+
     # The exit gate: the unit-composed vmlinux must be byte-identical to the
     # monolithic vmlinux from the reference build (the plan build itself for
     # ccache/full, the dedicated referenceKernel for skeleton).
@@ -417,7 +526,7 @@ only to make the plan's inputs body-independent.
   in
     imported
     // {
-      inherit plan unitsNix srcTree skeletonTree referenceKernel vmlinuxEquivalence modulesEquivalence;
+      inherit plan unitsNix srcTree skeletonTree referenceKernel cachePushRoot vmlinuxEquivalence modulesEquivalence;
     };
 in {
   inherit buildKernel;

--- a/packages/nix/nix-kbuild-unit/src/render.rs
+++ b/packages/nix/nix-kbuild-unit/src/render.rs
@@ -56,11 +56,18 @@ pub fn render_units_nix(plan: &Plan, content_addressed: bool) -> color_eyre::Res
         .filter(|target| !reachable.contains(target))
         .collect();
 
-    // Thin archives resolve members at read time, so a unit's build tree
-    // needs its full transitive dep closure, not just direct deps.
-    let mut closures: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    // Thin archives resolve members by path at read time, so a consumer's
+    // build tree must materialize the archive's members, recursively through
+    // nested thin archives. Everything else a saved command reads (`ld -r`
+    // outputs, compiled objects, modpost dumps) is self-contained, so direct
+    // deps suffice. Carrying the full transitive closure instead re-linked
+    // every `.ko` after any single-module body edit: the dep list rode
+    // through `Module.symvers` to every module object (#3413).
+    let mut expansions: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    let mut dep_sets: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
     for &target in &reachable {
-        closure_of(target, &direct_deps, &mut closures)?;
+        let deps = unit_dep_set(target, &units, &direct_deps, &mut expansions)?;
+        dep_sets.insert(target, deps);
     }
 
     let srcarch = detect_srcarch(&units)?;
@@ -85,7 +92,7 @@ pub fn render_units_nix(plan: &Plan, content_addressed: bool) -> color_eyre::Res
             &mut entries,
             entry,
             kind,
-            &closures[target],
+            &dep_sets[target],
             &scopes[target],
             provides.get(target).map_or(&[][..], Vec::as_slice),
         );
@@ -334,12 +341,34 @@ fn resolve_member<'plan>(
     Ok(())
 }
 
-fn closure_of<'plan>(
+/// The dep units whose outputs `target`'s build tree materializes: its
+/// direct deps, plus each thin-archive dep's member expansion.
+fn unit_dep_set<'plan>(
     target: &'plan str,
+    units: &BTreeMap<&'plan str, (&'plan CmdEntry, UnitKind)>,
     direct_deps: &BTreeMap<&'plan str, BTreeSet<&'plan str>>,
-    closures: &mut BTreeMap<&'plan str, BTreeSet<&'plan str>>,
+    expansions: &mut BTreeMap<&'plan str, BTreeSet<&'plan str>>,
+) -> color_eyre::Result<BTreeSet<&'plan str>> {
+    let mut deps = BTreeSet::new();
+    for &dep in &direct_deps[target] {
+        deps.insert(dep);
+        if units[dep].1 == UnitKind::Archive {
+            archive_expansion(dep, units, direct_deps, expansions)?;
+            deps.extend(&expansions[dep]);
+        }
+    }
+    Ok(deps)
+}
+
+/// Memoized member set of one thin archive: its direct deps plus, through
+/// nested thin archives, theirs.
+fn archive_expansion<'plan>(
+    target: &'plan str,
+    units: &BTreeMap<&'plan str, (&'plan CmdEntry, UnitKind)>,
+    direct_deps: &BTreeMap<&'plan str, BTreeSet<&'plan str>>,
+    expansions: &mut BTreeMap<&'plan str, BTreeSet<&'plan str>>,
 ) -> color_eyre::Result<()> {
-    if closures.contains_key(target) {
+    if expansions.contains_key(target) {
         return Ok(());
     }
     // Iterative DFS with an explicit in-progress set for cycle detection.
@@ -347,16 +376,18 @@ fn closure_of<'plan>(
     let mut in_progress: BTreeSet<&str> = BTreeSet::new();
     while let Some((current, children_done)) = stack.pop() {
         if children_done {
-            let mut closure = BTreeSet::new();
+            let mut expansion = BTreeSet::new();
             for &dep in &direct_deps[current] {
-                closure.insert(dep);
-                closure.extend(&closures[dep]);
+                expansion.insert(dep);
+                if units[dep].1 == UnitKind::Archive {
+                    expansion.extend(&expansions[dep]);
+                }
             }
-            closures.insert(current, closure);
+            expansions.insert(current, expansion);
             in_progress.remove(current);
             continue;
         }
-        if closures.contains_key(current) {
+        if expansions.contains_key(current) {
             continue;
         }
         if !in_progress.insert(current) {
@@ -364,6 +395,9 @@ fn closure_of<'plan>(
         }
         stack.push((current, true));
         for &dep in &direct_deps[current] {
+            if units[dep].1 != UnitKind::Archive || expansions.contains_key(dep) {
+                continue;
+            }
             if in_progress.contains(dep) {
                 bail!("dependency cycle through unit {dep}");
             }
@@ -553,7 +587,7 @@ fn render_unit(
     out: &mut String,
     entry: &CmdEntry,
     kind: UnitKind,
-    closure: &BTreeSet<&str>,
+    dep_set: &BTreeSet<&str>,
     scope: &SourceScope,
     provides: &[&str],
 ) {
@@ -562,9 +596,9 @@ fn render_unit(
     writeln!(out, "      pname = {};", nix_string(&pname(target))).expect("write to string");
     writeln!(out, "      target = {};", nix_string(target)).expect("write to string");
     writeln!(out, "      kbuildCmd = {};", nix_string(&entry.cmd)).expect("write to string");
-    if !closure.is_empty() {
+    if !dep_set.is_empty() {
         writeln!(out, "      depUnits = [").expect("write to string");
-        for dep in closure {
+        for dep in dep_set {
             writeln!(out, "        units.{}", nix_string(dep)).expect("write to string");
         }
         writeln!(out, "      ];").expect("write to string");
@@ -830,7 +864,8 @@ mod tests {
         let rendered = render_units_nix(&sample_plan(), false).expect("render");
 
         // vmlinux.o must see the archives AND their members (thin archives
-        // resolve member paths at read time).
+        // resolve member paths at read time), recursively through nested
+        // thin archives.
         let aggregate = rendered
             .split("\"vmlinux.o\" = mkUnit {")
             .nth(1)
@@ -844,9 +879,55 @@ mod tests {
             "units.\"kernel/built-in.a\"",
             "units.\"kernel/fork.o\"",
         ] {
-            assert!(aggregate.contains(dep), "vmlinux.o closure missing {dep}");
+            assert!(aggregate.contains(dep), "vmlinux.o dep set missing {dep}");
         }
         assert!(rendered.contains("contentAddressed = false;"));
+    }
+
+    #[test]
+    fn trims_dep_sets_to_thin_archive_consumers() {
+        let rendered = render_units_nix(&module_plan(), true).expect("render");
+        let unit_body = |target: &str| {
+            rendered
+                .split(&format!("\"{target}\" = mkUnit {{"))
+                .nth(1)
+                .unwrap_or_else(|| panic!("{target} unit rendered"))
+                .split("};")
+                .next()
+                .expect("unit body")
+                .to_owned()
+        };
+
+        // `ld -r` outputs and modpost dumps are self-contained, so consumers
+        // stop at their direct deps: the full transitive closure re-linked
+        // every .ko after any single-module body edit, because each .ko rode
+        // through <mod>.mod.o -> Module.symvers -> every module object.
+        let ko = unit_body("drivers/net/dummy.ko");
+        for absent in [
+            "units.\"Module.symvers\"",
+            "units.\"vmlinux.o\"",
+            "units.\"fs/nfs/nfs.o\"",
+            "units.\"fs/nfs/client.o\"",
+        ] {
+            assert!(!ko.contains(absent), "dummy.ko must not carry {absent}");
+        }
+
+        let mod_o = unit_body("drivers/net/dummy.mod.o");
+        assert!(mod_o.contains("units.\"Module.symvers\""));
+        assert!(!mod_o.contains("units.\"vmlinux.o\""));
+
+        // modpost reads the self-contained vmlinux.o, never the thin
+        // archives (or their members) behind it.
+        let symvers = unit_body("vmlinux.symvers");
+        assert!(symvers.contains("units.\"vmlinux.o\""));
+        assert!(!symvers.contains("units.\"vmlinux.a\""));
+        assert!(!symvers.contains("units.\"kernel/fork.o\""));
+
+        // The vmlinux link consumes vmlinux.o and the ksymtab object only.
+        let link = unit_body("vmlinux");
+        assert!(link.contains("units.\"vmlinux.o\""));
+        assert!(!link.contains("units.\"vmlinux.a\""));
+        assert!(!link.contains("units.\"kernel/fork.o\""));
     }
 
     #[test]

--- a/packages/nix/nix-kbuild-unit/src/render.rs
+++ b/packages/nix/nix-kbuild-unit/src/render.rs
@@ -56,31 +56,7 @@ pub fn render_units_nix(plan: &Plan, content_addressed: bool) -> color_eyre::Res
         .filter(|target| !reachable.contains(target))
         .collect();
 
-    // Thin archives resolve members by path at read time, so a consumer's
-    // build tree must materialize the archive's members, recursively through
-    // nested thin archives. Everything else a saved command reads (`ld -r`
-    // outputs, compiled objects, modpost dumps) is self-contained, so direct
-    // deps suffice. Carrying the full transitive closure instead re-linked
-    // every `.ko` after any single-module body edit: the dep list rode
-    // through `Module.symvers` to every module object (#3413).
-    let mut expansions: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
-    let mut closures: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
-    let mut dep_sets: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
-    for &target in &reachable {
-        // The vmlinux link is the one exception to the trim:
-        // scripts/link-vmlinux.sh links the KBUILD_VMLINUX_OBJS/LIBS
-        // archives directly (vmlinux.a, lib/lib.a, ... -- an env-driven
-        // list no argv or .cmd records; x86_64 defconfig under IBT links
-        // vmlinux.o instead), so its tree keeps the full transitive
-        // closure, exactly what every unit carried before the trim.
-        let deps = if units[target].1 == UnitKind::Link {
-            full_closure(target, &direct_deps, &mut closures)?;
-            closures[target].clone()
-        } else {
-            unit_dep_set(target, &units, &direct_deps, &mut expansions)?
-        };
-        dep_sets.insert(target, deps);
-    }
+    let dep_sets = compute_dep_sets(&reachable, &units, &direct_deps)?;
 
     let srcarch = detect_srcarch(&units)?;
 
@@ -370,6 +346,39 @@ fn unit_dep_set<'plan>(
         }
     }
     Ok(deps)
+}
+
+/// The dep units each build tree materializes. Thin archives resolve
+/// members by path at read time, so a consumer's tree must carry the
+/// archive's members, recursively through nested thin archives; everything
+/// else a saved command reads (`ld -r` outputs, compiled objects, modpost
+/// dumps) is self-contained, so direct deps suffice. Carrying the full
+/// transitive closure instead re-linked every `.ko` after any single-module
+/// body edit: the dep list rode through `Module.symvers` to every module
+/// object (#3413). The vmlinux link is the one exception:
+/// scripts/link-vmlinux.sh links the `KBUILD_VMLINUX_OBJS`/`LIBS` archives
+/// directly (vmlinux.a, lib/lib.a, ... -- an env-driven list no argv or
+/// .cmd records; `x86_64` defconfig under IBT links vmlinux.o instead), so
+/// its tree keeps the full transitive closure, exactly what every unit
+/// carried before the trim.
+fn compute_dep_sets<'plan>(
+    reachable: &BTreeSet<&'plan str>,
+    units: &BTreeMap<&'plan str, (&'plan CmdEntry, UnitKind)>,
+    direct_deps: &BTreeMap<&'plan str, BTreeSet<&'plan str>>,
+) -> color_eyre::Result<BTreeMap<&'plan str, BTreeSet<&'plan str>>> {
+    let mut expansions: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    let mut closures: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    let mut dep_sets: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    for &target in reachable {
+        let deps = if units[target].1 == UnitKind::Link {
+            full_closure(target, direct_deps, &mut closures)?;
+            closures[target].clone()
+        } else {
+            unit_dep_set(target, units, direct_deps, &mut expansions)?
+        };
+        dep_sets.insert(target, deps);
+    }
+    Ok(dep_sets)
 }
 
 /// Memoized full transitive dep closure (the vmlinux link unit's dep set).

--- a/packages/nix/nix-kbuild-unit/src/render.rs
+++ b/packages/nix/nix-kbuild-unit/src/render.rs
@@ -64,9 +64,21 @@ pub fn render_units_nix(plan: &Plan, content_addressed: bool) -> color_eyre::Res
     // every `.ko` after any single-module body edit: the dep list rode
     // through `Module.symvers` to every module object (#3413).
     let mut expansions: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    let mut closures: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
     let mut dep_sets: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
     for &target in &reachable {
-        let deps = unit_dep_set(target, &units, &direct_deps, &mut expansions)?;
+        // The vmlinux link is the one exception to the trim:
+        // scripts/link-vmlinux.sh links the KBUILD_VMLINUX_OBJS/LIBS
+        // archives directly (vmlinux.a, lib/lib.a, ... -- an env-driven
+        // list no argv or .cmd records; x86_64 defconfig under IBT links
+        // vmlinux.o instead), so its tree keeps the full transitive
+        // closure, exactly what every unit carried before the trim.
+        let deps = if units[target].1 == UnitKind::Link {
+            full_closure(target, &direct_deps, &mut closures)?;
+            closures[target].clone()
+        } else {
+            unit_dep_set(target, &units, &direct_deps, &mut expansions)?
+        };
         dep_sets.insert(target, deps);
     }
 
@@ -358,6 +370,46 @@ fn unit_dep_set<'plan>(
         }
     }
     Ok(deps)
+}
+
+/// Memoized full transitive dep closure (the vmlinux link unit's dep set).
+/// Iterative DFS with an explicit in-progress set for cycle detection.
+fn full_closure<'plan>(
+    target: &'plan str,
+    direct_deps: &BTreeMap<&'plan str, BTreeSet<&'plan str>>,
+    closures: &mut BTreeMap<&'plan str, BTreeSet<&'plan str>>,
+) -> color_eyre::Result<()> {
+    if closures.contains_key(target) {
+        return Ok(());
+    }
+    let mut stack = vec![(target, false)];
+    let mut in_progress: BTreeSet<&str> = BTreeSet::new();
+    while let Some((current, children_done)) = stack.pop() {
+        if children_done {
+            let mut closure = BTreeSet::new();
+            for &dep in &direct_deps[current] {
+                closure.insert(dep);
+                closure.extend(&closures[dep]);
+            }
+            closures.insert(current, closure);
+            in_progress.remove(current);
+            continue;
+        }
+        if closures.contains_key(current) {
+            continue;
+        }
+        if !in_progress.insert(current) {
+            bail!("dependency cycle through unit {current}");
+        }
+        stack.push((current, true));
+        for &dep in &direct_deps[current] {
+            if in_progress.contains(dep) {
+                bail!("dependency cycle through unit {dep}");
+            }
+            stack.push((dep, false));
+        }
+    }
+    Ok(())
 }
 
 /// Memoized member set of one thin archive: its direct deps plus, through
@@ -923,11 +975,17 @@ mod tests {
         assert!(!symvers.contains("units.\"vmlinux.a\""));
         assert!(!symvers.contains("units.\"kernel/fork.o\""));
 
-        // The vmlinux link consumes vmlinux.o and the ksymtab object only.
+        // The vmlinux link is exempt: link-vmlinux.sh links the
+        // KBUILD_VMLINUX_OBJS/LIBS archives directly (an env-driven list no
+        // .cmd records), so it keeps the full transitive closure.
         let link = unit_body("vmlinux");
-        assert!(link.contains("units.\"vmlinux.o\""));
-        assert!(!link.contains("units.\"vmlinux.a\""));
-        assert!(!link.contains("units.\"kernel/fork.o\""));
+        for dep in [
+            "units.\"vmlinux.o\"",
+            "units.\"vmlinux.a\"",
+            "units.\"kernel/fork.o\"",
+        ] {
+            assert!(link.contains(dep), "vmlinux link closure missing {dep}");
+        }
     }
 
     #[test]

--- a/packages/nix/nix-kbuild-unit/src/render.rs
+++ b/packages/nix/nix-kbuild-unit/src/render.rs
@@ -904,6 +904,28 @@ mod tests {
         plan
     }
 
+    /// Body of one rendered `mkUnit` block, for dep-set assertions.
+    fn unit_body<'a>(rendered: &'a str, target: &str) -> &'a str {
+        rendered
+            .split(&format!("\"{target}\" = mkUnit {{"))
+            .nth(1)
+            .unwrap_or_else(|| panic!("{target} unit rendered"))
+            .split("};")
+            .next()
+            .expect("unit body")
+    }
+
+    /// Assert which dep edges a rendered unit body carries and omits.
+    #[track_caller]
+    fn assert_dep_edges(body: &str, unit: &str, carries: &[&str], omits: &[&str]) {
+        for dep in carries {
+            assert!(body.contains(dep), "{unit} dep set missing {dep}");
+        }
+        for dep in omits {
+            assert!(!body.contains(dep), "{unit} must not carry {dep}");
+        }
+    }
+
     #[test]
     fn renders_reachable_units_and_prunes_the_rest() {
         let rendered = render_units_nix(&sample_plan(), true).expect("render");
@@ -927,74 +949,69 @@ mod tests {
         // vmlinux.o must see the archives AND their members (thin archives
         // resolve member paths at read time), recursively through nested
         // thin archives.
-        let aggregate = rendered
-            .split("\"vmlinux.o\" = mkUnit {")
-            .nth(1)
-            .expect("vmlinux.o unit rendered")
-            .split("};")
-            .next()
-            .expect("unit body");
-        for dep in [
-            "units.\"vmlinux.a\"",
-            "units.\"built-in.a\"",
-            "units.\"kernel/built-in.a\"",
-            "units.\"kernel/fork.o\"",
-        ] {
-            assert!(aggregate.contains(dep), "vmlinux.o dep set missing {dep}");
-        }
+        assert_dep_edges(
+            unit_body(&rendered, "vmlinux.o"),
+            "vmlinux.o",
+            &[
+                "units.\"vmlinux.a\"",
+                "units.\"built-in.a\"",
+                "units.\"kernel/built-in.a\"",
+                "units.\"kernel/fork.o\"",
+            ],
+            &[],
+        );
         assert!(rendered.contains("contentAddressed = false;"));
     }
 
     #[test]
     fn trims_dep_sets_to_thin_archive_consumers() {
         let rendered = render_units_nix(&module_plan(), true).expect("render");
-        let unit_body = |target: &str| {
-            rendered
-                .split(&format!("\"{target}\" = mkUnit {{"))
-                .nth(1)
-                .unwrap_or_else(|| panic!("{target} unit rendered"))
-                .split("};")
-                .next()
-                .expect("unit body")
-                .to_owned()
-        };
 
         // `ld -r` outputs and modpost dumps are self-contained, so consumers
         // stop at their direct deps: the full transitive closure re-linked
         // every .ko after any single-module body edit, because each .ko rode
         // through <mod>.mod.o -> Module.symvers -> every module object.
-        let ko = unit_body("drivers/net/dummy.ko");
-        for absent in [
-            "units.\"Module.symvers\"",
-            "units.\"vmlinux.o\"",
-            "units.\"fs/nfs/nfs.o\"",
-            "units.\"fs/nfs/client.o\"",
-        ] {
-            assert!(!ko.contains(absent), "dummy.ko must not carry {absent}");
-        }
+        assert_dep_edges(
+            unit_body(&rendered, "drivers/net/dummy.ko"),
+            "dummy.ko",
+            &[],
+            &[
+                "units.\"Module.symvers\"",
+                "units.\"vmlinux.o\"",
+                "units.\"fs/nfs/nfs.o\"",
+                "units.\"fs/nfs/client.o\"",
+            ],
+        );
 
-        let mod_o = unit_body("drivers/net/dummy.mod.o");
-        assert!(mod_o.contains("units.\"Module.symvers\""));
-        assert!(!mod_o.contains("units.\"vmlinux.o\""));
+        assert_dep_edges(
+            unit_body(&rendered, "drivers/net/dummy.mod.o"),
+            "dummy.mod.o",
+            &["units.\"Module.symvers\""],
+            &["units.\"vmlinux.o\""],
+        );
 
         // modpost reads the self-contained vmlinux.o, never the thin
         // archives (or their members) behind it.
-        let symvers = unit_body("vmlinux.symvers");
-        assert!(symvers.contains("units.\"vmlinux.o\""));
-        assert!(!symvers.contains("units.\"vmlinux.a\""));
-        assert!(!symvers.contains("units.\"kernel/fork.o\""));
+        assert_dep_edges(
+            unit_body(&rendered, "vmlinux.symvers"),
+            "vmlinux.symvers",
+            &["units.\"vmlinux.o\""],
+            &["units.\"vmlinux.a\"", "units.\"kernel/fork.o\""],
+        );
 
         // The vmlinux link is exempt: link-vmlinux.sh links the
         // KBUILD_VMLINUX_OBJS/LIBS archives directly (an env-driven list no
         // .cmd records), so it keeps the full transitive closure.
-        let link = unit_body("vmlinux");
-        for dep in [
-            "units.\"vmlinux.o\"",
-            "units.\"vmlinux.a\"",
-            "units.\"kernel/fork.o\"",
-        ] {
-            assert!(link.contains(dep), "vmlinux link closure missing {dep}");
-        }
+        assert_dep_edges(
+            unit_body(&rendered, "vmlinux"),
+            "vmlinux",
+            &[
+                "units.\"vmlinux.o\"",
+                "units.\"vmlinux.a\"",
+                "units.\"kernel/fork.o\"",
+            ],
+            &[],
+        );
     }
 
     #[test]
@@ -1072,13 +1089,7 @@ mod tests {
             .next()
             .expect("unit body");
         assert!(stub.contains("units.\"drivers/firmware/efi/libstub/alignedmem.o\""));
-        let aggregate = rendered
-            .split("\"vmlinux.o\" = mkUnit {")
-            .nth(1)
-            .expect("vmlinux.o unit rendered")
-            .split("};")
-            .next()
-            .expect("unit body");
+        let aggregate = unit_body(&rendered, "vmlinux.o");
         assert!(aggregate.contains("units.\"drivers/firmware/efi/libstub/lib.a\""));
         assert!(aggregate.contains("units.\"drivers/firmware/efi/libstub/alignedmem.stub.o\""));
     }

--- a/packages/nix/nix-kbuild-unit/src/skeleton.rs
+++ b/packages/nix/nix-kbuild-unit/src/skeleton.rs
@@ -53,6 +53,12 @@ pub const DEFAULT_KEEP: &[&str] = &[
     // rejects non-x86 plans (detect_srcarch).
     "arch/x86/entry/vdso/vclock_gettime.c",
     "arch/x86/entry/vdso/vgetcpu.c",
+    // CONFIG_VDSO_GETRANDOM (6.11+, on at defconfig, invisible at
+    // tinyconfig): stubbing these dropped __vdso_getrandom from the plan's
+    // vdso64.so and left the stubs' .modinfo in it, so the composed vmlinux
+    // diverged from the reference at the embedded image.
+    "arch/x86/entry/vdso/vgetrandom.c",
+    "arch/x86/entry/vdso/vgetrandom-chacha.S",
     "arch/x86/entry/vdso/vdso-note.S",
     "arch/x86/entry/vdso/vsgx.S",
     "arch/x86/entry/vdso/vdso2c.c",
@@ -486,6 +492,14 @@ static const char *s = \"/* not a comment\";
         assert_eq!(reduction_lang("kernel/bounds.c", no_extra), None);
         assert_eq!(
             reduction_lang("arch/x86/entry/vdso/vgetcpu.c", no_extra),
+            None
+        );
+        assert_eq!(
+            reduction_lang("arch/x86/entry/vdso/vgetrandom.c", no_extra),
+            None
+        );
+        assert_eq!(
+            reduction_lang("arch/x86/entry/vdso/vgetrandom-chacha.S", no_extra),
             None
         );
         assert_eq!(reduction_lang("lib/vdso/gettimeofday.c", no_extra), None);

--- a/packages/site/src/lib/updates/kbuild-unit-fleet-cache.svx
+++ b/packages/site/src/lib/updates/kbuild-unit-fleet-cache.svx
@@ -1,0 +1,17 @@
+---
+id: kbuild-unit-fleet-cache
+postedAt: 2026-07-19T12:00:00-07:00
+title: "Kernel units ride the fleet cache, and plan reruns cut off"
+tags: [nix, kernel, kbuild-unit, cache]
+links:
+  - label: library
+    href: https://github.com/indexable-inc/index/blob/main/lib/kernel/kbuild-unit.nix
+  - label: issue
+    href: https://github.com/indexable-inc/index/issues/3413
+---
+
+kbuild-unit's per-TU kernel builds now share over the ordinary Nix cache. Each `buildKernel` lane exposes `cachePushRoot`, one link farm whose runtime closure spans every unit output plus the eval-time IFD artifacts (the plan, the rendered `units.nix`, the generated snapshot, the skeleton tree). Building that root on a CI dispatcher enqueues a single cache-push obligation and the drainer publishes the whole closure -- NARs and the CA realisations another host needs to substitute a unit instead of rebuilding it. This replaces the per-derivation `post-build-hook` path for mass unit builds, which enqueued each of defconfig's 3.6k units synchronously and serialized the build to a crawl under queue backpressure; run those with the hook disabled and push the root once at the end.
+
+Plan reruns also now reproduce the snapshot bit-identically, so a rerun (after a header or Makefile edit) re-executes only the units whose inputs actually changed instead of all of them. Three nondeterminism carriers are pinned: the build tree always unpacks to a fixed `kbuild-tree` directory name (DWARF `comp_dir` and the vdso build-id record the absolute build path, and the name used to shift with the src derivation -- which also made the skeleton plan's embedded vdso diverge from the reference kernel's), snapshotted host tools under `tools/` are stripped of debug info (objtool differed only in `.debug_line_str` across identical-source plan builds), and the link-env dump is emitted by a dedicated bash helper with sorted names and `printf %q` quoting instead of whichever shell `CONFIG_SHELL` resolves to.
+
+Finally, unit dep lists shrank to what a replay actually reads: only thin-archive consumers carry the archive's member expansion, everything else stops at direct deps. A one-module body edit now rebuilds that module's TU, its `.ko` link, and the modpost pass -- the other modules no longer re-link at all.


### PR DESCRIPTION
Part of #3413 (kbuild-unit P3, master issue #3409). PR C of the P3 series, the final mandatory piece: fleet cache lane + plan-rerun reproducibility + dep-closure trim. Builds on PR A (#3574) and PR B (#3575).

## What

- **Fleet cache lane**: `buildKernel` exposes `cachePushRoot`, one `linkFarm` whose runtime closure spans every unit output (`allUnits`) plus the eval-time IFD artifacts (plan, rendered `units.nix`, generated snapshot, and the skeleton tree on skeleton lanes). Building it on a CI dispatcher enqueues ONE cache-push obligation; the drainer publishes the recursive closure -- NARs and the CA realisations another host needs to substitute units instead of rebuilding. Mass unit builds still run with the per-drv `post-build-hook` disabled: at 3.6k units the synchronous per-drv enqueue serialized the whole build under queue backpressure (PR A finding). A hook-side exemption for unit drvs is ix-repo scope; issue to follow.
- **Plan-rerun reproducibility** (the PR A findings, so any plan rerun CA-cuts at defconfig scale):
  - The plan and reference builds unpack to a fixed `kbuild-tree` directory (matching what unit replays use). DWARF `comp_dir` and the vdso build-id record the absolute build path; a name that shifted with the src derivation (`kbuild-unit-skeleton` vs `kbuild-unit-src-source`) made the snapshot's vdso -- which re-enters the unit graph through the generated `vdso-image-*.c` -- diverge from the reference kernel's.
  - Snapshotted host tools under `tools/` are stripped of debug info after harvest: `tools/build` compiles with `-g`, and objtool differed only in `.debug_line_str` across identical-source plan builds.
  - `.kbuild-unit-link-env` is emitted by a dedicated bash helper (`printf %q`, `LC_ALL=C`-sorted names) instead of `export -p`, whose quoting style belongs to whichever shell `CONFIG_SHELL` resolves to and flipped across runs. The helper is called by bare name so the patched `link-vmlinux.sh` in the snapshot stays store-path-free.
- **Dep-closure trim**: units carry direct deps plus thin-archive member expansion only (thin archives resolve members by path at read time; everything else a saved command reads is self-contained). Previously every `.ko` carried the full transitive closure through `Module.symvers` to every module object, so one module body edit re-linked all modules (8 no-op relinks in the PR A probe).

## Validation

Fleet validation evidence (tinyconfig + defconfig equivalence gates, plan-rerun A/B, cache-lane publish through the real hook path, and the body/header edit loop timings) is being appended as it completes; the exit-criteria comment will land on #3413.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cache root aggregation, stable build paths, and trimmed dep sets to kbuild-unit
> - Adds a `cachePushRoot` link farm to `buildKernel` that bundles all unit outputs, the rendered `units.nix`, the generated snapshot, and the plan into a single closure for one-shot cache pushes.
> - Stabilizes build paths by renaming unpacked sources to a fixed `kbuild-tree` directory in both plan and reference builds, making any path-influenced bytes deterministic.
> - Replaces `export -p`-based link env dumps with a new `kbuild-unit-link-env-dump` helper that sorts and quotes variables canonically, producing a stable `.kbuild-unit-link-env`.
> - Changes `depUnits` in rendered `units.nix` to use trimmed dep sets: thin-archive consumers carry member expansions, other units use direct deps only, and the vmlinux link keeps the full transitive closure.
> - Extends the skeleton keep-list with `vgetrandom.c` and `vgetrandom-chacha.S` so vDSO images match reference bytes.
> - Behavioral Change: the bytes in generated snapshot and plan outputs change due to stable paths, new env dump format, and debug section stripping from snapshotted host tools.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae1891c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->