### PR TITLE
ci: main Check runs group per-commit and never cancel (#3669)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,11 +22,16 @@ permissions:
   contents: read
 
 concurrency:
-  group: check-${{ github.ref }}
-  # A newer PR synchronization or main push makes the older revision's result
-  # unusable. Cancel it immediately so obsolete work never waits in front of,
-  # or consumes a runner after, the current head. Tag refs remain independent.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+  # PR refs supersede: a newer synchronization makes the older revision's
+  # result unusable, so group per-ref and cancel it. Main is the opposite:
+  # required checks are non-strict, so two individually-green PRs can rebase
+  # into a red union that no PR run ever validated (#3669: every main Check
+  # from 10:56Z-11:08Z on 2026-07-19 was cancelled by the next push, so an
+  # 8.5h site breakage surfaced as a frozen cache-ready pin instead of a
+  # named commit). Main groups per-commit and never cancels, so every merged
+  # commit carries its own completed verdict. Tag refs remain independent.
+  group: check-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && (github.event_name == 'pull_request' || github.event_name == 'push') }}
 
 env:
   # The self-hosted runner's Nix daemon owns substituters (cache.ix.dev plus the

--- a/packages/site/src/lib/updates/check-main-per-commit.svx
+++ b/packages/site/src/lib/updates/check-main-per-commit.svx
@@ -1,0 +1,16 @@
+---
+id: check-main-per-commit
+postedAt: '2026-07-19T04:35:00-07:00'
+title: every main commit now gets a completed Check verdict
+links:
+  - label: 'index#3669'
+    href: 'https://github.com/indexable-inc/index/issues/3669'
+  - label: 'the 8.5h incident fix'
+    href: 'https://github.com/indexable-inc/index/pull/3668'
+tags:
+  - ci
+---
+
+Main's Check runs used to share one concurrency slot: each push cancelled the previous commit's run, so during a merge storm no main commit finished validation (every run from 10:56Z to 11:08Z on 2026-07-19 was cancelled). Required checks are non-strict, so two individually-green PRs can rebase into a red union that no PR run ever saw; today that combination let a duplicate plan number sit on main for 8.5 hours, surfacing as a frozen `cache-ready` pin instead of a named commit.
+
+Check now groups main runs per-commit (`github.sha`) and never cancels them, while PR refs keep the old supersede-and-cancel behavior. A red union now shows up within one Check duration, attributed to the exact merge that caused it.


### PR DESCRIPTION
Main shared one concurrency slot with cancel-in-progress, so each push
cancelled the previous commit's run: during today's merge storm every
main Check from 10:56Z-11:08Z was cancelled, and a red union of two
green PRs (duplicate plan 0031) sat undetected for 8.5h, surfacing as a
frozen cache-ready pin instead of a named commit. Required checks are
non-strict, so PR runs never validate the rebased union; main's own
Check is the only union gate and must run to completion per commit.

PR refs keep the supersede-and-cancel behavior.

packages/site/src/lib/updates/check-main-per-commit.svx


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Group CI check runs per-commit on main and never cancel them
> - Updates [check.yml](https://github.com/indexable-inc/index/pull/3670/files#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428) concurrency config to use `github.sha` as the group key on `refs/heads/main`, giving each commit its own group that is never cancelled.
> - On non-main refs (PRs and feature branches), runs continue to share a per-ref group and are cancelled when superseded by newer pushes.
> - Adds an update post documenting the behavior change to the site's updates section.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68c0534.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->