### PR TITLE
nix fork: add nix-ninja incremental per-TU build lane

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,6 +301,23 @@
         "type": "github"
       }
     },
+    "nix-ninja-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778777365,
+        "narHash": "sha256-/jmN3Uvpg+4s2bcxzdCTHKro9HbHvswz/Aua3xzrxac=",
+        "owner": "pdtpartners",
+        "repo": "nix-ninja",
+        "rev": "f16edb417af156cdb777cc1201b67733b82b224e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pdtpartners",
+        "repo": "nix-ninja",
+        "rev": "f16edb417af156cdb777cc1201b67733b82b224e",
+        "type": "github"
+      }
+    },
     "nix-src": {
       "flake": false,
       "locked": {
@@ -591,6 +608,7 @@
         "mesa-src": "mesa-src",
         "nix-derivation-src": "nix-derivation-src",
         "nix-fast-build-src": "nix-fast-build-src",
+        "nix-ninja-src": "nix-ninja-src",
         "nix-src": "nix-src",
         "nixpkgs": "nixpkgs",
         "nu-jupyter-kernel-src": "nu-jupyter-kernel-src",

--- a/flake.nix
+++ b/flake.nix
@@ -253,6 +253,20 @@
       flake = false;
     };
 
+    # pdtpartners/nix-ninja: ninja-compatible build runner that turns each
+    # compilation unit of a meson/ninja graph into its own content-addressed
+    # Nix derivation (the incremental build lane for the patched nix fork,
+    # packages/nix/nix-ninja-build, issue #3655). Pre-alpha upstream, so
+    # pinned BY REV rather than by branch: the hourly flake-lock updater must
+    # not move it; bump deliberately after revalidating the lane. Consumed as
+    # a source tree (flake = false) and built with rustPlatform in
+    # packages/nix-ninja, not through its flake, which would drag crane/fenix
+    # inputs and only targets x86_64-linux.
+    nix-ninja-src = {
+      url = "github:pdtpartners/nix-ninja/f16edb417af156cdb777cc1201b67733b82b224e";
+      flake = false;
+    };
+
     # snix (Rust reimplementation of Nix; TVL-style depot, no flake.nix) consumed
     # as a source tree so `packages/snix` builds its CLI through cargo-unit
     # instead of the upstream crate2nix `Cargo.nix`. The Cargo workspace lives in
@@ -335,6 +349,7 @@
     fff-src,
     nu-jupyter-kernel-src,
     launchk-src,
+    nix-ninja-src,
     snix-src,
     clippy-src,
     codex-src,
@@ -412,6 +427,7 @@
         fff-src
         nu-jupyter-kernel-src
         launchk-src
+        nix-ninja-src
         snix-src
         clippy-src
         codex-src

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -16,6 +16,7 @@
   fff-src,
   nu-jupyter-kernel-src,
   launchk-src,
+  nix-ninja-src,
   snix-src,
   clippy-src,
   codex-src,
@@ -763,6 +764,7 @@
     fffSrc = fff-src;
     nuJupyterKernelSrc = nu-jupyter-kernel-src;
     launchkSrc = launchk-src;
+    nixNinjaSrc = nix-ninja-src;
     snixSrc = snix-src;
     mesaSrc = mesa-src;
     # Pinned toolchain evaluation context for the prebuilt public-SDK rlib:

--- a/packages/nix-ninja/default.nix
+++ b/packages/nix-ninja/default.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  rustPlatform,
+  runCommand,
+  ix,
+}:
+# pdtpartners/nix-ninja: a ninja-compatible CLI that parses the build.ninja
+# meson emits and creates one content-addressed derivation per compilation
+# unit (Nix dynamic derivations). External-Rust-tool house style per
+# skills/dependency-intake/SKILL.md; source pinned by rev as the
+# `nix-ninja-src` flake input (pre-alpha upstream, deliberate bumps only).
+#
+# Two binaries ship from one build and must travel together: `nix-ninja`
+# (the ninja replacement meson invokes via $NINJA) and `nix-ninja-task`
+# (the in-sandbox builder every generated derivation execs, so it must
+# resolve to a /nix/store path -- being in this output's bin/ satisfies
+# that). Consumed by packages/nix/nix-ninja-build, the incremental build
+# lane for the patched nix fork (#3655).
+let
+  src = ix.nixNinjaSrc;
+  nix-ninja = rustPlatform.buildRustPackage {
+    pname = "nix-ninja";
+    # No upstream release yet; nixpkgs unstable-version spelling of the pinned
+    # rev's commit date.
+    version = "0.1.0-unstable-2026-05-14";
+
+    inherit src;
+
+    cargoLock = {
+      lockFile = src + "/Cargo.lock";
+      # The lock carries three git dependencies (upstream's harmonia store
+      # model plus the author's n2/igraph forks), so importCargoLock needs
+      # their fixed-output hashes; refresh alongside a nix-ninja-src bump by
+      # copying the corrected hashes from the fetchgit mismatch errors.
+      outputHashes = {
+        "harmonia-store-core-0.0.0-alpha.0" = "sha256-mLAOJjFm4AGp2GNE+rHBMsxlKOIaBobiK3wQW95PalE=";
+        "include-graph-1.2.2" = "sha256-W5YuVwtdJnNbFY2PbcJ/pM0P6gL+jFZLjvxLnHuugvw=";
+        "n2-0.1.0" = "sha256-TwpX/UdbQwfSmNlb6baGTKnCRW4FJPJ6FX9i4L2jYtU=";
+      };
+    };
+
+    strictDeps = true;
+
+    # Only the two binaries the lane needs; the workspace's other members
+    # (deps-infer, nix-tool) ride along as path dependencies. Tests stay
+    # workspace-wide: the only #[test]s are hermetic depfile/include parsers
+    # in deps-infer.
+    cargoBuildFlags = [
+      "--package"
+      "nix-ninja"
+      "--package"
+      "nix-ninja-task"
+    ];
+
+    passthru.tests = {
+      # nix-ninja advertises itself to meson as ninja >= 1.8.2; the smoke test
+      # pins that contract (meson refuses the $NINJA override below 1.8.2).
+      smoke =
+        runCommand "nix-ninja-smoke" {
+          nativeBuildInputs = [nix-ninja];
+          strictDeps = true;
+        } ''
+          version=$(nix-ninja --version)
+          if [ "$version" != "1.8.2" ]; then
+            echo "expected ninja-compat version 1.8.2, got: $version" >&2
+            exit 1
+          fi
+          command -v nix-ninja-task >/dev/null
+          mkdir -p "$out"
+        '';
+    };
+
+    meta = {
+      description = "Ninja-compatible incremental C/C++ builds via Nix dynamic derivations (one content-addressed derivation per compilation unit)";
+      homepage = "https://github.com/pdtpartners/nix-ninja";
+      license = lib.licenses.mit;
+      mainProgram = "nix-ninja";
+      # Upstream's support claim; see package.nix for the system gating.
+      platforms = ["x86_64-linux"];
+    };
+  };
+in
+  nix-ninja

--- a/packages/nix-ninja/package.nix
+++ b/packages/nix-ninja/package.nix
@@ -1,0 +1,10 @@
+{
+  id = "nix-ninja";
+  # Upstream only supports x86_64-linux (its flake pins systems to that, and
+  # nix-ninja-task fixes up build outputs with patchelf, an ELF-only tool), so
+  # gate every surface to that system: advertising the package off-platform
+  # would make `nix flake check` force a build upstream never claims to work.
+  packageSet.systems = ["x86_64-linux"];
+  flake.systems = ["x86_64-linux"];
+  passthruTests = true;
+}

--- a/packages/nix/nix-ninja-build/default.nix
+++ b/packages/nix/nix-ninja-build/default.nix
@@ -1,0 +1,121 @@
+{
+  ix,
+  lib,
+  repoPackages,
+}:
+# Incremental build lane for the patched nix fork via nix-ninja (#3655):
+# `nix run .#nix-ninja-build-nix` materializes the patched source (the same
+# `ix.patchedSrc` tree packages/nix/nix ships), configures it with meson
+# inside upstream's own dev shell, and hands the ninja graph to nix-ninja,
+# which turns every compilation unit into its own content-addressed
+# derivation. A warm rerun after touching one .cc file recompiles only that
+# unit's derivation and relinks its dependents, instead of the whole-package
+# ~19 min packages/nix/nix rebuild. Additive and non-gating: no fork check
+# consumes this lane.
+#
+# Local/devshell consumption mode of nix-ninja: the client creates dynamic
+# derivations and runs `nix build` on your behalf, so the daemon must enable
+# the `dynamic-derivations` and `ca-derivations` experimental features (the
+# Linux fleet builders already do); `recursive-nix` is only needed for the
+# in-derivation mode this lane deliberately avoids.
+let
+  inherit (ix) pkgs;
+  inherit (repoPackages) nix-ninja nix-ix;
+
+  # The identical patched tree the fork package builds (same patch dir, same
+  # upstream pin), so this lane can never drift from packages/nix/nix.
+  patchedSrc = ix.patchedSrc {
+    name = "nix";
+    src = ix.nixSrc;
+    patchDir = ix.paths.root + "/packages/nix/nix/patches";
+  };
+
+  # Run under the fork client, not stock pkgs.nix: the generated derivations
+  # are dynamic derivations, which need a >= 2.30 master-based client, and the
+  # fork is the one client guaranteed protocol-compatible with the fleet
+  # daemons this lane builds against.
+  nixClient = lib.getExe nix-ix;
+
+  inner = ix.writeBashApplication pkgs {
+    name = "nix-ninja-build-nix-inner";
+    runtimeInputs = [nix-ninja];
+    text = ''
+      workdir=$1
+      target=''${2:-src/nix/nix}
+      cd "$workdir/src"
+
+      # The upstream dev shell exports CC_LD/CXX_LD=mold, which meson bakes
+      # into every link rule as -fuse-ld=mold. Inside a nix-ninja task
+      # sandbox that linker is unreachable: nix-ninja discovers sandbox PATH
+      # entries by which-ing the command's words, and `-fuse-ld=mold` is a
+      # flag, not a word, so links die with "collect2: cannot find ld". The
+      # wrapped bintools linker resolves through the cc wrapper's baked -B
+      # path and needs no discovery.
+      unset CC_LD CXX_LD
+
+      # Meson accepts nix-ninja as its ninja via $NINJA (it reports the
+      # minimum compatible version, 1.8.2). nix-ninja also re-execs
+      # nix-ninja-task from PATH inside the derivations it emits.
+      NINJA="$(command -v nix-ninja)"
+      export NINJA
+
+      if [ ! -d build ]; then
+        meson setup build
+      fi
+      cd build
+
+      log=$(mktemp)
+      start=$(date +%s)
+      nix-ninja "$target" 2>&1 | tee "$log"
+      end=$(date +%s)
+
+      compiled=$(grep -c 'Compiling C++ object' "$log" || true)
+      linked=$(grep -c 'Linking target' "$log" || true)
+      rm -f "$log"
+      echo "nix-ninja-build-nix: built $target in $((end - start))s ($compiled compilation units compiled, $linked targets linked)"
+
+      if [ -x "$target" ]; then
+        "./$target" --version
+      fi
+    '';
+    meta.description = "Inner nix-ninja driver for nix-ninja-build-nix (runs inside the patched tree's dev shell)";
+  };
+in
+  ix.writeBashApplication pkgs {
+    name = "nix-ninja-build-nix";
+    text = ''
+      workdir=''${NIX_NINJA_NIX_WORKDIR:-''${TMPDIR:-/tmp}/nix-ninja-build-nix-''${USER:-anon}}
+
+      if [ "''${1:-}" = "--fresh" ]; then
+        shift
+        rm -rf "$workdir/src" "$workdir/.base"
+      fi
+
+      mkdir -p "$workdir"
+      if [ ! -d "$workdir/src" ]; then
+        # --no-preserve=mode: the store tree is read-only; the workdir is the
+        # mutable checkout the incremental loop edits.
+        cp -R --no-preserve=mode ${patchedSrc}/ "$workdir/src"
+        # Same version marker the fork package compiles in (see
+        # packages/nix/nix/default.nix): meson reads .version, so the lane's
+        # binary identifies the exact patch series it was built from.
+        printf '%s\n' ${lib.escapeShellArg nix-ix.version} > "$workdir/src/.version"
+        printf '%s\n' ${patchedSrc} > "$workdir/.base"
+      elif [ "$(cat "$workdir/.base" 2>/dev/null)" != ${patchedSrc} ]; then
+        echo "nix-ninja-build-nix: warning: $workdir/src was materialized from an older patch series; rerun with --fresh to rebase it" >&2
+      fi
+
+      # Client-side feature gates for the dynamic derivations nix-ninja
+      # emits; the daemon side must already allow them (fleet Linux builders
+      # do).
+      export NIX_CONFIG="extra-experimental-features = nix-command flakes dynamic-derivations ca-derivations"
+
+      # Upstream's own dev shell (the patched tree keeps upstream's flake.nix
+      # and flake.lock) supplies meson and every library dependency exactly as
+      # nix upstream develops against; hand-rolling PKG_CONFIG_PATH and
+      # friends here would just re-derive it, badly. Impure boundary: first
+      # run evaluates that flake and fetches its locked inputs.
+      exec ${nixClient} develop "path:${patchedSrc}" --command ${lib.getExe inner} "$workdir" "$@"
+    '';
+    meta.description = "Incremental per-compilation-unit build of the patched nix fork via nix-ninja (local mode)";
+  }

--- a/packages/nix/nix-ninja-build/package.nix
+++ b/packages/nix/nix-ninja-build/package.nix
@@ -1,0 +1,9 @@
+{
+  id = "nix-ninja-build-nix";
+  # The incremental (per-compilation-unit) build lane for the patched nix
+  # fork. Gated to x86_64-linux because nix-ninja itself is (see
+  # packages/nix-ninja/package.nix); the whole-package lanes on every other
+  # system are untouched.
+  packageSet.systems = ["x86_64-linux"];
+  flake.systems = ["x86_64-linux"];
+}

--- a/packages/site/src/lib/updates/nix-ninja-incremental-fork-lane.svx
+++ b/packages/site/src/lib/updates/nix-ninja-incremental-fork-lane.svx
@@ -1,0 +1,54 @@
+---
+id: nix-ninja-incremental-fork-lane
+postedAt: 2026-07-19T12:30:00-07:00
+title: "nix fork: incremental per-compilation-unit builds via nix-ninja"
+tags: [nix, fork, nix-ninja, ca-derivations, dynamic-derivations]
+links:
+  - label: issue
+    href: https://github.com/indexable-inc/index/issues/3655
+  - label: nix-ninja
+    href: https://github.com/pdtpartners/nix-ninja
+---
+
+Iterating on the nix fork's patch series used to mean rebuilding the whole
+modular package on every change. The new lane hands the same patched tree to
+[nix-ninja](https://github.com/pdtpartners/nix-ninja), which parses the ninja
+graph meson emits and turns every compilation unit into its own
+content-addressed derivation, so a one-file change recompiles one derivation
+and relinks its dependents.
+
+`nix run .#nix-ninja-build-nix` (x86_64-linux) materializes the patched source
+(the identical `ix.patchedSrc` tree `packages/nix/nix` ships, with the fork
+version written into `.version`), configures it with meson inside upstream's
+own dev shell with `$NINJA` pointed at nix-ninja, and builds `src/nix/nix`.
+The result runs and identifies itself as the fork
+(`nix (Nix) 2.34.7+ix.p<count>.h<digest>`, the same version string the
+packaged fork reports). Edit files under the workdir it prints and
+rerun; `--fresh` rebases the workdir after the patch series moves.
+
+Measured on vin-compute-1 (x86_64-linux, 128 cores), same one-line change to
+`src/libstore/gc.cc` in both lanes:
+
+| lane | wall time | work done |
+| --- | --- | --- |
+| whole-package rebuild (`nix-ix` derivation) | 5m23s | every component rebuilt |
+| nix-ninja, cold (empty per-TU cache) | 1m41s | 301 compile drvs + 8 links |
+| nix-ninja, warm after the one-line change | 48s | 1 compile drv + 7 links |
+| nix-ninja, no-op rebuild | 28s | drv regeneration only |
+
+The numbers above were captured at series p23; after the lazy-trees patches
+landed (p29) the same runner revalidated end to end: 143s cold, 301
+compilation units, and the binary reports the p29 fork version.
+
+The lane uses nix-ninja's local mode: the client generates dynamic derivations
+and calls `nix build` itself, which needs the `dynamic-derivations` and
+`ca-derivations` experimental features on the daemon (the Linux fleet builders
+already enable both; `recursive-nix` is only needed for the in-derivation mode
+this lane does not use). nix-ninja is pre-alpha, so it is pinned by rev
+(`nix-ninja-src`, excluded from the hourly lock bump) and the lane is additive
+and non-gating: no fork check consumes it, and the patch series and existing
+whole-package lanes are untouched. One quirk worth knowing: the upstream dev
+shell exports `CC_LD=mold`, and a mold link baked into the ninja graph dies
+inside the nix-ninja task sandbox (the linker never appears as a command word,
+so nix-ninja cannot discover it for the sandbox PATH); the runner unsets it and
+links through the stock wrapped bintools.


### PR DESCRIPTION
## What

Adds an incremental, per-compilation-unit build lane for the patched nix fork via [nix-ninja](https://github.com/pdtpartners/nix-ninja) (pre-alpha, pinned by rev). Additive and non-gating: the patch series, the fork package, and every existing check are untouched.

- `nix-ninja-src` flake input (pinned by rev f16edb41, `flake = false`, excluded from routine lock bumps by the rev-pinned URL).
- `packages/nix-ninja`: rustPlatform build of the two binaries (`nix-ninja`, `nix-ninja-task`), x86_64-linux only (upstream's support claim; nix-ninja-task patchelfs ELF outputs). Smoke test pins the ninja-compat version contract (1.8.2).
- `packages/nix/nix-ninja-build`: `nix run .#nix-ninja-build-nix` materializes the identical `ix.patchedSrc` tree the fork package builds (fork version written into `.version`), enters upstream's own dev shell, points `$NINJA` at nix-ninja, and builds `src/nix/nix`. Each TU becomes its own content-addressed derivation; rerun after editing recompiles only affected TUs. `--fresh` rebases the workdir when the patch series moves.
- Site page: `packages/site/src/lib/updates/nix-ninja-incremental-fork-lane.svx`.

## Numbers

vin-compute-1 (x86_64-linux, 128 cores), same one-line edit to `src/libstore/gc.cc` in both lanes, series p23:

| lane | wall time | work done |
| --- | --- | --- |
| whole-package rebuild (`nix-ix`) | 5m23s | every component rebuilt |
| nix-ninja cold (empty per-TU cache) | 1m41s | 301 compile drvs + 8 links |
| nix-ninja warm after one-line edit | 48s | 1 compile drv + 7 links |
| nix-ninja no-op rebuild | 28s | drv regeneration only |

Cold and warm binaries run and report the fork version string (`nix (Nix) 2.34.7+ix.p23.h091c...`). Revalidated after the lazy-trees patches landed: the shipped runner rebuilt p29 end to end (143s cold, 301 TUs) and reports `2.34.7+ix.p29.h33d0...`.

## Consumption modes

- **Local mode (this lane, validated E2E):** nix-ninja emits dynamic derivations and runs `nix build` itself. Daemon needs `experimental-features = dynamic-derivations ca-derivations`; the Linux fleet builders already enable both (verified on vin-compute-1). `recursive-nix` is not needed.
- **In-derivation mode (stretch, attempted and documented, not shipped):** a mkMesonPackage-style derivation with `requiredSystemFeatures = ["recursive-nix"]` generating the dynamic graph inside the sandbox. The daemon accepts it with a trusted-user `--system-features 'recursive-nix ...'` override (the fleet's `system-features` setting does not advertise `recursive-nix`; enabling the lane fleet-wide would need `recursive-nix` appended to `nix.settings.system-features` on the builders). Attempt log: upstream's own `example-nix` fails on our builders because their pinned NixOS/nix master fails one functional test in-sandbox; a hand-rolled equivalent against our patched tree + nix-ix client got through meson configure, dependency inference, and full dynamic-graph generation inside the recursive-nix sandbox (output is a valid `xp-dyn-drv` derivation). Two sharp edges found: the outer derivation's `name` must end in `.drv` for the generated output to be realizable via `path^output`, and stdenv's ninja setup hook must be disabled or `ninja install` tramples `$out`. The fixed rerun (name suffixed `.drv`, install hooks disabled) timed out at 30 minutes under concurrent builder load before the generated graph could be realized from the CLI; the local lane is the deliverable.

## Upstream

Filed pdtpartners/nix-ninja#52: link tasks fail when meson bakes `-fuse-ld=<linker>` from `CC_LD`/`CXX_LD` because the linker never enters the task sandbox PATH (hit via upstream nix's dev shell exporting `CC_LD=mold`; the runner unsets it with a comment). No upstream PRs opened.

Closes #3655

(PR authored by an AI agent via Claude Code, Claude Opus 4.5)
