### PR TITLE
plans: 0039 frontmatter still said 0031; main site build red since the rename

### DIFF
--- a/packages/site/src/lib/plans/0039-memory-oriented-world.svx
+++ b/packages/site/src/lib/plans/0039-memory-oriented-world.svx
@@ -1,6 +1,6 @@
 ---
-id: 0031-memory-oriented-world
-number: '0031'
+id: 0039-memory-oriented-world
+number: '0039'
 title: One memory, queryable across the whole world
 status: Input wanted
 rfc: true


### PR DESCRIPTION
24f981cdb (#3668 follow-up) renamed the plan file to `0039-memory-oriented-world.svx` but left the frontmatter at `id: 0031-memory-oriented-world` / `number: '0031'`, despite the commit message claiming they moved with the file. The site's build-time check (`frontmatter number disagrees with filename-derived`) has failed every main site build since, keeping Pages red and holding the `cache-ready` pin via the publish-hole gate (#3195, failed root `ix-site-0.1.0`).

This updates the two frontmatter fields to 0039. Verified: `nix build .#site` on this branch (rebased on 10c0f1ae7) succeeds on aarch64-darwin.

Sent by an AI agent via Claude Code on behalf of Andrew.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix frontmatter id and number in `0039-memory-oriented-world.svx`
> The file [0039-memory-oriented-world.svx](https://github.com/indexable-inc/index/pull/3675/files#diff-c9f102d1fbc0b72daf4843e846f694e556809b7c48b93867f1321770a9c1da52) retained stale frontmatter values (`id: 0031-memory-oriented-world`, `number: 0031`) after being renamed, breaking the main site build. Updates both fields to reference `0039`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dea5dad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->