### PR TITLE
lint: plan/update/story id collisions fail the Check gate (#3669)

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -36,7 +36,7 @@
   # up in the `lint` derivation build, not at `nix run` time.
   lintStage = ix.writeNushellApplication pkgs {
     name = "lint-stage";
-    meta.description = "One lint stage (alejandra | statix | deadnix | astlog | astlog-rust | astlog-elixir | filenames | dirnames | ruff | clone); driven by `lint`";
+    meta.description = "One lint stage (alejandra | statix | deadnix | astlog | astlog-rust | astlog-elixir | filenames | dirnames | svg-dark | site-ids | ruff | clone); driven by `lint`";
     runtimeInputs = [
       pkgs.alejandra
       pkgs.deadnix
@@ -254,6 +254,85 @@
           exit 1
         }
       }
+      # Plan/update/story identity (packages/site/src/lib/plans, updates,
+      # stories) is enforced at SvelteKit build time -- plans.ts throws on a
+      # duplicate plan number or a frontmatter/filename mismatch -- but the
+      # Check gate never builds the site, so two individually-green PRs merged
+      # into a duplicate plan number 0031 and main's site build stayed red for
+      # 8.5h before the Pages workflow surfaced it (#3669). This stage
+      # front-loads the pure file-scan invariants into the gate every PR and
+      # main commit runs: within each content directory a four-digit filename
+      # prefix is claimed at most once, frontmatter `id` equals the filename
+      # stem (stems are unique per directory, so ids stay unique), and a
+      # frontmatter `number` agrees with the prefix (the #3668 rename fixed
+      # the collision but left the old `number` behind, which kept the site
+      # build red). The site build remains the full validator.
+      def frontmatter-field [front: list<string>, key: string] {
+        let matches = ($front | parse --regex ('^' + $key + ': *(?<value>.+)$'))
+        if ($matches | is-empty) { null } else {
+          $matches | get 0.value | str trim | str trim --char "'"
+        }
+      }
+      def "main site-ids" [] {
+        let errors = (
+          [plans updates stories]
+          | each {|kind|
+              let entries = (
+                fd --extension svx . $"packages/site/src/lib/($kind)"
+                | lines
+                | sort
+                | each {|path|
+                    let stem = ($path | path parse | get stem)
+                    let front = (open --raw $path | lines | skip 1 | take until {|line| $line == '---'})
+                    {
+                      path: $path
+                      stem: $stem
+                      id: (frontmatter-field $front id)
+                      number: (frontmatter-field $front number)
+                      prefix: ($stem | parse --regex '^(?<n>\d{4})-' | get -o 0.n)
+                    }
+                  }
+              )
+              let id_mismatches = (
+                $entries
+                | where {|e| $e.id != $e.stem}
+                | each {|e| $"  ($e.path): frontmatter id '($e.id)' disagrees with filename '($e.stem)'"}
+              )
+              let number_mismatches = (
+                $entries
+                | where {|e| $e.number != null and $e.number != $e.prefix}
+                | each {|e| $"  ($e.path): frontmatter number '($e.number)' disagrees with filename prefix '($e.prefix)'"}
+              )
+              let numbered = ($entries | where {|e| $e.prefix != null})
+              let duplicate_prefixes = (
+                if ($numbered | is-empty) { [] } else {
+                  $numbered
+                  | group-by prefix
+                  | transpose prefix claimants
+                  | where {|row| ($row.claimants | length) > 1}
+                  | each {|row| $"  number ($row.prefix) claimed by (($row.claimants | get path | str join ' and '))"}
+                }
+              )
+              let identified = ($entries | where {|e| $e.id != null})
+              let duplicate_ids = (
+                if ($identified | is-empty) { [] } else {
+                  $identified
+                  | group-by id
+                  | transpose id claimants
+                  | where {|row| ($row.claimants | length) > 1}
+                  | each {|row| $"  id ($row.id) claimed by (($row.claimants | get path | str join ' and '))"}
+                }
+              )
+              [$id_mismatches $number_mismatches $duplicate_prefixes $duplicate_ids] | flatten
+            }
+          | flatten
+        )
+        if ($errors | is-not-empty) {
+          print --stderr "site content identity is enforced by the SvelteKit build, which the Check gate never runs (#3669); keep filenames and frontmatter agreeing so collisions fail fast:"
+          $errors | each {|line| print --stderr $line }
+          exit 1
+        }
+      }
       # Repo-wide Python lint: the shared ruff selector (bug-catchers + security +
       # pathlib + pytest + explicit annotations + no `typing.cast`; see
       # lib/ruff-ann.nix) over EVERY tracked .py, so non-package dirs
@@ -283,7 +362,7 @@
         clone . out> /dev/null
       }
       def main [] {
-        error make { msg: "specify a stage: alejandra | statix | deadnix | astlog | astlog-rust | astlog-elixir | filenames | dirnames | svg-dark | ruff | clone" }
+        error make { msg: "specify a stage: alejandra | statix | deadnix | astlog | astlog-rust | astlog-elixir | filenames | dirnames | svg-dark | site-ids | ruff | clone" }
       }
     '';
   };
@@ -301,6 +380,7 @@
     "filenames"
     "dirnames"
     "svg-dark"
+    "site-ids"
     "ruff"
     "clone"
   ];

--- a/packages/site/src/lib/plans/0039-memory-oriented-world.svx
+++ b/packages/site/src/lib/plans/0039-memory-oriented-world.svx
@@ -1,6 +1,6 @@
 ---
-id: 0031-memory-oriented-world
-number: '0031'
+id: 0039-memory-oriented-world
+number: '0039'
 title: One memory, queryable across the whole world
 status: Input wanted
 rfc: true

--- a/packages/site/src/lib/updates/site-id-lint.svx
+++ b/packages/site/src/lib/updates/site-id-lint.svx
@@ -1,0 +1,18 @@
+---
+id: site-id-lint
+postedAt: '2026-07-19T04:45:00-07:00'
+title: plan and update id collisions now fail the merge gate
+links:
+  - label: 'index#3669'
+    href: 'https://github.com/indexable-inc/index/issues/3669'
+  - label: 'the collision renumber'
+    href: 'https://github.com/indexable-inc/index/pull/3668'
+  - label: 'per-commit main Check'
+    href: 'https://github.com/indexable-inc/index/pull/3670'
+tags:
+  - ci
+---
+
+The lint suite now validates plan, update, and story identity directly: within each of `packages/site/src/lib/{plans,updates,stories}`, a four-digit filename prefix may be claimed only once, frontmatter `id` must equal the filename stem, and a frontmatter `number` must agree with the prefix. Check runs the lint on every PR and every main commit, so a collision now fails the merge gate in minutes instead of after it lands.
+
+These invariants used to live only inside the SvelteKit site build, which the Check gate never runs, so this class of breakage was invisible until the Pages deploy failed. Two individually-green PRs merged into a duplicate plan number 0031 and main's site build stayed red for 8.5 hours (#3669); the renumber that fixed the collision (#3668) itself left the old `number: '0031'` frontmatter behind, which the new stage caught on its first local run, and this change repairs.


### PR DESCRIPTION
The Check gate (every PR, and after #3670 every main commit) never builds the site, but plan/update/story identity was enforced only inside the SvelteKit build: two individually-green PRs merged into duplicate plan number 0031 and main's site build stayed red for 8.5h, surfacing only in Pages and cache-push realise (#3669, fixed by #3668).

This adds a `site-ids` stage to the lint suite Check gates. Pure file scan over `packages/site/src/lib/plans`, `updates`, and `stories` (no node build, 0.5s):

- a four-digit filename prefix is claimed at most once per directory
- frontmatter `id` equals the filename stem (stems are unique per directory, so ids stay unique)
- frontmatter `number`, where present, agrees with the filename prefix

Each collision message names both claiming files.

The stage's first local run caught a live breakage: the #3668 renumber renamed `0031-memory-oriented-world.svx` to `0039-` but left frontmatter `id`/`number` at 0031, so `plans.ts` kept throwing and the Pages build is still red on main right now. The first commit repairs that; `nix build .#site` passes with it.

Proof of detection (temporary colliding files, since removed):

```
  packages/site/src/lib/plans/0031-collision-test.svx: frontmatter id 'wrong-id' disagrees with filename '0031-collision-test'
  packages/site/src/lib/plans/0031-collision-test.svx: frontmatter number '9999' disagrees with filename prefix '0031'
  number 0031 claimed by packages/site/src/lib/plans/0031-collision-test.svx and packages/site/src/lib/plans/0031-recommended-next-actions.svx
  packages/site/src/lib/updates/site-id-lint-dupe.svx: frontmatter id 'site-id-lint' disagrees with filename 'site-id-lint-dupe'
  id site-id-lint claimed by packages/site/src/lib/updates/site-id-lint-dupe.svx and packages/site/src/lib/updates/site-id-lint.svx
```

Full `nix run .#lint` is green on this branch (12 stages).

Site page: packages/site/src/lib/updates/site-id-lint.svx


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `site-ids` lint stage that fails on plan/update/story ID collisions
> - Adds a new `site-ids` lint stage in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/3676/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) that scans SVX files under `packages/site/src/lib/{plans,updates,stories}` and exits with status 1 if any file has a frontmatter `id` or `number` that mismatches its filename, or if duplicate IDs or numeric prefixes exist across files.
> - Fixes a pre-existing mismatch in [0039-memory-oriented-world.svx](https://github.com/indexable-inc/index/pull/3676/files#diff-c9f102d1fbc0b72daf4843e846f694e556809b7c48b93867f1321770a9c1da52) where frontmatter `id` and `number` were set to `0031` instead of `0039`.
> - Adds a site update entry documenting the new lint behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 000862a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->