### PR TITLE
hm: pin ~/.local/bin/claude to the wrapper and time activation steps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -543,6 +543,7 @@
       optionsModule = personalOptionsModule;
       indexSkillsSrc = paths.skills;
       tmuxModule = ./modules/home/tmux.nix;
+      activationTimingModule = ./modules/home/activation-timing.nix;
     };
     personalDarwinHomeModule = import ./users/andrewgazelka/profiles/darwin-home.nix {
       inherit indexPackages ix;
@@ -635,6 +636,11 @@
       # base directories instead of $HOME. Import it and set
       # `xdgTidy.enable = true`. See modules/home/xdg-tidy.nix.
       xdg-tidy = ./modules/home/xdg-tidy.nix;
+
+      # Wall time on every `Activating <name>` line plus a slowest-steps
+      # summary at the end of activation. See
+      # modules/home/activation-timing.nix.
+      activation-timing = ./modules/home/activation-timing.nix;
       # Cursor-shape feedback for zsh vi mode (beam insert, block command,
       # reset around every prompt/command). Import it and set
       # `zshViCursor.enable = true`. See modules/home/zsh-vi-cursor.nix.

--- a/modules/home/activation-timing.nix
+++ b/modules/home/activation-timing.nix
@@ -1,0 +1,69 @@
+# Per-step wall-clock timings for Home Manager activation.
+#
+# Home Manager prints one untimed "Activating <step>" line per activation
+# entry; every entry runs in the same bash process and announces itself
+# through `_iNote "Activating %s" <name>` in the generated script. The first
+# entry below interposes on that exact call: each new header first reports
+# how long the previous step took, and the closing entry prints a
+# slowest-steps summary plus the total (indexable-inc/index#3673).
+#
+# The anchors name both the darwin and linux tail entries: dag edges are
+# membership tests over existing nodes (home-manager modules/lib/dag.nix),
+# so names absent on a platform are inert.
+#
+# All math is bash integer arithmetic on $EPOCHREALTIME: the activation
+# script's PATH carries only the Home Manager tool closure (coreutils, sed,
+# grep, jq), so awk/bc are unavailable and, under `set -e`, fatal.
+{lib, ...}: {
+  home.activation = {
+    activationTimerStart = lib.hm.dag.entryBefore ["checkFilesChanged" "checkLinkTargets"] ''
+      # Milliseconds since the epoch; EPOCHREALTIME is "sec.micros" with a
+      # locale-dependent radix character, and the microsecond field's
+      # leading zeros would otherwise read as octal (hence 10#).
+      _ixActNowMs() {
+        local t=$EPOCHREALTIME
+        printf '%s' "$(( ''${t%[.,]*} * 1000 + 10#''${t#*[.,]} / 1000 ))"
+      }
+      _ixActFmt() {
+        printf '%d.%02ds' "$(( $1 / 1000 ))" "$(( $1 % 1000 / 10 ))"
+      }
+      _ixActStart=$(_ixActNowMs)
+      _ixActPrevTs=$_ixActStart
+      _ixActPrevName=""
+      declare -A _ixActDurations
+      # Keep the original under a new name, then wrap it. Only the
+      # "Activating %s" header participates in timing; other _iNote
+      # messages pass straight through.
+      eval "_ixActOrigINote() $(declare -f _iNote | tail -n +2)"
+      _ixActLap() {
+        local now
+        now=$(_ixActNowMs)
+        if [[ -n "$_ixActPrevName" ]]; then
+          _ixActDurations[$_ixActPrevName]=$(( now - _ixActPrevTs ))
+          printf '  %s\n' "$(_ixActFmt $(( now - _ixActPrevTs )))"
+        fi
+        _ixActPrevTs=$now
+        _ixActPrevName=$1
+      }
+      _iNote() {
+        if [[ "''${1:-}" == "Activating %s" && $# -ge 2 ]]; then
+          _ixActLap "$2"
+        fi
+        _ixActOrigINote "$@"
+      }
+    '';
+
+    # The report's own "Activating" header laps the final real step, so the
+    # summary below is complete without measuring itself.
+    activationTimerReport = lib.hm.dag.entryAfter ["setupLaunchAgents" "reloadSystemd" "onFilesChange"] ''
+      if [[ -n "''${_ixActStart:-}" ]]; then
+        echo "Slowest activation steps (total $(_ixActFmt $(( $(_ixActNowMs) - _ixActStart )))):"
+        for _ixActName in "''${!_ixActDurations[@]}"; do
+          printf '%s %s\n' "''${_ixActDurations[$_ixActName]}" "$_ixActName"
+        done | sort -rn | head -n 8 | while read -r _ixActMs _ixActStepName; do
+          printf '%9s  %s\n' "$(_ixActFmt "$_ixActMs")" "$_ixActStepName"
+        done
+      fi
+    '';
+  };
+}

--- a/packages/agent/home-manager/claude-code.nix
+++ b/packages/agent/home-manager/claude-code.nix
@@ -315,6 +315,19 @@ in {
       context = lib.mkIf cfg.houseContext.enable (lib.mkDefault houseContextText);
     };
 
+    # Claude Code's stock auto-updater installs native builds under
+    # ~/.local/share/claude/versions and re-points ~/.local/bin/claude at
+    # them, shadowing the nix wrapper on PATH; experimenting with unwrapped
+    # Claude Code strands the same symlink on stale builds. Re-pin it to the
+    # wrapper on every switch so a reset never survives an activation.
+    # TODO(indexable-inc/index#3671): we should not need this. "Don't
+    # uninstall" covers the common case, yet stray installs keep winning
+    # PATH; once the updater fight is fixed at the source, remove this.
+    home.file.".local/bin/claude" = lib.mkIf cfg.enable {
+      source = "${cfg.finalPackage}/bin/claude";
+      force = true;
+    };
+
     # The wrapper injects no `--settings` flag (#3180): its computed render is
     # seeded into the writable user settings.json instead, where Claude Code's
     # own runtime writes survive the merge and every key stays overridable by

--- a/packages/site/src/lib/updates/hm-activation-timings.svx
+++ b/packages/site/src/lib/updates/hm-activation-timings.svx
@@ -1,0 +1,15 @@
+---
+id: hm-activation-timings
+postedAt: 2026-07-19T12:00:00-07:00
+title: "Home Manager activation gets per-step timings; claude stays nix-pinned"
+tags: [home-manager, nix, claude-code]
+links:
+  - label: timings issue
+    href: https://github.com/indexable-inc/index/issues/3673
+  - label: claude pin issue
+    href: https://github.com/indexable-inc/index/issues/3671
+---
+
+Running `home-manager switch` used to print a bare "Activating step" line per activation entry with no hint of where the time went. A new `homeModules.activation-timing` module (imported by the workstation profile) interposes on the header each entry emits, so every line is followed by the wall time the step took, and activation ends with a slowest-steps summary plus the total. Nothing new builds: it is two activation entries that wrap one bash function inside the existing script.
+
+Separately, the claude-code home module now force-links `.local/bin/claude` back to the nix-managed wrapper on every switch. Claude Code's stock auto-updater installs native builds under `.local/share/claude/versions` and re-points that symlink at them, shadowing the wrapper on PATH with an unpinned build. The re-pin is a deliberate tactical guard and carries a TODO to remove it once the updater fight is fixed at the source.

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -1,6 +1,7 @@
 # Full personal workstation profile. Index-owned dependencies are closed over
 # by the flake export; host-owned values arrive through typed options.nix.
 {
+  activationTimingModule,
   codexModule,
   configRoot,
   indexPackages,
@@ -325,6 +326,9 @@ in {
   imports = [
     optionsModule
     personalServicesModule
+    # Times every activation step and prints a slowest-steps summary
+    # (indexable-inc/index#3673).
+    activationTimingModule
     # Declares `programs.codex.houseContext` (and the rest of the index codex
     # options) that this profile sets below; home-manager's stock
     # programs.codex module only carries enable/package/skills/context, so


### PR DESCRIPTION
Two workstation-facing Home Manager changes:

**Pin `~/.local/bin/claude` to the nix wrapper** (tracks #3671). Claude Code's stock auto-updater installs native builds under `~/.local/share/claude/versions/<v>` and re-points `~/.local/bin/claude` at them, shadowing the nix-managed wrapper on PATH (observed: wrapper 2.1.206 shadowed by native 2.1.215). The claude-code home module now force-links the symlink back to `cfg.finalPackage` every switch. Deliberate tactical guard with a `TODO(#3671)` to remove it once the updater fight is fixed at the source; #3671 stays open to track that.

**Per-step activation timings** (closes #3673). New `homeModules.activation-timing`: one activation entry sorted first interposes on the `_iNote "Activating %s"` header every entry emits (renaming the original function, wrapping it), so each step's wall time prints as the next header arrives; a closing entry prints a slowest-steps summary plus the total. Anchors name both darwin and linux tail entries; unknown dag names are inert membership tests. Imported by the workstation profile.

Verified locally: built `homeConfigurations."andrewgazelka@hydra".activationPackage` against this branch; the generated activate script carries the wrapper (header sorts first, summary last) and `home-files/.local/bin/claude` resolves to the wrapper binary.

(sent by an AI agent via Claude Code, Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `~/.local/bin/claude` to the Nix wrapper and add per-step Home Manager activation timing
> - Adds [activation-timing.nix](https://github.com/indexable-inc/index/pull/3677/files#diff-fc004486355dee2e005e42760b9e732544011444e4c12a0d15d1c4763077512a) which instruments Home Manager activation by wrapping `_iNote` to record wall-clock duration per step and prints a summary of the 8 slowest steps at the end.
> - Adds a `home.file` entry in [claude-code.nix](https://github.com/indexable-inc/index/pull/3677/files#diff-b941f4c92dd8de3d70290f80abe17e83e8710287c6a7430cad3d5f1c81cdbdab) that force-links `~/.local/bin/claude` to the Nix-managed wrapper on each activation, overriding any symlink the upstream auto-updater may have set.
> - Imports `activationTimingModule` into the [workstation profile](https://github.com/indexable-inc/index/pull/3677/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962) so timing runs on every activation for that profile.
> - Behavioral Change: activations for the workstation profile will now print per-step timing output; `~/.local/bin/claude` is forcibly rewritten on every activation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bed1bc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->