### PR TITLE
hm: activation timing summary rides the EXIT trap

### DIFF
--- a/modules/home/activation-timing.nix
+++ b/modules/home/activation-timing.nix
@@ -2,61 +2,65 @@
 #
 # Home Manager prints one untimed "Activating <step>" line per activation
 # entry; every entry runs in the same bash process and announces itself
-# through `_iNote "Activating %s" <name>` in the generated script. The first
-# entry below interposes on that exact call: each new header first reports
-# how long the previous step took, and the closing entry prints a
+# through `_iNote "Activating %s" <name>` in the generated script. The entry
+# below sorts first and interposes on that exact call: each new header first
+# reports how long the previous step took, and an EXIT trap prints a
 # slowest-steps summary plus the total (indexable-inc/index#3673).
 #
-# The anchors name both the darwin and linux tail entries: dag edges are
-# membership tests over existing nodes (home-manager modules/lib/dag.nix),
-# so names absent on a platform are inert.
+# The summary rides the EXIT trap rather than a dag entry: the dag has no
+# global sink, so entries without ordering constraints can legally sort
+# after any fixed anchor and would escape a summary entry (observed with
+# mutableFiles and friends). The generated script already arms an EXIT trap
+# (the new-generation gcroot cleanup), so the trap body chains to it.
 #
 # All math is bash integer arithmetic on $EPOCHREALTIME: the activation
 # script's PATH carries only the Home Manager tool closure (coreutils, sed,
 # grep, jq), so awk/bc are unavailable and, under `set -e`, fatal.
 {lib, ...}: {
-  home.activation = {
-    activationTimerStart = lib.hm.dag.entryBefore ["checkFilesChanged" "checkLinkTargets"] ''
-      # Milliseconds since the epoch; EPOCHREALTIME is "sec.micros" with a
-      # locale-dependent radix character, and the microsecond field's
-      # leading zeros would otherwise read as octal (hence 10#).
-      _ixActNowMs() {
-        local t=$EPOCHREALTIME
-        printf '%s' "$(( ''${t%[.,]*} * 1000 + 10#''${t#*[.,]} / 1000 ))"
-      }
-      _ixActFmt() {
-        printf '%d.%02ds' "$(( $1 / 1000 ))" "$(( $1 % 1000 / 10 ))"
-      }
-      _ixActStart=$(_ixActNowMs)
-      _ixActPrevTs=$_ixActStart
-      _ixActPrevName=""
-      declare -A _ixActDurations
-      # Keep the original under a new name, then wrap it. Only the
-      # "Activating %s" header participates in timing; other _iNote
-      # messages pass straight through.
-      eval "_ixActOrigINote() $(declare -f _iNote | tail -n +2)"
-      _ixActLap() {
-        local now
-        now=$(_ixActNowMs)
-        if [[ -n "$_ixActPrevName" ]]; then
-          _ixActDurations[$_ixActPrevName]=$(( now - _ixActPrevTs ))
-          printf '  %s\n' "$(_ixActFmt $(( now - _ixActPrevTs )))"
-        fi
-        _ixActPrevTs=$now
-        _ixActPrevName=$1
-      }
-      _iNote() {
-        if [[ "''${1:-}" == "Activating %s" && $# -ge 2 ]]; then
-          _ixActLap "$2"
-        fi
-        _ixActOrigINote "$@"
-      }
-    '';
-
-    # The report's own "Activating" header laps the final real step, so the
-    # summary below is complete without measuring itself.
-    activationTimerReport = lib.hm.dag.entryAfter ["setupLaunchAgents" "reloadSystemd" "onFilesChange"] ''
+  home.activation.activationTimerStart = lib.hm.dag.entryBefore ["checkFilesChanged" "checkLinkTargets"] ''
+    # Milliseconds since the epoch; EPOCHREALTIME is "sec.micros" with a
+    # locale-dependent radix character, and the microsecond field's leading
+    # zeros would otherwise read as octal (hence 10#).
+    _ixActNowMs() {
+      local t=$EPOCHREALTIME
+      printf '%s' "$(( ''${t%[.,]*} * 1000 + 10#''${t#*[.,]} / 1000 ))"
+    }
+    _ixActFmt() {
+      printf '%d.%02ds' "$(( $1 / 1000 ))" "$(( $1 % 1000 / 10 ))"
+    }
+    _ixActStart=$(_ixActNowMs)
+    _ixActPrevTs=$_ixActStart
+    _ixActPrevName=""
+    declare -A _ixActDurations
+    # Keep the original under a new name, then wrap it. Only the
+    # "Activating %s" header participates in timing; other _iNote messages
+    # pass straight through.
+    eval "_ixActOrigINote() $(declare -f _iNote | tail -n +2)"
+    _ixActLap() {
+      local now
+      now=$(_ixActNowMs)
+      if [[ -n "$_ixActPrevName" ]]; then
+        _ixActDurations[$_ixActPrevName]=$(( now - _ixActPrevTs ))
+        printf '  %s\n' "$(_ixActFmt $(( now - _ixActPrevTs )))"
+      fi
+      _ixActPrevTs=$now
+      _ixActPrevName=$1
+    }
+    _iNote() {
+      if [[ "''${1:-}" == "Activating %s" && $# -ge 2 ]]; then
+        _ixActLap "$2"
+      fi
+      _ixActOrigINote "$@"
+    }
+    # Extract the command body of the already-armed EXIT trap so the summary
+    # can chain to it; assumes the home-manager trap body itself contains no
+    # single quotes (true of the gcroot cleanup it arms today).
+    _ixActPrevExitCmd=$(trap -p EXIT)
+    _ixActPrevExitCmd=''${_ixActPrevExitCmd#trap -- \'}
+    _ixActPrevExitCmd=''${_ixActPrevExitCmd%\' EXIT}
+    _ixActSummary() {
       if [[ -n "''${_ixActStart:-}" ]]; then
+        _ixActLap end
         echo "Slowest activation steps (total $(_ixActFmt $(( $(_ixActNowMs) - _ixActStart )))):"
         for _ixActName in "''${!_ixActDurations[@]}"; do
           printf '%s %s\n' "''${_ixActDurations[$_ixActName]}" "$_ixActName"
@@ -64,6 +68,8 @@
           printf '%9s  %s\n' "$(_ixActFmt "$_ixActMs")" "$_ixActStepName"
         done
       fi
-    '';
-  };
+      eval "$_ixActPrevExitCmd"
+    }
+    trap '_ixActSummary' EXIT
+  '';
 }


### PR DESCRIPTION
Follow-up to #3677 / #3673. The dag has no global sink, so unconstrained entries (mutableFiles and friends) legally sorted after the summary entry: on hydra the summary printed at line 45 of a 93-line activation and the total missed the tail steps. The summary now rides an EXIT trap chained onto the gcroot-cleanup trap the generated script already arms, so it is unconditionally last (and also prints on a failed activation, which is when you want it most).

Verified live on hydra: built the homeConfiguration against this branch and ran the activation; the summary block is the final output with the full step set included.

(sent by an AI agent via Claude Code, Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move activation timing summary to EXIT trap in home-manager activation
> - Consolidates two activation DAG entries (`activationTimerStart` and `activationTimerReport`) into a single `activationTimerStart` entry in [activation-timing.nix](https://github.com/indexable-inc/index/pull/3680/files#diff-fc004486355dee2e005e42760b9e732544011444e4c12a0d15d1c4763077512a).
> - The summary is now printed via an EXIT trap (`_ixActSummary`) instead of a separate DAG step, ensuring timing covers all activation steps regardless of DAG ordering.
> - Chains to any previously installed EXIT trap body (e.g. the gcroot cleanup trap) so existing behavior is preserved.
> - Behavioral Change: The timing summary no longer appears as a named activation step with an 'Activating' banner; it now prints at process exit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ff6c05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->