### PR TITLE
readme: open in plain terms, lead with the fork-vs-wait bet

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
   </picture>
 </p>
 
-index is a Nix monorepo in the spirit of [nixpkgs](https://github.com/NixOS/nixpkgs) and [Raycast extensions](https://github.com/raycast/extensions): one shared definition of the software everyone here runs. Inside: [packages](packages/), patched toolchains ([Nix](packages/nix/nix/), [Clippy](packages/llm-clippy/)), [NixOS and Home Manager modules](modules/), [VM images](images/), and [CI](.github/workflows/). It is also the default world an [ix.dev](https://ix.dev) VM boots: ix is the runtime, index is what runs on it.
+[ix.dev](https://ix.dev) rents out cloud machines where you pay for what you use. index defines everything those machines run: the apps, the libraries they are built from, and the tools that build them, compilers included. Inside: [packages](packages/), patched toolchains ([Nix](packages/nix/nix/), [Clippy](packages/llm-clippy/)), [NixOS and Home Manager modules](modules/), [VM images](images/), and [CI](.github/workflows/).
 
-It exists because agents now write patches faster than upstream review can absorb them. A fix that takes an agent minutes can wait months in a review queue, and some projects refuse AI-written patches outright. Here the same change lands on main today, and upstream can adopt it whenever it wants. The [philosophy](https://indexable-inc.github.io/index/philosophy/) page has the full argument.
+Every dependency here, down to the compiler, is something this repo can patch: the moment upstream falls short, index forks it. Forking has always been a bad trade, a same-day fix paid for by re-applying it by hand on every upstream update, forever, which is why forks rot and why everyone waits on review queues instead. index bets that [agents have flipped the trade](https://indexable-inc.github.io/index/philosophy/): they carry the upkeep, the build graph checks their work, and whatever a fix breaks surfaces within the hour as a failed check.
 
-## Why
+## What you get
 
 <p align="center">
   <picture>
@@ -40,7 +40,7 @@ Patch a compiler, fix a library, tighten a lint: nothing quietly runs last year'
   </picture>
 </p>
 
-Patches live next to the code that needs them. No dependency has a bus factor outside the repo.
+Patches live next to the code that needs them: a slow review queue, or a project that refuses AI-written patches outright, blocks nothing. Upstream can adopt the fix whenever it wants.
 
 ### One standard for everything
 

--- a/packages/site/src/lib/philosophy/philosophy.svx
+++ b/packages/site/src/lib/philosophy/philosophy.svx
@@ -1,6 +1,6 @@
 # Philosophy
 
-Agents made writing code cheap. Waiting is now the expensive part.
+Agents collapsed the cost of writing a change. What stayed expensive is everything between a written fix and a running one: review queues, release cycles, rebuilds. Each principle below removes one of those waits.
 
 - **Never blocked.** Land it here now. Generate the upstream PR from the patch; never wait on it.
 - **One graph.** A change lands once and reaches everyone.

--- a/packages/site/src/lib/updates.ts
+++ b/packages/site/src/lib/updates.ts
@@ -50,7 +50,7 @@ export const siteUpdates: SiteUpdate[] = Object.entries(modules)
 export const siteUrl = 'https://indexable-inc.github.io/index/';
 export const siteFeedUrl = `${siteUrl}feed.xml`;
 export const siteIntro =
-  'Agents made writing code cheap; waiting on review queues and upstreams is now the expensive part. index is one open monorepo where every change lands now and reaches everyone: packages, NixOS modules, VM images, patched toolchains, and the agent infrastructure that ties them together.';
+  'Agents collapsed the cost of writing a change; the delay now lives between a written fix and a running one. index is one open monorepo where every change lands the same day and reaches everyone: packages, NixOS modules, VM images, patched toolchains, and the agent infrastructure that ties them together.';
 
 function stripFrontmatter(source: string): string {
   return source.replace(/^---\n[\s\S]*?\n---\n?/, '').trim();

--- a/packages/site/src/lib/updates/readme-fork-bet.svx
+++ b/packages/site/src/lib/updates/readme-fork-bet.svx
@@ -1,0 +1,17 @@
+---
+id: readme-fork-bet
+postedAt: 2026-07-19T04:54:15-07:00
+title: "README opens in plain terms and leads with the fork-vs-wait bet"
+tags: [docs, readme]
+links:
+  - label: README
+    href: https://github.com/indexable-inc/index/blob/main/README.md
+  - label: "#3678"
+    href: https://github.com/indexable-inc/index/issues/3678
+---
+
+The README used to open with "index is a Nix monorepo in the spirit of nixpkgs", which assumes the reader already knows Nix, nixpkgs, and monorepos. An outside reader's feedback showed what actually lands: say what ix is, say index is everything an ix machine runs, then the dilemma every developer already knows. Wait on upstream review, often for months, or fork and re-apply your fix by hand on every update, forever.
+
+The new intro is two paragraphs, then diagrams. Paragraph one: what ix is and what index contains. Paragraph two: any dependency that falls short gets forked and patched in place, forking is famously a bad trade, and the bet is that agents doing the upkeep with the build graph checking their work flips the trade. Nix is linked but never explained. The point that some projects refuse AI-written patches moved into the "Never blocked on upstream" diagram section, next to the picture that makes it.
+
+The hero, the flywheel section (now titled "What you get"), and the stories are unchanged.


### PR DESCRIPTION
Closes #3678.

Reworks the README top matter around feedback from an outside reader who only understood the repo after a friend re-explained it in plain terms. Used broadly, not copied; his placeholder metrics and comparison table were dropped rather than invented.

- Opens with what ix is and that index is everything an ix machine runs; no Nix, nixpkgs, or monorepo knowledge assumed. Nix is linked once, never defined.
- Second paragraph is the whole bet in three sentences: any dependency that falls short gets forked and patched in place, forking is famously a bad trade, agents plus the build gate flip the trade. Diagrams start immediately after.
- The refuses-AI-patches point moved into the "Never blocked on upstream" diagram section.
- Philosophy opener and the site meta description rewritten to match (the old "writing code cheap / waiting expensive" line).
- Hero, flywheel subsections (retitled "What you get"), and stories unchanged.

Site page: `packages/site/src/lib/updates/readme-fork-bet.svx`

(sent by an AI agent via Claude Code, Claude Opus 4.5)
