### PR TITLE
agent: visual explainers render human time in the reader's timezone

### DIFF
--- a/packages/agent/skills/visual-explainers/SKILL.md
+++ b/packages/agent/skills/visual-explainers/SKILL.md
@@ -71,6 +71,19 @@ When the task is an actual data chart rather than a system explainer:
 - Interaction still earns its place: a tooltip that shows the exact value, a
   toggle that isolates one series. Nothing autoplays.
 
+## Time
+
+- Render timestamps in the reader's local timezone, and check what that is
+  before writing any time into copy (`date +%Z` on the host, or better: keep
+  the machine ISO-8601 instant in the data and let the page format it with
+  `Intl.DateTimeFormat`, which is right for every reader). Hardcoded `13:45Z`
+  in prose makes the reader do arithmetic; that is the page's job.
+- Prefer human forms everywhere: "4h ago", "38m elapsed", "eta 5:10-5:25 pm",
+  a counter ticking from a real start instant. Machine timestamps belong in
+  the data layer, human time in the rendered layer.
+- Label the zone whenever the page states an absolute clock time, since the
+  artifact may be read later or from somewhere else.
+
 ## Worked example: the target shape
 
 "How Svelte HMR works": the reader edits a fake `Button.svelte` in a textarea,

--- a/packages/site/src/lib/updates/visual-explainers-human-time.svx
+++ b/packages/site/src/lib/updates/visual-explainers-human-time.svx
@@ -1,0 +1,14 @@
+---
+id: visual-explainers-human-time
+postedAt: '2026-07-19T05:20:00-07:00'
+title: visual explainers render human time in the reader's timezone
+links:
+  - label: 'visual-explainers skill'
+    href: 'https://github.com/indexable-inc/index/blob/main/packages/agent/skills/visual-explainers/SKILL.md'
+tags:
+  - agent
+---
+
+The visual-explainers skill now has a Time section: pages keep machine ISO-8601 instants in the data layer and render only human forms ("38m elapsed", "eta 5:10-5:25 pm"), formatted for the reader's local timezone via `Intl.DateTimeFormat` rather than hardcoded into copy.
+
+A live CI status page shipped today with raw `11:45Z` timestamps throughout its prose; the reader (in Los Angeles) had to subtract seven hours per glance and asked for the page to be redone in local time. Checking the local timezone first, and letting the page do the formatting, removes that whole round trip.


### PR DESCRIPTION
A live status page shipped with raw Z timestamps in its prose and the
reader had to subtract seven hours per glance. The skill now says: keep
machine instants in the data layer, render only human forms, format
with Intl.DateTimeFormat for the reader's zone, and check the local
timezone before writing any absolute time into copy.

packages/site/src/lib/updates/visual-explainers-human-time.svx


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add time-rendering guidance to visual-explainers skill to use reader's timezone
> Adds a `## Time` section to [SKILL.md](https://github.com/indexable-inc/index/pull/3682/files#diff-3d254f5916b3278718cc3b1cf320884ea598a3df730e4fe4c28c11a03ba7cd56) instructing the agent to render timestamps in the reader's local timezone using `Intl.DateTimeFormat`, prefer human-readable forms like "4h ago" or "eta 5:10–5:25 pm", and always label the timezone when showing absolute times. Also adds a [site update post](https://github.com/indexable-inc/index/pull/3682/files#diff-bb6745e2026cf0a3f55e3b4f316eb19bc2f51cc95cc1d0459871a01442c3b616) describing the change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15b4147.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->