### PR TITLE
site: record the 159h flake-bump saga (bump landed as 93ba54768)

### DIFF
--- a/packages/site/src/lib/updates/flake-bump-unstuck.svx
+++ b/packages/site/src/lib/updates/flake-bump-unstuck.svx
@@ -1,0 +1,19 @@
+---
+id: flake-bump-unstuck
+postedAt: '2026-07-19T12:40:00-07:00'
+title: the 159-hour flake bump lands, nixpkgs moves Jul 5 to Jul 18
+links:
+  - label: 'stuck bump PR #3021'
+    href: 'https://github.com/indexable-inc/index/pull/3021'
+  - label: 'escalation issue #3438'
+    href: 'https://github.com/indexable-inc/index/issues/3438'
+  - label: 'ix#7844 (what staleness cost)'
+    href: 'https://github.com/indexable-inc/ix/issues/7844'
+tags:
+  - ci
+  - interesting
+---
+
+Eight flake inputs move forward at once: `nixpkgs` (Jul 5 to Jul 18), `home-manager`, `rust-overlay`, `btop-src`, `nushell-src`, `snix-src`, and both zed inputs. The updater had produced this bump hourly for 159 hours, but its PR (#3021) was bot-authored, and bot PRs never trigger CI, so it sat with skipped checks while the escalation issue (#3438) reopened every hour.
+
+The staleness was not free: ix follows index's nixpkgs, so the old Jul 5 pin downgraded TigerBeetle under the billing ledger's one-way-upgraded data file when an unrelated pin bump relocked it (ix#7844). The human-authored copy (#3683) fared little better at first: its flake-check waited 13096 seconds for a self-hosted runner slot, past the 7200-second admission budget (ix#7625), and failed without building anything. The bump itself was pushed to main directly (93ba54768); the nushell-src move needed one follow-up for reedline's git outputHashes (3fce70541). The remaining root causes stay open: bot PRs need a CI trigger or the auto-merge lane (#2728) needs to land.


### PR DESCRIPTION
The eight-input bump this PR carried (nixpkgs Jul 5 -> Jul 18) landed on main directly as 93ba54768 while this PR's flake-check sat queued for 13096s, past the 7200s admission budget (indexable-inc/ix#7625) -- the run failed without building anything, and closure-gate mirrored it. Rebased onto main: the lock now matches main exactly, and what remains is the operator-facing site entry recording the saga (#3021 bot-authored so no CI, escalation #3438 red for 159h, staleness cost indexable-inc/ix#7844; nushell-src needed the reedline outputHashes follow-up 3fce70541 on main).

Supersedes #3021.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add site update entry documenting the 159-hour flake-bump saga
> Adds a new SVX content entry ([flake-bump-unstuck.svx](https://github.com/indexable-inc/index/pull/3683/files#diff-9cb58fa41f36bd6f6c228725695d18b7b63b31b2ff0086345390bbf59bfb5901)) to the site documenting the flake bump that landed as `93ba54768`, including CI behavior encountered and follow-ups.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fbf87b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->