### PR TITLE
prompt: calibrated-wording rule, absolutes only as measurements

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -2,7 +2,8 @@
 # validation, tag filtering, and rendering. Each entry is one attribute: the
 # key is the rule name (the `omitRules` handle and prompt order); the value
 # holds `text`, `reason`, and optional `tags`. `reason` is provenance for
-# auditing and pruning, never rendered. A rule renders where every tag it
+# auditing and pruning; it never reaches any rendered prompt, so anything
+# the agent must actually follow belongs in `text`. A rule renders where every tag it
 # declares matches the target (see ./default.nix); `system` marks rules that
 # belong only when this text IS the agent's whole system prompt.
 #
@@ -336,13 +337,16 @@
     forceMerge = {
       topics = ["workflow"];
       text = ''
-        Never bypass required checks, review, branch protection, or the merge
-        queue: no `gh pr merge --admin`, no `--force`. Fix it or wait; if
-        speed matters, ask a human.
+        Bypassing required checks, review, branch protection, or the merge
+        queue (`gh pr merge --admin`, `--force`) takes an explicit human
+        grant, and only for an infra-stalled check, never a failing one;
+        verify main afterward. Without the grant, fix it or wait.
       '';
       reason = ''
         Speed pressure tempted bypasses that skip the checks keeping main
-        releasable.
+        releasable. The original absolute misstated policy: a standing
+        grant (2026-07-17) covers infra-stalled checks on the user's own
+        repos, so the rule states the condition instead (index#3684).
       '';
     };
   }
@@ -395,6 +399,28 @@
         system card prompting guidance, measured to nearly eliminate
         fabricated status reports:
         https://www-cdn.anthropic.com/d00db56fa754a1b115b6dd7cb2e3c342ee809620.pdf
+      '';
+    };
+  }
+  {
+    calibratedClaims = {
+      topics = ["writing"];
+      text = ''
+        Word each claim at the strength of its evidence, the way a system
+        card does: "passed 40 of 41" over "works", "did not reproduce in
+        20 runs" over "impossible". An absolute ("always", "never",
+        "guaranteed") is a measurement report, not emphasis. Without the
+        measurement, speak the estimative ladder (unlikely, roughly even,
+        likely, almost certainly; "cannot rule out" for severe tails) and
+        name what was checked. Disclose the regression next to the win.
+      '';
+      reason = ''
+        Requested 2026-07-19: reports drifted into absolutes. Register
+        from the Claude Fable 5 system card ("extremely difficult (though
+        not impossible)", "a much less clear judgement than for previous
+        models", regressions disclosed beside headline results) and the
+        IC estimative lexicon (likely / cannot rule out /
+        low-moderate-high confidence).
       '';
     };
   }

--- a/packages/site/src/lib/updates/prompt-calibrated-claims.svx
+++ b/packages/site/src/lib/updates/prompt-calibrated-claims.svx
@@ -1,0 +1,17 @@
+---
+id: prompt-calibrated-claims
+postedAt: 2026-07-19T05:18:05-07:00
+title: "House prompt gains a calibrated-wording rule: no absolutes without a measurement"
+tags: [agent, prompt]
+links:
+  - label: rules.nix
+    href: https://github.com/indexable-inc/index/blob/main/packages/agent/prompt/rules.nix
+  - label: "#3684"
+    href: https://github.com/indexable-inc/index/issues/3684
+---
+
+Agent reports drifted into absolutes: "works", "never happens", "impossible". The house prompt now carries a `calibratedClaims` rule that words each claim at the strength of its evidence: "passed 40 of 41" over "works", "did not reproduce in 20 runs" over "impossible", and an absolute only as a measurement report. Where the measurement is missing, the rule prescribes the estimative ladder (unlikely, roughly even, likely, almost certainly, plus cannot-rule-out for severe tails) with the check's coverage named, and a regression disclosed next to the win it accompanies.
+
+The register is borrowed from the Claude Fable 5 system card, which the `faithfulReporting` rule already cites: findings there read "extremely difficult (though not impossible)" and "a much less clear judgement than for previous models", with safety regressions listed beside headline results. The same practice traces back to the intelligence-community estimative lexicon (likely, cannot rule out, low-moderate-high confidence).
+
+Rendered prompts pick the rule up on the next wrapper build; `omitRules = [ "calibratedClaims" ]` drops it.


### PR DESCRIPTION
Closes #3684.

Adds one rule, `calibratedClaims` (topic `writing`), rendered right after `faithfulReporting`:

> Word each claim at the strength of its evidence, the way a system card does: "passed 40 of 41" over "works", "did not reproduce in 20 runs" over "impossible". An absolute ("always", "never", "guaranteed") is a measurement report, not emphasis. Without the measurement, speak the estimative ladder (unlikely, roughly even, likely, almost certainly; "cannot rule out" for severe tails) and name what was checked. Disclose the regression next to the win.

The estimative vocabulary lives in the rendered `text`, since `reason` is metadata the agent never sees; the header comment now states that explicitly so future rules keep behavior out of `reason`.

Prior art searched per the request: the Claude Fable 5 system card writes in exactly this register ("extremely difficult (though not impossible)", "a much less clear judgement than for previous models", safety regressions disclosed beside headline results), and behind it the IC estimative lexicon (ICD 203). Both cited in the rule's `reason`.

Also rewords `forceMerge`, whose absolute misstated policy (a standing 2026-07-17 grant covers `--admin` on infra-stalled checks): the rule now states the condition, "takes an explicit human grant, and only for an infra-stalled check, never a failing one; verify main afterward."

Verified: rendered via the documented `nix eval --impure` recipe and reread; `nix run .#lint` green locally. Not yet verified: full flake check (CI).

Site page: `packages/site/src/lib/updates/prompt-calibrated-claims.svx`

(sent by an AI agent via Claude Code, Claude Opus 4.5)



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `calibratedClaims` prompt rule requiring evidence-calibrated wording
> - Adds a new `calibratedClaims` rule in [rules.nix](https://github.com/indexable-inc/index/pull/3686/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) under the `writing` topic, instructing the agent to word claims at the strength of evidence, avoid unmeasured absolutes, use an estimative ladder (unlikely/roughly even/likely/almost certainly), name what was checked, and disclose regressions alongside wins.
> - Updates the `forceMerge` rule to restrict bypassing checks to cases with an explicit human grant for infra-stalled (not failing) checks, and to verify `main` afterward; otherwise instructs to fix or wait.
> - Adds a site update post in [prompt-calibrated-claims.svx](https://github.com/indexable-inc/index/pull/3686/files#diff-397a7515b0967ce3ebf02f548e74a2da3dd605a179ddc9e5556b0bcd71f595d1) announcing the new rule.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 792a2d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->