### PR TITLE
hm: stop wasting 2.5s in activation steps

### DIFF
--- a/packages/site/src/lib/updates/activation-step-speedups.svx
+++ b/packages/site/src/lib/updates/activation-step-speedups.svx
@@ -1,0 +1,13 @@
+---
+id: activation-step-speedups
+postedAt: 2026-07-19T14:00:00-07:00
+title: "Two activation steps stop wasting 2.5 seconds"
+tags: [home-manager, nix, performance]
+links:
+  - label: issue
+    href: https://github.com/indexable-inc/index/issues/3687
+---
+
+The new per-step activation timings immediately paid for themselves. `clearBlockedCookies` spent 2 of its 2.1 seconds inside Python's import machinery: the step runs a bare `.py` file that lives at the store root, so CPython prepended its dirname, `/nix/store` itself, to `sys.path`, and every stdlib import miss re-listed the entire store. The actual cookie work costs 30 milliseconds. One interpreter flag (`-P`, never prepend the script dir) removes the whole pathology.
+
+`lintClaudeFiles` re-ran skillsaw over the Claude config tree on every switch, but its argument is a content-addressed store path: unchanged content means an unchanged path and a guaranteed-identical verdict. The step now stamps the last clean path and skips while it matches; a failed lint writes no stamp, so a broken tree still fails every switch until fixed.

--- a/users/andrewgazelka/profiles/darwin-home.nix
+++ b/users/andrewgazelka/profiles/darwin-home.nix
@@ -165,16 +165,24 @@ in {
   # structure, context budget, weak language, and cross-file consistency; uvx
   # fetches it from PyPI on first use and caches it, so later runs are offline.
   # It lints the exact tracked source that the generation will deploy.
+  # The lint target is a content-addressed store path, so an unchanged path
+  # is a guaranteed-identical verdict: stamp the last clean path and skip the
+  # ~0.5s uvx run while it matches. A failed lint writes no stamp, so a
+  # broken tree keeps failing every switch. See index#3687.
   home.activation.lintClaudeFiles = config.lib.dag.entryBefore ["writeBoundary"] ''
-    if [ -d ${configRoot + "/claude/global"} ]; then
+    _lintTarget=${configRoot + "/claude/global"}
+    _lintStamp="''${XDG_CACHE_HOME:-$HOME/.cache}/skillsaw-lint.stamp"
+    if [ -d "$_lintTarget" ] && [ "$(cat "$_lintStamp" 2>/dev/null)" != "$_lintTarget" ]; then
       echo "Linting Claude skills, commands, and agents…"
       ${pkgs.uv}/bin/uvx --quiet skillsaw lint \
         --type dot-claude \
-        ${configRoot + "/claude/global"} || {
+        "$_lintTarget" || {
           echo "✗ skillsaw lint failed — aborting home-manager switch" >&2
           echo "  Fix users/andrewgazelka/config/claude/global in index." >&2
           exit 1
         }
+      mkdir -p "$(dirname "$_lintStamp")"
+      printf '%s' "$_lintTarget" > "$_lintStamp"
     fi
   '';
 

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -85,7 +85,11 @@
   # blocked. See scripts/clear-blocked-cookies.py.
   clearBlockedCookies = ix.writeBashApplication pkgs {
     name = "clear-blocked-cookies";
-    text = ''exec ${pkgs.python3.interpreter} ${configRoot + "/scripts/clear-blocked-cookies.py"} "$@"'';
+    # -P: the script is a bare .py at the store root, so without it CPython
+    # prepends its dirname -- /nix/store itself -- to sys.path, and every
+    # stdlib import miss relists the whole store (~3s of a 3.2s run went to
+    # posix.listdir; the cookie work is ~0.03s). See index#3687.
+    text = ''exec ${pkgs.python3.interpreter} -P ${configRoot + "/scripts/clear-blocked-cookies.py"} "$@"'';
   };
 
   # Override fish to skip failing tests


### PR DESCRIPTION
Closes #3687. The per-step timings (#3673) found two of our own steps burning ~2.5s of an 8.3s activation; both fixes verified live on hydra by running the built activation twice (first run writes the lint stamp):

| step | before | after |
|---|---|---|
| clearBlockedCookies | 2.06s | 0.07s |
| lintClaudeFiles | 0.46s | skipped (stamp hit) |
| activation total | 8.35s | 5.57s |

**clearBlockedCookies**: the step runs a bare `.py` at the store root, so CPython prepends its dirname -- `/nix/store` itself -- to `sys.path`; cProfile showed 3.015s of 3.201s in `posix.listdir` re-listing the store on stdlib import misses. `-P` (never prepend script dir) removes the pathology; the cookie work itself is ~0.03s.

**lintClaudeFiles**: the lint argument is a content-addressed store path, so an unchanged path is a guaranteed-identical verdict. Stamp the last clean path, skip while it matches; a failed lint writes no stamp, so a broken tree keeps failing the switch.

Remaining activation cost is home-manager core (linkGeneration 3.42s, checkLinkTargets 1.18s), out of scope here.

(sent by an AI agent via Claude Code, Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache `lintClaudeFiles` activation step to skip redundant linting
> - Adds stamp-file caching to the `lintClaudeFiles` home-manager activation step in [darwin-home.nix](https://github.com/indexable-inc/index/pull/3688/files#diff-7b4b5d284711ad1f33b0b8435434d62bae77f9441d69ae1563fb02b61e408671): the lint only runs when the Claude config path has changed since the last successful run, saving ~2.5s on each `darwin-rebuild switch`.
> - The stamp is written only after a successful lint; failures still abort the switch without updating the stamp.
> - Adds a changelog entry in [activation-step-speedups.svx](https://github.com/indexable-inc/index/pull/3688/files#diff-09160b2eb0f110e4b683a62e8ecd5727ed2d2d7fb6bd2fec006e3567825924f6) describing the change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db619f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->