### PR TITLE
skills: visual-explainers goes board-first and static-first

### DIFF
--- a/packages/agent/skills/visual-explainers/SKILL.md
+++ b/packages/agent/skills/visual-explainers/SKILL.md
@@ -1,51 +1,72 @@
 ---
 name: visual-explainers
-description: "Build interactive visual explanations: single-file HTML explorables, system diagrams, and data charts where the reader learns by doing. Use whenever asked to visualize something, explain a system or mechanism visually, build an interactive or explorable explainer, diagram a pipeline or protocol, or chart data. Encodes the house philosophy: the visualization is the explanation, no decorative animation, progressive disclosure, one accent color, a single self-contained HTML file in vanilla JS."
+description: "Build visual explanations: live boards in the test-ide fleet dashboard (default) or single-file HTML explorables (fallback), plus system diagrams and data charts. Use whenever asked to visualize something, explain a system or mechanism visually, build an explainer, diagram a pipeline or protocol, or chart data. Encodes the house philosophy: static-first (the lesson is visible on load with zero clicks), boards reuse the dashboard's component catalog and theme tokens, interaction only for navigation or minute-plus disclosures, one accent color, no decorative animation."
 ---
 
 ## Visual explainers
 
-Make rich, simple, beautiful visualizations. The goal is that the reader walks
-away with a deep understanding of the system, gained by interacting with it,
-explained in plain words. Everything below serves that.
+Make rich, simple, beautiful visualizations. The reader should walk away
+with a deep understanding of the system after about thirty seconds of
+looking, explained in plain words. Everything below serves that.
 
-## The visualization is the explanation
+## Where they live
 
-The reader learns by doing (edit, click, toggle, drag), not by watching. If the
-page would teach the same thing as a static screenshot of itself, it is a
-diagram with extra steps; add the interaction that makes the reader's action
-the lesson.
+Default target is the fleet dashboard repo (test-ide) at `~/Projects/test`,
+its standard location on every machine (home-relative, so the same recipe
+works for any user). Write `canvas/boards/<your-session-id>/main.svelte`;
+the running app renders it live on this run's detail page and hot-swaps
+every save in.
 
-Every moving pixel must satisfy one of two tests: the reader caused it, or it
-encodes causality in the system being explained (pipeline stages lighting in
-the order they actually fire after the reader hits save). Delete everything
-else: entrance transitions, pulse loops, parallax, hover shimmer, animated
-gradients. No animation for animation's sake.
+Reuse before building. The board catalog (`$lib/components/board`) already
+has `CodeFile` (editor-style file pane), `DiffView` (IntelliJ-style
+side-by-side diff with center gutter bands; it computes the diff itself),
+`FileIcon` (vscode-icons), `Terminal` (starship-style shell replay), and the
+status primitives. Style only with the app's theme tokens (`bg-primary`,
+`border-border`, `text-muted-foreground`, ...); raw palette classes read as
+foreign in the shell. That repo's CLAUDE.md governs the design language.
+Promote any piece another board could reuse into the catalog instead of
+copying it.
 
-## Progressive disclosure
+Fall back to a single self-contained HTML file (inline CSS and JS, vanilla,
+opens from file:// with the network off) only when the dashboard repo is
+unavailable.
 
-Overview first. One idea per view. Details on demand: clicking a node, stage,
-or mark reveals its explanation in place, next to the thing it explains. Never
-dump all annotations at once; a page where every label is visible up front has
-already spent the reader's attention before they act.
+## Static-first: the lesson is visible on load
 
-Include a counterexample or contrast when it deepens understanding: show the
-world without the mechanism. A "full reload" button next to an HMR pipeline
-demonstrates exactly the state loss HMR prevents, and teaches more than a
-paragraph saying so.
+The full point must land with zero clicks: the diff, the mechanism, the
+real numbers, all on screen at once, with attention doing the layering --
+expected things faded, the surprise at full contrast. If the reader has to
+press a button to see the change, the page has hidden its own lesson, and
+they will not press it.
+
+Interaction earns its place in exactly two roles:
+
+- navigation between real artifacts (selecting a file in an explorer);
+- disclosing depth that would take over a minute to read inline (a drill,
+  a [why?] expander).
+
+Never for the core claim, never as ceremony. Every moving pixel must satisfy
+one of two tests: the reader caused it, or it encodes causality in the
+system being explained. Delete everything else: entrance transitions, pulse
+loops, parallax, hover shimmer, animated gradients.
+
+A counterexample deepens understanding: show the world without the
+mechanism as a short faded contrast block, not a second interactive mode.
 
 ## Deep but simple
 
-Plain words, short sentences. Use real payloads, real file contents, and real
-values from the actual system under discussion, never lorem ipsum or `foo`.
-The test of success is prediction, not recall: after using the page, the
-reader should be able to say what the system would do in a case the page never
-showed.
+Plain words, short sentences. Use real payloads, real file contents, real
+commit hashes and line numbers from the actual system under discussion,
+never lorem ipsum or `foo`. Show changed code as highlighted code -- diff
+gutters, added-line tint -- not as abstract cards or entity lists. The test
+of success is prediction, not recall: after the page, the reader can say
+what the system would do in a case the page never showed.
 
 ## Visual system
 
 - Dark-friendly. One accent color, plus at most one or two semantic colors
-  (error red, success green) used only for their meaning.
+  (error red, success green, VCS blue for modified) used only for their
+  meaning.
 - Generous whitespace. Monospace for code and data tokens.
 - No chart junk, no gradients as decoration, no drop shadows doing nothing.
 - No edge bars: the colored stripe down the left border of a card, callout,
@@ -53,19 +74,12 @@ showed.
   dashboard and readers discount the page on sight. Separate and emphasize
   blocks with whitespace and type, never a bar.
 
-## Form
-
-Default to a single self-contained HTML file the user can open locally: inline
-CSS and JS, no build step, no CDN fetches. Vanilla JS unless the task genuinely
-demands more. State lives in a few plain variables; a render function reflects
-it. This keeps the artifact portable, diffable, and editable by the reader.
-
 ## Data charts
 
 When the task is an actual data chart rather than a system explainer:
 
-- Honest axes: bar charts start at zero; never truncate an axis to manufacture
-  drama; label units.
+- Honest axes: bar charts start at zero; never truncate an axis to
+  manufacture drama; label units.
 - Direct labeling over legends: put the series name at the end of its line.
 - Accessible contrast for every mark and label, in dark and light.
 - Interaction still earns its place: a tooltip that shows the exact value, a
@@ -74,31 +88,35 @@ When the task is an actual data chart rather than a system explainer:
 ## Time
 
 - Render timestamps in the reader's local timezone, and check what that is
-  before writing any time into copy (`date +%Z` on the host, or better: keep
-  the machine ISO-8601 instant in the data and let the page format it with
-  `Intl.DateTimeFormat`, which is right for every reader). Hardcoded `13:45Z`
-  in prose makes the reader do arithmetic; that is the page's job.
-- Prefer human forms everywhere: "4h ago", "38m elapsed", "eta 5:10-5:25 pm",
-  a counter ticking from a real start instant. Machine timestamps belong in
-  the data layer, human time in the rendered layer.
+  before writing any time into copy (`date +%Z` on the host, or better:
+  keep the machine ISO-8601 instant in the data and let the page format it
+  with `Intl.DateTimeFormat`, which is right for every reader). Hardcoded
+  `13:45Z` in prose makes the reader do arithmetic; that is the page's job.
+- Prefer human forms everywhere: "4h ago", "38m elapsed", "eta 5:10-5:25
+  pm". Machine timestamps belong in the data layer, human time in the
+  rendered layer.
 - Label the zone whenever the page states an absolute clock time, since the
   artifact may be read later or from somewhere else.
 
 ## Worked example: the target shape
 
-"How Svelte HMR works": the reader edits a fake `Button.svelte` in a textarea,
-clicks the rendered counter a few times to build up state, then hits save. The
-pipeline stages (watcher, compile, patch, re-render) light in causal order,
-each clickable for an in-place explanation of what it just did, and the counter
-keeps its value. A "full reload" button beside it wipes the counter,
-demonstrating the state loss HMR exists to prevent. Every element of that page
-follows a rule above: interaction builds the state the lesson needs, motion
-encodes causal order, disclosure is per-stage on click, and the contrast
-button is the counterexample.
+"How sparse flake locks work": an explorer column where the three modified
+files render VCS-blue with an M badge, a DiffView already open on
+flake.lock showing the exact 18 added lines at their real line numbers with
+gutter bands mapping the splice across, a Terminal replaying the three real
+commands with the key output line in green, and one faded paragraph of
+contrast: what the same bump cost before the mechanism (a failed build, a
+72-line relock). Zero required clicks; picking a different file is the only
+interaction, and everything it reveals is another real artifact.
 
 ## Before shipping
 
-- Remove any motion the reader did not cause and the system does not explain.
-- Confirm the page opens from `file://` with the network disabled.
+- The lesson lands with zero clicks; nothing core hides behind interaction.
+- Remove any motion the reader did not cause and the system does not
+  explain.
 - Read every annotation: is anything visible before the reader needs it?
-- Replace any placeholder data that survived with values from the real system.
+- Replace any placeholder data that survived with values from the real
+  system.
+- Boards: `npm run check` in the dashboard repo passes, and
+  `GET /canvas/errors` is clean after the save. HTML fallback: the page
+  opens from `file://` with the network disabled.


### PR DESCRIPTION
Feedback from live use today (the sparse-locks explainer session): the explainer gated its lesson behind buttons, hand-rolled styling that clashed with the dashboard, and lived in a throwaway /tmp HTML file.

Skill changes:
- Boards in test-ide at ~/Projects/test are the default target (standard home-relative location, works across users); single-file HTML demoted to fallback.
- Static-first doctrine: the lesson must be visible with zero clicks; interaction only for navigation between real artifacts or disclosures that exceed about a minute of reading.
- Reuse mandate: board catalog components (CodeFile, DiffView, FileIcon, Terminal) and theme tokens; counterexamples as faded static contrast, not a second interactive mode.
- Worked example replaced with the sparse-locks board shape.

(sent by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rewrite visual-explainers skill to be board-first and static-first
> Updates [SKILL.md](https://github.com/indexable-inc/index/pull/3695/files#diff-3d254f5916b3278718cc3b1cf320884ea598a3df730e4fe4c28c11a03ba7cd56) to make fleet dashboard live boards the default output and single-file HTML a fallback, replacing the prior single-file-first approach.
>
> - Static-first replaces progressive disclosure as the core design rule: the lesson must be fully visible on load, with interaction limited to navigation and disclosures taking over a minute to read
> - Adds a 'Where they live' section covering board path conventions, hot-reload behavior, and guidance to reuse components and theme tokens from the board catalog
> - Updates the worked example from a Svelte HMR explorable to a sparse flake locks board with explorer, DiffView, and Terminal replay
> - Updates the 'Before shipping' checklist to require `npm run check` and a clean `GET /canvas/errors` state; HTML offline requirement is now fallback-only
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1b27ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->