### PR TITLE
ci: watchdog covers both cache workflows with lane-correct ceilings (#3693)

### DIFF
--- a/.github/workflows/cache-push-watchdog.yml
+++ b/.github/workflows/cache-push-watchdog.yml
@@ -1,12 +1,25 @@
 name: Cache push watchdog
 
-# cache-push publishes packages to cache.ix.dev and advances `cache-ready`, the
-# ref darwin consumers pin (RFC 0009, #1862). On 2026-07-06 (#1968) the pin
-# froze for 13+ hours with no alert. The corrected root cause (see #1968):
+# The cache publish pipeline is two workflows since the 2026-07-19 darwin
+# split (#3672): cache-push.yml realises the x86_64-linux roots (including
+# the Linux->Darwin cross closure) and advances `cache-ready`, the pin every
+# fleet consumer tracks (RFC 0009, #1862); cache-push-darwin.yml realises the
+# native aarch64-darwin roots on a hosted mac, under its own concurrency
+# group, and advances `cache-ready-darwin` for dev macs. This watchdog sweeps
+# BOTH lanes from one cron via the job matrix below, parameterized over
+# (workflow file, pin ref, max run age) with each lane's ceiling derived from
+# that workflow's own job timeouts (#3693). If #3587 deletes the darwin lane
+# once every root cross-builds, its matrix row goes with it.
+#
+# Origin: on 2026-07-06 (#1968) the pin froze for 13+ hours with no alert.
+# The corrected root cause (see #1968), from when both lanes still shared one
+# workflow and one `cache-push` concurrency group:
 #
 #   - The darwin lane ran multi-hour (pre-#1966 ENOSPC thrash; one run's
-#     darwin-build hit its 240-min job timeout exactly), so each acquired run
-#     held the `cache-push` concurrency group for hours.
+#     darwin-build hit its then-240-min job timeout exactly), so each
+#     acquired run held the shared group for hours. The split (#3672) removed
+#     that cross-lane starvation by construction, but each lane can still
+#     wedge itself the same way inside its own group.
 #   - GitHub keeps at most ONE pending run per concurrency group: every new
 #     push supersedes and auto-cancels the previously pending run (documented
 #     behavior; `cancel-in-progress: false` only protects the RUNNING run).
@@ -18,33 +31,39 @@ name: Cache push watchdog
 #
 # Nothing in that chain fails loudly on its own: supersede-cancels are not
 # failures, and a pin that silently stops moving looks like success. This
-# watchdog is the out-of-band detector, on a short cron, with three signals:
+# watchdog is the out-of-band detector, on a short cron, with three signals
+# evaluated per lane:
 #
-#   1. ZOMBIE HOLDER: a cache-push run active longer than the sum of its
-#      job timeouts. Job-level `timeout-minutes` does not cover queue wait
-#      (a job stuck "waiting for a runner" waits forever, e.g. dispatcher
-#      outage), so a run can hold the concurrency group indefinitely with a
-#      queued-but-never-assigned job. Cancel + redispatch.
+#   1. ZOMBIE HOLDER: a run active longer than the sum of that workflow's
+#      job timeouts (per-lane ceiling, see the matrix). Job-level
+#      `timeout-minutes` does not cover queue wait (a job stuck "waiting for
+#      a runner" waits forever, e.g. dispatcher outage), so a run can hold a
+#      concurrency group indefinitely with a queued-but-never-assigned job.
+#      Cancel + redispatch.
 #   2. MATERIALIZATION STALL: a run pending with zero jobs past a grace
 #      window while NO other run holds the group. Zero jobs behind a holder
 #      is normal concurrency queuing and is deliberately NOT flagged; with no
 #      holder it means GitHub never scheduled the run. Cancel + redispatch.
-#   3. PIN DRIFT: cache-ready far behind main while no cache-push run is
-#      active at all (the pipeline gave up rather than being busy). Alert +
-#      one self-heal dispatch, deduped against recent heals so a slow lane
-#      cannot trigger a dispatch storm.
+#   3. PIN DRIFT: the lane's pin ref far behind main while no run of that
+#      lane's workflow is active at all (the pipeline gave up rather than
+#      being busy). Alert + one self-heal dispatch, deduped against recent
+#      heals so a slow lane cannot trigger a dispatch storm. A pin ref that
+#      does not exist is reported and skipped: `cache-ready-darwin` has never
+#      been created (as of #3693), so until the first darwin publish lands
+#      there is nothing to compare.
 #
-# Every wedge files/updates one tracking issue AND fails this job (red in the
-# Actions tab); a clean check closes the issue with a resolution comment. A
-# watchdog-internal failure (rate limit, auth) exits loudly WITHOUT claiming
-# health or closing the issue. There is no success-only path. Alerts use the
-# find-or-update tracking-issue channel (as cve-scan.yml / blast-radius.yml);
-# this repo has no Slack webhook secret.
+# Every wedge files/updates one tracking issue PER LANE (the linux lane stays
+# on the pre-split issue thread) AND fails that lane's matrix job (red in the
+# Actions tab); a clean check closes that lane's issue with a resolution
+# comment. A watchdog-internal failure (rate limit, auth) exits loudly
+# WITHOUT claiming health or closing the issue. There is no success-only
+# path. Alerts use the find-or-update tracking-issue channel (as cve-scan.yml
+# / blast-radius.yml); this repo has no Slack webhook secret.
 #
-# "Ran green" vs "published every root": since #3195 those coincide. A
-# cache-push run whose lanes recorded failed realise roots concludes failure
-# (advance-cache-ready refuses the pin move), so chronic root failures show
-# as red runs plus pin drift (signal 3), never as silent green.
+# "Ran green" vs "published every root": since #3195 those coincide, in both
+# lanes. A run whose realise phase recorded failed roots concludes failure
+# (the pin-advance job refuses the move), so chronic root failures show as
+# red runs plus pin drift (signal 3), never as silent green.
 
 on:
   schedule:
@@ -58,10 +77,10 @@ on:
         type: boolean
         default: false
 
-# Read runs/jobs, cancel + redispatch cache-push, and maintain the tracking
-# issue. `actions: write` covers both `gh run cancel` and `gh workflow run`
-# (workflow_dispatch); issue writes do not need a PAT (unlike PR creation,
-# which the enterprise blocks for GITHUB_TOKEN).
+# Read runs/jobs, cancel + redispatch the cache workflows, and maintain the
+# tracking issues. `actions: write` covers both `gh run cancel` and
+# `gh workflow run` (workflow_dispatch); issue writes do not need a PAT
+# (unlike PR creation, which the enterprise blocks for GITHUB_TOKEN).
 permissions:
   contents: read
   actions: write
@@ -78,33 +97,61 @@ concurrency:
 
 jobs:
   watch:
+    name: watch (${{ matrix.workflow }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      # A wedged lane must not cancel the sweep of the healthy one.
+      fail-fast: false
+      matrix:
+        # One row per publish lane: (workflow file, pin ref, signal-1
+        # ceiling, tracking-issue marker). The ceiling is the sum of that
+        # workflow's serial job timeouts plus 30 min slack -- the same
+        # construction as the pre-split 520 (push 180 + darwin-build 240 +
+        # darwin-push 60 + advance-cache-ready 10, + 30), now per lane, so
+        # linux zombie detection no longer waits out a darwin-sized budget.
+        include:
+          - workflow: cache-push.yml
+            pin_ref: cache-ready
+            # push 150 + advance-cache-ready 10, + 30 slack.
+            max_run_age_min: "190"
+            # The pre-split marker, verbatim: keeps this lane on the
+            # tracking-issue thread the watchdog has always used (#2551).
+            marker: cache-push-watchdog-tracking
+          - workflow: cache-push-darwin.yml
+            pin_ref: cache-ready-darwin
+            # darwin-build 330 + darwin-push 60, + 30 slack.
+            max_run_age_min: "420"
+            marker: cache-push-watchdog-tracking-darwin
     env:
       GH_TOKEN: ${{ github.token }}
       REPOSITORY: ${{ github.repository }}
-      # Signal 1: sum of cache-push's serial job timeouts (push 180 + darwin
-      # relay chain) plus slack. Anything older is a zombie holding the group.
-      MAX_RUN_AGE_MIN: "520"
-      # Signal 2: a healthy dispatch takes ~1 min (the fleet dispatcher's
-      # recovery loop polls every ~66s); 20 min is far past any normal wait.
+      WORKFLOW_FILE: ${{ matrix.workflow }}
+      PIN_REF: ${{ matrix.pin_ref }}
+      MARKER: ${{ matrix.marker }}
+      # Signal 1 ceiling; derived per lane in the matrix above.
+      MAX_RUN_AGE_MIN: ${{ matrix.max_run_age_min }}
+      # Signal 2: a healthy run materializes jobs in ~1 min (the fleet
+      # dispatcher's recovery loop polls every ~66s; GitHub-hosted lanes
+      # materialize immediately); 20 min is far past any normal wait.
       STALL_GRACE_MIN: "20"
-      # Signal 3: merge traffic peaks at ~6 commits/hour and a cold darwin
-      # lane holds the group 1-3h, so a healthy-but-busy pipeline routinely
-      # sits 10-20 commits behind. 25 with the no-active-run gate below means
-      # "far behind AND nothing even trying".
+      # Signal 3: merge traffic peaks at ~6 commits/hour and one run holds
+      # its group for a whole pass (worst observed: 138 min linux, 2-3 h
+      # darwin), so a healthy-but-busy lane routinely sits 10-20 commits
+      # behind. 25 with the no-active-run gate below means "far behind AND
+      # nothing even trying".
       DRIFT_MAX_COMMITS: "25"
       # Signal 3 dispatch dedup: do not stack a second heal while one
       # dispatched inside this window may still be queued behind the group.
       HEAL_COOLDOWN_MIN: "90"
       DRY_RUN: ${{ inputs.dry_run && '1' || '' }}
     steps:
-      - name: Detect and heal cache-push wedges
+      - name: Detect and heal publish-lane wedges
         run: |
           set -euo pipefail
 
-          issue_marker="<!-- cache-push-watchdog-tracking -->"
-          issue_title="cache-push watchdog: publish pipeline wedged"
+          issue_marker="<!-- ${MARKER} -->"
+          issue_title="cache-push watchdog: ${WORKFLOW_FILE} pipeline wedged"
           now_epoch="$(date -u +%s)"
 
           note() { echo "::notice::watchdog: $*"; }
@@ -117,12 +164,13 @@ jobs:
           healed=""    # set once a redispatch happened this tick
 
           dispatch_heal() {
-            # full_pass heals holes left by cancelled/partial pushes.
-            if gh workflow run cache-push.yml --repo "${REPOSITORY}" --ref main -f full_pass=true; then
-              add_finding "- **Self-heal**: dispatched a fresh \`cache-push\` (full_pass) on main."
+            # full_pass heals holes left by cancelled/partial pushes; both
+            # lane workflows expose the same workflow_dispatch input.
+            if gh workflow run "${WORKFLOW_FILE}" --repo "${REPOSITORY}" --ref main -f full_pass=true; then
+              add_finding "- **Self-heal**: dispatched a fresh \`${WORKFLOW_FILE}\` (full_pass) on main."
               healed=1
             else
-              echo "::error::watchdog failed to redispatch cache-push"
+              echo "::error::watchdog failed to redispatch ${WORKFLOW_FILE}"
             fi
           }
 
@@ -131,9 +179,9 @@ jobs:
           # API outage into an empty array and a false "healthy".
           runs_file=/tmp/active-runs.tsv
           # shellcheck disable=SC2016  # \(...) is jq string interpolation, not shell
-          gh api "repos/${REPOSITORY}/actions/workflows/cache-push.yml/runs?per_page=20" \
+          gh api "repos/${REPOSITORY}/actions/workflows/${WORKFLOW_FILE}/runs?per_page=20" \
             --jq '.workflow_runs[] | select((.status=="queued" or .status=="in_progress" or .status=="pending") and .head_branch=="main") | "\(.id)\t\(.created_at)\t\(.event)"' \
-            > "$runs_file" || fail_loud "listing cache-push runs failed"
+            > "$runs_file" || fail_loud "listing ${WORKFLOW_FILE} runs failed"
 
           # One pass over the active runs: age + job count for each, and
           # whether any run actually holds the concurrency group (has jobs).
@@ -152,7 +200,7 @@ jobs:
           # --- Signal 1: zombie holder ----------------------------------------
           while IFS=$'\t' read -r id age_min njobs event; do
             if [ "$age_min" -ge "${MAX_RUN_AGE_MIN}" ]; then
-              echo "::error::run ${id} active for ${age_min} min (>= ${MAX_RUN_AGE_MIN}): exceeds the sum of cache-push job timeouts; a queued-but-never-assigned job holds the group with no timeout (#1968)"
+              echo "::error::run ${id} active for ${age_min} min (>= ${MAX_RUN_AGE_MIN}): exceeds the sum of ${WORKFLOW_FILE} job timeouts; a queued-but-never-assigned job holds the group with no timeout (#1968)"
               add_finding "- **Zombie run**: [${id}](https://github.com/${REPOSITORY}/actions/runs/${id}) active ${age_min} min with ${njobs} job(s)."
               if [ -z "${DRY_RUN}" ]; then
                 gh run cancel "${id}" --repo "${REPOSITORY}" || echo "::warning::could not cancel ${id} (may have just completed)"
@@ -185,32 +233,32 @@ jobs:
           main_sha="$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')" \
             || fail_loud "reading main ref failed"
           ready_sha=""
-          if ! ready_sha="$(gh api "repos/${REPOSITORY}/git/ref/heads/cache-ready" --jq '.object.sha')"; then
-            note "cache-ready ref does not exist yet; nothing to compare"
+          if ! ready_sha="$(gh api "repos/${REPOSITORY}/git/ref/heads/${PIN_REF}" --jq '.object.sha')"; then
+            note "${PIN_REF} ref does not exist yet; nothing to compare"
           fi
           if [ -n "$ready_sha" ]; then
             cmp_file=/tmp/compare.json
             gh api "repos/${REPOSITORY}/compare/${ready_sha}...${main_sha}" > "$cmp_file" \
-              || fail_loud "comparing cache-ready to main failed"
+              || fail_loud "comparing ${PIN_REF} to main failed"
             behind="$(jq -r '.ahead_by' "$cmp_file")"
             cmp_status="$(jq -r '.status' "$cmp_file")"
-            note "cache-ready is ${behind} commit(s) behind main (ready=${ready_sha:0:8}, main=${main_sha:0:8}, status=${cmp_status})"
-            # ahead/identical are the only healthy shapes for base=cache-ready,
-            # head=main. diverged means cache-ready carries commits main does
+            note "${PIN_REF} is ${behind} commit(s) behind main (ready=${ready_sha:0:8}, main=${main_sha:0:8}, status=${cmp_status})"
+            # ahead/identical are the only healthy shapes for base=pin,
+            # head=main. diverged means the pin carries commits main does
             # not (a force-move past the fast-forward-only guard) -- alert,
             # never self-heal over it.
             if [ "$cmp_status" != "ahead" ] && [ "$cmp_status" != "identical" ]; then
-              echo "::error::cache-ready...main compare status is '${cmp_status}': the pin has diverged from main and needs operator attention"
-              add_finding "- **cache-ready diverged**: compare status \`${cmp_status}\` (\`${ready_sha:0:8}\` vs \`${main_sha:0:8}\`)."
+              echo "::error::${PIN_REF}...main compare status is '${cmp_status}': the pin has diverged from main and needs operator attention"
+              add_finding "- **${PIN_REF} diverged**: compare status \`${cmp_status}\` (\`${ready_sha:0:8}\` vs \`${main_sha:0:8}\`)."
             elif [ "${behind}" -ge "${DRIFT_MAX_COMMITS}" ]; then
               if [ -s "$runs_file" ]; then
                 # A run is queued or in progress: the pipeline is working on
                 # it, so the drift is backlog, not a wedge. Signals 1-2 above
                 # own the case where that run itself is stuck.
-                note "cache-ready is ${behind} behind but a cache-push run is active; not healing"
+                note "${PIN_REF} is ${behind} behind but a ${WORKFLOW_FILE} run is active; not healing"
               else
-                echo "::error::cache-ready is ${behind} commits behind main (>= ${DRIFT_MAX_COMMITS}) with NO cache-push run active: the pipeline gave up (#1862, #1968)"
-                add_finding "- **cache-ready drift**: ${behind} commits behind main (\`${ready_sha:0:8}\` vs \`${main_sha:0:8}\`) with no active run."
+                echo "::error::${PIN_REF} is ${behind} commits behind main (>= ${DRIFT_MAX_COMMITS}) with NO ${WORKFLOW_FILE} run active: the pipeline gave up (#1862, #1968)"
+                add_finding "- **${PIN_REF} drift**: ${behind} commits behind main (\`${ready_sha:0:8}\` vs \`${main_sha:0:8}\`) with no active run."
                 # Dedup: a heal dispatched recently may still be realising (a
                 # full pass runs long); do not stack another behind it. The
                 # cutoff is interpolated into the jq program because gh's
@@ -218,7 +266,7 @@ jobs:
                 # ISO timestamp, so no quoting hazard.
                 cutoff="$(date -u -d "@$(( now_epoch - HEAL_COOLDOWN_MIN * 60 ))" +%Y-%m-%dT%H:%M:%SZ)"
                 recent_heal="$(gh api \
-                  "repos/${REPOSITORY}/actions/workflows/cache-push.yml/runs?event=workflow_dispatch&per_page=5" \
+                  "repos/${REPOSITORY}/actions/workflows/${WORKFLOW_FILE}/runs?event=workflow_dispatch&per_page=5" \
                   --jq "[.workflow_runs[] | select(.created_at > \"${cutoff}\")] | length")" \
                   || fail_loud "listing recent heal dispatches failed"
                 if [ -z "${DRY_RUN}" ] && [ -z "$healed" ] && [ "$recent_heal" -eq 0 ]; then
@@ -230,13 +278,18 @@ jobs:
             fi
           fi
 
-          # --- Maintain the tracking issue ------------------------------------
+          # --- Maintain the tracking issue (one per lane) ----------------------
           # --state all so a closed issue is reopened instead of minting a new
-          # one per wedge/heal cycle (C3 in the #1969 review).
+          # one per wedge/heal cycle (C3 in the #1969 review). GitHub search
+          # tokenizes on punctuation, so a phrase query cannot tell the darwin
+          # marker from the linux one (whose tokens are its prefix): search the
+          # shared stem, then match the exact lane marker over the candidate
+          # bodies locally.
           issue_json=/tmp/issue.json
-          gh issue list --repo "${REPOSITORY}" --state all \
-              --search "in:body \"${issue_marker}\"" \
-              --json number,state --jq '.[0] // empty' > "$issue_json" \
+          gh issue list --repo "${REPOSITORY}" --state all --limit 50 \
+              --search "in:body cache-push-watchdog-tracking" \
+              --json number,state,body \
+              --jq "[.[] | select(.body | contains(\"${issue_marker}\"))][0] // empty" > "$issue_json" \
             || fail_loud "searching for the tracking issue failed"
           number="$(jq -r '.number // empty' "$issue_json")"
           issue_state="$(jq -r '.state // empty' "$issue_json")"
@@ -244,15 +297,15 @@ jobs:
           if [ -n "${finding}" ]; then
             {
               echo "${issue_marker}"
-              echo "## cache-push watchdog detected a wedge"
+              echo "## cache-push watchdog detected a wedge in \`${WORKFLOW_FILE}\`"
               echo
-              echo "Last checked: \`$(date -u +'%Y-%m-%dT%H:%M:%SZ')\` by run [${GITHUB_RUN_ID}](https://github.com/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID})."
+              echo "Pin ref: \`${PIN_REF}\`. Last checked: \`$(date -u +'%Y-%m-%dT%H:%M:%SZ')\` by run [${GITHUB_RUN_ID}](https://github.com/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID})."
               echo
               echo "${finding}"
               echo
-              echo "The watchdog cancels wedged runs and redispatches automatically. If this issue keeps reopening, the underlying failure is recurring faster than the self-heal; see #1968 for the failure taxonomy."
+              echo "The watchdog cancels wedged runs and redispatches automatically. If this issue keeps reopening, the underlying failure is recurring faster than the self-heal; see #1968 for the failure taxonomy and #3672 for the lane split."
               echo
-              echo "_Filed by cache-push-watchdog.yml. Made with Claude Opus 4.8._"
+              echo "_Filed by cache-push-watchdog.yml. Made with Claude Fable 5._"
             } > /tmp/watchdog-issue.md
             if [ -n "${DRY_RUN}" ]; then
               note "DRY_RUN: would file/update tracking issue with findings"
@@ -272,10 +325,10 @@ jobs:
             # not only in the issue. The self-heal already ran above.
             exit 1
           else
-            note "cache-push pipeline healthy"
+            note "${WORKFLOW_FILE} pipeline healthy"
             if [ -z "${DRY_RUN}" ] && [ -n "${number}" ] && [ "${issue_state}" = "OPEN" ]; then
               gh issue comment "${number}" --repo "${REPOSITORY}" \
-                --body "Resolved: cache-push pipeline healthy at \`$(date -u +'%Y-%m-%dT%H:%M:%SZ')\` (run ${GITHUB_RUN_ID}). Closing."
+                --body "Resolved: ${WORKFLOW_FILE} pipeline healthy at \`$(date -u +'%Y-%m-%dT%H:%M:%SZ')\` (run ${GITHUB_RUN_ID}). Closing."
               gh issue close "${number}" --repo "${REPOSITORY}"
             fi
           fi

--- a/packages/site/src/lib/updates/watchdog-split-coverage.svx
+++ b/packages/site/src/lib/updates/watchdog-split-coverage.svx
@@ -1,0 +1,32 @@
+---
+id: watchdog-split-coverage
+postedAt: 2026-07-19T06:11:00-07:00
+title: "Cache watchdog covers both publish lanes, with lane-correct wedge ceilings"
+tags: [ci]
+links:
+  - label: "#3693: stale ceiling, unwatched darwin lane"
+    href: https://github.com/indexable-inc/index/issues/3693
+  - label: "PR #3672: the darwin split"
+    href: https://github.com/indexable-inc/index/pull/3672
+---
+
+A wedged linux cache push is now flagged after 190 minutes instead of 520,
+and the darwin publish lane is watched at all. `cache-push-watchdog.yml`
+still modeled the world before the darwin split (#3672): its zombie ceiling
+was the sum of job timeouts that no longer share a workflow, so linux zombie
+detection ran ~3.4x slower than the lane's real budget, and the darwin lane
+had no watchdog whatsoever -- no zombie detection, no stall detection, and no
+drift signal for `cache-ready-darwin`, a pin ref that has never been created
+and so could drift unboundedly without an alert.
+
+The watchdog's one cron now sweeps a two-row matrix of (workflow, pin ref,
+ceiling): `cache-push.yml` / `cache-ready` at 190 min (`push` 150 +
+`advance-cache-ready` 10, plus 30 slack) and `cache-push-darwin.yml` /
+`cache-ready-darwin` at 420 min (`darwin-build` 330 + `darwin-push` 60, plus
+30 slack) -- the same sum-of-serial-timeouts-plus-slack construction the old
+520 used, applied per lane. The three signals and the tracking-issue
+mechanics are unchanged, evaluated per lane: each lane files its own
+tracking issue naming the workflow that wedged (linux keeps the pre-split
+thread), and the missing `cache-ready-darwin` ref reports "does not exist
+yet; nothing to compare" until the first darwin publish creates it. When
+#3587 deletes the darwin lane, its matrix row goes with it.


### PR DESCRIPTION
Closes #3693.

`cache-push-watchdog.yml` still modeled the pre-#3672 single-workflow world: a 520-min zombie ceiling summing job timeouts that no longer share a workflow, and no coverage at all of `cache-push-darwin.yml` / `cache-ready-darwin`.

The watchdog's single cron now sweeps a two-row job matrix parameterized over (workflow file, pin ref, max run age):

| lane | pin ref | ceiling | derivation |
|---|---|---|---|
| `cache-push.yml` | `cache-ready` | 190 min | `push` 150 + `advance-cache-ready` 10, + 30 slack |
| `cache-push-darwin.yml` | `cache-ready-darwin` | 420 min | `darwin-build` 330 + `darwin-push` 60, + 30 slack |

Same sum-of-serial-timeouts-plus-slack construction as the old 520 (then: push 180 + darwin-build 240 + darwin-push 60 + advance 10, + 30), now per lane, so linux zombie detection no longer waits out a darwin-sized budget.

- The three signals and the tracking-issue mechanics are unchanged, evaluated per lane with `fail-fast: false` so one wedged lane cannot cancel the other's sweep.
- Each lane maintains its own tracking issue naming the workflow that wedged. The linux lane keeps the pre-split marker verbatim so it stays on the existing thread (#2551); the darwin lane gets `cache-push-watchdog-tracking-darwin`. GitHub search tokenizes on punctuation (the linux marker's tokens are a prefix of the darwin one's), so the query searches the shared stem and the exact marker is matched locally over candidate bodies.
- Signal 3 for `cache-ready-darwin` keeps the existing "does not exist yet; nothing to compare" notice path -- that ref has never been created.
- Both lane workflows expose the same `full_pass` dispatch input, so the self-heal dispatch parameterizes cleanly.
- Header failure-taxonomy references updated for the split world (#3672/#3586/#3587); the #1968 origin story stays, marked pre-split.

actionlint (with shellcheck) from the locked nixpkgs passes on all three workflows.

Site update: packages/site/src/lib/updates/watchdog-split-coverage.svx

Made with Claude Fable 5.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend cache-push watchdog to cover both Linux and Darwin publish lanes with lane-specific ceilings
> - Converts [cache-push-watchdog.yml](.github/workflows/cache-push-watchdog.yml) from a single job to a `strategy.matrix` with two rows: `cache-push.yml` (190-minute ceiling, `cache-ready` pin) and `cache-push-darwin.yml` (420-minute ceiling, `cache-ready-darwin` pin).
> - Each matrix job independently monitors stalls and drift, cancels zombie runs, redispatches the correct workflow, and files/updates a tracking issue keyed by a lane-specific marker.
> - Sets `fail-fast: false` so a wedged lane does not cancel the other lane's watchdog job.
> - Behavioral Change: Linux monitoring timeout drops from 520 to 190 minutes; Darwin lane is newly monitored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d98ad88.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->