### PR TITLE
ci: updater PRs run CI and land themselves (GitHub App identity) (#3692)

### DIFF
--- a/.github/workflows/update-cargo.yml
+++ b/.github/workflows/update-cargo.yml
@@ -83,15 +83,73 @@ jobs:
           # also normalizes the lockfile after the breaking edits above.
           cargo update
 
+      # PRs authored by the default GITHUB_TOKEN never trigger `pull_request`
+      # workflows on private repos, so the rolling bump PR gets no
+      # `flake-check` and can only land when a human re-authors it (#3692;
+      # the flake.lock bump #3021 sat 159 hours that way). Author the push
+      # and the merge as the ix-playbook-agent GitHub App instead (contents +
+      # pull-requests write, the same identity ix's updaters use) so CI runs
+      # on every bump. Until the PLAYBOOK_APP_CLIENT_ID variable and
+      # PLAYBOOK_APP_PRIVATE_KEY secret are configured, this is skipped and
+      # the workflow keeps today's GITHUB_TOKEN behavior: the PR opens but
+      # its CI stays silent.
+      - name: Mint PR token
+        id: app-token
+        if: ${{ vars.PLAYBOOK_APP_CLIENT_ID != '' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.PLAYBOOK_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PLAYBOOK_APP_PRIVATE_KEY }}
+
+      # The merge half of the loop (#3692): each tick first lands the bump a
+      # previous tick pushed, once CI proved it green. This runs before this
+      # tick's own push below, which would reset the PR's checks back to
+      # pending. The merge is an explicit API rebase (the only merge method
+      # main allows), not native auto-merge, and never a bypass: a PR that
+      # cannot merge on its own merits stays open. Merging with the app token
+      # also means the resulting push to main triggers the post-merge
+      # workflows, which a GITHUB_TOKEN merge would not.
+      - name: Merge the previous green bump
+        if: ${{ steps.app-token.outputs.token != '' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          BUMP_BRANCH: update-cargo
+        run: |
+          set -euo pipefail
+          number="$(gh pr list --repo "$REPOSITORY" --head "$BUMP_BRANCH" --base main \
+            --state open --json number --jq '.[0].number // empty')"
+          if [ -z "$number" ]; then
+            echo "no open rolling PR on ${BUMP_BRANCH}; nothing to merge"
+            exit 0
+          fi
+          state="$(gh pr view "$number" --repo "$REPOSITORY" \
+            --json mergeStateStatus --jq .mergeStateStatus)"
+          case "$state" in
+            # UNSTABLE is "required checks green, a non-required context red
+            # or pending"; bot-authored PRs always carry the skipped
+            # non-required `approve` context, so requiring CLEAN would never
+            # merge anything.
+            CLEAN | UNSTABLE)
+              gh pr merge --rebase --repo "$REPOSITORY" "$number"
+              echo "merged rolling PR #${number} (mergeStateStatus ${state})"
+              ;;
+            # BLOCKED: a required check (flake-check, closure-gate) is pending
+            # or red. DIRTY: merge conflict. UNKNOWN: GitHub is still
+            # computing. Each heals on a later tick after the push below
+            # refreshes the branch and its checks.
+            *)
+              echo "rolling PR #${number} not mergeable (mergeStateStatus ${state}); leaving it for a later tick"
+              ;;
+          esac
+
       # Opens (or updates) a single PR, and only when something changed:
       # create-pull-request no-ops on an empty diff. It reuses the
       # `update-cargo` branch so each run advances the same PR.
       #
-      # `token`: a PR opened with the default GITHUB_TOKEN does not trigger the
-      # `pull_request` workflows (`flake-check`), so branch protection would
-      # block the merge. Set an `AUTOBUMP_TOKEN` repo secret (a PAT or GitHub
-      # App token) to make the PR run CI; without it this falls back to
-      # GITHUB_TOKEN and a maintainer must re-trigger `flake-check`.
+      # `token`: the app token minted above, so the PR triggers `pull_request`
+      # CI (`flake-check`) and the next scheduled tick can merge it; the
+      # GITHUB_TOKEN fallback opens a PR whose CI never runs (#3692).
       # Notify the human behind a manual dispatch: review request + assignee +
       # body mention, all empty (a no-op) on the scheduled runs, which have no
       # triggering human.
@@ -102,7 +160,7 @@ jobs:
       - name: Open pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.AUTOBUMP_TOKEN || github.token }}
+          token: ${{ steps.app-token.outputs.token || github.token }}
           assignees: ${{ steps.trigger.outputs.user }}
           reviewers: ${{ steps.trigger.outputs.user }}
           base: main

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -20,7 +20,7 @@ on:
         type: string
         default: ""
       app-client-id:
-        description: "Client id of a GitHub App (contents + pull-requests write) that authors the bump PR; empty falls back to GITHUB_TOKEN, whose PRs never get pull_request CI on private repos."
+        description: "Client id of a GitHub App (contents + pull-requests write) that authors the bump PR; empty falls back to the PLAYBOOK_APP_CLIENT_ID variable, then to GITHUB_TOKEN, whose PRs never get pull_request CI on private repos."
         type: string
         default: ""
       runner-label:
@@ -42,6 +42,13 @@ on:
     secrets:
       app-private-key:
         description: "Private key for app-client-id."
+        required: false
+      # UPPER_SNAKE, unlike its siblings: the name must match the repository
+      # secret that index's own scheduled/dispatched runs resolve (those
+      # events read secrets.* from the repository, not from workflow_call).
+      # A caller passes app-private-key instead and never needs this.
+      PLAYBOOK_APP_PRIVATE_KEY:
+        description: "Repository-secret twin of app-private-key for index's own scheduled runs."
         required: false
       slack-bot-token:
         description: "Slack bot token (chat:write) for escalation posts; empty escalates through the tracking issue only."
@@ -91,13 +98,65 @@ jobs:
       # fork-approval API cannot clear them (ix#6566). When the caller supplies
       # a GitHub App with contents + pull-requests write, mint a token scoped
       # to this repository and author the PR with it so CI triggers normally.
+      # index's own scheduled and dispatched runs have no workflow_call
+      # inputs, so they fall back to the repo's PLAYBOOK_APP_CLIENT_ID
+      # variable + PLAYBOOK_APP_PRIVATE_KEY secret (the same ix-playbook-agent
+      # identity ix passes in), closing the loop of #3692: the rolling bump
+      # PR #3021 sat 159 hours with no flake-check because it was authored by
+      # GITHUB_TOKEN. With neither configured the step is skipped and the PR
+      # falls back to GITHUB_TOKEN below, where CI stays silent.
       - name: Mint PR token
         id: app-token
-        if: ${{ inputs.app-client-id != '' }}
+        if: ${{ (inputs.app-client-id || vars.PLAYBOOK_APP_CLIENT_ID) != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ inputs.app-client-id }}
-          private-key: ${{ secrets.app-private-key }}
+          client-id: ${{ inputs.app-client-id || vars.PLAYBOOK_APP_CLIENT_ID }}
+          private-key: ${{ secrets.app-private-key || secrets.PLAYBOOK_APP_PRIVATE_KEY }}
+
+      # The merge half of the loop (#3692): each tick first lands the bump a
+      # previous tick pushed, once CI proved it green. This runs before this
+      # tick's own push below, which would reset the PR's checks back to
+      # pending. The merge is an explicit API rebase (the only merge method
+      # main allows), not native auto-merge, and never a bypass: a PR that
+      # cannot merge on its own merits stays open. Merging with the app token
+      # also means the resulting push to main triggers the post-merge
+      # workflows, which a GITHUB_TOKEN merge would not. Scoped to index
+      # itself: a cross-repo caller (ix) keeps its own merge policy. A PR
+      # stuck unmergeable past the threshold is the escalate job's to report
+      # (#3438), not this step's.
+      - name: Merge the previous green bump
+        if: ${{ steps.app-token.outputs.token != '' && github.repository == 'indexable-inc/index' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          BUMP_BRANCH: update-flake-lock
+        run: |
+          set -euo pipefail
+          number="$(gh pr list --repo "$REPOSITORY" --head "$BUMP_BRANCH" --base main \
+            --state open --json number --jq '.[0].number // empty')"
+          if [ -z "$number" ]; then
+            echo "no open rolling PR on ${BUMP_BRANCH}; nothing to merge"
+            exit 0
+          fi
+          state="$(gh pr view "$number" --repo "$REPOSITORY" \
+            --json mergeStateStatus --jq .mergeStateStatus)"
+          case "$state" in
+            # UNSTABLE is "required checks green, a non-required context red
+            # or pending"; bot-authored PRs always carry the skipped
+            # non-required `approve` context, so requiring CLEAN would never
+            # merge anything.
+            CLEAN | UNSTABLE)
+              gh pr merge --rebase --repo "$REPOSITORY" "$number"
+              echo "merged rolling PR #${number} (mergeStateStatus ${state})"
+              ;;
+            # BLOCKED: a required check (flake-check, closure-gate) is pending
+            # or red. DIRTY: merge conflict. UNKNOWN: GitHub is still
+            # computing. Each heals on a later tick after the push below
+            # refreshes the branch and its checks.
+            *)
+              echo "rolling PR #${number} not mergeable (mergeStateStatus ${state}); leaving it for a later tick"
+              ;;
+          esac
 
       # Notify the human behind a manual dispatch (of this workflow or of a
       # cross-repo caller such as ix: a reusable workflow shares the caller's

--- a/.github/workflows/update-rust-nightly.yml
+++ b/.github/workflows/update-rust-nightly.yml
@@ -40,6 +40,66 @@ jobs:
       - name: Verify the pinned nightly evaluates
         run: nix eval .#packages.x86_64-linux.agents.drvPath
 
+      # PRs authored by the default GITHUB_TOKEN never trigger `pull_request`
+      # workflows on private repos, so the rolling bump PR gets no
+      # `flake-check` and can only land when a human re-authors it (#3692;
+      # the flake.lock bump #3021 sat 159 hours that way). Author the push
+      # and the merge as the ix-playbook-agent GitHub App instead (contents +
+      # pull-requests write, the same identity ix's updaters use) so CI runs
+      # on every bump. Until the PLAYBOOK_APP_CLIENT_ID variable and
+      # PLAYBOOK_APP_PRIVATE_KEY secret are configured, this is skipped and
+      # the workflow keeps today's GITHUB_TOKEN behavior: the PR opens but
+      # its CI stays silent.
+      - name: Mint PR token
+        id: app-token
+        if: ${{ vars.PLAYBOOK_APP_CLIENT_ID != '' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.PLAYBOOK_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PLAYBOOK_APP_PRIVATE_KEY }}
+
+      # The merge half of the loop (#3692): each tick first lands the bump a
+      # previous tick pushed, once CI proved it green. This runs before this
+      # tick's own push below, which would reset the PR's checks back to
+      # pending. The merge is an explicit API rebase (the only merge method
+      # main allows), not native auto-merge, and never a bypass: a PR that
+      # cannot merge on its own merits stays open. Merging with the app token
+      # also means the resulting push to main triggers the post-merge
+      # workflows, which a GITHUB_TOKEN merge would not.
+      - name: Merge the previous green bump
+        if: ${{ steps.app-token.outputs.token != '' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          BUMP_BRANCH: update-rust-nightly
+        run: |
+          set -euo pipefail
+          number="$(gh pr list --repo "$REPOSITORY" --head "$BUMP_BRANCH" --base main \
+            --state open --json number --jq '.[0].number // empty')"
+          if [ -z "$number" ]; then
+            echo "no open rolling PR on ${BUMP_BRANCH}; nothing to merge"
+            exit 0
+          fi
+          state="$(gh pr view "$number" --repo "$REPOSITORY" \
+            --json mergeStateStatus --jq .mergeStateStatus)"
+          case "$state" in
+            # UNSTABLE is "required checks green, a non-required context red
+            # or pending"; bot-authored PRs always carry the skipped
+            # non-required `approve` context, so requiring CLEAN would never
+            # merge anything.
+            CLEAN | UNSTABLE)
+              gh pr merge --rebase --repo "$REPOSITORY" "$number"
+              echo "merged rolling PR #${number} (mergeStateStatus ${state})"
+              ;;
+            # BLOCKED: a required check (flake-check, closure-gate) is pending
+            # or red. DIRTY: merge conflict. UNKNOWN: GitHub is still
+            # computing. Each heals on a later tick after the push below
+            # refreshes the branch and its checks.
+            *)
+              echo "rolling PR #${number} not mergeable (mergeStateStatus ${state}); leaving it for a later tick"
+              ;;
+          esac
+
       # Opens (or updates) a single PR, and only when something changed:
       # create-pull-request no-ops on an empty diff (which is also what the
       # script above produces when the manifest isn't newer, or when the
@@ -47,11 +107,9 @@ jobs:
       # requires). It reuses the `update-rust-nightly` branch so each run
       # advances the same PR.
       #
-      # `token`: a PR opened with the default GITHUB_TOKEN does not trigger
-      # the `pull_request` workflows (`flake-check`), so branch protection
-      # would block the merge. Set an `AUTOBUMP_TOKEN` repo secret (a PAT or
-      # GitHub App token) to make the PR run CI; without it this falls back
-      # to GITHUB_TOKEN and a maintainer must re-trigger `flake-check`.
+      # `token`: the app token minted above, so the PR triggers `pull_request`
+      # CI (`flake-check`) and the next scheduled tick can merge it; the
+      # GITHUB_TOKEN fallback opens a PR whose CI never runs (#3692).
       # Notify the human behind a manual dispatch: review request + assignee +
       # body mention, all empty (a no-op) on the scheduled runs, which have no
       # triggering human.
@@ -62,7 +120,7 @@ jobs:
       - name: Open pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.AUTOBUMP_TOKEN || github.token }}
+          token: ${{ steps.app-token.outputs.token || github.token }}
           assignees: ${{ steps.trigger.outputs.user }}
           reviewers: ${{ steps.trigger.outputs.user }}
           base: main

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -103,15 +103,75 @@ jobs:
             echo "::endgroup::"
           done
 
+      # PRs authored by the default GITHUB_TOKEN never trigger `pull_request`
+      # workflows on private repos, so the rolling bump PR gets no
+      # `flake-check` and can only land when a human re-authors it (#3692;
+      # the flake.lock bump #3021 sat 159 hours that way). Author the push
+      # and the merge as the ix-playbook-agent GitHub App instead (contents +
+      # pull-requests write, the same identity ix's updaters use) so CI runs
+      # on every bump. Until the PLAYBOOK_APP_CLIENT_ID variable and
+      # PLAYBOOK_APP_PRIVATE_KEY secret are configured, this is skipped and
+      # the workflow keeps today's GITHUB_TOKEN behavior: the PR opens but
+      # its CI stays silent.
+      # Minted here, after the long update step, because installation tokens
+      # expire after one hour and this job's update can run for most of that.
+      - name: Mint PR token
+        id: app-token
+        if: ${{ vars.PLAYBOOK_APP_CLIENT_ID != '' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.PLAYBOOK_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PLAYBOOK_APP_PRIVATE_KEY }}
+
+      # The merge half of the loop (#3692): each tick first lands the bump a
+      # previous tick pushed, once CI proved it green. This runs before this
+      # tick's own push below, which would reset the PR's checks back to
+      # pending. The merge is an explicit API rebase (the only merge method
+      # main allows), not native auto-merge, and never a bypass: a PR that
+      # cannot merge on its own merits stays open. Merging with the app token
+      # also means the resulting push to main triggers the post-merge
+      # workflows, which a GITHUB_TOKEN merge would not.
+      - name: Merge the previous green bump
+        if: ${{ steps.app-token.outputs.token != '' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          BUMP_BRANCH: update-content
+        run: |
+          set -euo pipefail
+          number="$(gh pr list --repo "$REPOSITORY" --head "$BUMP_BRANCH" --base main \
+            --state open --json number --jq '.[0].number // empty')"
+          if [ -z "$number" ]; then
+            echo "no open rolling PR on ${BUMP_BRANCH}; nothing to merge"
+            exit 0
+          fi
+          state="$(gh pr view "$number" --repo "$REPOSITORY" \
+            --json mergeStateStatus --jq .mergeStateStatus)"
+          case "$state" in
+            # UNSTABLE is "required checks green, a non-required context red
+            # or pending"; bot-authored PRs always carry the skipped
+            # non-required `approve` context, so requiring CLEAN would never
+            # merge anything.
+            CLEAN | UNSTABLE)
+              gh pr merge --rebase --repo "$REPOSITORY" "$number"
+              echo "merged rolling PR #${number} (mergeStateStatus ${state})"
+              ;;
+            # BLOCKED: a required check (flake-check, closure-gate) is pending
+            # or red. DIRTY: merge conflict. UNKNOWN: GitHub is still
+            # computing. Each heals on a later tick after the push below
+            # refreshes the branch and its checks.
+            *)
+              echo "rolling PR #${number} not mergeable (mergeStateStatus ${state}); leaving it for a later tick"
+              ;;
+          esac
+
       # Opens (or updates) a single PR with all refreshed content, and only when
       # something changed: create-pull-request no-ops on an empty diff. It
       # reuses the `update-content` branch so each run advances the same PR.
       #
-      # `token`: a PR opened with the default GITHUB_TOKEN does not trigger the
-      # `pull_request` workflows (`flake-check`), so branch protection would
-      # block the merge. Set an `AUTOBUMP_TOKEN` repo secret (a PAT or GitHub
-      # App token) to make the PR run CI; without it this falls back to
-      # GITHUB_TOKEN and a maintainer must re-trigger `flake-check`.
+      # `token`: the app token minted above, so the PR triggers `pull_request`
+      # CI (`flake-check`) and the next scheduled tick can merge it; the
+      # GITHUB_TOKEN fallback opens a PR whose CI never runs (#3692).
       # Notify the human behind a manual dispatch: review request + assignee +
       # body mention, all empty (a no-op) on the scheduled runs, which have no
       # triggering human.
@@ -122,7 +182,7 @@ jobs:
       - name: Open pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.AUTOBUMP_TOKEN || github.token }}
+          token: ${{ steps.app-token.outputs.token || github.token }}
           assignees: ${{ steps.trigger.outputs.user }}
           reviewers: ${{ steps.trigger.outputs.user }}
           base: main

--- a/packages/site/src/lib/updates/updater-prs-run-ci-and-land-themselves.svx
+++ b/packages/site/src/lib/updates/updater-prs-run-ci-and-land-themselves.svx
@@ -1,0 +1,37 @@
+---
+id: updater-prs-run-ci-and-land-themselves
+postedAt: "2026-07-19T06:18:00-07:00"
+title: "updater PRs run CI and land themselves"
+links:
+  - label: "closed loop #3692"
+    href: "https://github.com/indexable-inc/index/issues/3692"
+  - label: "escalation deadman #3438"
+    href: "https://github.com/indexable-inc/index/issues/3438"
+  - label: "the 159-hour PR #3021"
+    href: "https://github.com/indexable-inc/index/pull/3021"
+tags:
+  - ci
+---
+
+The four updater workflows (flake.lock, cargo, rust-nightly, content) now
+author their rolling PRs as the ix-playbook-agent GitHub App, and each
+scheduled tick merges the previous tick's bump via `gh pr merge --rebase`
+once `flake-check` has proved it green. A correct bump lands on main with
+no human in the loop.
+
+Before this, the rolling PRs were pushed with the workflow's own
+`GITHUB_TOKEN`, and GitHub deliberately never triggers `pull_request`
+workflows on events that token creates. So `flake-check` never ran, nothing
+could merge, and bumps only landed when a human re-authored them: the
+flake.lock PR carried a correct nixpkgs bump for 159 hours while prod broke
+downstream of the stale pin (ix#7844).
+
+The merge is an explicit API call on the next tick, not native auto-merge:
+the PR merges only when GitHub already reports it mergeable on its own
+merits, rebase-only, no admin bypass. The escalation job from #3438 stays
+untouched as the deadman that reports any bump stuck past its threshold.
+
+The loop stays dormant until the `PLAYBOOK_APP_CLIENT_ID` variable and
+`PLAYBOOK_APP_PRIVATE_KEY` secret exist on the repo; until then the
+workflows keep today's behavior. The identity is the same app ix's
+updaters already push with.


### PR DESCRIPTION
Implements #3692 (supersedes #2728, which is triply blocked as written; see its last comment).

**Before:** the four updater workflows push their rolling PRs with the workflow's own `GITHUB_TOKEN`. GitHub deliberately never triggers `pull_request` workflows on events that token creates, so `flake-check` never runs, nothing can merge, and bumps land only when a human re-authors them — the flake.lock PR #3021 carried a correct nixpkgs bump for 159 hours while the stale pin broke prod downstream (ix#7844).

**After:** each updater mints an installation token for the **ix-playbook-agent** GitHub App (`actions/create-github-app-token`, pinned; the same identity ix's updaters already push with) and uses it to author the push and the PR, so CI runs on every bump. The merge half runs at the start of every scheduled tick: if the rolling PR from a previous tick is mergeable on its own merits (`mergeStateStatus` CLEAN, or UNSTABLE — bot PRs always carry the skipped non-required `approve` context), the tick lands it with `gh pr merge --rebase`. No native auto-merge, no `--admin`, and the merge itself uses the app token so the resulting push to main triggers the post-merge workflows. The #3438 escalate job is untouched and stays the deadman for anything stuck past its threshold.

In the reusable `update-flake-lock.yml`, index's own scheduled/dispatched runs (which have no `workflow_call` inputs) fall back to the repo's `PLAYBOOK_APP_CLIENT_ID` variable + `PLAYBOOK_APP_PRIVATE_KEY` secret; the merge step is scoped to `indexable-inc/index` so cross-repo callers (ix) keep their own merge policy.

**Dormant until credentials exist:** the mint step is gated on `vars.PLAYBOOK_APP_CLIENT_ID`, so until the variable and secret are set the workflows keep today's exact behavior. One manual step arms the loop (app private keys have no generation API):

1. Generate a private key for ix-playbook-agent: https://github.com/organizations/indexable-inc/settings/apps/ix-playbook-agent (apps support multiple active keys; ix's copy keeps working), then
2. `gh secret set PLAYBOOK_APP_PRIVATE_KEY -R indexable-inc/index < ~/Downloads/ix-playbook-agent.*.private-key.pem`
3. `gh variable set PLAYBOOK_APP_CLIENT_ID -R indexable-inc/index --body "Iv23liI9DwaHuyVstttP"`

(Set the secret before the variable: the variable alone makes the mint step run and fail loudly.)

**Repo-settings fix applied alongside:** main's ruleset (16845582) still said `allowed_merge_methods: ["squash"]` while the repository has squash disabled and rebase enabled — an empty intersection, so only bypass actors (which is why human merges kept working) could merge at all. Updated the ruleset to `["rebase"]` to match the actual policy; without this the app's non-bypass merge would always be refused.

Site page: `packages/site/src/lib/updates/updater-prs-run-ci-and-land-themselves.svx`

(sent by an AI agent via Claude Code, Fable 5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Configure updater PRs to run CI and auto-merge via GitHub App identity
> - Adds a 'Mint PR token' step to each updater workflow ([update-cargo.yml](.github/workflows/update-cargo.yml), [update-flake-lock.yml](.github/workflows/update-flake-lock.yml), [update-rust-nightly.yml](.github/workflows/update-rust-nightly.yml), [update.yml](.github/workflows/update.yml)) that mints a GitHub App installation token when `PLAYBOOK_APP_CLIENT_ID` and `PLAYBOOK_APP_PRIVATE_KEY` are configured.
> - Adds a 'Merge the previous green bump' step to each workflow that finds the previously opened updater PR and rebase-merges it when GitHub reports `mergeStateStatus` as `CLEAN` or `UNSTABLE`; otherwise defers to a later run.
> - PRs authored with the App token trigger CI (unlike `GITHUB_TOKEN`-authored PRs), enabling the auto-merge path. Falls back to `github.token` when app credentials are absent.
> - Adds a site post in [updater-prs-run-ci-and-land-themselves.svx](https://github.com/indexable-inc/index/pull/3698/files#diff-f4f256798df0a2a23a1d4307643303e340d6fb5e775669c747cb16dce8632f6f) documenting the new behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e8ad9c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->