### PR TITLE
prompt+config: encode Fable 5 system-card perf guidance

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -53,7 +53,16 @@
   # let-block:
   #  - context1M = false: every 1M path in the CLI (the [1m] model suffix, the
   #    silent auto-upgrade, the context-1m beta header) is ~5x input price;
-  #    past-the-window work belongs in subagents.
+  #    past-the-window work belongs in subagents. Cost tradeoff, not
+  #    perf-neutral: the Fable 5 system card measured its agentic scores at
+  #    max-effort adaptive thinking, 128K max output tokens per turn, and
+  #    contexts up to 1M (footnote 27: raising the per-turn cap from 16K to
+  #    128K moved the OSWorld score). Do not additionally lower per-turn
+  #    output caps (CLAUDE_CODE_MAX_OUTPUT_TOKENS) or effort; tight caps
+  #    silently degrade agentic performance. This posture is Claude Code
+  #    harness only; other harnesses and raw API callers set their own.
+  #    Subagents need not all run fable; match model strength to subtask
+  #    difficulty.
   #  - cron = false: drops the scheduling/loop tools.
   #  - autoCompactWindow = 300000: native-1M models (Fable 5, Sonnet 5,
   #    Opus 4.8) otherwise autocompact near the 1M cliff; 300K matches the

--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -217,14 +217,16 @@
     fixAtSource = {
       topics = ["architecture"];
       text = ''
-        Fix at the source, upstream when the cause is upstream. No fallbacks,
-        silent retries, or defensive defaults; fail loudly. A tactical fix
-        gets an issue or a background agent for the root fix. Third-party
-        endgames need user go-ahead.
+        Fix at the source, upstream when the cause is upstream. A
+        pre-existing flaw you touch is a bug to fix and flag, never a
+        convention to keep. No fallbacks, silent retries, or defensive
+        defaults; fail loudly. A tactical fix gets an issue or a background
+        agent for the root fix. Third-party endgames need user go-ahead.
       '';
       reason = ''
         `fallback = true` silently masked a corrupted cache.ix.dev (ix#6139);
-        workarounds became permanent.
+        workarounds became permanent. Fable 5 reframes planted flaws as
+        conventions and preserves them (system card sec 6.3.5.1).
       '';
     };
   }
@@ -277,11 +279,14 @@
         The harness subagent and task tools are absent by design. Delegate
         through the index kernel to named background agents: one worktree per
         editor, main session on orchestration, model strength matched to
-        difficulty.
+        difficulty. Fan out when subtasks are independent; iterating
+        serially over independent items forfeits the win.
       '';
       reason = ''
         Harness Agent/Task schemas were denied to reclaim context (#2404);
-        briefs promising them produced relay swarms (index#2153).
+        briefs promising them produced relay swarms (index#2153). Fable 5
+        system card sec 8.15: async-subagent fan-out beats single-agent on
+        both score and latency.
       '';
     };
   }


### PR DESCRIPTION
Encodes three Fable 5 system-card perf findings:

- rules.nix fixAtSource: a pre-existing flaw you touch is a bug to fix and flag, never a convention to keep (card sec 6.3.5.1).
- rules.nix backgroundSubagents: fan out when subtasks are independent; serial iteration over independent items forfeits the win (card sec 8.15).
- claude-code features comment: the context1M bullet now names the measured posture (max-effort adaptive thinking, 128K per-turn output, up to 1M context; footnote 27) so nobody tightens per-turn caps or effort thinking it is perf-neutral.

Closes #3699

(authored by an AI agent via Claude Code, Fable 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update agent prompt rules with Fable 5 system-card performance guidance
> - Updates the `fixAtSource` rule in [rules.nix](https://github.com/indexable-inc/index/pull/3702/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to explicitly treat pre-existing flaws as bugs to fix and flag, not conventions to preserve; cites Fable 5 system card as motivation for the stricter wording.
> - Extends the delegation guidance rule to recommend fan-out for independent subtasks, warning that serial iteration over independent items forfeits parallelism benefits; cites Fable 5 system card §8.15 on async-subagent performance.
> - Adds expanded comments in [default.nix](https://github.com/indexable-inc/index/pull/3702/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) about context cost/performance tradeoffs and subagent model selection (no executable changes).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0ba56b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->