### PR TITLE
claude-code: typed fableFallback knob for the Fable 5 refusal fallback

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -55,6 +55,13 @@
   #    silent auto-upgrade, the context-1m beta header) is ~5x input price;
   #    past-the-window work belongs in subagents.
   #  - cron = false: drops the scheduling/loop tools.
+  #  - fableFallback = true: stock behavior. When Fable 5's safety classifiers
+  #    flag a turn, the CLI re-serves it on Opus 4.8 and keeps the session
+  #    there (Fable 5 system card sec 1.5; the /config toggle "switch models
+  #    when a message is flagged"). false bakes
+  #    CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK so a flagged turn stops visibly
+  #    instead: on eval or perf-sensitive work a visible failure beats a
+  #    silent Opus 4.8 degradation.
   #  - autoCompactWindow = 300000: native-1M models (Fable 5, Sonnet 5,
   #    Opus 4.8) otherwise autocompact near the 1M cliff; 300K matches the
   #    standard (non-[1m]) working window the picker labels "300K High".
@@ -243,10 +250,14 @@
   featureToggleEnvVars = {
     context1M = "CLAUDE_CODE_DISABLE_1M_CONTEXT";
     cron = "CLAUDE_CODE_DISABLE_CRON";
+    # Read by the CLI (verified via strings on 2.1.215: gates the refusal
+    # fallback path alongside the switchModelsOnFlag setting).
+    fableFallback = "CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK";
   };
   defaultFeatures = {
     context1M = false;
     cron = false;
+    fableFallback = true;
     autoCompactWindow = 300000;
   };
   unknownFeatures = lib.subtractLists (builtins.attrNames defaultFeatures) (builtins.attrNames features);


### PR DESCRIPTION
When Fable 5's safety classifiers flag a turn in Claude Code, the CLI re-serves the turn on Opus 4.8 and keeps the session there. For eval or perf-sensitive work a visible stop beats that silent degradation.

Research (#3701, phase 1): the CLI does expose control. `strings` on the installed 2.1.215 binary shows it reads `CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK` from the env registry (`function Bj(){return!Z.CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK&&!JCe()}`), and the fallback path also gates on the `switchModelsOnFlag` settings key, surfaced as the documented `/config` toggle "switch models when a message is flagged" (code.claude.com/docs/en/model-config, "Ask before switching"). The system card sec 1.5 "not configurable" wording applies to other Claude interfaces, not Claude Code.

Change: a typed `fableFallback` feature knob in `packages/agent/claude-code/default.nix`, following the context1M/cron pattern. Default `true` bakes nothing (stock automatic fallback). `false` bakes `CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK=1` both as a soft launch-env default and into settings `env`, so a flagged turn stops visibly. install-check needs no extension: its feature checks are derived from the same nix values, and the default posture bakes nothing.

Verified by eval: default `settings.env` is unchanged; `override { features.fableFallback = false; }` renders the var.

Closes #3701

(authored by an AI agent via Claude Code, Fable 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add typed `fableFallback` knob for the Fable 5 refusal fallback in claude-code
> Adds a `fableFallback` entry to the `featureToggleEnvVars` map in [default.nix](https://github.com/indexable-inc/index/pull/3703/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8), wiring it to the `CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK` environment variable that the CLI reads to gate the refusal-fallback path. The feature is enabled by default in `defaultFeatures`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c3c6e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->