### PR TITLE
claude-code: harness topology comment (async subagents, not peer mesh)

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -62,7 +62,17 @@
   #    silently degrade agentic performance. This posture is Claude Code
   #    harness only; other harnesses and raw API callers set their own.
   #    Subagents need not all run fable; match model strength to subtask
-  #    difficulty.
+  #    difficulty. Topology note: the card's best multi-agent harness is NOT
+  #    a peer mesh. Of the three tested (sec 8.15.3), "async subagents"
+  #    (hierarchy: a lead keeps the task tools, spawns async long-lived
+  #    subagents that see only the lead's instructions, only the lead's
+  #    answer is graded) reached the highest score (BrowseComp 93.3, sec
+  #    8.15.1); the peer mesh ("fixed-agent team", identical peers all
+  #    seeing the full task) wins on latency (2.2-2.7x speedups). Both
+  #    non-blocking variants beat the blocking orchestrator on latency and
+  #    tokens. Messaging is mesh-capable in both (any agent can message any
+  #    other); the task flow of the top scorer is hierarchical. index#3700
+  #    tracks the reusable BEAM implementation.
   #  - cron = false: drops the scheduling/loop tools.
   #  - autoCompactWindow = 300000: native-1M models (Fable 5, Sonnet 5,
   #    Opus 4.8) otherwise autocompact near the 1M cliff; 300K matches the


### PR DESCRIPTION
Documents next to the token-cap comment which multi-agent topology the Fable 5 system card actually measured as best: hierarchical async subagents for score (BrowseComp 93.3, sec 8.15.1/8.15.3), peer mesh (fixed-agent team) for latency, both non-blocking variants over the blocking orchestrator. Refs #3700.

(authored by an AI agent via Claude Code, Fable 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document async subagents topology in claude-code harness config
> Adds a comment to [default.nix](https://github.com/indexable-inc/index/pull/3705/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) describing the multi-agent harness topology, noting that the architecture uses an async subagents hierarchy rather than a peer mesh, and documenting observed performance and latency tradeoffs between the two approaches. No executable code is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8a7bc6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->