### PR TITLE
agent-harness-ex: async-subagents harness scaffold (Fable 5 sec 8.15.3)

### DIFF
--- a/packages/agent-harness-ex/.formatter.exs
+++ b/packages/agent-harness-ex/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/packages/agent-harness-ex/.gitignore
+++ b/packages/agent-harness-ex/.gitignore
@@ -1,0 +1,23 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+agent_harness-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/packages/agent-harness-ex/README.md
+++ b/packages/agent-harness-ex/README.md
@@ -1,0 +1,151 @@
+# agent-harness-ex
+
+What does the best-performing multi-agent configuration in the Fable 5
+system card look like when you build it out of the thing it was already
+describing, processes with mailboxes?
+
+`agent-harness-ex` is that harness as a plain OTP library: the card's
+"async subagents" design (long-lived agents, immediate spawns, Send
+Message / Wait for Message, a lead with create/delete/status tools) mapped
+one-to-one onto supervised BEAM processes. It implements every semantic in
+the card except the model call itself, which the host injects through a
+single behaviour, so the library never talks to any API.
+
+## Why this harness
+
+The system card (packages/system-cards/cards/anthropic/
+claude-fable-5-mythos-5.md, sec 8.15.3) evaluates three multi-agent
+harnesses; async subagents is the one where the lead keeps its own task
+tools and spawns asynchronous, long-lived subagents. Its reported wins over
+a single agent (sec 8.15.5 and index#3700): BrowseComp 93.3 vs 88.0, and on
+ProgramBench +7.9pp with 3.2x less critical-path latency to reach a 60
+percent pass rate. Long-lived context is also the token argument: waking an
+existing subagent costs less than re-establishing a fresh one per subtask.
+
+The card's operating parameters, which are this library's defaults:
+
+| Knob | Card (sec 8.15.3) | Here |
+| --- | --- | --- |
+| Per-agent token limit | 1M, no compaction | `token_budget: 1_000_000`, per spawn or per harness |
+| Concurrent subagents | 4 (ProgramBench) | `max_concurrent: 4` |
+| Lifetime subagents | 20 (ProgramBench) | `max_total: 20` |
+| Subagent model | unspecified | `:model`, required per spawn (or `:default_model`), opaque to the harness |
+
+## Semantics
+
+* `create_subagent(harness, instructions, opts)` returns immediately with
+  the new agent's id; the runner starts working in the background
+  (lead-only tool).
+* A subagent receives only the lead-provided instructions, never the
+  original task description. That is structural: instructions are the only
+  task-shaped input `Runner.run/2` gets.
+* `send_message(harness, from, to, text)` queues; the recipient sees it
+  after its next tool result, when its runner drains `checkpoint/2`.
+  Any agent can message any other agent, including the lead.
+* `wait_for_message(harness, id, timeout)` blocks until a message arrives
+  (it drains the whole mailbox).
+* When a runner returns `{:ok, final}`, the final response is delivered to
+  the lead as a `:final` message and the subagent goes `:idle`. Messaging
+  an idle subagent wakes it: the text becomes its new instructions.
+* `delete_subagent/2` terminates the agent (and its runner task) and frees
+  a concurrency slot; `subagent_status/1,2` answers `:working`, `:idle`, or
+  `:terminated`.
+* `add_usage/3` charges an agent's token budget and returns
+  `{:error, :budget_exhausted}` once it is spent; runners stop there.
+
+## Supervision tree
+
+One harness instance, named `name` by the host:
+
+    AgentHarness (Supervisor, :one_for_all)
+    |-- Registry            name.Registry        {:agent, id} -> pid
+    |-- Task.Supervisor     name.TaskSupervisor  one task per working runner
+    |-- DynamicSupervisor   name.AgentSupervisor one AgentHarness.Agent per agent
+    |   |-- Agent "lead"    the embedding session's mailbox (created at init)
+    |   |-- Agent "sub-1"   mailbox + status + budget + runner task
+    |   `-- ...
+    `-- AgentHarness.Coordinator  name.Coordinator  roster, caps, admission
+
+`:one_for_all` because the coordinator's roster, the registry, and the
+dynamic supervisor's children describe each other; restarting one alone
+would leave the survivors pointing at processes that no longer exist.
+
+The agent GenServer never blocks on the model: the runner executes in a
+`Task.Supervisor` task (`async_nolink`), so delivery, status, and deletion
+stay responsive mid-sample. Agents are `restart: :temporary`; a crashed
+agent is a `:terminated` roster entry (its runner's crash, by contrast,
+does not kill the agent: it becomes an `:error` message to the lead and the
+agent idles, ready for new instructions).
+
+## Message wire shape
+
+Everything agents exchange is one struct, `AgentHarness.Message`:
+
+    %AgentHarness.Message{
+      from: "sub-2",            # sender agent id ("lead" for the lead)
+      to: "lead",               # recipient agent id
+      text: "found the bug in ...",
+      kind: :message,           # | :final | :error
+      sent_at_ms: 1789000000000 # System.system_time(:millisecond)
+    }
+
+`:final` and `:error` are how a runner's ending reaches the lead; both
+arrive through the same mailbox as ordinary messages, so the lead needs no
+separate completion channel.
+
+## The Runner seam
+
+    defmodule MyApp.ClaudeRunner do
+      @behaviour AgentHarness.Runner
+
+      @impl true
+      def run(instructions, ctx) do
+        # sample ctx.model, execute tool calls, and around each tool result:
+        {:ok, %{messages: msgs}} = AgentHarness.checkpoint(ctx.harness, ctx.agent_id)
+        # splice msgs into the transcript; on the Wait for Message tool:
+        {:ok, msgs} = AgentHarness.wait_for_message(ctx.harness, ctx.agent_id)
+        # charge usage after each turn:
+        {:ok, _left} = AgentHarness.add_usage(ctx.harness, ctx.agent_id, turn_tokens)
+        {:ok, "final response text"}
+      end
+    end
+
+The contract (also on the behaviour's doc): checkpoint after every tool
+result, wait on the Wait tool, charge usage and stop when exhausted, return
+`{:ok, final}`. The harness owns queueing, waking, status, caps, and
+budget arithmetic; the runner owns the transcript and the API.
+
+## Composing with ix-mcp-ex
+
+The consumer this was built for is packages/mcp-ex (the workstation MCP
+kernel), which takes the library as a mix path dependency. The intended
+wiring, deliberately not yet exposed as MCP tools:
+
+* Supervision: `{AgentHarness, name: IxMcp.Harness, runner: IxMcp.ClaudeRunner}`
+  slots into `IxMcp.Application`'s one_for_one list next to the Jobs
+  machinery it mirrors (`IxMcp.Jobs.Registry` / `IxMcp.Jobs.Supervisor`).
+* The Jobs nursery stays the tool executor. A runner turn that wants shell
+  or Elixir work calls `IxMcp.Jobs.run/2` exactly like a cell does, so
+  subagent tool calls get the same nursery ownership, output capture, and
+  cancellation story as every other kernel job (no parallel machinery).
+* The lead is the MCP session itself. The server drains
+  `AgentHarness.checkpoint(harness, "lead")` after each `tools/call` and
+  appends the messages to that tool result, which gives the outer Claude
+  the card's exact delivery rule.
+* Planned tool surface (follow-up work, not in this package):
+  `create_subagent`, `delete_subagent`, `subagent_status` (lead-only), and
+  `send_message`, `wait_for_message` (all agents), each a thin adapter over
+  the functions above. The runner implementation with the real Claude
+  client also lives on the mcp-ex side; this package stops at the
+  behaviour.
+
+## Not yet decided / punted
+
+* Roster names are never reused: a terminated subagent keeps its id so
+  status stays answerable, and a new spawn under the same name is
+  `:name_taken`. Pick a fresh name instead.
+* The budget is enforced cooperatively (runners stop on
+  `:budget_exhausted`); the harness does not kill an over-budget task.
+* No persistence: a harness restart (`:one_for_all`) loses mailboxes and
+  the roster. Fine for a kernel session; revisit if harnesses outlive
+  sessions.

--- a/packages/agent-harness-ex/default.nix
+++ b/packages/agent-harness-ex/default.nix
@@ -1,0 +1,122 @@
+{
+  lib,
+  ix,
+}: let
+  # Read the package set from `ix` rather than a `pkgs` callPackage formal
+  # (which `override` can't reach); `ix.pkgs` is the caller's set.
+  inherit (ix) pkgs;
+
+  # mix.exs declares `~> 1.18`; same toolchain pairing as the consumer
+  # (packages/mcp-ex), so the path dep never compiles under a different
+  # Elixir than the one that gated it here.
+  elixir = ix.languages.elixir.toolchain pkgs {version = "1.18";};
+  erlang = ix.languages.erlang.toolchain pkgs {version = "27";};
+
+  version = "0.1.0"; # keep in sync with mix.exs
+
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [
+      ./lib
+      ./test
+      ./mix.exs
+      ./mix.lock
+      ./.formatter.exs
+    ];
+  };
+
+  # Test-env mix deps (credo + its deps) as a fixed-output derivation so the
+  # sandboxed check runs offline; the library itself has zero runtime deps.
+  # The SRI pin lives in the sibling pins.json (repo policy: no inline hash
+  # literals); it has no URL (the FOD content is derived from mix.lock), so
+  # refresh it after a lock change by building and copying the `got:` hash
+  # from the mismatch error.
+  mixFodDeps = pkgs.beamPackages.fetchMixDeps {
+    pname = "agent-harness-ex-deps";
+    inherit version elixir;
+    src = lib.fileset.toSource {
+      root = ./.;
+      fileset = lib.fileset.unions [
+        ./mix.exs
+        ./mix.lock
+      ];
+    };
+    mixEnv = "test";
+    inherit ((ix.pins.loadPins ./pins.json).mix-deps) hash;
+  };
+
+  # The required Elixir quality lane: compile --warnings-as-errors (Elixir
+  # 1.18's set-theoretic type checker), format, `mix credo --strict` against
+  # the shared lib/elixir/credo.exs, and the ExUnit suite covering the
+  # harness semantics (immediate spawn, checkpoint delivery, blocking wait,
+  # slot accounting, caps, budget).
+  elixirCheck = ix.buildElixirCheck pkgs {
+    pname = "agent-harness-ex-check";
+    inherit version src elixir erlang;
+    mixDeps = mixFodDeps;
+  };
+
+  meta = {
+    description = "The Fable 5 async-subagents harness (system card sec 8.15.3) as an OTP library: agents as processes, mailboxes as Send/Wait";
+    license = lib.licenses.mit;
+  };
+
+  # The package output is the compiled :agent_harness OTP app, the same
+  # shape tui-ex ships, so a release or an ERL_LIBS path can load it without
+  # mix. ix-mcp-ex consumes the *source* as a mix path dependency instead;
+  # this artifact exists so the library builds standalone and stays cached.
+  package = pkgs.stdenv.mkDerivation {
+    pname = "agent-harness-ex";
+    inherit version src meta;
+    strictDeps = true;
+    # Mix >= 1.18 starts Mix.PubSub, which opens a loopback TCP socket at
+    # compile time; the darwin sandbox denies plain sockets without this.
+    __darwinAllowLocalNetworking = true;
+
+    # hex provides the SCM module Mix needs to parse the lockfile (which
+    # names the test-only credo dep even though prod never compiles it).
+    nativeBuildInputs = [
+      erlang
+      elixir
+      (pkgs.beamPackages.hex.override {inherit elixir;})
+    ];
+
+    env = {
+      # prod, so the test-only credo dep is not consulted: the library has
+      # no runtime deps and this build never touches the network.
+      MIX_ENV = "prod";
+      HEX_OFFLINE = "1";
+      LANG = "C.UTF-8";
+      LC_CTYPE = "C.UTF-8";
+    };
+
+    postUnpack = ''
+      export MIX_HOME="$TEMPDIR/mix"
+      export HEX_HOME="$TEMPDIR/hex"
+    '';
+
+    buildPhase = ''
+      # shell
+      runHook preBuild
+      mix compile --no-deps-check --warnings-as-errors
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      # shell
+      runHook preInstall
+      mkdir -p "$out/lib"
+      cp -R "_build/prod/lib/agent_harness" "$out/lib/agent_harness"
+      runHook postInstall
+    '';
+  };
+in
+  package.overrideAttrs (old: {
+    passthru =
+      (old.passthru or {})
+      // {
+        tests = {
+          elixir = elixirCheck;
+        };
+      };
+  })

--- a/packages/agent-harness-ex/lib/agent_harness.ex
+++ b/packages/agent-harness-ex/lib/agent_harness.ex
@@ -1,0 +1,173 @@
+defmodule AgentHarness do
+  @moduledoc """
+  The Fable 5 system card's async-subagents multi-agent harness as a BEAM
+  library (card sec 8.15.3; index#3700). One `AgentHarness` supervisor is
+  one harness instance: a lead (the embedding session's mailbox) plus
+  long-lived subagent processes it spawns, messages, and deletes.
+
+  See README.md for the design doc. The semantics in one breath: spawning
+  returns immediately; a subagent sees only the instructions the lead wrote;
+  messages queue and are drained after the recipient's next tool result
+  (`checkpoint/2`) or on demand (`wait_for_message/3`); a runner's final
+  response lands in the lead's mailbox and the subagent idles until a new
+  message wakes it; `delete_subagent/2` frees a concurrency slot.
+
+  The library never calls a model API. The host injects an
+  `AgentHarness.Runner` implementation, and everything here is plain OTP:
+
+      children = [
+        {AgentHarness, name: MyApp.Harness, runner: MyApp.ClaudeRunner}
+      ]
+
+  Options for `start_link/1` / `child_spec/1`:
+
+    * `:name` (required) - atom naming this instance's process family.
+    * `:runner` (required) - the `AgentHarness.Runner` module.
+    * `:max_concurrent` - live subagent cap, default 4 (the card's
+      ProgramBench setting).
+    * `:max_total` - lifetime spawn cap, default 20 (ditto).
+    * `:token_budget` - per-agent token budget, default 1_000_000 (the
+      card runs each agent with a 1M-token limit, no compaction).
+    * `:default_model` - fallback for spawns that omit `:model`; opaque to
+      the harness. There is no built-in default: the model is a per-spawn
+      decision.
+
+  `create_subagent/3` options: `:name`, `:model`, `:token_budget`,
+  `:runner` (per-spawn overrides), plus anything the host's runner wants to
+  find in `ctx.opts`.
+  """
+
+  alias AgentHarness.Agent
+  alias AgentHarness.Coordinator
+  alias AgentHarness.Message
+  alias AgentHarness.Names
+
+  @type harness :: atom()
+  @type agent_id :: String.t()
+  @type status :: :working | :idle | :terminated
+  @type create_error :: :max_concurrent | :max_total | :name_taken | :missing_model
+
+  @default_max_concurrent 4
+  @default_max_total 20
+  @default_token_budget 1_000_000
+
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: {__MODULE__, Keyword.fetch!(opts, :name)},
+      start: {__MODULE__, :start_link, [opts]},
+      type: :supervisor
+    }
+  end
+
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :name)
+
+    config = %{
+      runner: Keyword.fetch!(opts, :runner),
+      max_concurrent: Keyword.get(opts, :max_concurrent, @default_max_concurrent),
+      max_total: Keyword.get(opts, :max_total, @default_max_total),
+      token_budget: Keyword.get(opts, :token_budget, @default_token_budget),
+      default_model: Keyword.get(opts, :default_model)
+    }
+
+    children = [
+      {Registry, keys: :unique, name: Names.registry(name)},
+      {Task.Supervisor, name: Names.task_supervisor(name)},
+      {DynamicSupervisor, name: Names.agent_supervisor(name), strategy: :one_for_one},
+      {Coordinator, {name, config}}
+    ]
+
+    # one_for_all: the coordinator's roster mirrors the agents under the
+    # DynamicSupervisor, and the Registry maps between them. Restarting any
+    # one of the three alone would leave the survivors describing processes
+    # that no longer exist, so a crash resets the whole instance.
+    Supervisor.start_link(children, strategy: :one_for_all, name: name)
+  end
+
+  @doc "The lead's well-known agent id."
+  @spec lead_id() :: agent_id()
+  def lead_id, do: Names.lead_id()
+
+  @doc """
+  Spawn an async, long-lived subagent (lead-only tool). Returns immediately
+  with the new agent's id; the runner starts working in the background.
+  """
+  @spec create_subagent(harness(), String.t(), keyword()) ::
+          {:ok, agent_id()} | {:error, create_error()}
+  def create_subagent(harness, instructions, opts \\ []) when is_binary(instructions) do
+    GenServer.call(Names.coordinator(harness), {:create, instructions, opts})
+  end
+
+  @doc "Terminate a subagent and free its concurrency slot (lead-only tool)."
+  @spec delete_subagent(harness(), agent_id()) :: :ok | {:error, :not_found}
+  def delete_subagent(harness, id) do
+    GenServer.call(Names.coordinator(harness), {:delete, id})
+  end
+
+  @doc "Status of every subagent ever created on this harness (lead-only tool)."
+  @spec subagent_status(harness()) :: %{agent_id() => status()}
+  def subagent_status(harness) do
+    GenServer.call(Names.coordinator(harness), :status_all)
+  end
+
+  @spec subagent_status(harness(), agent_id()) :: {:ok, status()} | {:error, :not_found}
+  def subagent_status(harness, id) do
+    GenServer.call(Names.coordinator(harness), {:status, id})
+  end
+
+  @doc """
+  Queue a message for `to` (any agent, including `lead_id/0`). It is
+  delivered at the recipient's next `checkpoint/2` (i.e. after its next tool
+  result), or immediately if the recipient is blocked in
+  `wait_for_message/3`. Messaging an idle subagent wakes it: the text
+  becomes its new instructions.
+  """
+  @spec send_message(harness(), agent_id(), agent_id(), String.t()) ::
+          :ok | {:error, :not_found}
+  def send_message(harness, from, to, text) when is_binary(text) do
+    call_agent(harness, to, fn pid ->
+      Agent.deliver(pid, Message.new(from, to, text, :message))
+    end)
+  end
+
+  @doc "Block until a message arrives for `id` (drains the whole mailbox)."
+  @spec wait_for_message(harness(), agent_id(), timeout()) ::
+          {:ok, [Message.t()]} | :timeout | {:error, :not_found}
+  def wait_for_message(harness, id, timeout \\ :infinity) do
+    call_agent(harness, id, fn pid -> Agent.wait_for_message(pid, timeout) end)
+  end
+
+  @doc """
+  Drain `id`'s queued messages and read its remaining token budget. Runners
+  call this after every tool result; hosts call it for the lead after every
+  tool call of the outer session.
+  """
+  @spec checkpoint(harness(), agent_id()) ::
+          {:ok, %{messages: [Message.t()], tokens_remaining: non_neg_integer()}}
+          | {:error, :not_found}
+  def checkpoint(harness, id) do
+    call_agent(harness, id, fn pid -> {:ok, Agent.checkpoint(pid)} end)
+  end
+
+  @doc "Record token consumption against `id`'s budget."
+  @spec add_usage(harness(), agent_id(), non_neg_integer()) ::
+          {:ok, non_neg_integer()} | {:error, :budget_exhausted | :not_found}
+  def add_usage(harness, id, tokens) do
+    case call_agent(harness, id, fn pid -> Agent.add_usage(pid, tokens) end) do
+      {:error, :not_found} -> {:error, :not_found}
+      other -> other
+    end
+  end
+
+  defp call_agent(harness, id, fun) do
+    case Registry.lookup(Names.registry(harness), {:agent, id}) do
+      [{pid, _value}] -> fun.(pid)
+      [] -> {:error, :not_found}
+    end
+  catch
+    # The agent died between lookup and call; same answer as a missed lookup.
+    :exit, {:noproc, _call} -> {:error, :not_found}
+  end
+end

--- a/packages/agent-harness-ex/lib/agent_harness.ex
+++ b/packages/agent-harness-ex/lib/agent_harness.ex
@@ -122,7 +122,8 @@ defmodule AgentHarness do
   delivered at the recipient's next `checkpoint/2` (i.e. after its next tool
   result), or immediately if the recipient is blocked in
   `wait_for_message/3`. Messaging an idle subagent wakes it: the text
-  becomes its new instructions.
+  becomes its new instructions. The `from` id is host-trusted: nothing
+  verifies the sender until the MCP surface adds enforcement.
   """
   @spec send_message(harness(), agent_id(), agent_id(), String.t()) ::
           :ok | {:error, :not_found}
@@ -155,10 +156,7 @@ defmodule AgentHarness do
   @spec add_usage(harness(), agent_id(), non_neg_integer()) ::
           {:ok, non_neg_integer()} | {:error, :budget_exhausted | :not_found}
   def add_usage(harness, id, tokens) do
-    case call_agent(harness, id, fn pid -> Agent.add_usage(pid, tokens) end) do
-      {:error, :not_found} -> {:error, :not_found}
-      other -> other
-    end
+    call_agent(harness, id, fn pid -> Agent.add_usage(pid, tokens) end)
   end
 
   defp call_agent(harness, id, fun) do
@@ -167,7 +165,10 @@ defmodule AgentHarness do
       [] -> {:error, :not_found}
     end
   catch
-    # The agent died between lookup and call; same answer as a missed lookup.
+    # The agent died between lookup and call, or mid-call (e.g. a concurrent
+    # delete_subagent shutting it down); same answer as a missed lookup.
     :exit, {:noproc, _call} -> {:error, :not_found}
+    :exit, {:shutdown, _call} -> {:error, :not_found}
+    :exit, {{:shutdown, _reason}, _call} -> {:error, :not_found}
   end
 end

--- a/packages/agent-harness-ex/lib/agent_harness/agent.ex
+++ b/packages/agent-harness-ex/lib/agent_harness/agent.ex
@@ -215,8 +215,36 @@ defmodule AgentHarness.Agent do
 
   defp finish_run(state, result) do
     route_to_lead(state, final_message(state, result))
-    %{state | task: nil, status: :idle}
+    state = drop_waiters(%{state | task: nil, status: :idle})
+    wake_from_mailbox(state)
   end
+
+  # The only process that can legitimately be blocked in wait_for_message
+  # here is the run that just ended (a crashed runner's stranded call), so
+  # answer :timeout (a no-op for a dead caller) instead of leaving a stale
+  # waiter to swallow the next wake message.
+  defp drop_waiters(state) do
+    Enum.each(state.waiters, fn {from, timer} ->
+      cancel_timer(timer)
+      GenServer.reply(from, :timeout)
+    end)
+
+    %{state | waiters: []}
+  end
+
+  # A message that landed during the final-composition window (after the
+  # runner's last checkpoint, before its return) queued instead of waking
+  # the agent. Same rule as the idle-wake clause in accept/2: the head
+  # becomes the new instructions and the rest of the queue stays FIFO for
+  # the next checkpoint.
+  defp wake_from_mailbox(%{role: :subagent} = state) do
+    case :queue.out(state.mailbox) do
+      {{:value, msg}, rest} -> start_run(%{state | mailbox: rest}, msg.text)
+      {:empty, _empty} -> state
+    end
+  end
+
+  defp wake_from_mailbox(state), do: state
 
   defp final_message(state, {:ok, text}) when is_binary(text) do
     Message.new(state.id, Names.lead_id(), text, :final)

--- a/packages/agent-harness-ex/lib/agent_harness/agent.ex
+++ b/packages/agent-harness-ex/lib/agent_harness/agent.ex
@@ -1,0 +1,252 @@
+defmodule AgentHarness.Agent do
+  @moduledoc """
+  One agent as a process: mailbox, status, budget, and the runner task.
+
+  The GenServer only routes; the model conversation runs in a
+  `Task.Supervisor` task (`async_nolink`) so message delivery, status
+  queries, and cancellation stay live while the runner samples. The card's
+  status ladder maps onto process state: a live task is `:working`, no task
+  is `:idle`, and a dead process is `:terminated` (remembered by the roster
+  in `AgentHarness.Coordinator`, since a dead process answers nothing).
+
+  Delivery semantics live in `accept/2`, in priority order: a blocked
+  `wait_for_message` caller is answered immediately, an idle subagent is
+  woken with the message text as its new instructions, and otherwise the
+  message queues until the runner's next `checkpoint/1` (which the runner
+  calls after each tool result).
+  """
+
+  use GenServer, restart: :temporary
+
+  alias AgentHarness.Context
+  alias AgentHarness.Message
+  alias AgentHarness.Names
+
+  @type status :: :working | :idle
+
+  @type start_args :: %{
+          required(:harness) => atom(),
+          required(:id) => String.t(),
+          required(:role) => :lead | :subagent,
+          required(:instructions) => String.t() | nil,
+          required(:runner) => module(),
+          required(:model) => term(),
+          required(:token_budget) => pos_integer(),
+          required(:opts) => keyword()
+        }
+
+  # -- client (called by the AgentHarness facade after a Registry lookup) --
+
+  @spec start_link(start_args()) :: GenServer.on_start()
+  def start_link(%{harness: harness, id: id} = args) do
+    GenServer.start_link(__MODULE__, args, name: via(harness, id))
+  end
+
+  @spec via(atom(), String.t()) :: {:via, Registry, {atom(), {:agent, String.t()}}}
+  def via(harness, id), do: {:via, Registry, {Names.registry(harness), {:agent, id}}}
+
+  @spec deliver(GenServer.server(), Message.t()) :: :ok
+  def deliver(server, %Message{} = msg), do: GenServer.call(server, {:deliver, msg})
+
+  @doc "Blocks until a message arrives; the server owns the timeout."
+  @spec wait_for_message(GenServer.server(), timeout()) :: {:ok, [Message.t()]} | :timeout
+  def wait_for_message(server, timeout), do: GenServer.call(server, {:wait, timeout}, :infinity)
+
+  @doc "Drain queued messages; the runner calls this after every tool result."
+  @spec checkpoint(GenServer.server()) ::
+          %{messages: [Message.t()], tokens_remaining: non_neg_integer()}
+  def checkpoint(server), do: GenServer.call(server, :checkpoint)
+
+  @spec add_usage(GenServer.server(), non_neg_integer()) ::
+          {:ok, non_neg_integer()} | {:error, :budget_exhausted}
+  def add_usage(server, tokens) when is_integer(tokens) and tokens >= 0 do
+    GenServer.call(server, {:add_usage, tokens})
+  end
+
+  @spec status(GenServer.server()) :: status()
+  def status(server), do: GenServer.call(server, :status)
+
+  # -- server --
+
+  @impl true
+  def init(args) do
+    # Trapping exits makes terminate/2 run on supervisor shutdown, so the
+    # runner task dies with its agent instead of leaking past delete.
+    Process.flag(:trap_exit, true)
+
+    state = %{
+      harness: args.harness,
+      id: args.id,
+      role: args.role,
+      runner: args.runner,
+      model: args.model,
+      opts: args.opts,
+      budget_limit: args.token_budget,
+      budget_used: 0,
+      status: :idle,
+      task: nil,
+      mailbox: :queue.new(),
+      waiters: []
+    }
+
+    case args.role do
+      :lead -> {:ok, state}
+      :subagent -> {:ok, start_run(state, args.instructions)}
+    end
+  end
+
+  @impl true
+  def handle_call({:deliver, msg}, _from, state) do
+    {:reply, :ok, accept(state, msg)}
+  end
+
+  def handle_call({:wait, timeout}, from, state) do
+    case :queue.to_list(state.mailbox) do
+      [] ->
+        timer = schedule_wait_timeout(from, timeout)
+        {:noreply, %{state | waiters: state.waiters ++ [{from, timer}]}}
+
+      msgs ->
+        {:reply, {:ok, msgs}, %{state | mailbox: :queue.new()}}
+    end
+  end
+
+  def handle_call(:checkpoint, _from, state) do
+    reply = %{
+      messages: :queue.to_list(state.mailbox),
+      tokens_remaining: tokens_remaining(state)
+    }
+
+    {:reply, reply, %{state | mailbox: :queue.new()}}
+  end
+
+  def handle_call({:add_usage, tokens}, _from, state) do
+    next = %{state | budget_used: state.budget_used + tokens}
+
+    reply =
+      if next.budget_used > next.budget_limit do
+        {:error, :budget_exhausted}
+      else
+        {:ok, tokens_remaining(next)}
+      end
+
+    {:reply, reply, next}
+  end
+
+  def handle_call(:status, _from, state) do
+    {:reply, state.status, state}
+  end
+
+  @impl true
+  def handle_cast({:deliver, msg}, state) do
+    {:noreply, accept(state, msg)}
+  end
+
+  @impl true
+  def handle_info({ref, result}, %{task: %{ref: ref}} = state) do
+    Process.demonitor(ref, [:flush])
+    {:noreply, finish_run(state, result)}
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, reason}, %{task: %{ref: ref}} = state) do
+    {:noreply, finish_run(state, {:error, {:runner_crash, reason}})}
+  end
+
+  def handle_info({:wait_timeout, from}, state) do
+    case Enum.split_with(state.waiters, fn {waiter, _timer} -> waiter == from end) do
+      {[], _all} ->
+        {:noreply, state}
+
+      {[_expired], rest} ->
+        GenServer.reply(from, :timeout)
+        {:noreply, %{state | waiters: rest}}
+    end
+  end
+
+  # Late task replies (after a timeout-triggered demonitor race) and stray
+  # exits from trapped links have no state to change.
+  def handle_info(_other, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, %{task: %{pid: pid}} = state) do
+    Task.Supervisor.terminate_child(Names.task_supervisor(state.harness), pid)
+    :ok
+  end
+
+  def terminate(_reason, _state), do: :ok
+
+  # -- delivery, in priority order (see @moduledoc) --
+
+  defp accept(%{waiters: [{from, timer} | rest]} = state, msg) do
+    cancel_timer(timer)
+    GenServer.reply(from, {:ok, [msg]})
+    %{state | waiters: rest}
+  end
+
+  defp accept(%{role: :subagent, status: :idle} = state, msg) do
+    # The card: a finished subagent "idles until the lead wakes it with new
+    # instructions". Waking is just messaging an idle agent; the message
+    # text becomes the new instructions and starts a fresh run.
+    start_run(state, msg.text)
+  end
+
+  defp accept(state, msg) do
+    %{state | mailbox: :queue.in(msg, state.mailbox)}
+  end
+
+  defp start_run(state, instructions) do
+    ctx = %Context{
+      harness: state.harness,
+      agent_id: state.id,
+      model: state.model,
+      token_budget: state.budget_limit,
+      opts: state.opts
+    }
+
+    runner = state.runner
+
+    task =
+      Task.Supervisor.async_nolink(Names.task_supervisor(state.harness), fn ->
+        runner.run(instructions, ctx)
+      end)
+
+    %{state | task: %{pid: task.pid, ref: task.ref}, status: :working}
+  end
+
+  defp finish_run(state, result) do
+    route_to_lead(state, final_message(state, result))
+    %{state | task: nil, status: :idle}
+  end
+
+  defp final_message(state, {:ok, text}) when is_binary(text) do
+    Message.new(state.id, Names.lead_id(), text, :final)
+  end
+
+  defp final_message(state, other) do
+    Message.new(state.id, Names.lead_id(), inspect(other), :error)
+  end
+
+  defp route_to_lead(state, msg) do
+    # Cast, not call: the lead may itself be mid-call into this agent, and a
+    # final response must never deadlock the pair.
+    case Registry.lookup(Names.registry(state.harness), {:agent, Names.lead_id()}) do
+      [{pid, _value}] -> GenServer.cast(pid, {:deliver, msg})
+      [] -> :ok
+    end
+  end
+
+  defp tokens_remaining(state), do: max(state.budget_limit - state.budget_used, 0)
+
+  defp schedule_wait_timeout(_from, :infinity), do: nil
+
+  defp schedule_wait_timeout(from, timeout) do
+    Process.send_after(self(), {:wait_timeout, from}, timeout)
+  end
+
+  defp cancel_timer(nil), do: :ok
+
+  defp cancel_timer(timer) do
+    Process.cancel_timer(timer)
+    :ok
+  end
+end

--- a/packages/agent-harness-ex/lib/agent_harness/context.ex
+++ b/packages/agent-harness-ex/lib/agent_harness/context.ex
@@ -1,0 +1,22 @@
+defmodule AgentHarness.Context do
+  @moduledoc """
+  The handle a `AgentHarness.Runner` receives alongside its instructions.
+
+  It carries everything the runner needs to talk back to the harness
+  (`harness` + `agent_id` address the agent's own mailbox through the public
+  `AgentHarness` functions) plus the per-spawn knobs the harness itself never
+  interprets: `model` is an opaque term chosen at `create_subagent` time, and
+  `opts` is the full spawn option list for host-specific extras.
+  """
+
+  @enforce_keys [:harness, :agent_id, :model, :token_budget]
+  defstruct [:harness, :agent_id, :model, :token_budget, opts: []]
+
+  @type t :: %__MODULE__{
+          harness: atom(),
+          agent_id: String.t(),
+          model: term(),
+          token_budget: pos_integer(),
+          opts: keyword()
+        }
+end

--- a/packages/agent-harness-ex/lib/agent_harness/coordinator.ex
+++ b/packages/agent-harness-ex/lib/agent_harness/coordinator.ex
@@ -96,7 +96,7 @@ defmodule AgentHarness.Coordinator do
   # -- admission --
 
   defp admit(state, opts) do
-    id = Keyword.get(opts, :name, "sub-#{state.total_created + 1}")
+    id = Keyword.get_lazy(opts, :name, fn -> default_id(state) end)
     model = Keyword.get(opts, :model, state.config.default_model)
 
     cond do
@@ -140,6 +140,21 @@ defmodule AgentHarness.Coordinator do
     }
 
     DynamicSupervisor.start_child(Names.agent_supervisor(state.harness), {Agent, args})
+  end
+
+  # Default ids share the roster namespace with user-chosen names, so a
+  # host that once named an agent "sub-2" must not lose its next anonymous
+  # spawn to :name_taken; skip taken numbers instead of failing admission.
+  defp default_id(state), do: default_id(state.roster, state.total_created + 1)
+
+  defp default_id(roster, n) do
+    id = "sub-#{n}"
+
+    if Map.has_key?(roster, id) do
+      default_id(roster, n + 1)
+    else
+      id
+    end
   end
 
   # -- roster --

--- a/packages/agent-harness-ex/lib/agent_harness/coordinator.ex
+++ b/packages/agent-harness-ex/lib/agent_harness/coordinator.ex
@@ -1,0 +1,164 @@
+defmodule AgentHarness.Coordinator do
+  @moduledoc """
+  The roster and the caps: admission control for `create_subagent`, slot
+  accounting for `delete_subagent`, and the status ladder for
+  `subagent_status`.
+
+  The roster remembers every subagent ever created, including dead ones, so
+  status queries can answer `:terminated` instead of "not found" after a
+  delete or a crash (a Registry lookup alone forgets the dead). Concurrency
+  counts only live entries; the lifetime total only ever grows, which is
+  what makes `max_total` a real cap rather than a high-water mark.
+
+  The lead agent is created here at init so subagent final responses always
+  have a mailbox to land in. It lives outside the roster: the caps and the
+  status tool are about subagents.
+  """
+
+  use GenServer
+
+  alias AgentHarness.Agent
+  alias AgentHarness.Names
+
+  @type config :: %{
+          runner: module(),
+          max_concurrent: pos_integer(),
+          max_total: pos_integer(),
+          token_budget: pos_integer(),
+          default_model: term()
+        }
+
+  @spec start_link({atom(), config()}) :: GenServer.on_start()
+  def start_link({harness, config}) do
+    GenServer.start_link(__MODULE__, {harness, config}, name: Names.coordinator(harness))
+  end
+
+  @impl true
+  def init({harness, config}) do
+    state = %{
+      harness: harness,
+      config: config,
+      total_created: 0,
+      roster: %{},
+      monitors: %{}
+    }
+
+    {:ok, _lead} = start_agent(state, Names.lead_id(), :lead, nil, config.default_model, [])
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call({:create, instructions, opts}, _from, state) do
+    case admit(state, opts) do
+      {:ok, id, model} -> do_create(state, id, model, instructions, opts)
+      {:error, reason} -> {:reply, {:error, reason}, state}
+    end
+  end
+
+  def handle_call({:delete, id}, _from, state) do
+    case Map.get(state.roster, id) do
+      nil ->
+        {:reply, {:error, :not_found}, state}
+
+      %{alive: false} ->
+        # Idempotent: the slot is already free.
+        {:reply, :ok, state}
+
+      %{pid: pid} ->
+        :ok = DynamicSupervisor.terminate_child(Names.agent_supervisor(state.harness), pid)
+        {:reply, :ok, %{state | roster: mark_terminated(state.roster, id)}}
+    end
+  end
+
+  def handle_call({:status, id}, _from, state) do
+    case Map.get(state.roster, id) do
+      nil -> {:reply, {:error, :not_found}, state}
+      entry -> {:reply, {:ok, entry_status(entry)}, state}
+    end
+  end
+
+  def handle_call(:status_all, _from, state) do
+    statuses = Map.new(state.roster, fn {id, entry} -> {id, entry_status(entry)} end)
+    {:reply, statuses, state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    case Map.pop(state.monitors, ref) do
+      {nil, _monitors} ->
+        {:noreply, state}
+
+      {id, monitors} ->
+        {:noreply, %{state | monitors: monitors, roster: mark_terminated(state.roster, id)}}
+    end
+  end
+
+  # -- admission --
+
+  defp admit(state, opts) do
+    id = Keyword.get(opts, :name, "sub-#{state.total_created + 1}")
+    model = Keyword.get(opts, :model, state.config.default_model)
+
+    cond do
+      state.total_created >= state.config.max_total -> {:error, :max_total}
+      live_count(state.roster) >= state.config.max_concurrent -> {:error, :max_concurrent}
+      Map.has_key?(state.roster, id) -> {:error, :name_taken}
+      is_nil(model) -> {:error, :missing_model}
+      true -> {:ok, id, model}
+    end
+  end
+
+  defp do_create(state, id, model, instructions, opts) do
+    case start_agent(state, id, :subagent, instructions, model, opts) do
+      {:ok, pid} ->
+        ref = Process.monitor(pid)
+
+        next = %{
+          state
+          | total_created: state.total_created + 1,
+            roster: Map.put(state.roster, id, %{pid: pid, alive: true}),
+            monitors: Map.put(state.monitors, ref, id)
+        }
+
+        {:reply, {:ok, id}, next}
+
+      {:error, {:already_started, _pid}} ->
+        {:reply, {:error, :name_taken}, state}
+    end
+  end
+
+  defp start_agent(state, id, role, instructions, model, opts) do
+    args = %{
+      harness: state.harness,
+      id: id,
+      role: role,
+      instructions: instructions,
+      runner: Keyword.get(opts, :runner, state.config.runner),
+      model: model,
+      token_budget: Keyword.get(opts, :token_budget, state.config.token_budget),
+      opts: opts
+    }
+
+    DynamicSupervisor.start_child(Names.agent_supervisor(state.harness), {Agent, args})
+  end
+
+  # -- roster --
+
+  defp live_count(roster) do
+    Enum.count(roster, fn {_id, entry} -> entry.alive end)
+  end
+
+  defp mark_terminated(roster, id) do
+    Map.update!(roster, id, &%{&1 | alive: false})
+  end
+
+  defp entry_status(%{alive: false}), do: :terminated
+
+  defp entry_status(%{pid: pid}) do
+    Agent.status(pid)
+  catch
+    # The agent died between the roster read and the call (its :DOWN is
+    # still in flight); that is just :terminated observed early.
+    :exit, _reason -> :terminated
+  end
+end

--- a/packages/agent-harness-ex/lib/agent_harness/message.ex
+++ b/packages/agent-harness-ex/lib/agent_harness/message.ex
@@ -1,0 +1,39 @@
+defmodule AgentHarness.Message do
+  @moduledoc """
+  The wire shape of everything agents exchange.
+
+  Three kinds ride the same struct:
+
+    * `:message` - an explicit Send Message between any two agents.
+    * `:final` - a subagent's final response, routed to the lead when its
+      runner returns `{:ok, text}` (the card: "a subagent's final response
+      is delivered to the lead as a message").
+    * `:error` - the runner returned an error or crashed; `text` carries the
+      inspected reason so the lead can decide whether to re-instruct.
+  """
+
+  @enforce_keys [:from, :to, :text, :kind, :sent_at_ms]
+  defstruct [:from, :to, :text, :kind, :sent_at_ms]
+
+  @type kind :: :message | :final | :error
+
+  @type t :: %__MODULE__{
+          from: String.t(),
+          to: String.t(),
+          text: String.t(),
+          kind: kind(),
+          sent_at_ms: integer()
+        }
+
+  @spec new(String.t(), String.t(), String.t(), kind()) :: t()
+  def new(from, to, text, kind)
+      when is_binary(from) and is_binary(to) and is_binary(text) do
+    %__MODULE__{
+      from: from,
+      to: to,
+      text: text,
+      kind: kind,
+      sent_at_ms: System.system_time(:millisecond)
+    }
+  end
+end

--- a/packages/agent-harness-ex/lib/agent_harness/names.ex
+++ b/packages/agent-harness-ex/lib/agent_harness/names.ex
@@ -1,0 +1,22 @@
+defmodule AgentHarness.Names do
+  @moduledoc false
+
+  # One harness instance = one process family. Every registered name is
+  # derived from the instance name the host chose, so several harnesses can
+  # coexist in one VM (e.g. one per kernel session).
+
+  @spec registry(atom()) :: atom()
+  def registry(harness), do: Module.concat(harness, Registry)
+
+  @spec agent_supervisor(atom()) :: atom()
+  def agent_supervisor(harness), do: Module.concat(harness, AgentSupervisor)
+
+  @spec task_supervisor(atom()) :: atom()
+  def task_supervisor(harness), do: Module.concat(harness, TaskSupervisor)
+
+  @spec coordinator(atom()) :: atom()
+  def coordinator(harness), do: Module.concat(harness, Coordinator)
+
+  @spec lead_id() :: String.t()
+  def lead_id, do: "lead"
+end

--- a/packages/agent-harness-ex/lib/agent_harness/names.ex
+++ b/packages/agent-harness-ex/lib/agent_harness/names.ex
@@ -1,9 +1,11 @@
 defmodule AgentHarness.Names do
-  @moduledoc false
-
-  # One harness instance = one process family. Every registered name is
-  # derived from the instance name the host chose, so several harnesses can
-  # coexist in one VM (e.g. one per kernel session).
+  @moduledoc """
+  One harness instance = one process family. Every registered name is
+  derived from the instance name the host chose, so several harnesses can
+  coexist in one VM (e.g. one per kernel session). Deriving names mints
+  atoms, which are never garbage collected, so hosts must draw harness
+  names from a bounded set.
+  """
 
   @spec registry(atom()) :: atom()
   def registry(harness), do: Module.concat(harness, Registry)

--- a/packages/agent-harness-ex/lib/agent_harness/runner.ex
+++ b/packages/agent-harness-ex/lib/agent_harness/runner.ex
@@ -1,0 +1,32 @@
+defmodule AgentHarness.Runner do
+  @moduledoc """
+  The model-call seam: the one behaviour a host implements to plug a real
+  LLM client into the harness. The library never talks to any API itself.
+
+  `c:run/2` executes one full working phase of an agent, in a supervised
+  task owned by that agent: the agentic loop of sampling the model,
+  executing tool calls, and repeating until the model produces a final
+  response. The contract with the harness:
+
+    * Call `AgentHarness.checkpoint/2` after every tool result and splice
+      the returned messages into the transcript. That is what implements the
+      card's delivery rule ("inserted following the recipient's next tool
+      result"); the harness only queues.
+    * Call `AgentHarness.wait_for_message/3` when the model invokes its
+      Wait for Message tool; the call blocks until a message arrives.
+    * Report token consumption through `AgentHarness.add_usage/3` and stop
+      when it returns `{:error, :budget_exhausted}`.
+    * Return `{:ok, final_text}` with the agent's final response; the
+      harness routes it to the lead and idles the agent. `{:error, reason}`
+      (or a crash) reaches the lead as an `:error` message instead.
+
+  Instructions are the only task context a subagent ever receives: the
+  harness hands the runner exactly what the lead wrote, never the lead's own
+  task description.
+  """
+
+  alias AgentHarness.Context
+
+  @callback run(instructions :: String.t(), ctx :: Context.t()) ::
+              {:ok, String.t()} | {:error, term()}
+end

--- a/packages/agent-harness-ex/mix.exs
+++ b/packages/agent-harness-ex/mix.exs
@@ -1,0 +1,29 @@
+defmodule AgentHarness.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :agent_harness,
+      version: "0.1.0",
+      elixir: "~> 1.18",
+      start_permanent: Mix.env() == :prod,
+      elixirc_options: [warnings_as_errors: true],
+      deps: deps()
+    ]
+  end
+
+  # A library: no application module. The host (ix-mcp-ex) places
+  # `AgentHarness` under its own supervision tree via child_spec/1.
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [
+      # Static-analysis gate, test-only so the library carries zero runtime
+      # deps; the sandboxed check runs `mix credo` in :test where the deps
+      # FOD provides it.
+      {:credo, "~> 1.7", only: :test, runtime: false}
+    ]
+  end
+end

--- a/packages/agent-harness-ex/mix.lock
+++ b/packages/agent-harness-ex/mix.lock
@@ -1,0 +1,6 @@
+%{
+  "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
+  "credo": {:hex, :credo, "1.7.19", "cc52129665fc7c15143d47838fda0f9cd6dac9ceced7bf4da6f85fcbfe64b12a", [:mix], [{:bunt, "~> 0.2.1 or ~> 1.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2 or ~> 1.0", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "2d8bc95d5a7bb99dd2613621d4f08c6a3575c3fd4b62e6a2b48a100352a557b8"},
+  "file_system": {:hex, :file_system, "1.1.1", "31864f4685b0148f25bd3fbef2b1228457c0c89024ad67f7a81a3ffbc0bbad3a", [:mix], [], "hexpm", "7a15ff97dfe526aeefb090a7a9d3d03aa907e100e262a0f8f7746b78f8f87a5d"},
+  "jason": {:hex, :jason, "1.4.5", "2e3a008590b0b8d7388c20293e9dcc9cf3e5d642fd2a114e4cbbb52e595d940a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0 or ~> 3.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b0c823996102bcd0239b3c2444eb00409b72f6a140c1950bc8b457d836b30684"},
+}

--- a/packages/agent-harness-ex/package.nix
+++ b/packages/agent-harness-ex/package.nix
@@ -1,0 +1,13 @@
+# Registry metadata. agent-harness-ex is the BEAM implementation of the
+# Fable 5 system card's async-subagents multi-agent harness (sec 8.15.3,
+# index#3700): agents as supervised processes with mailbox-backed
+# Send Message / Wait for Message semantics. ix-mcp-ex consumes it as a mix
+# path dependency; the flake output builds the compiled :agent_harness OTP
+# app and `passthru.tests.elixir` gates the ExUnit/Credo lane.
+{
+  id = "agent-harness-ex";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+  passthruTests = true;
+}

--- a/packages/agent-harness-ex/pins.json
+++ b/packages/agent-harness-ex/pins.json
@@ -1,0 +1,5 @@
+{
+  "mix-deps": {
+    "hash": "sha256-EXaJddUakJETdzPNFWgJRgBWG4VcrP/Z5tOCuE+BXdo="
+  }
+}

--- a/packages/agent-harness-ex/test/agent_harness_test.exs
+++ b/packages/agent-harness-ex/test/agent_harness_test.exs
@@ -48,7 +48,7 @@ defmodule AgentHarnessTest do
     @impl true
     def run(_instructions, ctx) do
       notify = Keyword.fetch!(ctx.opts, :notify)
-      send(notify, {:waiting, ctx.agent_id})
+      send(notify, {:waiting, self(), ctx.agent_id})
       {:ok, msgs} = AgentHarness.wait_for_message(ctx.harness, ctx.agent_id)
       send(notify, {:got, msgs})
       {:ok, "woken"}
@@ -62,6 +62,33 @@ defmodule AgentHarnessTest do
     def run(instructions, ctx) do
       send(Keyword.fetch!(ctx.opts, :notify), {:run, ctx.agent_id, instructions})
       {:ok, "answer:" <> instructions}
+    end
+  end
+
+  defmodule LatchRunner do
+    @behaviour AgentHarness.Runner
+
+    # Holds the final response open behind a test-controlled latch: the
+    # window between the runner's last checkpoint and its return is where a
+    # send_message must not strand (the agent is still :working, so nothing
+    # would wake it later).
+    @impl true
+    def run(instructions, ctx) do
+      notify = Keyword.fetch!(ctx.opts, :notify)
+      send(notify, {:run, self(), ctx.agent_id, instructions})
+      loop(instructions, ctx, notify)
+    end
+
+    defp loop(instructions, ctx, notify) do
+      receive do
+        :checkpoint ->
+          {:ok, %{messages: msgs}} = AgentHarness.checkpoint(ctx.harness, ctx.agent_id)
+          send(notify, {:drained, msgs})
+          loop(instructions, ctx, notify)
+
+        :release ->
+          {:ok, "final:" <> instructions}
+      end
     end
   end
 
@@ -110,7 +137,7 @@ defmodule AgentHarnessTest do
   test "wait_for_message blocks until a message arrives" do
     harness = start_harness(runner: WaitingRunner)
     {:ok, id} = create(harness)
-    assert_receive {:waiting, ^id}
+    assert_receive {:waiting, _task, ^id}
 
     refute_receive {:got, _msgs}, 100
 
@@ -169,8 +196,85 @@ defmodule AgentHarnessTest do
     assert {:ok, %{tokens_remaining: 0}} = AgentHarness.checkpoint(harness, id)
   end
 
+  test "a runner crash while blocked in wait_for_message does not strand the agent" do
+    harness = start_harness(runner: WaitingRunner)
+    {:ok, id} = create(harness)
+    assert_receive {:waiting, task, ^id}
+
+    # Pin the race: the runner notifies before its wait call registers, so
+    # wait for the agent to actually hold the waiter before killing it.
+    agent = GenServer.whereis(AgentHarness.Agent.via(harness, id))
+    wait_until(fn -> match?(%{waiters: [_ | _]}, :sys.get_state(agent)) end)
+
+    Process.exit(task, :kill)
+
+    # The crash surfaces to the lead as an :error final and the agent idles.
+    assert {:ok, [msg]} = AgentHarness.wait_for_message(harness, AgentHarness.lead_id(), 1_000)
+    assert msg.kind == :error
+    assert msg.from == id
+    assert {:ok, :idle} = AgentHarness.subagent_status(harness, id)
+
+    # Regression (C2): the dead run's stale waiter must not swallow the
+    # wake; the message has to start a fresh run.
+    :ok = AgentHarness.send_message(harness, "lead", id, "wake")
+    assert_receive {:waiting, _task2, ^id}
+    assert {:ok, :working} = AgentHarness.subagent_status(harness, id)
+  end
+
+  test "a message landing during the final-composition window re-runs the agent" do
+    harness = start_harness(runner: LatchRunner)
+    {:ok, id} = create(harness)
+    assert_receive {:run, task, ^id, "instructions"}
+
+    # The agent is :working and past its last checkpoint; these queue.
+    :ok = AgentHarness.send_message(harness, "lead", id, "follow-up")
+    :ok = AgentHarness.send_message(harness, "lead", id, "second")
+
+    send(task, :release)
+    assert {:ok, [final]} = AgentHarness.wait_for_message(harness, AgentHarness.lead_id(), 1_000)
+    assert final.text == "final:instructions"
+
+    # Regression (C1): the queued head becomes the new instructions instead
+    # of idling over it...
+    assert_receive {:run, task2, ^id, "follow-up"}
+
+    # ...and the rest of the queue stays FIFO for the next checkpoint.
+    send(task2, :checkpoint)
+    assert_receive {:drained, [msg]}
+    assert msg.text == "second"
+
+    send(task2, :release)
+  end
+
+  test "default subagent ids skip names the host already took" do
+    harness = start_harness([])
+
+    {:ok, "sub-2"} =
+      AgentHarness.create_subagent(harness, "instructions", name: "sub-2", notify: self())
+
+    # total_created is now 1, so the naive default for the next spawn would
+    # be the taken "sub-2"; admission must pick a free id instead.
+    assert {:ok, id} = create(harness)
+    assert id != "sub-2"
+    assert {:ok, :working} = AgentHarness.subagent_status(harness, id)
+  end
+
   test "messaging an unknown agent reports not_found" do
     harness = start_harness([])
     assert {:error, :not_found} = AgentHarness.send_message(harness, "lead", "ghost", "hi")
+  end
+
+  defp wait_until(fun, tries \\ 50) do
+    cond do
+      fun.() ->
+        :ok
+
+      tries == 0 ->
+        flunk("condition never became true")
+
+      true ->
+        Process.sleep(10)
+        wait_until(fun, tries - 1)
+    end
   end
 end

--- a/packages/agent-harness-ex/test/agent_harness_test.exs
+++ b/packages/agent-harness-ex/test/agent_harness_test.exs
@@ -1,0 +1,176 @@
+defmodule AgentHarnessTest do
+  use ExUnit.Case, async: true
+
+  # Test runners: each simulates one shape of agentic loop and reports its
+  # progress to the test process via the :notify pid in ctx.opts.
+
+  defmodule SleepyRunner do
+    @behaviour AgentHarness.Runner
+
+    @impl true
+    def run(instructions, ctx) do
+      send(Keyword.fetch!(ctx.opts, :notify), {:started, self(), ctx.agent_id, instructions})
+
+      receive do
+        :finish -> {:ok, "finished"}
+      end
+    end
+  end
+
+  defmodule CheckpointRunner do
+    @behaviour AgentHarness.Runner
+
+    @impl true
+    def run(_instructions, ctx) do
+      notify = Keyword.fetch!(ctx.opts, :notify)
+      send(notify, {:runner, self(), ctx.agent_id})
+      loop(ctx, notify)
+    end
+
+    # Each :tool_result from the test stands in for one finished tool call;
+    # the checkpoint after it is where queued messages become visible.
+    defp loop(ctx, notify) do
+      receive do
+        :tool_result ->
+          {:ok, %{messages: msgs}} = AgentHarness.checkpoint(ctx.harness, ctx.agent_id)
+          send(notify, {:checkpoint, msgs})
+          loop(ctx, notify)
+
+        :finish ->
+          {:ok, "done"}
+      end
+    end
+  end
+
+  defmodule WaitingRunner do
+    @behaviour AgentHarness.Runner
+
+    @impl true
+    def run(_instructions, ctx) do
+      notify = Keyword.fetch!(ctx.opts, :notify)
+      send(notify, {:waiting, ctx.agent_id})
+      {:ok, msgs} = AgentHarness.wait_for_message(ctx.harness, ctx.agent_id)
+      send(notify, {:got, msgs})
+      {:ok, "woken"}
+    end
+  end
+
+  defmodule EchoRunner do
+    @behaviour AgentHarness.Runner
+
+    @impl true
+    def run(instructions, ctx) do
+      send(Keyword.fetch!(ctx.opts, :notify), {:run, ctx.agent_id, instructions})
+      {:ok, "answer:" <> instructions}
+    end
+  end
+
+  defp start_harness(opts) do
+    name = :"agent_harness_test_#{System.unique_integer([:positive])}"
+    defaults = [name: name, runner: SleepyRunner, default_model: "stub-model"]
+    start_supervised!({AgentHarness, Keyword.merge(defaults, opts)})
+    name
+  end
+
+  defp create(harness, opts \\ []) do
+    AgentHarness.create_subagent(harness, "instructions", Keyword.put(opts, :notify, self()))
+  end
+
+  test "create_subagent returns immediately while the runner keeps working" do
+    harness = start_harness([])
+
+    {elapsed_us, {:ok, id}} = :timer.tc(fn -> create(harness) end)
+
+    # The runner blocks forever (until :finish); only the spawn is timed.
+    assert elapsed_us < 500_000
+    assert_receive {:started, _task, ^id, "instructions"}
+    assert {:ok, :working} = AgentHarness.subagent_status(harness, id)
+  end
+
+  test "messages are delivered at the checkpoint after the next tool result, not before" do
+    harness = start_harness(runner: CheckpointRunner)
+    {:ok, id} = create(harness)
+    assert_receive {:runner, task, ^id}
+
+    # A tool result before any send drains nothing.
+    send(task, :tool_result)
+    assert_receive {:checkpoint, []}
+
+    :ok = AgentHarness.send_message(harness, "lead", id, "hello")
+
+    # The queued message surfaces only at the checkpoint after the next
+    # tool result.
+    send(task, :tool_result)
+    assert_receive {:checkpoint, [msg]}
+    assert %AgentHarness.Message{from: "lead", to: ^id, text: "hello", kind: :message} = msg
+
+    send(task, :finish)
+  end
+
+  test "wait_for_message blocks until a message arrives" do
+    harness = start_harness(runner: WaitingRunner)
+    {:ok, id} = create(harness)
+    assert_receive {:waiting, ^id}
+
+    refute_receive {:got, _msgs}, 100
+
+    :ok = AgentHarness.send_message(harness, "lead", id, "wake up")
+    assert_receive {:got, [msg]}
+    assert msg.text == "wake up"
+  end
+
+  test "the final response reaches the lead, the agent idles, and a message wakes it" do
+    harness = start_harness(runner: EchoRunner)
+    {:ok, id} = create(harness)
+    assert_receive {:run, ^id, "instructions"}
+
+    assert {:ok, [final]} = AgentHarness.wait_for_message(harness, AgentHarness.lead_id(), 1_000)
+    assert final.kind == :final
+    assert final.from == id
+    assert final.text == "answer:instructions"
+    assert {:ok, :idle} = AgentHarness.subagent_status(harness, id)
+
+    # Waking: a message to an idle subagent becomes its new instructions.
+    :ok = AgentHarness.send_message(harness, "lead", id, "round two")
+    assert_receive {:run, ^id, "round two"}
+    assert {:ok, [final2]} = AgentHarness.wait_for_message(harness, AgentHarness.lead_id(), 1_000)
+    assert final2.text == "answer:round two"
+  end
+
+  test "delete_subagent frees a concurrency slot" do
+    harness = start_harness(max_concurrent: 2)
+
+    {:ok, a} = create(harness)
+    {:ok, _b} = create(harness)
+    assert {:error, :max_concurrent} = create(harness)
+
+    assert :ok = AgentHarness.delete_subagent(harness, a)
+    assert {:ok, :terminated} = AgentHarness.subagent_status(harness, a)
+    assert {:ok, _c} = create(harness)
+  end
+
+  test "max_total caps lifetime spawns even after deletes" do
+    harness = start_harness(max_total: 2)
+
+    {:ok, a} = create(harness)
+    :ok = AgentHarness.delete_subagent(harness, a)
+    {:ok, b} = create(harness)
+    :ok = AgentHarness.delete_subagent(harness, b)
+
+    assert {:error, :max_total} = create(harness)
+  end
+
+  test "per-agent token budget is enforced" do
+    harness = start_harness([])
+    {:ok, id} = create(harness, token_budget: 100)
+
+    assert {:ok, 60} = AgentHarness.add_usage(harness, id, 40)
+    assert {:error, :budget_exhausted} = AgentHarness.add_usage(harness, id, 100)
+    assert {:ok, %{tokens_remaining: 0}} = AgentHarness.checkpoint(harness, id)
+  end
+
+  test "messaging an unknown agent reports not_found" do
+    harness = start_harness([])
+    assert {:error, :not_found} = AgentHarness.send_message(harness, "lead", "ghost", "hi")
+  end
+end

--- a/packages/agent-harness-ex/test/test_helper.exs
+++ b/packages/agent-harness-ex/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/packages/mcp-ex/default.nix
+++ b/packages/mcp-ex/default.nix
@@ -36,7 +36,9 @@
   # next to the unpacked project so the relative path resolves in the
   # sandbox. Reached through the package registry (`.src` of the sibling's
   # derivation) so its fileset stays the single source of truth and no `../`
-  # literal crosses package directories here.
+  # literal crosses package directories here. Tripwire: if agent-harness-ex
+  # ever gains a hex dep, the mixFodDeps FOD content below changes while its
+  # pins.json hash will not; bump the pin there.
   stageAgentHarness = ''
     cp --no-preserve=mode -R ${repoPackages.agent-harness-ex.src} "$NIX_BUILD_TOP/agent-harness-ex"
   '';

--- a/packages/mcp-ex/default.nix
+++ b/packages/mcp-ex/default.nix
@@ -31,6 +31,16 @@
     ];
   };
 
+  # The :agent_harness mix path dependency (mix.exs points at
+  # ../agent-harness-ex): every builder below stages the sibling's source
+  # next to the unpacked project so the relative path resolves in the
+  # sandbox. Reached through the package registry (`.src` of the sibling's
+  # derivation) so its fileset stays the single source of truth and no `../`
+  # literal crosses package directories here.
+  stageAgentHarness = ''
+    cp --no-preserve=mode -R ${repoPackages.agent-harness-ex.src} "$NIX_BUILD_TOP/agent-harness-ex"
+  '';
+
   # Mix deps (exqlite + its build deps, plus test-only credo) as a
   # fixed-output derivation so the sandboxed builds run offline; mixEnv=test
   # is a superset of prod, so the release build stages the same FOD. The SRI
@@ -42,6 +52,8 @@
     pname = "ix-mcp-ex-deps";
     inherit version src elixir;
     mixEnv = "test";
+    # deps.get loads mix.exs of every dep, path deps included.
+    postUnpack = stageAgentHarness;
     inherit ((ix.pins.loadPins ./pins.json).mix-deps) hash;
   };
 
@@ -60,6 +72,7 @@
     pname = "ix-mcp-ex-check";
     inherit version src elixir erlang;
     mixDeps = mixFodDeps;
+    setupHook = stageAgentHarness;
     # IX_MCP_TUI_EX makes the suite's local-TUI tests run in the sandbox
     # (test_helper.exs skips them when it is unset).
     extraEnv = rebar3Env // {IX_MCP_TUI_EX = tuiExApp;};
@@ -105,6 +118,7 @@
       export HEX_HOME="$TEMPDIR/hex"
       export MIX_DEPS_PATH="$TEMPDIR/deps"
       cp --no-preserve=mode -R "${mixFodDeps}" "$MIX_DEPS_PATH"
+      ${stageAgentHarness}
     '';
 
     buildPhase = ''

--- a/packages/mcp-ex/mix.exs
+++ b/packages/mcp-ex/mix.exs
@@ -25,6 +25,11 @@ defmodule IxMcp.MixProject do
   defp deps do
     [
       {:exqlite, "~> 0.39"},
+      # The Fable 5 async-subagents harness (packages/agent-harness-ex,
+      # #3700): agents as supervised processes with mailbox-backed Send/Wait
+      # semantics. A path dep so the harness rides into the release; the MCP
+      # tool surface over it is follow-up work, nothing is exposed yet.
+      {:agent_harness, path: "../agent-harness-ex"},
       # Static-analysis gate, test-only so the sandboxed check runs `mix credo`
       # offline where the deps FOD provides it.
       {:credo, "~> 1.7", only: :test, runtime: false}


### PR DESCRIPTION
Part of #3700. Design doc plus working scaffold of the Fable 5 system card's "async subagents" multi-agent harness (packages/system-cards/cards/anthropic/claude-fable-5-mythos-5.md, sec 8.15.3) as a new Elixir library, packages/agent-harness-ex, consumed by packages/mcp-ex as a mix path dependency.

What is in the package

- Supervision tree per harness instance (`:one_for_all`): Registry, Task.Supervisor, DynamicSupervisor of `AgentHarness.Agent` GenServers, and a Coordinator holding the roster and caps. The lead is an agent too (a mailbox for the embedding session), created at init.
- Card semantics: `create_subagent` returns immediately; subagents receive only lead-provided instructions; `send_message` queues until the recipient's next tool result (`checkpoint/2`) or unblocks a `wait_for_message/3`; a runner's final response is delivered to the lead as a `:final` message and the agent idles until a message wakes it (the text becomes new instructions); `delete_subagent` frees a concurrency slot; `subagent_status` answers working / idle / terminated.
- Defaults follow the card: `max_concurrent: 4`, `max_total: 20`, `token_budget: 1_000_000` per agent; the model is a required per-spawn opaque parameter (no model is hardcoded).
- The model-call seam is the `AgentHarness.Runner` behaviour; the package never talks to an API. mcp-ex will inject its Claude client there (follow-up), with tool execution riding the existing `IxMcp.Jobs` nursery; README.md is the design doc and covers the composition.
- ExUnit suite (8 tests) covers immediate spawn, checkpoint-boundary delivery, blocking wait, final-to-lead plus wake, slot freeing on delete, lifetime cap, budget exhaustion, and unknown-recipient errors.

Design decisions

- Delivery is cooperative: the harness queues, the runner drains at tool boundaries. That is exactly the card's "inserted following the recipient's next tool result" rule, kept out of the transport so the library stays API-free.
- Waking equals messaging an idle subagent; no separate wake tool.
- A runner crash does not kill its agent: the lead gets an `:error` message and the agent idles, matching the long-lived-subagent design.
- mcp-ex reaches the sibling source through the package registry (`repoPackages.agent-harness-ex.src` staged next to the unpacked project) rather than a `../` fileset, which the astlog no-parent-path rule blocks.

Not done here (follow-up)

- No MCP tools exposed yet; the tool surface (`create_subagent`, `delete_subagent`, `subagent_status`, `send_message`, `wait_for_message`) and the Claude runner live on the mcp-ex side.
- Budget enforcement is cooperative (runners stop on `:budget_exhausted`); the harness does not kill over-budget tasks.
- Subagent names are never reused after termination (`:name_taken`).

Validation: `nix build .#agent-harness-ex`, `.#agent-harness-ex.tests.elixir` (compile with warnings-as-errors, format, credo strict, 8/8 tests), `.#mcp-ex`, `.#mcp-ex.tests.elixir`, `.#mcp-ex.tests.smoke` all green; `nix run .#lint` has no findings on touched files (the filenames complaint about packages/system-cards/catalog.json pre-exists on main).

(authored by an AI agent via Claude Code, Fable 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add async-subagents harness scaffold for Elixir (Fable 5 sec 8.15.3)
> Introduces the `agent-harness-ex` Elixir OTP library implementing a supervised async-subagents harness.
>
> - [`AgentHarness`](https://github.com/indexable-inc/index/pull/3707/files#diff-ec3666195172a061c0b36b8ce2ce3c5176cec55b6bd339eefce3c56383a6bab5) starts a `:one_for_all` supervision tree (Registry, Task.Supervisor, DynamicSupervisor, Coordinator) and exposes a synchronous public API for creating/deleting subagents, sending/waiting for messages, checkpointing mailboxes, and tracking token usage.
> - [`AgentHarness.Agent`](https://github.com/indexable-inc/index/pull/3707/files#diff-d4c30c7c69271b5d2b24f78df2172356b3798f35b09c53675192a5fff4a22bda) is a GenServer per agent maintaining a FIFO mailbox, blocking `wait_for_message` callers, cooperative token budgets, and a runner `Task` that reports `:final`/`:error` to the lead on completion.
> - [`AgentHarness.Coordinator`](https://github.com/indexable-inc/index/pull/3707/files#diff-a4504686b0dd2650467fb5cea6473a9dfe93a4830a5e64b2cea5565ec2e0359c) enforces `max_total` and `max_concurrent` caps, allocates unique agent IDs, and tracks live vs. terminated roster entries.
> - The [`Runner`](https://github.com/indexable-inc/index/pull/3707/files#diff-847e7dab5668041a99ed56a4eb4e3280bac65b155a39e22dd6a4daeff600ae71) behaviour defines the `run/2` callback contract; runners receive a [`Context`](https://github.com/indexable-inc/index/pull/3707/files#diff-9526e9510b60c6f2585ba5a71fe4f2447da34fba1b13df34b5c928ef7f991b0f) struct with harness, identity, model, budget, and opts.
> - Nix build in [`default.nix`](https://github.com/indexable-inc/index/pull/3707/files#diff-8e78d7b5765319f13a5b7684e9ccd063dad7577f0fc227f351117fc68a996343) pins Elixir 1.18/Erlang 27, builds the OTP app offline, and exposes a QA gate (compile, format, credo, ExUnit).
> - [`mcp-ex`](https://github.com/indexable-inc/index/pull/3707/files#diff-6ad1ac5555f6431fc6e4b310df10a8aeac0fd1f8af4704575c2640ca9c49ad90) gains a path dependency on `agent_harness`; its Nix build stages the sibling source into the sandbox for offline resolution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ace64e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->