### PR TITLE
home-manager: vendored series gains the symlinked-parent fix

### DIFF
--- a/packages/home-manager/patches/0001-files-batch-symlink-creation-and-target-checks-in-ac.patch
+++ b/packages/home-manager/patches/0001-files-batch-symlink-creation-and-target-checks-in-ac.patch
@@ -25,10 +25,10 @@ identical resulting tree.
 Refs indexable-inc/index#3689
 
 diff --git a/modules/files.nix b/modules/files.nix
-index 121b72e24..97261fd93 100644
+index 121b72e24..4bda944b8 100644
 --- a/modules/files.nix
 +++ b/modules/files.nix
-@@ -191,7 +191,73 @@ in
+@@ -191,7 +191,80 @@ in
  
            newGenFiles="$1"
            shift
@@ -45,7 +45,14 @@ index 121b72e24..97261fd93 100644
            for sourcePath in "$@" ; do
 +            relativePath="''${sourcePath#$newGenFiles/}"
 +            targetPath="$HOME/$relativePath"
-+            if [[ -L "$targetPath" ]] ; then
++            if [[ -L "''${targetPath%/*}" ]] ; then
++              # The parent directory is itself a symlink (e.g. a stale
++              # whole-directory link from an older layout). The batched
++              # `ln -n -t` below would refuse it ("Not a directory"), while
++              # the original per-file `ln -T` traverses it; keep upstream
++              # behavior on the slow path.
++              slowSources+=("$sourcePath")
++            elif [[ -L "$targetPath" ]] ; then
 +              symlinkTargets+=("$targetPath")
 +              symlinkSources+=("$sourcePath")
 +            elif [[ -e "$targetPath" ]] ; then
@@ -102,7 +109,7 @@ index 121b72e24..97261fd93 100644
              relativePath="''${sourcePath#$newGenFiles/}"
              targetPath="$HOME/$relativePath"
              if [[ -e "$targetPath" && ! -L "$targetPath" ]] ; then
-@@ -209,7 +275,7 @@ in
+@@ -209,7 +282,7 @@ in
              fi
  
              if [[ -e "$targetPath" && ! -L "$targetPath" ]] && cmp -s "$sourcePath" "$targetPath" ; then


### PR DESCRIPTION
The #3697 series predates the parent-dir-is-symlink fix already live on the ix-patched branch and in the config lock (53fc997ee); this re-exports it canonically so rebase-patches cannot regress the fork branch. Verified: patched-src-home-manager and patch-dag-home-manager checks green locally; the fixed patch is the one gated live on hydra (two clean activations, empty tree diff). Refs #3689.

(sent by an AI agent via Claude Code, Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix symlinked-parent path handling in home-manager vendored patch
> Updates the [vendored patch](https://github.com/indexable-inc/index/pull/3709/files#diff-1977a99883a4a1aa45e5ce3f53468ee527dbd7e35dcd7ce9087efb6c346a3cbf) to detect when a target file's parent directory is a symlink and route it to the slow path instead of the batched `ln -n -t` operation. The batched form fails with "Not a directory" on symlinked parents, while the original per-file `ln -T` correctly traverses them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01cc2d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->