### PR TITLE
mcp-ex: point agents at Fleet remote execution

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/fleet.ex
+++ b/packages/mcp-ex/lib/ix_mcp/fleet.ex
@@ -30,6 +30,13 @@ defmodule IxMcp.Fleet do
       Fleet.exec(:"beamd@host-a.tailnet.ts.net", "System.schedulers_online()")
       Fleet.exec_any("node() |> to_string()")            # a random node
       Fleet.multicall(Fleet.nodes(), "node()", timeout: 10_000)
+
+  When to reach for this: CPU-heavy or parallelizable pure-Elixir compute (fan
+  out with `multicall/3`), linux-only behavior checks, and work wanting many
+  cores or hosts -- nodes are root on the fleet. Stay local for anything
+  touching this workstation's files, repos, or bindings, small low-latency
+  evals, stateful work (bindings do not persist remotely), and darwin-specific
+  behavior.
   """
 
   @nodes_env "IX_BEAM_NODES"

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -47,12 +47,22 @@ defmodule IxMcp.MCP.Tools do
                                             .send_key(term, "enter" | "ctrl+c" | ...),
                                             .wait_for(term, pattern),
                                             .snapshot/1, .close/1
+      Fleet.multicall(Fleet.nodes(), code)  run Elixir across the fleet's server cores
+                                            (Fleet.exec_least_loaded/2 for one node)
       Api.api("tail") / Api.help(Jobs, :tail)   discovery over this whole surface
 
   Each cell runs in its own BEAM process, so a blocking cell never delays
   other jobs or this server -- and Ix.trace/0 and Ix.restart/0 work from a
   fresh cell even while other jobs run or wedge, so a stuck job never locks
   you out of recovery.
+
+  Prefer Fleet for CPU-heavy or parallelizable pure-Elixir compute, linux-only
+  behavior checks, and work wanting many cores or hosts (fleet nodes are root);
+  keep it local for anything touching this workstation's files, repos, or
+  bindings, small low-latency evals, stateful work (remote bindings do NOT
+  persist -- code ships as source strings), and darwin-specific behavior.
+  Fleet.nodes() == [] means no fleet is configured (helpers return
+  {:error, :no_nodes}); the remote env is minimal (shell-outs limited).
   """
 
   @doc "The in-language surface cheat sheet (also shipped as server instructions)."

--- a/packages/site/src/lib/updates/mcp-ex-fleet-guidance.svx
+++ b/packages/site/src/lib/updates/mcp-ex-fleet-guidance.svx
@@ -1,0 +1,15 @@
+---
+id: mcp-ex-fleet-guidance
+postedAt: 2026-07-19T12:00:00-07:00
+title: "mcp-ex instructions now steer agents to the fleet for the work it wins"
+tags: [mcp, fleet]
+links:
+  - label: fleet.ex
+    href: https://github.com/indexable-inc/index/blob/main/packages/mcp-ex/lib/ix_mcp/fleet.ex
+  - label: issue #3711
+    href: https://github.com/indexable-inc/index/issues/3711
+---
+
+`IxMcp.Fleet` reaches beamd on the fleet hosts (700+ idle server cores, root, OTP 28) from the laptop that runs the MCP server, but nothing in the server's instructions mentioned it, so agents hand-rolled ssh for work that should fan out. The `exec` tool description, the server instructions, and the in-cell `Api.help(IxMcp.Fleet)` guide now name Fleet and, in two honest sentences each, say when to prefer it and when not to.
+
+Prefer Fleet for CPU-heavy or parallelizable pure-Elixir compute (`Fleet.multicall/3`, `Fleet.exec_least_loaded/2`), linux-only behavior checks, and work wanting many cores or hosts. Keep work local when it touches the workstation's files, repos, or bindings, is a small low-latency eval, is stateful (remote bindings do not persist -- code ships as source strings), or is darwin-specific. `Fleet.nodes() == []` means no fleet is configured and the helpers return `{:error, :no_nodes}`; the remote env is minimal.


### PR DESCRIPTION
Closes #3711.

`IxMcp.Fleet` reaches beamd on the fleet hosts (700+ idle server cores, root, OTP 28) from the laptop running the MCP server, but no instruction surface mentioned it, so agents hand-rolled ssh. This adds two honest sentences each to the shared `@surface_guide` (which feeds both the server instructions and the `exec` description) and the in-cell `IxMcp.Fleet` moduledoc: prefer Fleet for CPU-heavy/parallel pure-Elixir compute, linux-only checks, and many-core/multi-host work; stay local for workstation files/repos/bindings, small low-latency evals, stateful work (remote bindings do not persist), and darwin. Covers the empty-nodes case (`Fleet.nodes() == []` -> `{:error, :no_nodes}`) and the minimal remote env.

Validation: `mix format` clean on all edited files; the change is doc-string-only, so credo and compile-warnings are unaffected. Per the prompt-eval norm, one rendered reread of the interpolated server instructions and `exec` description was enough (a full A/B is overkill for a terse doc addition).

sent by an AI agent via Claude Code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Fleet remote execution guidance to mcp-ex agent instructions
> Updates module docs in [`IxMcp.Fleet`](https://github.com/indexable-inc/index/pull/3713/files#diff-f963afd2cb8ce622b244fbab551e894f946ed3a61480357d3eaa55367c5e05fc) and [`IxMcp.MCP.Tools`](https://github.com/indexable-inc/index/pull/3713/files#diff-c1967b7edcd9f2a8628cd2ebf989cfe1e0daf0af2416367f04b4e816c897e776) to direct agents toward using Fleet for CPU-heavy or parallelizable pure-Elixir workloads, linux-only checks, and multi-core/host needs. Guidance also clarifies when to stay local (workstation files/repos, low-latency evals, stateful work, darwin-specific behavior) and notes that `Fleet.nodes() == []` means no fleet is configured. A new [site update post](https://github.com/indexable-inc/index/pull/3713/files#diff-e1200f6bd6c6b264101122d50af98332e8b55f82b8ee8e7382c3ca96c10dceea) is added summarizing the change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77d196d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->