### PR TITLE
site: make the Plans map pan and zoom like a real map

### DIFF
--- a/packages/site/src/lib/ScoreChart.svelte
+++ b/packages/site/src/lib/ScoreChart.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { SvelteMap } from 'svelte/reactivity';
   import { scoreOf, type ScoreDimension, type ScoredItem } from './scores';
 
   const {
@@ -38,6 +39,13 @@
   const plotW = W - PAD.left - PAD.right;
   const plotH = H - PAD.top - PAD.bottom;
 
+  // The map viewport, in viewBox units. The panned/zoomed world is clamped so
+  // content always covers this rect (a bit of the plot is always on screen).
+  const vL = PAD.left;
+  const vR = W - PAD.right;
+  const vT = PAD.top;
+  const vB = H - PAD.bottom;
+
   function sx(v: number): number {
     return PAD.left + ((v - 1) / 9) * plotW;
   }
@@ -72,9 +80,292 @@
   });
 
   let hovered = $state<Point | null>(null);
+
+  // --- Direct-manipulation transform (Apple-Maps feel) --------------------
+  // World -> view is one similarity transform in viewBox units:
+  //   viewX = k * baseX + panX. Only positions transform; marker size, stroke
+  //   and label size stay constant (semantic zoom). Gesture handlers write
+  //   k/panX/panY straight from the event, so there is no easing mid-gesture
+  //   and no $effect that both reads and writes the transform (which loops).
+  const MIN_K = 1;
+  const MAX_K = 8;
+
+  let k = $state(1);
+  let panX = $state(0);
+  let panY = $state(0);
+
+  const transformed = $derived(k !== 1 || panX !== 0 || panY !== 0);
+
+  function tx(x: number): number {
+    return k * x + panX;
+  }
+  function ty(y: number): number {
+    return k * y + panY;
+  }
+
+  // Content base bounds equal the plot rect, so clamp the pan to keep the
+  // transformed rect covering the viewport: no empty gutters, ever.
+  function clampPan(): void {
+    panX = Math.min(vL * (1 - k), Math.max(vR * (1 - k), panX));
+    panY = Math.min(vT * (1 - k), Math.max(vB * (1 - k), panY));
+  }
+
+  let svgEl: SVGSVGElement | undefined = $state();
+  let plotEl: HTMLDivElement | undefined = $state();
+
+  // Client pixels -> viewBox units, honouring any responsive downscale.
+  function toView(clientX: number, clientY: number): { x: number; y: number } {
+    if (svgEl === undefined) return { x: 0, y: 0 };
+    const r = svgEl.getBoundingClientRect();
+    return { x: ((clientX - r.left) / r.width) * W, y: ((clientY - r.top) / r.height) * H };
+  }
+
+  function viewScale(): number {
+    if (svgEl === undefined) return 1;
+    return W / svgEl.getBoundingClientRect().width;
+  }
+
+  // Zoom by `factor` about a viewBox anchor, keeping the world point under the
+  // anchor fixed: cursor/centroid-anchored zoom.
+  function zoomAt(ax: number, ay: number, factor: number): void {
+    const nk = Math.min(MAX_K, Math.max(MIN_K, k * factor));
+    if (nk === k) return;
+    const worldX = (ax - panX) / k;
+    const worldY = (ay - panY) / k;
+    k = nk;
+    panX = ax - k * worldX;
+    panY = ay - k * worldY;
+    clampPan();
+  }
+
+  function panBy(dx: number, dy: number): void {
+    panX += dx;
+    panY += dy;
+    clampPan();
+  }
+
+  function reset(): void {
+    stopInertia();
+    k = 1;
+    panX = 0;
+    panY = 0;
+  }
+
+  // --- Pointer gestures ----------------------------------------------------
+  const DRAG_THRESHOLD = 4; // client px a press must travel to become a drag
+  const pointers = new SvelteMap<number, { x: number; y: number }>();
+  let dragging = $state(false);
+  let downX = 0;
+  let downY = 0;
+  let suppressClick = false;
+  let pinchPrev: { cx: number; cy: number; dist: number } | null = null;
+
+  // Inertia is the only motion we keep; a flick coasts and decays, and any new
+  // contact kills it.
+  let velX = 0;
+  let velY = 0;
+  let lastMoveAt = 0;
+  let inertiaRAF = 0;
+
+  function stopInertia(): void {
+    if (inertiaRAF !== 0) {
+      cancelAnimationFrame(inertiaRAF);
+      inertiaRAF = 0;
+    }
+    velX = 0;
+    velY = 0;
+  }
+
+  function startInertia(): void {
+    if (Math.hypot(velX, velY) < 0.02) return;
+    let last = performance.now();
+    const step = (): void => {
+      const now = performance.now();
+      const dt = now - last;
+      last = now;
+      panBy(velX * dt, velY * dt);
+      const decay = Math.pow(0.95, dt / 16);
+      velX *= decay;
+      velY *= decay;
+      if (Math.hypot(velX, velY) < 0.01) {
+        inertiaRAF = 0;
+        return;
+      }
+      inertiaRAF = requestAnimationFrame(step);
+    };
+    inertiaRAF = requestAnimationFrame(step);
+  }
+
+  function pinchState(): { cx: number; cy: number; dist: number } {
+    const pts = [...pointers.values()];
+    const mid = toView((pts[0].x + pts[1].x) / 2, (pts[0].y + pts[1].y) / 2);
+    const dist = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+    return { cx: mid.x, cy: mid.y, dist };
+  }
+
+  function onPointerDown(e: PointerEvent): void {
+    if ((e.target as Element).closest('.map-controls') !== null) return;
+    stopInertia();
+    suppressClick = false;
+    pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (pointers.size === 1) {
+      downX = e.clientX;
+      downY = e.clientY;
+      lastMoveAt = performance.now();
+    } else if (pointers.size === 2) {
+      dragging = true;
+      hovered = null;
+      pinchPrev = pinchState();
+      for (const id of pointers.keys()) {
+        try {
+          plotEl?.setPointerCapture(id);
+        } catch {
+          // capture is best-effort
+        }
+      }
+    }
+  }
+
+  function onPointerMove(e: PointerEvent): void {
+    const prev = pointers.get(e.pointerId);
+    if (prev === undefined) return;
+    pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+    if (pointers.size >= 2) {
+      if (pinchPrev === null) return;
+      const now = pinchState();
+      const factor = now.dist === 0 || pinchPrev.dist === 0 ? 1 : now.dist / pinchPrev.dist;
+      panBy(now.cx - pinchPrev.cx, now.cy - pinchPrev.cy);
+      zoomAt(now.cx, now.cy, factor);
+      pinchPrev = now;
+      return;
+    }
+
+    if (!dragging) {
+      if (Math.hypot(e.clientX - downX, e.clientY - downY) <= DRAG_THRESHOLD) return;
+      dragging = true;
+      hovered = null;
+      try {
+        plotEl?.setPointerCapture(e.pointerId);
+      } catch {
+        // capture is best-effort
+      }
+    }
+
+    const s = viewScale();
+    const dvx = (e.clientX - prev.x) * s;
+    const dvy = (e.clientY - prev.y) * s;
+    panBy(dvx, dvy);
+
+    const now = performance.now();
+    const dt = Math.max(1, now - lastMoveAt);
+    velX = dvx / dt;
+    velY = dvy / dt;
+    lastMoveAt = now;
+  }
+
+  function onPointerUp(e: PointerEvent): void {
+    pointers.delete(e.pointerId);
+    try {
+      plotEl?.releasePointerCapture(e.pointerId);
+    } catch {
+      // release is best-effort
+    }
+    if (pointers.size < 2) pinchPrev = null;
+    if (pointers.size === 0) {
+      if (dragging) {
+        suppressClick = true;
+        startInertia();
+      }
+      dragging = false;
+    }
+  }
+
+  // A drag ends with a synthetic click on the anchor under the pointer; swallow
+  // it in the capture phase so a pan never opens a Plan. A real tap, which
+  // never crosses the threshold, leaves the flag clear and clicks through.
+  function onClickCapture(e: MouseEvent): void {
+    if (suppressClick) {
+      e.preventDefault();
+      e.stopPropagation();
+      suppressClick = false;
+    }
+  }
+
+  function onDblClick(e: MouseEvent): void {
+    if ((e.target as Element).closest('.map-controls') !== null) return;
+    e.preventDefault();
+    const a = toView(e.clientX, e.clientY);
+    zoomAt(a.x, a.y, 1.8);
+  }
+
+  // Trackpad pinch arrives as ctrl+wheel (Chrome/Firefox); plain wheel and
+  // two-finger scroll pan, like a map. Safari pinch uses the gesture events
+  // wired in the effect below. Both need a non-passive listener to preventDefault.
+  function onWheel(e: WheelEvent): void {
+    e.preventDefault();
+    stopInertia();
+    if (e.ctrlKey) {
+      const a = toView(e.clientX, e.clientY);
+      zoomAt(a.x, a.y, Math.exp(-e.deltaY * 0.01));
+    } else {
+      const s = viewScale();
+      panBy(-e.deltaX * s, -e.deltaY * s);
+    }
+  }
+
+  type GestureLikeEvent = Event & { scale: number; clientX: number; clientY: number };
+  let gestureStartK = 1;
+  let gestureAnchor = { x: 0, y: 0 };
+
+  function onGestureStart(e: GestureLikeEvent): void {
+    e.preventDefault();
+    stopInertia();
+    gestureStartK = k;
+    gestureAnchor = toView(e.clientX, e.clientY);
+  }
+
+  function onGestureChange(e: GestureLikeEvent): void {
+    e.preventDefault();
+    const target = Math.min(MAX_K, Math.max(MIN_K, gestureStartK * e.scale));
+    zoomAt(gestureAnchor.x, gestureAnchor.y, target / k);
+  }
+
+  function zoomButton(factor: number): void {
+    zoomAt((vL + vR) / 2, (vT + vB) / 2, factor);
+  }
+
+  let expanded = $state(false);
+
+  function onKeyDown(e: KeyboardEvent): void {
+    if (expanded && e.key === 'Escape') expanded = false;
+  }
+
+  // Wheel and Safari gesture events must be non-passive to preventDefault, so
+  // wire them by hand. This effect reads plotEl only, never writes it, so it
+  // cannot loop.
+  $effect(() => {
+    const el = plotEl;
+    if (el === undefined) return;
+    const wheel = onWheel as EventListener;
+    const gStart = onGestureStart as unknown as EventListener;
+    const gChange = onGestureChange as unknown as EventListener;
+    el.addEventListener('wheel', wheel, { passive: false });
+    el.addEventListener('gesturestart', gStart, { passive: false });
+    el.addEventListener('gesturechange', gChange, { passive: false });
+    return () => {
+      el.removeEventListener('wheel', wheel);
+      el.removeEventListener('gesturestart', gStart);
+      el.removeEventListener('gesturechange', gChange);
+    };
+  });
+
+  const clipId = `plot-clip-${Math.random().toString(36).slice(2)}`;
 </script>
 
-<figure class="chart">
+<svelte:window onkeydown={onKeyDown} />
+
+<figure class="chart" class:expanded>
   <div class="controls">
     <label>
       x
@@ -92,14 +383,70 @@
         {/each}
       </select>
     </label>
+    <button class="expand" type="button" onclick={() => (expanded = !expanded)}>
+      {expanded ? 'Collapse' : 'Expand'}
+    </button>
   </div>
 
-  <div class="plot">
-    <svg width={W} height={H} viewBox="0 0 {W} {H}" role="img" aria-label="Items plotted by {xDim.label} against {yDim.label}">
-      {#each [1, 4, 7, 10] as v (v)}
-        <line class="grid" x1={sx(v)} y1={sy(1)} x2={sx(v)} y2={sy(10)} />
-        <line class="grid" x1={sx(1)} y1={sy(v)} x2={sx(10)} y2={sy(v)} />
-      {/each}
+  <!-- Direct-manipulation map surface; keyboard users pan/zoom via the controls. -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="plot"
+    class:grabbing={dragging}
+    bind:this={plotEl}
+    onpointerdown={onPointerDown}
+    onpointermove={onPointerMove}
+    onpointerup={onPointerUp}
+    onpointercancel={onPointerUp}
+    onclickcapture={onClickCapture}
+    ondblclick={onDblClick}
+  >
+    <svg
+      bind:this={svgEl}
+      width={W}
+      height={H}
+      viewBox="0 0 {W} {H}"
+      role="img"
+      aria-label="Items plotted by {xDim.label} against {yDim.label}; drag to pan, pinch or scroll to zoom"
+    >
+      <defs>
+        <clipPath id={clipId}>
+          <rect x={vL - 8} y={0} width={W - vL + 8} height={vB} />
+        </clipPath>
+      </defs>
+
+      <g clip-path="url(#{clipId})">
+        {#each [1, 4, 7, 10] as v (v)}
+          <line class="grid" x1={tx(sx(v))} y1={ty(sy(1))} x2={tx(sx(v))} y2={ty(sy(10))} />
+          <line class="grid" x1={tx(sx(1))} y1={ty(sy(v))} x2={tx(sx(10))} y2={ty(sy(v))} />
+        {/each}
+
+        {#each points as point (point.item.id)}
+          <!-- Callers pass resolve()d hrefs; a generic component cannot resolve. -->
+          <!-- eslint-disable svelte/no-navigation-without-resolve -->
+          <a
+            onpointerenter={() => {
+              if (!dragging) hovered = point;
+            }}
+            onpointerleave={() => (hovered = null)}
+            href={point.item.href}
+          >
+            <g class="mark" class:dimmed={hovered !== null && hovered !== point}>
+              <circle class="hit" cx={tx(point.px)} cy={ty(point.py)} r="14" />
+              <rect
+                class="dot"
+                x={tx(point.px) - 5}
+                y={ty(point.py) - 5}
+                width="10"
+                height="10"
+                style:--c={point.item.colorVar}
+              />
+              <text class="mark-label" x={tx(point.px) + 10} y={ty(point.py) + 5}>{point.item.label}</text>
+            </g>
+          </a>
+          <!-- eslint-enable svelte/no-navigation-without-resolve -->
+        {/each}
+      </g>
 
       <text class="axis-end" x={sx(1)} y={H - 6} text-anchor="start">{xDim.low}</text>
       <text class="axis-end" x={sx(10)} y={H - 6} text-anchor="end">{xDim.high} →</text>
@@ -109,33 +456,28 @@
       <text class="axis-end" x={14} y={sy(10)} transform="rotate(-90, 14, {sy(10)})" text-anchor="end">
         {yDim.high} →
       </text>
-
-      {#each points as point (point.item.id)}
-        <!-- Callers pass resolve()d hrefs; a generic component cannot resolve. -->
-        <!-- eslint-disable svelte/no-navigation-without-resolve -->
-        <a
-          onpointerenter={() => (hovered = point)}
-          onpointerleave={() => (hovered = null)}
-          href={point.item.href}
-        >
-          <g class="mark" class:dimmed={hovered !== null && hovered !== point}>
-            <circle class="hit" cx={point.px} cy={point.py} r="14" />
-            <rect class="dot" x={point.px - 5} y={point.py - 5} width="10" height="10" style:--c={point.item.colorVar} />
-            <text class="mark-label" x={point.px + 10} y={point.py + 5}>{point.item.label}</text>
-          </g>
-        </a>
-        <!-- eslint-enable svelte/no-navigation-without-resolve -->
-      {/each}
     </svg>
 
-    {#if hovered}
+    <div class="map-controls">
+      <button type="button" onclick={() => {
+          zoomButton(1.5);
+        }} aria-label="Zoom in">+</button>
+      <button type="button" onclick={() => {
+          zoomButton(1 / 1.5);
+        }} aria-label="Zoom out">&minus;</button>
+      {#if transformed}
+        <button type="button" onclick={reset} aria-label="Reset view">Reset</button>
+      {/if}
+    </div>
+
+    {#if hovered !== null && !dragging}
       <div
         class="tooltip"
-        class:flip={hovered.px > W * 0.55}
-        style:left={`${((hovered.px / W) * 100).toFixed(2)}%`}
-        style:top={`${((hovered.py / H) * 100).toFixed(2)}%`}
+        class:flip={tx(hovered.px) > W * 0.55}
+        style:left={`${((tx(hovered.px) / W) * 100).toFixed(2)}%`}
+        style:top={`${((ty(hovered.py) / H) * 100).toFixed(2)}%`}
       >
-        <strong>{hovered.item.label}</strong> · {hovered.item.title}
+        <strong>{hovered.item.label}</strong> &middot; {hovered.item.title}
         <span class="detail">{hovered.item.detail}</span>
         {#each [xDim, yDim] as dim (dim.key)}
           {@const score = scoreOf(hovered.item.id, hovered.item.scores, dim.key)}
@@ -187,6 +529,25 @@
     border-color: var(--fg-muted);
   }
 
+  .controls .expand {
+    margin-left: auto;
+    font: inherit;
+    height: var(--cell-h);
+    color: var(--fg-muted);
+    background: var(--bg);
+    border: 1px solid var(--rule);
+    border-radius: var(--radius);
+    padding: 0 1ch;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+  }
+
+  .controls .expand:hover {
+    border-color: var(--fg-muted);
+    color: var(--fg);
+  }
+
   .plot {
     position: relative;
     /* The frame's top and bottom 1px rules take no grid space: pull the
@@ -198,6 +559,13 @@
     border: 1px solid var(--rule);
     border-radius: var(--radius);
     /* No overflow clipping: the tooltip must escape the chart box. */
+    /* The map owns every gesture; stop the page from scrolling/zooming under it. */
+    touch-action: none;
+    cursor: grab;
+  }
+
+  .plot.grabbing {
+    cursor: grabbing;
   }
 
   svg {
@@ -249,6 +617,35 @@
     fill: var(--fg-muted);
   }
 
+  /* Zoom / reset overlay, pinned to the map's top-right like a map's chrome. */
+  .map-controls {
+    position: absolute;
+    top: 1ch;
+    right: 1ch;
+    display: flex;
+    gap: 1ch;
+  }
+
+  .map-controls button {
+    font: inherit;
+    min-width: var(--cell-h);
+    height: var(--cell-h);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--fg-muted);
+    background: var(--bg);
+    border: 1px solid var(--rule);
+    border-radius: var(--radius);
+    padding: 0 1ch;
+    cursor: pointer;
+  }
+
+  .map-controls button:hover {
+    border-color: var(--fg-muted);
+    color: var(--fg);
+  }
+
   .tooltip {
     position: absolute;
     transform: translate(2ch, -50%);
@@ -271,5 +668,31 @@
   .tooltip .why {
     display: block;
     color: var(--fg-muted);
+  }
+
+  /* Expanded: the map fills the screen; Escape or Collapse exits. */
+  .chart.expanded {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    margin: 0;
+    padding: var(--cell-h) 2ch;
+    background: var(--bg);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .chart.expanded .plot {
+    flex: 1;
+    width: auto;
+    max-width: none;
+    min-height: 0;
+    margin-bottom: 0;
+  }
+
+  .chart.expanded svg {
+    width: 100%;
+    height: 100%;
+    max-width: none;
   }
 </style>

--- a/packages/site/src/lib/updates/plans-map-pan-zoom.svx
+++ b/packages/site/src/lib/updates/plans-map-pan-zoom.svx
@@ -1,0 +1,28 @@
+---
+id: plans-map-pan-zoom
+postedAt: 2026-07-19T12:00:00-07:00
+title: "The Plans map now pans and zooms like a real map"
+links:
+  - { label: "Plans", href: "https://ix.dev/plans" }
+  - { label: "issue #3712", href: "https://github.com/indexable-inc/index/issues/3712" }
+tags:
+  - site
+  - plans
+---
+
+The scatter on the Plans page used to be a static picture. It is now a
+direct-manipulation map. Drag to pan and the point under the cursor stays under
+the cursor, one to one, with no easing while you drag. Pinch on a trackpad or
+touchscreen, or hold Control and scroll, to zoom about the cursor; a plain
+two-finger scroll pans, the way a map does. Double-click zooms in on the spot
+you clicked.
+
+Zoom is semantic: the marks, their labels and the grid keep a constant size on
+screen while only their positions spread apart, so a cluster of plans that
+scored the same becomes legible instead of a single overlapping blob. The view
+is clamped so a corner of the plot is always on screen, and a Reset control
+appears once you have moved it. An Expand button grows the map to fill the
+window; Escape brings it back.
+
+Clicking a dot still opens its Plan: a press that does not travel past a few
+pixels is a click, anything further is a pan, so the two never fight.


### PR DESCRIPTION
## What

The Plans "Map" (the ScoreChart scatter on `/plans`) is now a direct-manipulation map instead of a static picture.

- **1:1 pan** — drag and the world point under the pointer stays under the pointer; no easing mid-gesture.
- **Cursor-anchored zoom** — trackpad pinch (ctrl+wheel in Chrome/Firefox, `gesturechange` in Safari) and touch pinch zoom about the cursor/centroid; a plain wheel or two-finger scroll pans, like a map.
- **Semantic zoom** — marks, labels and grid keep a constant screen size while only positions spread, so a cluster of same-scored plans becomes legible.
- **Double-click** zooms in about the click point.
- **Clamped** so a corner of the plot is always on screen; a **Reset** control appears once moved.
- **Expand** grows the map to fullscreen; **Escape** exits.
- Clicking a dot still opens its Plan — a press only becomes a pan past a small movement threshold, so click and drag never fight. A short flick coasts (the one bit of motion), killed on any new contact.

Implemented as a single similarity transform in viewBox units applied to positions only (Pointer Events + `setPointerCapture`); marker size is untouched.

Closes #3712.

## Validation

- `svelte-check`: 0 errors, 0 warnings.
- `eslint` (strictTypeChecked): clean.
- Real render check via Playwright driving the dev server — 15/15:
  - svg renders 1:1 (scale 1.000); pan exact (drag 90x/55y -> dot moves 90.0/55.0);
  - ctrl+wheel zoom anchored (anchor dot moved 1.4px); marker size constant (10px -> 10px); dots spread on zoom;
  - reset restores initial positions; double-click zooms about the click; click-through opens `/plans/0001-router-vm/`; expand fullscreen + Escape exit.

Note: the local `bun run build` and dev SSR fail on `main` too, from a pre-existing metadata parse of one unrelated updates file (`pin-freeze-postmortem.svx`) under the locally-installed mdsvex version; the hermetic `nix build .#site` pins the toolchain around it. My new files are clean under both check and lint.

---
Sent by an AI agent (Claude Code) on behalf of Andrew.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pan, zoom, and expand interactions to the Plans map chart
> - Adds drag-to-pan, pinch/ctrl+wheel/double-click zoom, and inertial panning to [`ScoreChart.svelte`](https://github.com/indexable-inc/index/pull/3718/files#diff-771c653930184abe42dece3f260102d389fc95a25d3b6f872e48ef44584a69f9); grid lines and marks transform with the view while axes remain fixed and content is clipped to the plot frame.
> - Implements a full similarity transform (`k`, `panX`, `panY`) with `clampPan` to prevent empty gutters from appearing at any zoom level.
> - Handles pointer, wheel, and Safari gesture events (including non-passive listeners) for consistent cross-browser and touch support; suppresses clicks after drag to avoid unintended link navigation.
> - Adds map chrome: Zoom In, Zoom Out, and Reset overlay buttons (shown only when transformed), plus an Expand/Collapse toggle that fills the window; Escape collapses the expanded view.
> - Adds an update post in [`plans-map-pan-zoom.svx`](https://github.com/indexable-inc/index/pull/3718/files#diff-80869096f8dd467ef32032bebccbfadf79063c52278440d5eb418202fe5a90fe) describing the feature.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec3c462.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->