### PR TITLE
kbuild-unit: flatten the per-edit constant (#3706)

### DIFF
--- a/lib/kernel/kbuild-unit.nix
+++ b/lib/kernel/kbuild-unit.nix
@@ -27,6 +27,19 @@ What the plan kbuild compiles is governed by `planStrategy` (#3413):
 - "full": exact pre-#3413 behavior (plan = reference), kept as the
   debugging baseline.
 
+The skeleton reduction is sharded per top-level source directory (drivers/
+one level deeper), each shard a CA derivation over an eval-time
+`builtins.path` slice of just that directory, composed back into one tree
+whose bytes -- and therefore store path -- match a whole-tree reduction
+(#3706). A body edit re-reduces exactly the directory it touched; every
+other shard, the composed skeleton, and the plan behind it resolve to
+already-realised outputs. The same slicing serves the pre-unpacked
+`srcTree` argument (a developer working tree as a plain path, under
+--impure eval), which keeps whole-tree store ingestion out of the edit
+loop entirely: builtins.path re-ingests only the directory an edit
+touched, and the per-file source farm in units.nix re-keys only the
+edited translation units.
+
 On CONFIG_MODULES=y configs the plan also runs `make modules`, and the unit
 graph extends over module objects, both modpost passes (`vmlinux.symvers`
 with its generated ksymtab source, `Module.symvers` with each module's
@@ -259,7 +272,28 @@ only to make the plan's inputs body-independent.
   '';
 
   buildKernel = {
-    src,
+    # The kernel source tarball (pkgs.linux_*.src), unpacked once below.
+    # Exactly one of `src`/`srcTree` must be given.
+    src ? null,
+    # A pre-unpacked kernel tree instead: a derivation output (say
+    # applyPatches over a checkout) or a plain path (a developer working
+    # tree, which needs --impure eval). Slicing reads straight from the
+    # tree, so a plain-path edit loop never pays a whole-tree store copy
+    # (#3706).
+    srcTree ? null,
+    # Pre-ingested per-directory slices instead of a tree: an attrset from
+    # slice key to store path, with the same key shape the automatic
+    # slicing produces ("" for the files directly at the tree root, one key
+    # per top-level directory, and "<dir>/<sub>" plus a files-only "<dir>"
+    # for deep-sharded directories such as drivers/). This scopes the
+    # driver-side cost of an edit loop to the directory an edit touched
+    # (`nix store add` it and re-evaluate); note that current Nix still
+    # re-ingests eval-time sources once per evaluation -- builtins.path has
+    # no cross-eval memoization -- which is the measured residual of the
+    # #3706 loop. Needs --impure eval, like a plain-path srcTree: pure
+    # evaluation refuses to read store paths it was not handed context
+    # for. Outputs stay fully content-addressed either way.
+    srcSlices ? null,
     configTarget ? "tinyconfig",
     contentAddressed ? true,
     planStrategy ? "skeleton",
@@ -297,30 +331,265 @@ only to make the plan's inputs body-independent.
         or (throw "kbuild-unit: unknown planStrategy \"${planStrategy}\" (expected \"skeleton\", \"ccache\", or \"full\")");
 
     # The kernel `src` is a tarball; units and harvest need the unpacked tree
-    # as a directory (symlink-farm base and byte-compare reference).
-    srcTree = pkgs.srcOnly {
-      name = "kbuild-unit-src";
-      inherit src;
-      # Unpack only; omitting stdenv trips this repo's abort-on-warn.
-      stdenv = pkgs.stdenvNoCC;
-    };
+    # as a directory (symlink-farm base and byte-compare reference). A caller
+    # that already has the tree passes `srcTree` and skips the unpack.
+    tree =
+      if builtins.length (lib.filter (given: given != null) [src srcTree srcSlices]) != 1
+      then throw "kbuild-unit: pass exactly one of src (tarball), srcTree (unpacked tree), or srcSlices (pre-ingested slices)"
+      else if srcTree != null
+      then srcTree
+      else if src != null
+      then
+        pkgs.srcOnly {
+          name = "kbuild-unit-src";
+          inherit src;
+          # Unpack only; omitting stdenv trips this repo's abort-on-warn.
+          stdenv = pkgs.stdenvNoCC;
+        }
+      else throw "kbuild-unit: srcSlices given; there is no whole tree to read";
 
-    # Directives-only reduction of the tree (#3413). CA: a function-body edit
-    # rebuilds this derivation but lands the identical output path, so the
-    # plan's resolved derivation is already realised and does not rerun. A
-    # header/Makefile/Kconfig edit changes the skeleton and reruns the plan.
-    skeletonTree =
-      pkgs.runCommand "kbuild-unit-skeleton"
+    # A plain-path tree (developer working tree) is read in place; a
+    # derivation tree is realised once and read from its output (the readDir
+    # below is the eval/build boundary: instantiating the plan now needs the
+    # tree built first, which was already true in practice via the source
+    # farm in units.nix).
+    treeIsPath = builtins.isPath tree;
+    treeRoot =
+      if treeIsPath
+      then tree
+      else "${tree}";
+    treeSubPath = rel:
+      if treeIsPath
+      then tree + ("/" + rel)
+      else "${tree}/${rel}";
+
+    # `.git` never enters the slices: an unpacked tarball has none, and a
+    # working tree must slice identically to the tarball it came from
+    # (setlocalversion must also never see it, or the plan would grow a
+    # local-version suffix the reference build lacks). It is a directory in
+    # a checkout but a file in a linked worktree, so both shapes go.
+    treeEntries = builtins.readDir treeRoot;
+    treeDirNames =
+      lib.filter
+      (name: treeEntries.${name} == "directory" && name != ".git")
+      (builtins.attrNames treeEntries);
+    subDirNames = dir: let
+      entries = builtins.readDir (treeSubPath dir);
+    in
+      lib.filter (name: entries.${name} == "directory") (builtins.attrNames entries);
+
+    # Per-directory slices (#3706): each top-level directory (and each
+    # drivers/ subdirectory) becomes its own content-addressed store path,
+    # so an edit re-ingests exactly the directory it touched while every
+    # other slice keeps its store path. Everything downstream keys on the
+    # slices -- the skeleton shards, the per-file source farm, and the link
+    # unit's directory scopes (units.nix resolves srctree paths through
+    # them) -- which is what lets Nix's source-ingestion memoization hold
+    # across evals for everything an edit did not touch: builtins.path
+    # re-hashing is only cheap when its source sits inside an unchanged,
+    # valid store path.
+    #
+    # Slices are always eval-ingested source paths, never derivation
+    # outputs: builtins.path cannot consume a content-addressed derivation
+    # output (its eval-time string is an unresolved placeholder), so a
+    # `src`/`srcTree` tree pays one whole-tree hash per edit here. An edit
+    # loop that wants to pay only for the directory it touched pre-ingests
+    # its slices and passes `srcSlices` instead.
+    sanitizeRel = rel: lib.replaceStrings ["/"] ["-"] rel;
+    sliceName = key: merge: "kbuild-src-slice-${
+      if key == ""
+      then "root-files"
+      else sanitizeRel key + lib.optionalString merge "-files"
+    }";
+    dirSlice = name: rel:
+      builtins.path {
+        inherit name;
+        path = treeSubPath rel;
+      };
+    # Files directly inside `subPath` (the tree root, or a deep-sharded
+    # directory): rejecting directories in the filter also stops the walk,
+    # so this touches one level only.
+    filesOnlySlice = name: subPath:
+      builtins.path {
+        inherit name;
+        path =
+          if subPath == ""
+          then treeRoot
+          else treeSubPath subPath;
+        filter = path: type: type != "directory" && baseNameOf path != ".git";
+      };
+
+    # Directories sharded one level deeper: drivers/ alone is well over half
+    # of the tree, so a top-level shard would still re-reduce all of it on
+    # any driver edit.
+    deepSharded = ["drivers"];
+
+    # One slice (and skeleton shard) per spec: `dest` is both the slice key
+    # units.nix resolves srctree paths through and where the shard's output
+    # lands in the composed tree; `merge` marks a files-only spec (content
+    # merges into an existing directory, and the slice serves the files
+    # directly inside that directory) as opposed to a directory spec (the
+    # slice *is* the directory).
+    shardSpecs =
+      if srcSlices != null
+      then let
+        keys = builtins.attrNames srcSlices;
+      in
+        map (
+          key: let
+            # A key with children (or the root) is a files-only slice; the
+            # rest are whole directories. Same shape the automatic slicing
+            # produces below.
+            merge = key == "" || lib.any (other: lib.hasPrefix "${key}/" other) keys;
+          in {
+            dest = key;
+            inherit merge;
+            # Re-ingesting normalizes the given path (string or path) into
+            # a tracked source path; when it already sits in the store and
+            # is unchanged, this memoizes instead of re-hashing.
+            slice = builtins.path {
+              name = sliceName key merge;
+              path = srcSlices.${key};
+            };
+          }
+        )
+        keys
+      else autoShardSpecs;
+
+    autoShardSpecs =
+      [
+        {
+          dest = "";
+          merge = true;
+          slice = filesOnlySlice (sliceName "" true) "";
+        }
+      ]
+      ++ lib.concatMap (
+        dir:
+          if lib.elem dir deepSharded
+          then
+            [
+              {
+                dest = dir;
+                merge = true;
+                slice = filesOnlySlice (sliceName dir true) dir;
+              }
+            ]
+            ++ map (sub: {
+              dest = "${dir}/${sub}";
+              merge = false;
+              slice = dirSlice (sliceName "${dir}/${sub}" false) "${dir}/${sub}";
+            }) (subDirNames dir)
+          else [
+            {
+              dest = dir;
+              merge = false;
+              slice = dirSlice (sliceName dir false) dir;
+            }
+          ]
+      )
+      treeDirNames;
+
+    # Directives-only reduction of one slice (#3413, sharded per #3706).
+    # `--prefix` re-roots classification so the keep-allowlist and the
+    # scripts//tools/ verbatim rules keep matching tree-relative paths. CA:
+    # a body edit rebuilds exactly its own shard, which lands the identical
+    # output path, so the compose below (and the plan behind it) resolves to
+    # already-realised outputs and never reruns. A header/Makefile/Kconfig
+    # edit changes its shard's output and legitimately reruns the plan.
+    shardFor = {
+      dest,
+      merge,
+      slice,
+    }:
+      pkgs.runCommand "kbuild-unit-skeleton-shard${lib.optionalString (dest != "") "-${sanitizeRel dest}"}${lib.optionalString (merge && dest != "") "-files"}"
       ({nativeBuildInputs = [nixKbuildUnit];} // lib.optionalAttrs contentAddressed contentAddressing)
       ''
-        nix-kbuild-unit skeleton --src ${srcTree} --out $out \
+        nix-kbuild-unit skeleton --src ${slice} --out $out \
+          --prefix ${lib.escapeShellArg dest} \
           ${lib.concatMapStringsSep " " (glob: "--keep ${lib.escapeShellArg glob}") skeletonKeep}
       '';
+
+    shards = map (spec: spec // {drv = shardFor spec;}) shardSpecs;
+
+    # Compose per-spec pieces back into one tree at each spec's dest;
+    # `getPath` selects the piece (a shard's reduced output for the
+    # skeleton, the raw slice for the whole-tree compose).
+    composeTree = name: specs: getPath:
+      pkgs.runCommand name
+      (lib.optionalAttrs contentAddressed contentAddressing)
+      ''
+        mkdir -p $out
+        ${lib.concatMapStrings (
+            spec: let
+              dest =
+                if spec.dest == ""
+                then "$out"
+                else "$out/${lib.escapeShellArg spec.dest}";
+              parent = builtins.dirOf spec.dest;
+            in
+              if spec.merge
+              then ''
+                mkdir -p ${dest}
+                cp -a ${getPath spec}/. ${dest}/
+                # cp -a src/. propagates the store piece's read-only mode
+                # onto the target directory; later pieces still copy into
+                # it. NAR serialization carries no directory modes, so this
+                # cannot perturb the content address.
+                chmod u+w ${dest}
+              ''
+              else ''
+                ${lib.optionalString (parent != ".") "mkdir -p $out/${lib.escapeShellArg parent}\n"}cp -a ${getPath spec} ${dest}
+              ''
+          )
+          specs}
+      '';
+
+    # The composed skeleton, byte-identical (same CA store path) to the
+    # previous single-derivation whole-tree reduction, so the plan contract
+    # does not move. The compose only re-runs when a shard's *output*
+    # changes; after a body edit every shard resolves to its existing
+    # realisation and the compose never executes.
+    skeletonTree = composeTree "kbuild-unit-skeleton" shards (shard: shard.drv);
+
+    # Every shard in one farm: probes build it to warm exactly the sharded
+    # reduction, and the cache lane pushes it so other hosts substitute
+    # shard realisations instead of re-reducing.
+    skeletonShards = pkgs.linkFarm "kbuild-unit-skeleton-shards" (map (shard: {
+        name =
+          if shard.dest == ""
+          then "root-files"
+          else sanitizeRel shard.dest + lib.optionalString shard.merge "-files";
+        path = shard.drv;
+      })
+      shards);
+
+    # A derivation-consumable whole-tree path. For a plain-path tree the
+    # copy happens lazily at instantiation -- the equivalence gates and the
+    # non-skeleton plan strategies force it, the skeleton edit loop never
+    # does -- and `.git` stays out for the same reason it stays out of the
+    # slices.
+    wholeTree =
+      if srcSlices != null
+      then
+        # No whole tree was given; compose one from the slices (content-
+        # identical to the tree they came from). Only the equivalence
+        # gates' reference build and the non-skeleton plan strategies force
+        # this.
+        composeTree "kbuild-unit-src" shardSpecs (spec: spec.slice)
+      else if treeIsPath
+      then
+        builtins.path {
+          name = "kbuild-unit-src";
+          path = tree;
+          filter = path: _type: baseNameOf path != ".git";
+        }
+      else tree;
 
     planSrc =
       if planStrategy == "skeleton"
       then skeletonTree
-      else srcTree;
+      else wholeTree;
 
     plan = pkgs.stdenv.mkDerivation ({
         pname = "kbuild-unit-plan";
@@ -415,7 +684,7 @@ only to make the plan's inputs body-independent.
     referenceKernel = pkgs.stdenv.mkDerivation ({
         pname = "kbuild-unit-reference";
         version = configTarget;
-        src = srcTree;
+        src = wholeTree;
         nativeBuildInputs = kbuildInputs;
         env = reproEnv;
         dontFixup = true;
@@ -462,9 +731,18 @@ only to make the plan's inputs body-independent.
         cp -a ${plan}/generated $out
       '';
 
+    # The slice map units.nix resolves srctree-relative paths through:
+    # exact directory keys plus the files-only slices keyed by their
+    # directory ("" for the tree root).
+    sliceMap = builtins.listToAttrs (map (shard: {
+        name = shard.dest;
+        value = shard.slice;
+      })
+      shardSpecs);
+
     imported = import unitsNix {
       inherit pkgs;
-      src = srcTree;
+      srcSlices = sliceMap;
       generated = "${generatedSnapshot}";
       extraNativeBuildInputs = kbuildInputs;
       extraEnv = reproEnv;
@@ -500,10 +778,16 @@ only to make the plan's inputs body-independent.
           path = plan;
         }
       ]
-      ++ lib.optional (planStrategy == "skeleton") {
-        name = "skeleton";
-        path = skeletonTree;
-      }
+      ++ lib.optionals (planStrategy == "skeleton") [
+        {
+          name = "skeleton";
+          path = skeletonTree;
+        }
+        {
+          name = "skeleton-shards";
+          path = skeletonShards;
+        }
+      ]
     );
 
     # The exit gate: the unit-composed vmlinux must be byte-identical to the
@@ -540,9 +824,18 @@ only to make the plan's inputs body-independent.
           echo "$count modules byte-identical" > $out
         '';
   in
-    imported
-    // {
-      inherit plan unitsNix srcTree skeletonTree referenceKernel cachePushRoot vmlinuxEquivalence modulesEquivalence;
+    # Explicit exports rather than `imported // ...`: an attrset update
+    # forces the import's attribute names, which walks the whole IFD chain
+    # (plan build included) just to look at plan-side attrs like
+    # `skeletonTree` or `srcTree`. Spelled out, only the unit-graph attrs
+    # touch the import (#3706).
+    {
+      inherit (imported) units kernelRelease vmlinux modpost moduleSymvers modules allUnits prunedTargets;
+      inherit plan unitsNix skeletonTree skeletonShards referenceKernel cachePushRoot vmlinuxEquivalence modulesEquivalence;
+      srcTree =
+        if srcSlices != null
+        then wholeTree
+        else tree;
     };
 in {
   inherit buildKernel;

--- a/packages/nix/nix-kbuild-unit/src/main.rs
+++ b/packages/nix/nix-kbuild-unit/src/main.rs
@@ -70,6 +70,11 @@ struct SkeletonArgs {
     /// allowlist (repeatable; `*` matches within a path segment, `**` across).
     #[arg(long = "keep", value_name = "GLOB")]
     keep: Vec<String>,
+
+    /// Classify every path as if it lived under this tree-relative prefix
+    /// (sharded reduction of one subtree, #3706); empty means the tree root.
+    #[arg(long, value_name = "PREFIX", default_value = "")]
+    prefix: String,
 }
 
 fn main() -> color_eyre::Result<()> {
@@ -83,7 +88,7 @@ fn main() -> color_eyre::Result<()> {
             println!();
         }
         Command::Skeleton(args) => {
-            skeleton::skeleton(&args.src, &args.out, &args.keep)
+            skeleton::skeleton(&args.src, &args.out, &args.keep, &args.prefix)
                 .wrap_err("reducing source tree to a skeleton")?;
         }
         Command::Render(args) => {

--- a/packages/nix/nix-kbuild-unit/src/skeleton.rs
+++ b/packages/nix/nix-kbuild-unit/src/skeleton.rs
@@ -19,6 +19,7 @@
 //! recognize them and substitute stub objects without any allowlist plumbing:
 //! the reducer's keep decision *is* the shim's stub decision.
 
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::{WrapErr as _, bail};
@@ -103,7 +104,21 @@ pub const DEFAULT_KEEP: &[&str] = &[
 
 /// Reduce `src` into `out` (created if absent), keeping `extra_keep` globs
 /// verbatim on top of [`DEFAULT_KEEP`].
-pub fn skeleton(src: &Path, out: &Path, extra_keep: &[String]) -> color_eyre::Result<()> {
+///
+/// `prefix` re-roots classification for sharded reduction (#3706): when the
+/// caller reduces one subtree (say the content of `net/`) as its own
+/// derivation, every path inside is classified as `<prefix>/<rel>` so the
+/// keep-allowlist and the `scripts/`/`tools/` verbatim rules keep matching
+/// tree-relative paths, while the output layout stays relative to `src`.
+/// Empty means `src` is the tree root. Composing per-subtree shards (plus a
+/// files-only root shard) therefore reproduces the whole-tree reduction
+/// byte-for-byte.
+pub fn skeleton(
+    src: &Path,
+    out: &Path,
+    extra_keep: &[String],
+    prefix: &str,
+) -> color_eyre::Result<()> {
     std::fs::create_dir_all(out).wrap_err_with(|| format!("creating {}", out.display()))?;
     let mut stack = vec![PathBuf::new()];
     while let Some(rel_dir) = stack.pop() {
@@ -131,7 +146,12 @@ pub fn skeleton(src: &Path, out: &Path, extra_keep: &[String]) -> color_eyre::Re
                     .wrap_err_with(|| format!("recreating symlink {rel_str}"))?;
                 continue;
             }
-            match reduction_lang(rel_str, extra_keep) {
+            let classified = if prefix.is_empty() {
+                Cow::Borrowed(rel_str)
+            } else {
+                Cow::Owned(format!("{prefix}/{rel_str}"))
+            };
+            match reduction_lang(&classified, extra_keep) {
                 Some(lang) => {
                     let bytes = std::fs::read(entry.path())
                         .wrap_err_with(|| format!("reading {rel_str}"))?;
@@ -338,6 +358,35 @@ fn segment_match(pattern: &[u8], segment: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Write one fixture file under `src`, creating parent directories.
+    fn write_fixture(src: &Path, rel: &str, contents: &str) {
+        let path = src.join(rel);
+        std::fs::create_dir_all(path.parent().expect("rel has parent")).expect("mkdir");
+        std::fs::write(path, contents).expect("write fixture");
+    }
+
+    /// Every file under `root`, keyed by root-relative path.
+    fn collect_files(root: &Path) -> std::collections::BTreeMap<PathBuf, Vec<u8>> {
+        let mut files = std::collections::BTreeMap::new();
+        let mut stack = vec![root.to_path_buf()];
+        while let Some(dir) = stack.pop() {
+            for entry in std::fs::read_dir(&dir).expect("read output dir") {
+                let entry = entry.expect("dir entry");
+                if entry.file_type().expect("file type").is_dir() {
+                    stack.push(entry.path());
+                } else {
+                    let rel = entry
+                        .path()
+                        .strip_prefix(root)
+                        .expect("under root")
+                        .to_owned();
+                    files.insert(rel, std::fs::read(entry.path()).expect("read file"));
+                }
+            }
+        }
+        files
+    }
 
     fn reduced(text: &str, lang: Lang) -> String {
         String::from_utf8(reduce(text.as_bytes(), lang)).expect("reduced output is UTF-8")
@@ -583,20 +632,16 @@ static const char *s = \"/* not a comment\";
         let src = tmp.path().join("src");
         let out = tmp.path().join("out");
 
-        let write = |rel: &str, contents: &str| {
-            let path = src.join(rel);
-            std::fs::create_dir_all(path.parent().expect("rel has parent")).expect("mkdir");
-            std::fs::write(path, contents).expect("write fixture");
-        };
-        write("kernel/fork.c", "#include <a.h>\nint fork_body;\n");
-        write("kernel/bounds.c", "int kept_whole;\n");
-        write(
+        write_fixture(&src, "kernel/fork.c", "#include <a.h>\nint fork_body;\n");
+        write_fixture(&src, "kernel/bounds.c", "int kept_whole;\n");
+        write_fixture(
+            &src,
             "include/linux/a.h",
             "static inline int f(void) { return 1; }\n",
         );
-        write("arch/x86/kernel/vmlinux.lds.S", "SECTIONS { }\n");
-        write("scripts/mod/modpost.c", "int host_tool;\n");
-        write("Makefile", "obj-y := fork.o\n");
+        write_fixture(&src, "arch/x86/kernel/vmlinux.lds.S", "SECTIONS { }\n");
+        write_fixture(&src, "scripts/mod/modpost.c", "int host_tool;\n");
+        write_fixture(&src, "Makefile", "obj-y := fork.o\n");
         std::fs::create_dir_all(src.join("scripts/dtc/include-prefixes")).expect("mkdir");
         std::os::unix::fs::symlink(
             "../../../arch/x86/boot/dts",
@@ -604,7 +649,7 @@ static const char *s = \"/* not a comment\";
         )
         .expect("symlink fixture");
 
-        skeleton(&src, &out, &[]).expect("skeleton");
+        skeleton(&src, &out, &[], "").expect("skeleton");
 
         let read = |rel: &str| std::fs::read_to_string(out.join(rel)).expect("read output");
         assert_eq!(read("kernel/fork.c"), format!("{MARKER}#include <a.h>\n"));
@@ -635,43 +680,122 @@ static const char *s = \"/* not a comment\";
     }
 
     #[test]
+    fn prefix_reroots_classification() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("scripts-content");
+        let out = tmp.path().join("out");
+        std::fs::create_dir_all(src.join("mod")).expect("mkdir");
+        std::fs::write(src.join("mod/modpost.c"), "int host_tool_body;\n").expect("write");
+
+        // Reduced as a tree root, mod/modpost.c is an ordinary kernel TU...
+        skeleton(&src, &out, &[], "").expect("skeleton without prefix");
+        let reduced_out = std::fs::read_to_string(out.join("mod/modpost.c")).expect("read output");
+        assert!(reduced_out.starts_with(MARKER));
+
+        // ...but as the content of scripts/ it is a host tool and stays
+        // verbatim, exactly as in the whole-tree reduction.
+        let out_scripts = tmp.path().join("out-scripts");
+        skeleton(&src, &out_scripts, &[], "scripts").expect("skeleton with prefix");
+        assert_eq!(
+            std::fs::read_to_string(out_scripts.join("mod/modpost.c")).expect("read output"),
+            "int host_tool_body;\n"
+        );
+
+        // The keep-allowlist also matches through the prefix.
+        let kernel_src = tmp.path().join("kernel-content");
+        std::fs::create_dir_all(&kernel_src).expect("mkdir");
+        std::fs::write(kernel_src.join("bounds.c"), "int kept_whole;\n").expect("write");
+        std::fs::write(kernel_src.join("fork.c"), "int reduced_body;\n").expect("write");
+        let out_kernel = tmp.path().join("out-kernel");
+        skeleton(&kernel_src, &out_kernel, &[], "kernel").expect("skeleton with prefix");
+        assert_eq!(
+            std::fs::read_to_string(out_kernel.join("bounds.c")).expect("read output"),
+            "int kept_whole;\n"
+        );
+        assert!(
+            std::fs::read_to_string(out_kernel.join("fork.c"))
+                .expect("read output")
+                .starts_with(MARKER)
+        );
+    }
+
+    #[test]
+    fn sharded_reduction_composes_to_the_whole_tree_reduction() {
+        // The #3706 contract: per-top-level-directory shards (plus a
+        // files-only root shard) must compose byte-for-byte to the single
+        // whole-tree reduction, or the sharded skeleton would change the
+        // plan's input and re-run it.
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let src = tmp.path().join("src");
+        write_fixture(&src, "Makefile", "obj-y := fork.o\n");
+        write_fixture(&src, "Kconfig", "source \"kernel/Kconfig\"\n");
+        write_fixture(&src, "kernel/fork.c", "#include <a.h>\nint body;\n");
+        write_fixture(&src, "kernel/bounds.c", "int kept_whole;\n");
+        write_fixture(&src, "scripts/mod/modpost.c", "int host_tool;\n");
+        write_fixture(
+            &src,
+            "include/linux/a.h",
+            "static inline int f(void) { return 1; }\n",
+        );
+        write_fixture(
+            &src,
+            "drivers/net/dummy.c",
+            "#include <b.h>\nint driver_body;\n",
+        );
+        write_fixture(&src, "drivers/Makefile", "obj-y += net/\n");
+
+        let whole = tmp.path().join("whole");
+        skeleton(&src, &whole, &[], "").expect("whole-tree reduction");
+
+        // Compose: files-only root shard + one shard per top-level dir,
+        // with drivers/ sharded one level deeper (files + subdirs), the way
+        // lib/kernel/kbuild-unit.nix composes them.
+        let composed = tmp.path().join("composed");
+        std::fs::create_dir_all(&composed).expect("mkdir");
+        let root_shard = tmp.path().join("shard-root");
+        std::fs::create_dir_all(&root_shard).expect("mkdir");
+        for entry in std::fs::read_dir(&src).expect("list src") {
+            let entry = entry.expect("dir entry");
+            let name = entry.file_name();
+            if entry.file_type().expect("file type").is_dir() {
+                continue;
+            }
+            std::fs::copy(entry.path(), root_shard.join(&name)).expect("copy root file");
+        }
+        skeleton(&root_shard, &composed, &[], "").expect("root files shard");
+        for dir in ["kernel", "scripts", "include"] {
+            skeleton(&src.join(dir), &composed.join(dir), &[], dir).expect("dir shard");
+        }
+        let drivers_files = tmp.path().join("shard-drivers-files");
+        std::fs::create_dir_all(&drivers_files).expect("mkdir");
+        std::fs::copy(src.join("drivers/Makefile"), drivers_files.join("Makefile"))
+            .expect("copy drivers file");
+        skeleton(&drivers_files, &composed.join("drivers"), &[], "drivers")
+            .expect("drivers files shard");
+        skeleton(
+            &src.join("drivers/net"),
+            &composed.join("drivers/net"),
+            &[],
+            "drivers/net",
+        )
+        .expect("drivers subdir shard");
+
+        assert_eq!(collect_files(&whole), collect_files(&composed));
+    }
+
+    #[test]
     fn deterministic_over_reruns() {
         let tmp = tempfile::tempdir().expect("create tempdir");
         let src = tmp.path().join("src");
-        let write = |rel: &str, contents: &str| {
-            let path = src.join(rel);
-            std::fs::create_dir_all(path.parent().expect("rel has parent")).expect("mkdir");
-            std::fs::write(path, contents).expect("write fixture");
-        };
-        write("kernel/fork.c", "#include <a.h>\nint body;\n");
-        write("kernel/sub/dir.c", "#define D 1\nint body;\n");
-        write("Makefile", "obj-y := fork.o\n");
+        write_fixture(&src, "kernel/fork.c", "#include <a.h>\nint body;\n");
+        write_fixture(&src, "kernel/sub/dir.c", "#define D 1\nint body;\n");
+        write_fixture(&src, "Makefile", "obj-y := fork.o\n");
 
         let out_a = tmp.path().join("a");
         let out_b = tmp.path().join("b");
-        skeleton(&src, &out_a, &[]).expect("first run");
-        skeleton(&src, &out_b, &[]).expect("second run");
+        skeleton(&src, &out_a, &[], "").expect("first run");
+        skeleton(&src, &out_b, &[], "").expect("second run");
 
-        let collect = |root: &Path| {
-            let mut files = std::collections::BTreeMap::new();
-            let mut stack = vec![root.to_path_buf()];
-            while let Some(dir) = stack.pop() {
-                for entry in std::fs::read_dir(&dir).expect("read output dir") {
-                    let entry = entry.expect("dir entry");
-                    if entry.file_type().expect("file type").is_dir() {
-                        stack.push(entry.path());
-                    } else {
-                        let rel = entry
-                            .path()
-                            .strip_prefix(root)
-                            .expect("under root")
-                            .to_owned();
-                        files.insert(rel, std::fs::read(entry.path()).expect("read file"));
-                    }
-                }
-            }
-            files
-        };
-        assert_eq!(collect(&out_a), collect(&out_b));
+        assert_eq!(collect_files(&out_a), collect_files(&out_b));
     }
 }

--- a/packages/nix/nix-kbuild-unit/templates/units.nix.in
+++ b/packages/nix/nix-kbuild-unit/templates/units.nix.in
@@ -8,7 +8,7 @@
 # (#3413). See lib/kernel/kbuild-unit.nix.
 {
   pkgs,
-  src,
+  srcSlices,
   generated,
   extraNativeBuildInputs ? [ ],
   extraEnv ? { },
@@ -19,7 +19,29 @@ let
   kernelRelease = {{ kernel_release }};
   contentAddressed = {{ content_addressed }};
 
-  srcRoot = builtins.toString src;
+  # Resolve a srctree-relative path against the per-directory source slices
+  # (#3706): exact slice key first (directory prefixes like "include"),
+  # then the deepest sharded directory (drivers/net before drivers), then
+  # the top-level directory, then the root files slice (key ""). Slices are
+  # content-addressed store paths that change only when their directory's
+  # content changes, so the hashing below memoizes across evals for
+  # everything an edit did not touch.
+  slicePathFor =
+    rel:
+    let
+      parts = lib.splitString "/" rel;
+      n = builtins.length parts;
+      depth2 = lib.concatStringsSep "/" (lib.take 2 parts);
+      top = builtins.head parts;
+    in
+    if srcSlices ? ${rel} then
+      "${srcSlices.${rel}}"
+    else if n >= 3 && srcSlices ? ${depth2} then
+      "${srcSlices.${depth2}}/${lib.concatStringsSep "/" (lib.drop 2 parts)}"
+    else if n >= 2 && srcSlices ? ${top} then
+      "${srcSlices.${top}}/${lib.concatStringsSep "/" (lib.drop 1 parts)}"
+    else
+      "${srcSlices.""}/${rel}";
 
   # One content-addressed store path per pristine source file. Units link
   # exactly the files their .cmd recorded, so an edit invalidates only the
@@ -29,25 +51,18 @@ let
     name: rel:
     builtins.path {
       inherit name;
-      path = "${srcRoot}/${rel}";
+      path = slicePathFor rel;
     };
 
-  # Scoped copy of whole directory prefixes for units that consume trees
-  # rather than tracked file lists (the vmlinux link's script-driven
-  # compiles read Makefile includes and header dirs no .cmd records).
+  # Scoped copy of one directory prefix for units that consume trees rather
+  # than tracked file lists (the vmlinux link's script-driven compiles read
+  # Makefile includes and header dirs no .cmd records). Ingested from its
+  # slice, so an edit outside the prefix neither re-hashes nor re-keys it.
   dirScope =
-    name: prefixes:
+    prefix:
     builtins.path {
-      inherit name;
-      path = srcRoot;
-      filter =
-        path: _type:
-        let
-          rel = lib.removePrefix (srcRoot + "/") (builtins.toString path);
-        in
-        builtins.any (
-          prefix: rel == prefix || lib.hasPrefix (prefix + "/") rel || lib.hasPrefix (rel + "/") prefix
-        ) prefixes;
+      name = "kbuild-src-dir-${lib.replaceStrings [ "/" ] [ "-" ] prefix}";
+      path = slicePathFor prefix;
     };
 
   sourceFarm = {
@@ -92,9 +107,12 @@ let
           runHook preBuild
           tree="$NIX_BUILD_TOP/kbuild-tree"
           mkdir -p "$tree"
-          ${lib.optionalString (sourceDirs != [ ]) ''
-            cp -rs --no-preserve=mode ${dirScope "${pname}-src-dirs" sourceDirs}/. "$tree/"
-          ''}
+          ${lib.optionalString (sourceDirs != [ ]) (
+            lib.concatMapStrings (prefix: ''
+              mkdir -p "$tree/${prefix}"
+              cp -rs --no-preserve=mode ${dirScope prefix}/. "$tree/${prefix}/"
+            '') sourceDirs
+          )}
           mapfile -t srcRels < "$sourceFileRelsPath"
           mapfile -t srcPaths < "$sourceFilePathsPath"
           for i in "''${!srcRels[@]}"; do

--- a/packages/site/src/lib/updates/kbuild-unit-edit-constant.svx
+++ b/packages/site/src/lib/updates/kbuild-unit-edit-constant.svx
@@ -1,0 +1,17 @@
+---
+id: kbuild-unit-edit-constant
+postedAt: 2026-07-19T09:00:00-07:00
+title: "Kernel edit loops stop re-paying the whole tree"
+tags: [nix, kernel, kbuild-unit, performance]
+links:
+  - label: library
+    href: https://github.com/indexable-inc/index/blob/main/lib/kernel/kbuild-unit.nix
+  - label: issue
+    href: https://github.com/indexable-inc/index/issues/3706
+---
+
+A one-line kernel body edit rebuilds a handful of derivations in seconds, but the measured defconfig loop was 1m51s: the rest was a flat per-edit tax -- whole-tree re-skeletonization, whole-tree source re-ingestion, and flake eval -- paid regardless of what changed. Three changes flatten it.
+
+Skeletonization is now sharded. Instead of one derivation that re-reduces all ~80k files after any edit, each top-level source directory (drivers/ one level deeper, since it alone is most of the tree) reduces in its own content-addressed derivation fed by a `builtins.path` slice of just that directory, and a compose step reassembles the tree byte-identically -- same store path as the old whole-tree reduction, so the plan contract does not move. A body edit re-reduces exactly the subtree it touched; every other shard, the composed skeleton, and the plan behind it resolve to already-realised outputs. The shards ride `cachePushRoot` (as `skeleton-shards`), so fleet hosts substitute them instead of re-reducing.
+
+Everything downstream now keys on those slices: the per-file source farm and the link unit's directory scopes resolve srctree paths through them, so Nix's source-ingestion memoization holds across evals for whatever an edit did not touch. `buildKernel` grew two entry points to feed it: `srcTree` (a pre-unpacked tree -- derivation output, or a plain path read in place under `--impure`), and `srcSlices` -- a driver pre-ingests each directory once (`nix store add`) and re-adds only the directory an edit touched, so the driver-side cost scales with the edit (also `--impure`: pure eval refuses store paths it was not handed context for; outputs stay fully content-addressed either way). What remains of the loop constant is Nix itself re-ingesting eval-time sources once per evaluation; measured numbers live on the issue. `.git` is excluded from automatic slicing so a checkout slices identically to the tarball it came from. Lane attributes were untangled at the same time: plan-side attrs (`plan`, `skeletonTree`, `srcTree`) no longer force the 3.6k-derivation units import just to be looked at.


### PR DESCRIPTION
Flattens the flat per-edit tax of the kbuild-unit incremental kernel build (#3706). A one-line body edit rebuilds a handful of derivations in seconds, but the measured defconfig loop was 1m51s at #3413 exit (94.6s re-measured at the merge base on the same host/day); the rest was whole-tree re-skeletonization, whole-tree source re-ingestion, and eval work independent of the edit.

Three levers, all keeping every output content-addressed and byte-identical:

1. **Sharded skeletonization.** The directives-only reduction now runs one CA derivation per top-level source directory (drivers/ one level deeper), composed back byte-identically -- the composed tree lands on the *same store path* as the whole-tree reduction (verified at tinyconfig and defconfig: `SKELETON_PATH_IDENTICAL`), so the plan contract does not move. A body edit re-reduces exactly the subtree it touched (~1s shard instead of ~80k files). The new `--prefix` flag on `nix-kbuild-unit skeleton` re-roots classification; a Rust test proves shards compose to the whole-tree reduction byte-for-byte.

2. **Per-directory slices feeding every source consumer.** The per-file source farm (#3412) and the link unit's directory scopes now resolve through per-directory slices, and `buildKernel` gained two tree entry points: `srcTree` (pre-unpacked tree: derivation output, or plain path under `--impure`) and `srcSlices` (pre-ingested per-directory store paths; a driver re-adds only the edited directory -- measured 0.18s). The farm's store paths are byte-stable through the routing: priming the branch re-executed the plan once (new renderer binary) and **zero units**.

3. **Importless plan attrs + honest eval keying.** Lane attrs are spelled out instead of `imported // ...`, so plan-side attrs no longer force the 3.6k-derivation units import. The flake-hash sensitivity is gone (edits live outside the flake in the srcTree/srcSlices lanes).

Validation (fleet, warm stores, substitution off, post-build hook disabled per #3413), full evidence on #3706:
- Equivalence gates green at tinyconfig and defconfig at PR head; sharded skeleton store path identical to the whole-tree one at both scales; plan-rerun no-op benchmark still 2.4s.
- Measured loops (defconfig, hil-compute-3): module body edit 67-85s across the three source modes (baseline 94.6s, #3413-era 111s), built-in 97-107s (was 162s), header 165-171s (was 187s). Executed derivations are now exactly the affected set: 5 / 9 / 60, with one skeleton shard re-reducing instead of the whole tree.
- The ~30s body-edit bar is **not met**: the residual is a flat ~46s of eval-time source re-ingestion -- `builtins.path` has no cross-eval memoization in current Nix, so the ~25k-file farm re-hashes every evaluation regardless of slicing. That is an evaluator problem, not a lane problem; filed as #3725 (source-ingestion cache for the patched-Nix lane) with the measured segments.

Long-form: packages/site/src/lib/updates/kbuild-unit-edit-constant.svx

Refs #3706

(sent by an AI agent via Claude Code)
