### PR TITLE
site: quote postmortem title, fail loudly on unparsed frontmatter

### DIFF
--- a/packages/site/src/lib/updates.ts
+++ b/packages/site/src/lib/updates.ts
@@ -28,7 +28,10 @@ type SvxModule = {
   default: Component;
   // The raw frontmatter shape. `tags` is optional here because mdsvex does
   // not validate; the loader below normalizes to a required `string[]`.
-  metadata: Omit<SiteUpdateMeta, 'tags'> & { tags?: string[] };
+  // `metadata` itself is absent when the frontmatter fails to parse
+  // (e.g. an unquoted title containing a colon); the loader rejects that
+  // loudly, naming the file.
+  metadata?: Omit<SiteUpdateMeta, 'tags'> & { tags?: string[] };
 };
 
 const modules = import.meta.glob<SvxModule>('./updates/*.svx', { eager: true });
@@ -39,12 +42,20 @@ const rawModules = import.meta.glob<string>('./updates/*.svx', {
 });
 
 export const siteUpdates: SiteUpdate[] = Object.entries(modules)
-  .map(([path, mod]) => ({
-    ...mod.metadata,
-    tags: (mod.metadata.tags ?? []).map((tag) => tag.toLowerCase()),
-    component: mod.default,
-    rawBody: stripFrontmatter(rawModules[path] ?? '')
-  }))
+  .map(([path, mod]) => {
+    if (mod.metadata === undefined) {
+      // Malformed frontmatter (e.g. an unquoted title containing a colon)
+      // makes mdsvex emit a module with no metadata; name the file instead
+      // of crashing on `undefined.tags` deep inside the prerender.
+      throw new Error(`${path}: frontmatter failed to parse (no metadata export)`);
+    }
+    return {
+      ...mod.metadata,
+      tags: (mod.metadata.tags ?? []).map((tag) => tag.toLowerCase()),
+      component: mod.default,
+      rawBody: stripFrontmatter(rawModules[path] ?? '')
+    };
+  })
   .sort((a, b) => Date.parse(b.postedAt) - Date.parse(a.postedAt));
 
 export const siteUrl = 'https://indexable-inc.github.io/index/';

--- a/packages/site/src/lib/updates/pin-freeze-postmortem.svx
+++ b/packages/site/src/lib/updates/pin-freeze-postmortem.svx
@@ -1,7 +1,7 @@
 ---
 id: pin-freeze-postmortem
 postedAt: '2026-07-19T06:15:00-07:00'
-title: one frozen pin, five root causes: a morning of CI archaeology
+title: 'one frozen pin, five root causes: a morning of CI archaeology'
 links:
   - label: 'union gap #3669'
     href: 'https://github.com/indexable-inc/index/issues/3669'


### PR DESCRIPTION
Fixes the site/Pages build red since 0fe84d96 (~13:00Z): the pin-freeze postmortem title is unquoted YAML containing a colon, so mdsvex emits the module with no metadata export and prerender dies with `Cannot read properties of undefined (reading tags)`. Every Pages deploy since has failed, so ix.dev is serving a stale site (including the new Plans map from #3718).

Two changes: quote the title, and make the updates loader throw a named-file error when metadata is missing so the next malformed frontmatter fails loudly at the source. Hermetic `nix build .#site` red at origin/main, green with this branch.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix frontmatter parsing in postmortem and throw on missing metadata in site updates
> - Quotes the colon-containing title in [pin-freeze-postmortem.svx](https://github.com/indexable-inc/index/pull/3720/files#diff-20e78da7ab4414725884a190b3c700ec51969fd728efff6a9e0aafa74af160cd) so its frontmatter parses correctly.
> - Updates [updates.ts](https://github.com/indexable-inc/index/pull/3720/files#diff-8385bcb03c190b4f8f3e68a626fc11b628e55aab40b9ef3c903649633de16ff6) to throw a named error when an `.svx` module lacks a `metadata` export, surfacing the offending file path instead of failing silently later.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4b9f3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->