### PR TITLE
nushell: add reedline git outputHashes entry, unbreak main flake-check

### DIFF
--- a/packages/nushell/default.nix
+++ b/packages/nushell/default.nix
@@ -20,6 +20,12 @@
     src = source;
     workspaceRoot = source;
     cargoLock = source + "/Cargo.lock";
+    # Upstream nushell pins reedline to a git rev on its main branch; the key
+    # must match the Cargo.lock source string exactly, rev included. Refresh
+    # after a nushell-src bump when eval reports a missing hash (index#3723).
+    outputHashes = {
+      "git+https://github.com/nushell/reedline?branch=main#f776f5079e49d075c071660ae0f9b040b3ff909b" = "sha256-Gy9OQJ2oAaZvy0XZ4dTDXEJa8caVHEh2yS5PovA8oi8=";
+    };
     cargoArgs = [
       "-p"
       "nu"


### PR DESCRIPTION
Main flake-check has been red repo-wide since the 93ba54768 flake.lock bump moved nushell-src: upstream's Cargo.lock now pins reedline to a git rev absent from outputHashes, and every PR's merge-with-main check fails at eval with "outputHashes is missing hashes for git source strings in Cargo.lock".

Adds the single entry, keyed by the exact lock source string. Repro: `nix eval .#nushell.drvPath` fails on main, passes here (evals to nu-0.114.2.drv). Closes #3723.

(authored by an AI agent via Claude Code, Fable 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `outputHashes` entry for reedline git dependency in nushell package
> Adds a fixed-output hash for the reedline git dependency (rev `f776f5079e49d075c071660ae0f9b040b3ff909b`) in [packages/nushell/default.nix](https://github.com/indexable-inc/index/pull/3724/files#diff-212de844c8fed6fd8a442afd968fc1e2d861bf53ea419887738348234aa5b572). This fixes the flake check by supplying the sha256 hash Nix requires when vendoring git-sourced Cargo dependencies. Comments are included to clarify how to update the hash after future nushell source bumps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5fb32c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->