### PR TITLE
skills/visual-explainers: pre for code blocks in HTML fallback, explicit-HTML trigger

### DIFF
--- a/packages/agent/skills/visual-explainers/SKILL.md
+++ b/packages/agent/skills/visual-explainers/SKILL.md
@@ -28,8 +28,11 @@ Promote any piece another board could reuse into the catalog instead of
 copying it.
 
 Fall back to a single self-contained HTML file (inline CSS and JS, vanilla,
-opens from file:// with the network off) only when the dashboard repo is
-unavailable.
+opens from file:// with the network off) when the dashboard repo is
+unavailable or the user explicitly asks for an HTML file. In the fallback,
+put multi-line code or command blocks in `pre`: newlines inside a styled
+`div` collapse silently into one run-on paragraph, and the page looks fine
+in the editor while shipping broken.
 
 ## Static-first: the lesson is visible on load
 


### PR DESCRIPTION
Two gaps hit in a live session (see #3726):

1. Multi-line code/command blocks in the HTML fallback must be `pre`; newlines inside a styled `div` collapse silently into one run-on paragraph.
2. The fallback now also triggers when the user explicitly asks for an HTML file, not only when the dashboard repo is unavailable.

Fixes #3726

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix code block rendering and expand fallback trigger in visual-explainers skill
> Updates [SKILL.md](https://github.com/indexable-inc/index/pull/3727/files#diff-3d254f5916b3278718cc3b1cf320884ea598a3df730e4fe4c28c11a03ba7cd56) with two changes to the HTML fallback behavior:
> - Wraps multi-line code and command blocks in `<pre>` to prevent newline collapse inside styled `<div>` elements
> - Expands the fallback trigger condition to include explicit user requests for an HTML file, not just dashboard repo unavailability
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 984191b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->