### PR TITLE
skills: kernel-deploy, roll out kernel changes over the shared cache

### DIFF
--- a/packages/agent/skills/kernel-deploy/SKILL.md
+++ b/packages/agent/skills/kernel-deploy/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: kernel-deploy
+description: "Rolling out kernel changes across cluster nodes: build once on one host, push the kbuild-unit cachePushRoot once, every other node substitutes. Use when a change touches the kernel (patch, config, src bump) and more than one node needs it."
+---
+
+## Deploying kernel changes
+
+A kernel change is the most expensive rebuild in the tree. One host builds
+it; the cache carries it; every other node substitutes. Never let two nodes
+build the same kernel.
+
+## Landed changes
+
+Merge to main. `cache-push.yml` realises the push roots on the CI pool and
+publishes to cache.ix.dev; `advance-cache-ready` moves the consumer pin once
+every root realised. Then roll nodes with the fleet verbs (`switch` for an
+in-place system switch, `up` to push and replace on a new image; see
+`doc/ix/fleet.md`). Nodes substitute the new system closure instead of
+rebuilding it.
+
+## Iterating before merge: the kbuild-unit shared cache
+
+For kernel iteration, use the per-TU lanes under `legacyPackages`
+(x86_64-linux only, #3413): `kernel-unit` (tinyconfig),
+`kernel-unit-defconfig`, `kernel-unit-ccache` (static fallback plan
+strategy).
+
+On one trusted builder:
+
+```sh
+# 1. Mass unit build with the per-derivation cache hook OFF: one synchronous
+#    enqueue per unit serialized 3.6k-unit builds under queue backpressure.
+nix build --option post-build-hook '' .#kernel-unit-defconfig.allUnits
+
+# 2. Push once, under normal settings. cachePushRoot is one linkFarm whose
+#    runtime closure spans every unit output plus the IFD artifacts (plan,
+#    rendered units.nix, snapshot, skeleton tree). Building it enqueues ONE
+#    obligation; the drainer publishes the NARs and the CA realisations
+#    other hosts need to substitute instead of rebuild.
+nix build .#kernel-unit-defconfig.cachePushRoot
+```
+
+On every other node, build normally; units substitute from the cache:
+
+```sh
+nix build .#kernel-unit-defconfig.vmlinux
+```
+
+## Why iteration stays cheap
+
+- Plan reruns reproduce the snapshot bit-identically (#3667), so a header or
+  Makefile edit re-executes only the units whose inputs changed; the rest
+  substitute from the last push, including one made by another host.
+- Dep sets are trimmed: a one-module body edit rebuilds that module's TU,
+  its `.ko` link, and the modpost pass. No other module re-links.
+- First eval of a fresh plan pays the IFD (a full monolithic kernel build at
+  eval time). Push the root right after so no second host pays it again.
+
+## Validate before rolling out
+
+The byte-equivalence gates prove the unit-composed kernel matches the
+monolithic reference build:
+
+```sh
+nix build .#kernel-unit-defconfig.vmlinuxEquivalence \
+  .#kernel-unit-defconfig.modulesEquivalence
+```


### PR DESCRIPTION
Closes #3730.

## What

Adds `packages/agent/skills/kernel-deploy/SKILL.md`: the workflow for rolling out kernel changes across cluster nodes, built on the kbuild-unit fleet cache lane from #3667.

- Landed changes: merge to main, cache-push.yml publishes, `advance-cache-ready` moves the pin, nodes roll via the fleet verbs and substitute.
- Pre-merge iteration: mass unit build with `--option post-build-hook ''` on one trusted builder, then `nix build .#<lane>.cachePushRoot` once so every other node substitutes units instead of rebuilding.
- Why iteration stays cheap: bit-identical plan reruns, trimmed dep sets, IFD paid once per fresh plan.
- Validation gates (`vmlinuxEquivalence`, `modulesEquivalence`) before rollout.

## Validation

- `nix build .#skills` on the branch: `kernel-deploy` appears in the materialized skills dir with intact frontmatter.
- `nix run .#lint`: 3 blocking findings, all pre-existing on main in `lib/kernel/kbuild-unit.nix` (two are astlog false positives on `inherit name`, filed as #3731); none from this change.

(sent by an AI agent via Claude Code, Claude Opus 4.6)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add kernel-deploy skill documentation for rolling out kernel changes over shared cache
> Adds [SKILL.md](https://github.com/indexable-inc/index/pull/3732/files#diff-5c4ba527ce55fcb9e64a4c5a9a73e6b6fe27f98ab17e25ca681497624121ce47) documenting the `kernel-deploy` workflow for deploying kernel changes across cluster nodes.
>
> - Covers CI push roots and fleet roll commands for cluster-wide deployment
> - Documents an iteration workflow using the `kbuild-unit` shared cache, including nix build commands for mass unit builds, cache push, and substitution
> - Explains the rationale for cheap iteration: plan reproducibility, trimmed dependency sets, and IFD cost avoidance
> - Describes validation via byte-equivalence builds for `vmlinux` and modules
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e787b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->