### PR TITLE
zed: bump zed-src to the regenerated ix-patched head

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -832,11 +832,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1784469527,
-        "narHash": "sha256-KEHzrBRiB5CQ/qsy2MWMZxgV4MF0FqsQO/iUmqyi+/8=",
+        "lastModified": 1784488930,
+        "narHash": "sha256-9HvIk/s+k6ptwRbAkbzdzeX4P/ChlZVnV4befgAG+Gw=",
         "owner": "indexable-inc",
         "repo": "zed",
-        "rev": "2cdcb7caf34fdf158a302ea38549c379bf161a87",
+        "rev": "b72cf7701e5cbfbcaa3324da8fd7b8895476e346",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
`patches/0003-editor-navigate-directly-to-a-single-reference.patch` landed while `flake.lock` still pinned `zed-src` to pre-0003 `2cdcb7ca`, so `packages/zed/default.nix`'s `diff patchedSource zedSource` guard fails every darwin build of `zed-editor` (log: `Files .../zed-patched/Cargo.lock and .../source/Cargo.lock differ`, plus the gpui files). This bumps `zed-src` to `b72cf770`, the `ix-patched` head the regen workflow pushed for the current series; `zed-upstream` is unchanged.

Verified locally on hydra (aarch64-darwin): with this rev pair the guard's inputs match the committed patches; the full zed-editor build is running in my hm switch now.

Refs #3744 (the guard is darwin-only so linux CI cannot catch this class).

(opened by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump zed-src to the regenerated ix-patched head
> Updates [flake.lock](https://github.com/indexable-inc/index/pull/3745/files#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9c) to point `zed-src` at the latest regenerated ix-patched commit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 743fed8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->