### PR TITLE
nix: stamp submodule metadata on relative path flake inputs (p30)

### DIFF
--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -688,6 +688,18 @@
           upstream = "hold";
           reason = "Fork policy gate for the 0025-0028 backports (indexable-inc/index#3645): upstream ships the behavior unconditionally, we default it off pending fleet-wide equivalence sweeps. Retire together with the backports when the base reaches 2.35+.";
         };
+        # 0030: a relative path input that is a git submodule of its parent
+        # is a pinned tree, but its lock node carried no metadata; consumers
+        # could not see the pin's age or provenance (a prompt segment showed
+        # a fresh pin as 20653 days old, indexable-inc/index#3733). Stamps
+        # the gitlink rev and its commit time into the locked ref, so
+        # flake.lock and inputs.<name>.{lastModified,rev,shortRev} carry
+        # them. Plain subdirectories stay unstamped: their time equals the
+        # parent's and would churn the lock on every parent commit.
+        "0030-libflake-stamp-submodule-metadata-on-relative-path-f.patch" = {
+          upstream = "hold";
+          reason = "Submodule metadata for relative path inputs (indexable-inc/index#3737); companion to 0024 in the sparseNodes direction (NixOS/nix#7730). Hold: humans submit Nix patches upstream per NixOS/nix#15984.";
+        };
       };
     }
     {

--- a/packages/nix/nix/patches/0030-libflake-stamp-submodule-metadata-on-relative-path-f.patch
+++ b/packages/nix/nix/patches/0030-libflake-stamp-submodule-metadata-on-relative-path-f.patch
@@ -1,0 +1,455 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew.gazelka@gmail.com>
+Date: Sun, 19 Jul 2026 13:48:54 -0700
+Subject: [PATCH] libflake: stamp submodule metadata on relative path flake
+ inputs
+
+A relative path flake input that is a git submodule of its parent is a
+pinned tree, but its lock node carried no metadata: path inputs have no
+eval-time lastModified (a git+file parent fetch canonicalizes mtimes)
+and no rev, so consumers cannot see the pin's age or provenance;
+inputs.<name>.lastModified evaluated as missing and a prompt segment
+rendered the pin as 20653 days old (indexable-inc/index#3733).
+
+Stamp the locked ref of a relative path input from the parent input's
+tree when the path is a pinned mount root: the gitlink rev and that
+commit's time. Both land in flake.lock ("path" inputs already accept
+rev/lastModified as fake tree info) and in the input's sourceInfo, so
+inputs.<name>.{lastModified,rev,shortRev} work like any git input's.
+Plain subdirectories are deliberately not stamped: their time equals
+the parent's, and stamping it would churn the lock on every parent
+commit.
+
+The metadata travels on SourceAccessor: the git fetcher records commit
+time and rev on the accessors it builds, including each submodule
+mount, and MountedSourceAccessor resolves path-aware queries through
+the nearest mount. The input cache now also keys entries by the locked
+input (with the finality marker stripped on lookup), so lock
+computation reuses the fetch's accessor instead of refetching or
+taking the substitution shortcut, whose flattened store copy knows no
+per-subtree metadata; if the parent's tree nonetheless arrives
+flattened, the previous lock's values are kept so stamps never flap
+between fetch modes. A last-modified of 0 (a workdir with no commits)
+is unknown, not stamped.
+
+Refs indexable-inc/index#3737
+Assisted-by: Claude Code
+
+diff --git a/src/libfetchers/git.cc b/src/libfetchers/git.cc
+index ac4288f9d..44e0e3314 100644
+--- a/src/libfetchers/git.cc
++++ b/src/libfetchers/git.cc
+@@ -1091,6 +1091,11 @@ struct GitInputScheme : InputScheme
+         auto accessor = repo->getAccessor(
+             rev, {.exportIgnore = exportIgnore, .smudgeLfs = smudgeLfs}, "«" + input.to_string() + "»");
+ 
++        /* Record the commit time on the accessor so consumers composing
++           accessors (submodule mounts) can surface it per subtree. */
++        accessor->lastModified = input.getLastModified();
++        accessor->rev = input.getRev();
++
+         /* If the repo has submodules, fetch them and return a mounted
+            input accessor consisting of the accessor for the top-level
+            repo and the accessors for the submodules. */
+@@ -1138,6 +1143,9 @@ struct GitInputScheme : InputScheme
+ 
+         assert(!origRev || origRev == rev);
+ 
++        accessor->lastModified = input.getLastModified();
++        accessor->rev = input.getRev();
++
+         return {accessor, std::move(input)};
+     }
+ 
+@@ -1222,6 +1230,9 @@ struct GitInputScheme : InputScheme
+             repoInfo.workdirInfo.headRev ? getLastModified(settings, repoInfo, repoPath, *repoInfo.workdirInfo.headRev)
+                                          : 0);
+ 
++        accessor->lastModified = input.getLastModified();
++        accessor->rev = input.getRev();
++
+         return {accessor, std::move(input)};
+     }
+ 
+diff --git a/src/libfetchers/input-cache.cc b/src/libfetchers/input-cache.cc
+index 652d5ce79..ccc119f0a 100644
+--- a/src/libfetchers/input-cache.cc
++++ b/src/libfetchers/input-cache.cc
+@@ -32,6 +32,12 @@ InputCache::CachedResult InputCache::getAccessor(
+                     originalInput.to_string());
+             }
+         }
++        /* Also cache under the locked input, so a later lookup by the
++           locked ref (e.g. relative-input metadata stamping during lock
++           computation) reuses this accessor instead of refetching or
++           taking the substitution shortcut, which returns a store
++           accessor stripped of the fetcher's tree metadata. */
++        upsert(fetched->lockedInput, *fetched);
+         upsert(originalInput, *fetched);
+     }
+ 
+diff --git a/src/libflake/flake.cc b/src/libflake/flake.cc
+index 250a34cf4..8382acea9 100644
+--- a/src/libflake/flake.cc
++++ b/src/libflake/flake.cc
+@@ -489,6 +489,8 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
+             std::shared_ptr<const Node> oldNode,
+             const InputAttrPath & followsPrefix,
+             const SourcePath & sourcePath,
++            const FlakeRef & parentFlakeRef,
++            const CanonPath & parentTreeBase,
+             bool trustLock)>
+             computeLocks;
+ 
+@@ -510,6 +512,18 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
+                            const InputAttrPath & followsPrefix,
+                            /* The source path of this node's flake. */
+                            const SourcePath & sourcePath,
++                           /* The locked ref of this node's flake (for a
++                              relative path flake, its nearest non-relative
++                              ancestor, whose accessor its source path
++                              composes through). Used to recover the parent
++                              input's tree metadata for relative inputs. */
++                           const FlakeRef & parentFlakeRef,
++                           /* This node's flake directory within
++                              parentFlakeRef's source tree (its subdir, or the
++                              composed relative path for a relative flake).
++                              Relative inputs are resolved against it when
++                              querying that tree's metadata. */
++                           const CanonPath & parentTreeBase,
+                            bool trustLock) {
+             debug("computing lock file node '%s'", printInputAttrPath(inputAttrPathPrefix));
+ 
+@@ -608,6 +622,81 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
+                             return std::nullopt;
+                     };
+ 
++                    /* A relative path input has no timestamp of its own,
++                       but the parent's tree knows one: the submodule commit
++                       time when the path is a submodule mount, else the
++                       enclosing tree's own last-modified. Stamp it on the
++                       locked ref so it reaches the lock file and the
++                       input's sourceInfo.lastModified like any other
++                       input's (indexable-inc/index#3737). */
++                    /* Tree base for a child flake's own recursion: a
++                       relative child composes through the same ancestor
++                       tree; a non-relative child starts a new tree at its
++                       subdir. */
++                    auto childTreeBase = [&](const FlakeRef & childLockedRef) {
++                        if (auto rel = childLockedRef.input.isRelative())
++                            return CanonPath(rel->string(), parentTreeBase);
++                        return CanonPath(childLockedRef.subdir);
++                    };
++
++                    auto stampRelativeTreeMetadata = [&](FlakeRef & lockedRef, const std::shared_ptr<const LockedNode> & oldLock) {
++                        if (!lockedRef.input.isRelative())
++                            return;
++                        /* An override resolves against the overrider's tree,
++                           whose input is not at hand here; skip rather than
++                           stamp from the wrong tree. */
++                        if (hasOverride)
++                            return;
++                        auto relativePath = lockedRef.input.isRelative();
++                        assert(relativePath);
++                        /* The input's location within the parent input's
++                           tree. The flake's own source path is useless here:
++                           it may be a flattened store copy in root-filesystem
++                           coordinates that lost the fetcher's tree metadata
++                           (submodule mounts and their commit info). */
++                        auto treePath = CanonPath(relativePath->string(), parentTreeBase);
++                        /* Query the parent input's accessor from the input
++                           cache; the fetch that led here already populated
++                           it. */
++                        /* Strip the finality marker: the input cache holds
++                           the entry under the locked input as fetched, and a
++                           final-marked copy would miss it and refetch, in
++                           the worst case through the substitution shortcut,
++                           whose flattened store tree knows no per-subtree
++                           metadata. */
++                        auto parentInput = parentFlakeRef.input;
++                        parentInput.attrs.erase("__final");
++                        auto parentAccessor =
++                            state.inputCache
++                                ->getAccessor(state.fetchSettings, *state.store, parentInput, fetchers::UseRegistries::No)
++                                .accessor;
++                        /* Only a path that is itself a pinned tree in the
++                           parent (a submodule mount root, marked by having a
++                           rev) gets stamped: its metadata changes only when
++                           the parent moves the gitlink, so locks stay
++                           byte-stable across unrelated parent commits. A
++                           plain subdirectory shares the parent's history and
++                           stamping its time would churn the lock on every
++                           parent commit for a value derivable from the
++                           parent itself. When the parent's tree came from a
++                           flattened store copy that knows no mounts, fall
++                           back to the previous lock's values so stamps never
++                           flap between fetch modes. */
++                        if (auto rev = parentAccessor->getRev(treePath)) {
++                            lockedRef.input.attrs.insert_or_assign("rev", rev->gitRev());
++                            auto lastModified = parentAccessor->getLastModified(treePath);
++                            /* 0 is the fetchers' "unknown" value, not a real
++                               time; an epoch-0 stamp is worse than none. */
++                            if (lastModified && *lastModified > 0)
++                                lockedRef.input.attrs.insert_or_assign("lastModified", uint64_t(*lastModified));
++                        } else if (oldLock && oldLock->originalRef.canonicalize() == input.ref->canonicalize()) {
++                            if (auto prev = fetchers::maybeGetStrAttr(oldLock->lockedRef.input.attrs, "rev"))
++                                lockedRef.input.attrs.insert_or_assign("rev", *prev);
++                            if (auto prev = fetchers::maybeGetIntAttr(oldLock->lockedRef.input.attrs, "lastModified"))
++                                lockedRef.input.attrs.insert_or_assign("lastModified", *prev);
++                        }
++                    };
++
+                     /* Get the input flake, resolve 'path:./...'
+                        flakerefs relative to the parent flake. */
+                     auto getInputFlake = [&](const FlakeRef & ref, const fetchers::UseRegistries useRegistries) {
+@@ -729,10 +818,20 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
+                                 oldLock,
+                                 followsPrefix,
+                                 inputFlake.path,
++                                inputFlake.lockedRef.input.isRelative() ? parentFlakeRef : inputFlake.lockedRef,
++                                childTreeBase(inputFlake.lockedRef),
+                                 false);
+                         } else {
+                             computeLocks(
+-                                fakeInputs, childNode, inputAttrPath, oldLock, followsPrefix, sourcePath, true);
++                                fakeInputs,
++                                childNode,
++                                inputAttrPath,
++                                oldLock,
++                                followsPrefix,
++                                sourcePath,
++                                parentFlakeRef,
++                                parentTreeBase,
++                                true);
+                         }
+ 
+                     } else {
+@@ -758,6 +857,8 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
+                             auto inputFlake = getInputFlake(
+                                 *input.ref, inputIsOverride ? fetchers::UseRegistries::All : useRegistriesInputs);
+ 
++                            stampRelativeTreeMetadata(inputFlake.lockedRef, oldLock);
++
+                             auto childNode =
+                                 make_ref<LockedNode>(inputFlake.lockedRef, ref, true, overriddenParentPath);
+ 
+@@ -780,6 +881,8 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
+                                 readLockFile(state.fetchSettings, inputFlake.lockFilePath()).root.get_ptr(),
+                                 inputAttrPath,
+                                 inputFlake.path,
++                                inputFlake.lockedRef.input.isRelative() ? parentFlakeRef : inputFlake.lockedRef,
++                                childTreeBase(inputFlake.lockedRef),
+                                 false);
+                         }
+ 
+@@ -801,6 +904,8 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
+                                 }
+                             }();
+ 
++                            stampRelativeTreeMetadata(lockedRef, oldLock);
++
+                             auto childNode = make_ref<LockedNode>(lockedRef, ref, false, overriddenParentPath);
+ 
+                             nodePaths.emplace(childNode, path);
+@@ -825,6 +930,8 @@ lockFlake(const Settings & settings, EvalState & state, const FlakeRef & topRef,
+             lockFlags.recreateLockFile ? nullptr : oldLockFile.root.get_ptr(),
+             {},
+             flake.path,
++            flake.lockedRef,
++            CanonPath(flake.lockedRef.subdir),
+             false);
+ 
+         for (auto & i : lockFlags.inputOverrides)
+diff --git a/src/libutil/include/nix/util/source-accessor.hh b/src/libutil/include/nix/util/source-accessor.hh
+index bcc25b99a..4f82ab833 100644
+--- a/src/libutil/include/nix/util/source-accessor.hh
++++ b/src/libutil/include/nix/util/source-accessor.hh
+@@ -205,13 +205,49 @@ struct SourceAccessor : std::enable_shared_from_this<SourceAccessor>
+         return {path, fingerprint};
+     }
+ 
++    /**
++     * The last-modified time of this tree, if known. Fetchers that
++     * know it set it (the Git fetcher uses the commit time) so that
++     * composite accessors can surface it per subtree.
++     */
++    std::optional<time_t> lastModified;
++
+     /**
+      * Return the maximum last-modified time of the files in this
+      * tree, if available.
+      */
+     virtual std::optional<time_t> getLastModified()
+     {
+-        return std::nullopt;
++        return lastModified;
++    }
++
++    /**
++     * Return the last-modified time of the tree containing `path`.
++     * Composite accessors (mounts) answer from the innermost mount,
++     * so a Git submodule reports its own commit time rather than its
++     * parent's; plain accessors answer path-independently.
++     */
++    virtual std::optional<time_t> getLastModified(const CanonPath & path)
++    {
++        return getLastModified();
++    }
++
++    /**
++     * The revision this tree was fetched from, if known (the Git
++     * fetcher sets it to the commit hash).
++     */
++    std::optional<Hash> rev;
++
++    /**
++     * Return the revision pinning the tree rooted at `path`. A rev
++     * describes a whole tree, so plain accessors only answer at the
++     * root; composite accessors answer at mount roots, so a Git
++     * submodule reports its own gitlink commit while paths inside a
++     * tree report nothing.
++     */
++    virtual std::optional<Hash> getRev(const CanonPath & path)
++    {
++        return path.isRoot() ? rev : std::nullopt;
+     }
+ 
+     /**
+diff --git a/src/libutil/mounted-source-accessor.cc b/src/libutil/mounted-source-accessor.cc
+index aab95f775..4fde29332 100644
+--- a/src/libutil/mounted-source-accessor.cc
++++ b/src/libutil/mounted-source-accessor.cc
+@@ -100,6 +100,28 @@ struct MountedSourceAccessorImpl : MountedSourceAccessor
+         return accessor->getFingerprint(subpath);
+     }
+ 
++    /* The path-taking overrides below would otherwise hide the
++       zero-argument base overloads. */
++    using SourceAccessor::getLastModified;
++    using SourceAccessor::getRev;
++
++    std::optional<Hash> getRev(const CanonPath & path) override
++    {
++        auto [accessor, subpath] = resolve(path);
++        return accessor->getRev(subpath);
++    }
++
++    std::optional<time_t> getLastModified(const CanonPath & path) override
++    {
++        auto [accessor, subpath] = resolve(path);
++        /* A mount that does not know its own time (e.g. a plain
++           filesystem accessor for a dirty workdir) falls back to the
++           whole tree's value. */
++        if (auto t = accessor->getLastModified(subpath))
++            return t;
++        return getLastModified();
++    }
++
+     void invalidateCache(const CanonPath & path) override
+     {
+         auto [accessor, subpath] = resolve(path);
+diff --git a/tests/functional/flakes/meson.build b/tests/functional/flakes/meson.build
+index de76a5580..4382e2ecc 100644
+--- a/tests/functional/flakes/meson.build
++++ b/tests/functional/flakes/meson.build
+@@ -29,6 +29,7 @@ suites += {
+     'non-flake-inputs.sh',
+     'relative-paths.sh',
+     'relative-paths-lockfile.sh',
++    'relative-paths-lastmodified.sh',
+     'symlink-paths.sh',
+     'debugger.sh',
+     'source-paths.sh',
+diff --git a/tests/functional/flakes/relative-paths-lastmodified.sh b/tests/functional/flakes/relative-paths-lastmodified.sh
+new file mode 100644
+index 000000000..e709b9a61
+--- /dev/null
++++ b/tests/functional/flakes/relative-paths-lastmodified.sh
+@@ -0,0 +1,87 @@
++#!/usr/bin/env bash
++
++source common.sh
++
++requireGit
++
++TODO_NixOS
++
++# Submodules can't be fetched locally by default (see fetchGitSubmodules.sh).
++export GIT_CONFIG_COUNT=1
++export GIT_CONFIG_KEY_0=protocol.file.allow
++export GIT_CONFIG_VALUE_0=always
++
++subRepo=$TEST_ROOT/lastmodified-sub
++rootRepo=$TEST_ROOT/lastmodified-root
++
++# Distinct deterministic commit times so the assertions cannot pass by accident.
++subTime=1700000000
++rootTime=1710000000
++
++createGitRepo "$subRepo"
++cat > "$subRepo"/flake.nix <<EOF
++{
++  outputs = { self }: { x = 1; };
++}
++EOF
++git -C "$subRepo" add flake.nix
++GIT_AUTHOR_DATE="$subTime +0000" GIT_COMMITTER_DATE="$subTime +0000" \
++  git -C "$subRepo" commit -m sub
++
++createGitRepo "$rootRepo"
++git -C "$rootRepo" submodule add "$subRepo" sub
++mkdir "$rootRepo"/plain
++cat > "$rootRepo"/plain/flake.nix <<EOF
++{
++  outputs = { self }: { x = 2; };
++}
++EOF
++cat > "$rootRepo"/flake.nix <<EOF
++{
++  inputs.sub.url = "path:./sub";
++  inputs.plain.url = "path:./plain";
++  outputs = { self, sub, plain }: {
++    subLastModified = sub.lastModified or "missing";
++    plainLastModified = plain.lastModified or "missing";
++    subRev = sub.rev or "missing";
++    plainRev = plain.rev or "missing";
++  };
++}
++EOF
++git -C "$rootRepo" add flake.nix plain/flake.nix
++GIT_AUTHOR_DATE="$rootTime +0000" GIT_COMMITTER_DATE="$rootTime +0000" \
++  git -C "$rootRepo" commit -m root
++
++flakeref="git+file://$rootRepo?submodules=1"
++
++# Evaluate without writing the lock so the tree stays clean (this test
++# environment rejects dirty, uncacheable trees).
++
++# A relative path input that is a submodule reports the submodule's own
++# commit time, not the parent's.
++[[ $(nix eval --no-write-lock-file --json "$flakeref#subLastModified") = "$subTime" ]]
++
++# A plain subdirectory is deliberately not stamped: its time equals the
++# parent's (derivable there), and stamping it would churn the lock on
++# every parent commit.
++[[ $(nix eval --no-write-lock-file --json "$flakeref#plainLastModified") = '"missing"' ]]
++
++# A submodule-backed input also reports the gitlink commit; a plain
++# subdirectory has no rev of its own (the parent's rev does not pin the
++# subdirectory alone).
++subRev=$(git -C "$subRepo" rev-parse HEAD)
++[[ $(nix eval --no-write-lock-file --raw "$flakeref#subRev") = "$subRev" ]]
++[[ $(nix eval --no-write-lock-file --raw "$flakeref#plainRev") = missing ]]
++
++# The stamped values are recorded in the lock file.
++nix flake lock "$flakeref"
++[[ $(jq -r '.nodes.sub.locked.lastModified' "$rootRepo"/flake.lock) = "$subTime" ]]
++[[ $(jq -r '.nodes.plain.locked.lastModified' "$rootRepo"/flake.lock) = null ]]
++[[ $(jq -r '.nodes.sub.locked.rev' "$rootRepo"/flake.lock) = "$subRev" ]]
++
++# The enriched lock must round-trip: a fresh evaluation of the committed
++# lock still works and reproduces the same values.
++git -C "$rootRepo" add flake.lock
++GIT_AUTHOR_DATE="$rootTime +0000" GIT_COMMITTER_DATE="$rootTime +0000" \
++  git -C "$rootRepo" commit -m lock
++[[ $(nix eval --json "$flakeref#subLastModified") = "$subTime" ]]

--- a/packages/nix/nix/patches/dag.json
+++ b/packages/nix/nix/patches/dag.json
@@ -135,6 +135,10 @@
       "deps": [
         "0028-libexpr-Handle-lazy-paths-in-builtins.storePath-bett.patch"
       ]
+    },
+    {
+      "patch": "0030-libflake-stamp-submodule-metadata-on-relative-path-f.patch",
+      "deps": []
     }
   ]
 }


### PR DESCRIPTION
`path:./index` submodule inputs now carry real metadata: patch 0030 stamps the gitlink rev and its commit time onto the locked ref, so both land in flake.lock (`path:./index?lastModified=...&rev=...`) and in `inputs.index.{lastModified,rev,shortRev}`. Plain subdirectory subflakes stay unstamped: their time equals the parent's, and stamping it would churn the lock on every parent commit.

Mechanics: the git fetcher records commit time and rev on the accessors it builds (each submodule mount included); MountedSourceAccessor resolves path-aware queries through the nearest mount; lock computation stamps relative inputs from the parent input's cached accessor (input cache now also keyed by locked input, finality marker stripped on lookup); flattened store-copy parents fall back to the previous lock's values so stamps never flap; lastModified 0 is treated as unknown.

Verification (all local, hydra):
- nix flakes functional suite 33/33, including the new `relative-paths-lastmodified` test (deterministic commit times; submodule time != parent time; rev = gitlink; lock persistence; round-trip after committing the lock)
- full test battery differential vs the unpatched p29 base: identical 4 pre-existing environment failures, no regression
- real config: `inputs.index.lastModified = 1784487167`, `inputs.index.rev = a2f3267e7edd...`, byte-equal to `git -C ~/.config/nix/index log -1`
- `checks.aarch64-darwin.patched-src-nix` passes; dag.json regenerated by `rebase-patches dag nix` (30 nodes, 10 edges); the darwin sandbox run of `patch-dag-nix-check` wedges at 0% CPU with an empty log on this loaded machine, twice; CI runs it on linux

Fixes #3737. Follow-ups after this reaches the deployed nix-ix: flip the starship pin segment back to eval-time baking (revert of the prompt-time git shell-out from #3733).

(authored by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stamp submodule rev and lastModified metadata on relative path flake inputs
> - Adds patch [`0030-libflake-stamp-submodule-metadata-on-relative-path-f.patch`](https://github.com/indexable-inc/index/pull/3750/files#diff-29fcb496e65e95ebfc4f1b9b8a136872ae71e7d825422c642c867569a326f43e) to the Nix fork build, targeting the flake locking logic in `src/libflake/flake.cc`.
> - When locking a flake, relative path inputs that correspond to git submodule mount roots now have their locked refs stamped with the submodule's commit hash (`rev`) and commit time (`lastModified`); plain subdirectories remain unstamped.
> - Extends `SourceAccessor` with optional `rev`/`lastModified` fields and path-aware `getRev(path)`/`getLastModified(path)` overloads so composite/mounted accessors can surface per-subtree metadata.
> - Caches fetched accessors under both the original and locked input in `input-cache.cc` to preserve tree metadata and avoid refetching.
> - A new functional test [`relative-paths-lastmodified.sh`](https://github.com/indexable-inc/index/pull/3750/files#diff-54c76b11a3c3351840f2d9ba313542291b7e62151a999683a78294a021a95023) verifies submodule inputs expose their own `lastModified`/`rev` while plain subdirectory inputs do not.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89bfe32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->