### PR TITLE
nix fork: abort daemon workers with their client, prune zombie-owned status entries

### DIFF
--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -724,6 +724,27 @@
           upstream = "hold";
           reason = "Fixes the lazy-trees mid-eval mutation race for mutable local trees (indexable-inc/index#3749). Upstream-nix candidate once lazy trees settle there, held: humans submit Nix patches upstream per NixOS/nix#15984.";
         };
+        # 0033: a daemon worker whose client dies can sleep forever in
+        # waitForInput's poll (interrupt delivery is edge-triggered; a
+        # trigger landing between the last checkInterrupt and the poll
+        # syscall is a lost wakeup), surviving its client for hours while
+        # holding goals, builders, and locks (indexable-inc/index#3752).
+        # Upstream master has the same gap: its Waker self-pipe only serves
+        # cross-thread goal wakeups and is not wired to triggerInterrupt.
+        "0033-libstore-wake-the-goal-loop-when-the-process-is-inte.patch" = {
+          upstream = "hold";
+          reason = "Level-triggered interrupt wakeup for the goal loop (indexable-inc/index#3752); upstream master's Waker pipe is not interrupt-wired, so the bug exists there too. Hold: humans submit Nix patches upstream per NixOS/nix#15984.";
+        };
+        # 0034: `nix store builds` pruned dead writers with kill(pid, 0),
+        # which still succeeds for zombies -- 33 phantom "in flight" builds
+        # owned by three zombie workers survived 10.5h on hydra
+        # (indexable-inc/index#3752). Writers now hold a lifetime flock on
+        # their entry; readers treat an acquirable lock (or, for legacy
+        # entries, a dead-or-zombie pid) as proof the writer is gone.
+        "0034-libstore-prove-build-status-writers-alive-with-a-lif.patch" = {
+          upstream = "hold";
+          reason = "Build-status series follow-up (zombie-proof staleness, indexable-inc/index#3752): engage on #15979 rather than open a competing PR.";
+        };
       };
     }
     {

--- a/packages/nix/nix/patches/0033-libstore-wake-the-goal-loop-when-the-process-is-inte.patch
+++ b/packages/nix/nix/patches/0033-libstore-wake-the-goal-loop-when-the-process-is-inte.patch
@@ -1,0 +1,206 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew.gazelka@gmail.com>
+Date: Sun, 19 Jul 2026 15:29:59 -0700
+Subject: [PATCH] libstore: wake the goal loop when the process is interrupted
+
+Interrupt delivery to the goal loop is edge-triggered twice over:
+triggerInterrupt() sets a flag that only checkInterrupt() call sites
+notice, and ReceiveInterrupts forwards the event as a one-shot SIGUSR1
+whose only effect is an EINTR in whatever syscall happens to be in
+flight. Worker::waitForInput() polls just the children's log fds, with
+no timeout when max-silent-time / timeout / min-free are unset (the
+common daemon configuration). So an interrupt that lands between the
+last checkInterrupt() and the poll() syscall is a lost wakeup: with
+every builder silent the poll never returns, and the daemon worker
+outlives its dead client indefinitely, still holding its goals,
+builders, build users, and path locks.
+
+That is the client-death half of the wedge class already policed for
+downloads (paused-transfer half-close) and automatic GC: on the ix
+fleet it strands per-connection daemon workers after a client is
+SIGKILLed; the surviving workers carry their builds as "in flight" and
+new builds of the same derivations queue behind their locks until the
+daemon is restarted (index#3752, previously index#3559).
+
+Give the worker a level-triggered wakeup instead: a self-pipe written
+by an interrupt callback and polled by waitForInput() alongside the
+children's fds. A wakeup can no longer be lost, so client disconnects
+(via MonitorFdHup) and SIGTERM abort the goal loop promptly and
+deterministically -- killing builders, releasing locks, and removing
+build-status entries through the normal unwind. The pipe is shared
+with the callback because triggerInterrupt() invokes a copy of it
+outside the registry lock, possibly during worker teardown; shared
+ownership keeps that late write on a still-open pipe instead of a
+recycled fd.
+
+The functional test grows a SIGKILL variant of the client-disconnect
+case: unlike SIGTERM, a SIGKILLed client cannot say goodbye on the
+socket, so the daemon worker must notice the disconnect on its own and
+drain both the builder and its status entry.
+
+Assisted-by: Claude <noreply@anthropic.com>
+
+diff --git a/src/libstore/build/worker.cc b/src/libstore/build/worker.cc
+index 8d6bdae2e..040a21928 100644
+--- a/src/libstore/build/worker.cc
++++ b/src/libstore/build/worker.cc
+@@ -14,6 +14,11 @@
+ #include "nix/util/signals.hh"
+ #include "nix/store/globals.hh"
+ 
++#ifndef _WIN32
++#  include <fcntl.h>
++#  include <unistd.h>
++#endif
++
+ namespace nix {
+ 
+ Worker::Worker(Store & store, Store & evalStore)
+@@ -37,6 +42,24 @@ Worker::Worker(Store & store, Store & evalStore)
+     nrLocalBuilds = 0;
+     nrSubstitutions = 0;
+     lastWokenUp = steady_time_point::min();
++
++#ifndef _WIN32
++    /* See the field doc in worker.hh: level-triggered interrupt wakeup for
++       `waitForInput`, so a client disconnect or SIGTERM aborts the goal loop
++       even when every builder is silent and no timeout is armed. */
++    interruptWakeupPipe = std::make_shared<Pipe>();
++    interruptWakeupPipe->create();
++    for (auto fd : {interruptWakeupPipe->readSide.get(), interruptWakeupPipe->writeSide.get()}) {
++        auto flags = fcntl(fd, F_GETFL);
++        if (flags == -1 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1)
++            throw SysError("making interrupt wakeup pipe non-blocking");
++    }
++    interruptWakeupCallback = createInterruptCallback([pipe = interruptWakeupPipe]() {
++        /* Non-blocking: if the pipe is full a wakeup is already pending and
++           dropping this write is fine. */
++        [[maybe_unused]] auto res = ::write(pipe->writeSide.get(), "i", 1);
++    });
++#endif
+ }
+ 
+ Worker::~Worker()
+@@ -465,6 +488,14 @@ void Worker::waitForInput()
+             state.fdToPollStatus[j] = state.pollStatus.size() - 1;
+         }
+     }
++
++    {
++        /* Register the interrupt wakeup pipe so an interrupt reliably wakes
++           this poll (see the field doc in worker.hh). */
++        auto wakeupFd = interruptWakeupPipe->readSide.get();
++        state.pollStatus.push_back((struct pollfd) {.fd = wakeupFd, .events = POLLIN});
++        state.fdToPollStatus[wakeupFd] = state.pollStatus.size() - 1;
++    }
+ #endif
+ 
+     state.poll(
+@@ -473,6 +504,18 @@ void Worker::waitForInput()
+ #endif
+         useTimeout ? (std::optional{timeout * 1000}) : std::nullopt);
+ 
++#ifndef _WIN32
++    /* Drain pending wakeup bytes and act on the interrupt now: with no
++       children (e.g. only goals polling for a lock) none of the loops below
++       would call checkInterrupt before going back to sleep. */
++    {
++        char buf[64];
++        while (::read(interruptWakeupPipe->readSide.get(), buf, sizeof(buf)) > 0)
++            ;
++    }
++    checkInterrupt();
++#endif
++
+     auto after = steady_time_point::clock::now();
+ 
+     /* Process all available file descriptors. FIXME: this is
+diff --git a/src/libstore/include/nix/store/build/worker.hh b/src/libstore/include/nix/store/build/worker.hh
+index baf5c5a4d..cc3ca242d 100644
+--- a/src/libstore/include/nix/store/build/worker.hh
++++ b/src/libstore/include/nix/store/build/worker.hh
+@@ -8,6 +8,7 @@
+ #include "nix/store/build-result.hh"
+ #include "nix/store/realisation.hh"
+ #include "nix/util/muxable-pipe.hh"
++#include "nix/util/signals.hh"
+ 
+ #include <functional>
+ #include <future>
+@@ -140,6 +141,28 @@ private:
+      */
+     std::map<StorePath, bool> pathContentsGoodCache;
+ 
++#ifndef _WIN32
++    /**
++     * Self-pipe polled by `waitForInput` alongside the children's log fds,
++     * written by an interrupt callback. Interrupt delivery is otherwise
++     * edge-triggered (`triggerInterrupt` sets a flag that only
++     * `checkInterrupt` call sites notice, and `ReceiveInterrupts` forwards
++     * it as a one-shot SIGUSR1): a trigger that lands between the last
++     * `checkInterrupt()` and the `poll()` syscall is a lost wakeup, and
++     * with every builder silent and no timeout armed that poll never
++     * returns -- the worker outlives its dead client, still holding its
++     * goals, builders, and locks. The pipe is level-triggered, so a wakeup
++     * can never be lost.
++     *
++     * Shared with the callback: `triggerInterrupt` invokes a copy of the
++     * callback outside the registry lock, so it can fire during worker
++     * teardown; the shared ownership keeps it writing to a still-open pipe
++     * instead of a recycled fd.
++     */
++    std::shared_ptr<Pipe> interruptWakeupPipe;
++    std::unique_ptr<InterruptCallback> interruptWakeupCallback;
++#endif
++
+ public:
+ 
+     const Activity act;
+diff --git a/tests/functional/build-status.sh b/tests/functional/build-status.sh
+index 92360e05c..ff7c9271b 100644
+--- a/tests/functional/build-status.sh
++++ b/tests/functional/build-status.sh
+@@ -95,6 +95,43 @@ if ! isTestOnNixOS; then
+     [[ -n $found ]]
+     cleanup
+ 
++    # A SIGKILLed client (it cannot say goodbye on the socket) must have the
++    # same effect: the daemon worker has to notice the disconnect on its own
++    # and abort the goal, its builder, and its status entry, even though the
++    # builder is completely silent and no timeout is armed (index#3752).
++    nix build --file build-status-liveness.nix --argstr mode disconnect --no-link &
++    buildPid=$!
++    handlerPid=
++    for _ in $(seq 1 100); do
++        handlerPid=$(nix store builds --json | jq -r --argjson clientPid "$buildPid" \
++            '.[] | select(.clientPid == $clientPid) | .pid' | head -1)
++        [[ -n $handlerPid ]] && break
++        sleep 0.2
++    done
++    [[ -n $handlerPid ]]
++    kill -9 "$buildPid"
++    wait "$buildPid" || true
++    drained=
++    for _ in $(seq 1 100); do
++        if ! kill -0 "$handlerPid" 2> /dev/null; then
++            drained=1
++            break
++        fi
++        sleep 0.2
++    done
++    [[ -n $drained ]]
++    # Its status entry must be gone with it.
++    emptied=
++    for _ in $(seq 1 100); do
++        if nix store builds --json | jq -e --argjson clientPid "$buildPid" \
++            'all(.[]; .clientPid != $clientPid)' > /dev/null; then
++            emptied=1
++            break
++        fi
++        sleep 0.2
++    done
++    [[ -n $emptied ]]
++
+     # Disconnecting the client must cancel the daemon-owned goal and its
+     # builder, not merely release the caller.
+     nix build --file build-status-liveness.nix --argstr mode disconnect --no-link &

--- a/packages/nix/nix/patches/0034-libstore-prove-build-status-writers-alive-with-a-lif.patch
+++ b/packages/nix/nix/patches/0034-libstore-prove-build-status-writers-alive-with-a-lif.patch
@@ -1,0 +1,296 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew.gazelka@gmail.com>
+Date: Sun, 19 Jul 2026 15:30:29 -0700
+Subject: [PATCH] libstore: prove build-status writers alive with a lifetime
+ lock
+
+`nix store builds` already prunes entries whose writer pid is gone, but
+its probe is kill(pid, 0) -- which still succeeds when the writer
+survives only as a zombie. A daemon worker that dies without unwinding
+(SIGKILL, a crash) leaks its status files, and if its parent never
+reaps it, every leaked entry keeps reporting a build "in flight"
+forever. That is exactly the observed incident shape on hydra: 33
+phantom "building" entries owned by three zombie daemon workers under
+an unreapable parent survived for 10.5 hours and misled every observer
+(nwm, agents, humans) until the daemon was kickstarted; killing another
+client mid-incident minted a second batch (index#3752).
+
+Liveness now rests on the kernel instead of pid semantics: the writer
+takes a lifetime flock on the entry (acquired on the temp file, before
+the rename makes it visible, so no reader can catch an unlocked live
+entry), and stamps "livenessLock": true in the JSON. Any kind of death
+-- SIGKILL, crash, or surviving as a zombie -- releases the lock, so a
+reader that can acquire it has proof the writer is gone; pid reuse
+cannot fake liveness either. Entries from older writers keep the pid
+probe as a fallback, now zombie-aware on Linux (/proc stat state) and
+Darwin (KERN_PROC p_stat), so mixed-version fleets still shed corpse
+entries.
+
+The functional test grows both staleness cases: a legacy entry owned by
+a real zombie, and a livenessLock entry whose lock nobody holds while
+its recorded pid is alive.
+
+Assisted-by: Claude <noreply@anthropic.com>
+
+diff --git a/src/libstore/build/build-status.cc b/src/libstore/build/build-status.cc
+index 54f1fedef..a3b5326a0 100644
+--- a/src/libstore/build/build-status.cc
++++ b/src/libstore/build/build-status.cc
+@@ -21,6 +21,11 @@
+ #include <sstream>
+ #include <unistd.h>
+ 
++#ifndef _WIN32
++#  include <fcntl.h>
++#  include <sys/file.h>
++#endif
++
+ namespace nix {
+ 
+ /**
+@@ -269,6 +274,10 @@ std::unique_ptr<BuildStatus> BuildStatus::forBuild(
+         j["uid"] = currentClientInfo.uid ? nlohmann::json(*currentClientInfo.uid) : nlohmann::json(nullptr);
+         j["logFile"] = logFile ? nlohmann::json(logFile->string()) : nlohmann::json(nullptr);
+         j["why"] = whyJSON(goal, store, isTopGoal(goal) ? "requested" : "outputsMissing");
++#ifndef _WIN32
++        /* Tell readers the file carries a lifetime flock (see `lockFd`). */
++        j["livenessLock"] = true;
++#endif
+ 
+         self->path = buildStatusDir() / (std::string(drvPath.to_string()) + "-" + std::to_string(getpid()) + ".json");
+         self->write(j.dump());
+@@ -377,6 +386,10 @@ std::unique_ptr<BuildStatus> BuildStatus::forSubstitution(Goal & goal, Store & s
+         j["uid"] = currentClientInfo.uid ? nlohmann::json(*currentClientInfo.uid) : nlohmann::json(nullptr);
+         j["logFile"] = nullptr;
+         j["why"] = whyJSON(goal, store, isTopGoal(goal) ? "requested" : "outputInvalid");
++#ifndef _WIN32
++        /* Tell readers the file carries a lifetime flock (see `lockFd`). */
++        j["livenessLock"] = true;
++#endif
+ 
+         self->path = buildStatusDir() / (std::string(storePath.to_string()) + "-" + std::to_string(getpid()) + ".json");
+         self->write(j.dump());
+@@ -395,6 +408,16 @@ void BuildStatus::write(std::string_view json)
+     auto tmp = path;
+     tmp += ".tmp";
+     writeFile(tmp, json);
++#ifndef _WIN32
++    /* Lock the entry before the rename makes it visible, so there is no
++       window in which a reader can mistake a live entry for a stale one.
++       The lock lives on the inode and thus follows the rename. */
++    lockFd = AutoCloseFD{open(tmp.c_str(), O_RDWR | O_CLOEXEC)};
++    if (!lockFd)
++        throw SysError("opening build status file %s", PathFmt(tmp));
++    if (flock(lockFd.get(), LOCK_EX | LOCK_NB) != 0)
++        throw SysError("locking build status file %s", PathFmt(tmp));
++#endif
+     std::filesystem::rename(tmp, path);
+     active = true;
+ }
+diff --git a/src/libstore/include/nix/store/build/build-status.hh b/src/libstore/include/nix/store/build/build-status.hh
+index 2d4d64983..fb00e3d9b 100644
+--- a/src/libstore/include/nix/store/build/build-status.hh
++++ b/src/libstore/include/nix/store/build/build-status.hh
+@@ -3,6 +3,7 @@
+ 
+ #include "nix/store/path.hh"
+ #include "nix/store/build/goal.hh"
++#include "nix/util/file-descriptor.hh"
+ 
+ #include <chrono>
+ #include <optional>
+@@ -97,6 +98,14 @@ class BuildStatus
+     std::filesystem::path path;
+     bool active = false;
+ 
++    /**
++     * Held (`flock`ed) for the lifetime of this object so readers can tell
++     * a live writer from a corpse: the kernel releases the lock on any kind
++     * of process death -- SIGKILL, a crash, or surviving only as a zombie --
++     * whereas the recorded pid keeps passing `kill(pid, 0)` for zombies.
++     */
++    AutoCloseFD lockFd;
++
+     std::optional<pid_t> builderPid;
+     std::string drvPath;
+     std::optional<std::filesystem::path> logFile;
+diff --git a/src/nix/store-builds.cc b/src/nix/store-builds.cc
+index 73ea8da98..7ebe2ccd8 100644
+--- a/src/nix/store-builds.cc
++++ b/src/nix/store-builds.cc
+@@ -2,6 +2,7 @@
+ #include "nix/main/common-args.hh"
+ #include "nix/store/globals.hh"
+ #include "nix/util/experimental-features.hh"
++#include "nix/util/file-descriptor.hh"
+ #include "nix/util/file-system.hh"
+ #include "nix/util/logging.hh"
+ 
+@@ -9,6 +10,14 @@
+ 
+ #include <csignal>
+ 
++#ifndef _WIN32
++#  include <fcntl.h>
++#  include <sys/file.h>
++#endif
++#ifdef __APPLE__
++#  include <sys/sysctl.h>
++#endif
++
+ using namespace nix;
+ 
+ /**
+@@ -35,6 +44,68 @@ static bool pidAlive(pid_t pid)
+     return errno != ESRCH;
+ }
+ 
++/**
++ * Is @p pid a zombie? `kill(pid, 0)` still succeeds for a zombie, so
++ * `pidAlive` alone keeps reporting builds "in flight" for workers that died
++ * unreaped -- the observed incident shape: 33 phantom entries owned by three
++ * zombie daemon workers under an unreapable parent, misleading every
++ * observer for 10.5 hours.
++ */
++static bool pidZombie(pid_t pid)
++{
++#ifdef __APPLE__
++    struct kinfo_proc info;
++    size_t len = sizeof(info);
++    int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
++    if (sysctl(mib, 4, &info, &len, nullptr, 0) != 0 || len < sizeof(info))
++        return false;
++    return info.kp_proc.p_stat == SZOMB;
++#elif defined(__linux__)
++    try {
++        auto stat = readFile(std::filesystem::path{"/proc"} / std::to_string(pid) / "stat");
++        /* The state field follows the parenthesized, possibly
++           space-containing command name. */
++        auto close = stat.rfind(')');
++        if (close == std::string::npos || close + 2 >= stat.size())
++            return false;
++        return stat[close + 2] == 'Z';
++    } catch (...) {
++        return false;
++    }
++#else
++    return false;
++#endif
++}
++
++/**
++ * Is the writer of the status file @p p still alive?
++ *
++ * Writers that set `livenessLock` hold an `flock` on the file for their
++ * lifetime; the kernel releases it on any kind of death (SIGKILL, crash,
++ * zombie), so an acquirable lock proves the writer is gone. Older entries
++ * fall back to probing the recorded pid, treating zombies as dead.
++ */
++static bool writerAlive(const std::filesystem::path & p, const nlohmann::json & j)
++{
++#ifndef _WIN32
++    if (j.value("livenessLock", false)) {
++        AutoCloseFD fd{open(p.c_str(), O_RDONLY | O_CLOEXEC)};
++        if (!fd)
++            return false;
++        /* Only a successful acquisition proves the writer gone; any flock
++           failure (EWOULDBLOCK from the live writer's lock, or a freak
++           EINTR/ENOLCK) keeps the entry. A genuinely stale file is pruned
++           on the next read. */
++        return flock(fd.get(), LOCK_SH | LOCK_NB) != 0;
++    }
++#endif
++    auto pidIt = j.find("pid");
++    if (pidIt == j.end() || !pidIt->is_number())
++        return true; /* no way to probe; keep the entry */
++    auto pid = pidIt->get<pid_t>();
++    return pidAlive(pid) && !pidZombie(pid);
++}
++
+ struct CmdStoreBuilds : Command, MixJSON
+ {
+     std::string description() override
+@@ -85,15 +156,12 @@ struct CmdStoreBuilds : Command, MixJSON
+                 }
+ 
+                 /* Drop entries whose writer is no longer alive. */
+-                auto pidIt = j.find("pid");
+-                if (pidIt != j.end() && pidIt->is_number()) {
+-                    if (!pidAlive(pidIt->get<pid_t>())) {
+-                        try {
+-                            std::filesystem::remove(p);
+-                        } catch (...) {
+-                        }
+-                        continue;
++                if (!writerAlive(p, j)) {
++                    try {
++                        std::filesystem::remove(p);
++                    } catch (...) {
+                     }
++                    continue;
+                 }
+ 
+                 entries.push_back(std::move(j));
+diff --git a/tests/functional/build-status.sh b/tests/functional/build-status.sh
+index ff7c9271b..99eead8f9 100644
+--- a/tests/functional/build-status.sh
++++ b/tests/functional/build-status.sh
+@@ -179,4 +179,58 @@ nix build --file build-status-liveness.nix --argstr mode silent \
+ 
+ [[ -z $daemonStarted ]] || killDaemon
+ 
++# Staleness: an entry whose writer survives only as a zombie is a corpse and
++# must not be reported (kill(pid, 0) still succeeds for zombies, which kept 33
++# phantom builds "in flight" for 10.5 hours in the motivating incident).
++statusDir=$TEST_ROOT/var/nix/status
++mkdir -p "$statusDir"
++
++# A process that leaves a never-reaped child: the inner sleep exits while its
++# parent has exec'd into a long sleep and never calls wait(2).
++zombiePidFile=$TEST_ROOT/zombie.pid
++sh -c 'sh -c "exit 0" & echo $! > '"$zombiePidFile"'; exec sleep 60' &
++keeperPid=$!
++zombiePid=
++for _ in $(seq 1 100); do
++    [[ -s $zombiePidFile ]] && zombiePid=$(cat "$zombiePidFile") && break
++    sleep 0.1
++done
++[[ -n $zombiePid ]]
++# Read the state from /proc where available (the Linux sandbox has no full
++# ps(1)); fall back to ps -o state= elsewhere (Darwin).
++processState() {
++    if [[ -r /proc/$1/stat ]]; then
++        local stat
++        stat=$(< "/proc/$1/stat")
++        stat=${stat##*) }
++        echo "${stat%% *}"
++    else
++        ps -o state= -p "$1" 2> /dev/null | tr -d ' '
++    fi
++}
++isZombie=
++for _ in $(seq 1 100); do
++    if [[ $(processState "$zombiePid" || true) == Z* ]]; then
++        isZombie=1
++        break
++    fi
++    sleep 0.1
++done
++[[ -n $isZombie ]]
++
++cat > "$statusDir/zzzz-fake-zombie.drv-$zombiePid.json" << EOF
++{"type": "build", "drvPath": "$NIX_STORE_DIR/zzzz-fake-zombie.drv", "pid": $zombiePid}
++EOF
++nix store builds --json | jq -e --argjson pid "$zombiePid" 'all(.[]; .pid != $pid)'
++[[ ! -e "$statusDir/zzzz-fake-zombie.drv-$zombiePid.json" ]]
++kill "$keeperPid" 2> /dev/null || true
++
++# Staleness: an entry that claims a liveness lock nobody holds is a corpse,
++# even if its recorded pid is alive (pids get reused).
++cat > "$statusDir/zzzz-fake-unlocked.drv-$$.json" << EOF
++{"type": "build", "drvPath": "$NIX_STORE_DIR/zzzz-fake-unlocked.drv", "pid": $$, "livenessLock": true}
++EOF
++nix store builds --json | jq -e 'all(.[]; .drvPath | endswith("zzzz-fake-unlocked.drv") | not)'
++[[ ! -e "$statusDir/zzzz-fake-unlocked.drv-$$.json" ]]
++
+ echo "build-status.sh: OK"

--- a/packages/nix/nix/patches/dag.json
+++ b/packages/nix/nix/patches/dag.json
@@ -151,6 +151,19 @@
       "deps": [
         "0029-libexpr-gate-lazy-input-mounting-behind-an-off-by-de.patch"
       ]
+    },
+    {
+      "patch": "0033-libstore-wake-the-goal-loop-when-the-process-is-inte.patch",
+      "deps": [
+        "0021-libstore-enforce-derivation-no-progress-deadlines.patch"
+      ]
+    },
+    {
+      "patch": "0034-libstore-prove-build-status-writers-alive-with-a-lif.patch",
+      "deps": [
+        "0007-nix-add-nix-store-builds-command.patch",
+        "0021-libstore-enforce-derivation-no-progress-deadlines.patch"
+      ]
     }
   ]
 }

--- a/packages/site/src/lib/updates/nix-daemon-dead-client-wedge.svx
+++ b/packages/site/src/lib/updates/nix-daemon-dead-client-wedge.svx
@@ -1,0 +1,46 @@
+---
+id: nix-daemon-dead-client-wedge
+postedAt: 2026-07-19T18:30:00-07:00
+title: "Daemon workers now die with their client, and zombie-owned builds stop reading as in flight"
+tags: [nix, daemon, fork, reliability]
+links:
+  - label: issue 3752
+    href: https://github.com/indexable-inc/index/issues/3752
+  - label: patch 0033
+    href: https://github.com/indexable-inc/index/blob/main/packages/nix/nix/patches/0033-libstore-wake-the-goal-loop-when-the-process-is-inte.patch
+  - label: patch 0034
+    href: https://github.com/indexable-inc/index/blob/main/packages/nix/nix/patches/0034-libstore-prove-build-status-writers-alive-with-a-lif.patch
+---
+
+On hydra this morning, `nix store builds` reported 33 builds "in
+flight" for 10.5 hours, owned by three daemon workers that existed only
+as zombies; new builds of the same derivations (`strsim` et al.) sat
+"building" for 55 minutes with flat logs, and only
+`launchctl kickstart -k system/org.nixos.nix-daemon` cleared the jam.
+Sibling of the CLOSE-WAIT downloader wedge (p22): that was the cache
+half-close, this is the client-death half.
+
+Two fork patches close it. Patch 0033 gives the goal loop a
+level-triggered interrupt wakeup: interrupts used to be a flag plus a
+one-shot SIGUSR1, so one landing between the last `checkInterrupt()`
+and the `poll()` syscall was lost, and a worker whose builders were
+silent (no `max-silent-time`, no `timeout`, no `min-free` -- our daemon
+config) slept forever, holding goals, builders, build users, and path
+locks of a client that no longer existed. A self-pipe in the
+`waitForInput` poll set now makes client death (via `MonitorFdHup`) and
+SIGTERM abort the worker deterministically. Upstream master has the
+same gap; its `Waker` pipe is not interrupt-wired.
+
+Patch 0034 makes the status directory stop trusting corpses: writers
+hold a lifetime `flock` on their entry (`"livenessLock": true`), which
+the kernel releases on any death -- SIGKILL, crash, or surviving as a
+zombie -- so `nix store builds` prunes them on sight. The old
+`kill(pid, 0)` probe kept phantom entries alive precisely because it
+succeeds for zombies; it remains only as a zombie-aware fallback for
+entries written by older daemons.
+
+Repro receipts on a throwaway daemon: before, a SIGKILLed worker's
+entry stayed listed with its builder orphaned; after, the SIGKILL
+client-disconnect and zombie-writer cases are functional tests
+(`tests/functional/build-status.sh`). Rolls to hosts on the next pin
+bump and to workstations via home-manager switch (p34).

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2930,7 +2930,7 @@
       }
       {
         assertion =
-          ix.forkClosureGates.closureOf clippyDag.nodes "0014-Add-anonymous-tuple-return-type-lint.patch"
+          ix.forkClosureGates.closureOf clippyDag.nodes "0012-Add-anonymous-tuple-return-type-lint.patch"
           == [
             "0002-Add-module_file_count-lint.patch"
             "0003-Add-excessive_file_length-lint.patch"
@@ -2938,9 +2938,9 @@
             "0007-Add-fallible_int_fallback-lint.patch"
             "0008-Add-magic_number-lint.patch"
             "0009-Add-drop_must_use-lint.patch"
-            "0014-Add-anonymous-tuple-return-type-lint.patch"
+            "0012-Add-anonymous-tuple-return-type-lint.patch"
           ];
-        message = "closureOf should reproduce the committed clippy dag.json transitive closure of 0014";
+        message = "closureOf should reproduce the committed clippy dag.json transitive closure of 0012";
       }
       {
         # Crosses the fork-packages.nix intent <-> package passthru boundary:


### PR DESCRIPTION
Fixes #3752 (dead-client daemon wedge; sibling of #3559's downloader half).

## Incident (hydra, 2026-07-19, daemon 2.34.7+ix.p29)

A bot-run nix client was SIGKILLed. Ten and a half hours later, `nix store builds --json` still reported **33 builds "in flight", owned by three daemon workers that existed only as `(nix)` zombies** (27 by pid 47606, 5 by 8745, 1 by 68961) under an unreapable parent; new builds of the same drvs (`strsim` et al.) sat "building" 55 minutes with flat logs; killing another client mid-incident minted a second batch of phantoms. Only `launchctl kickstart -k system/org.nixos.nix-daemon` cleared it.

## Root cause, in the fork source

1. **Lost interrupt wakeups** (patch 0031). Client death fires `MonitorFdHup` -> `triggerInterrupt()`, which sets a flag and forwards a one-shot SIGUSR1 (`ReceiveInterrupts`). `Worker::waitForInput` (src/libstore/build/worker.cc:399 pre-patch) polls only the children's log fds, with **no timeout** under our daemon config (`max-silent-time = 0`, `timeout = 0`, `min-free = 0` -- verified live on hydra). A trigger landing between the last `checkInterrupt()` and the `poll()` syscall is lost; with every builder silent that poll never returns, and the worker outlives its client indefinitely while holding goals, builders, build users, and path locks. One lost race = one permanent wedge; the same mechanism made #3559's children TERM-immune. Fix: a self-pipe written by an interrupt callback, registered in the poll set -- level-triggered, cannot be lost. (Checked upstream master for a cherry-pick first: its `Waker` self-pipe serves cross-thread goal wakeups only and is not wired to `triggerInterrupt`; NixOS/nix#15691 covers the Linux POLLERR spin + fork signal-thread restart, both already handled or inapplicable here.)

2. **Zombie-blind staleness** (patch 0032). `nix store builds` pruned entries whose writer failed `kill(pid, 0)` -- which succeeds for zombies, exactly what the incident's three workers were. Writers now hold a lifetime `flock` on their entry, acquired on the temp file before the rename so no reader can catch an unlocked live entry; the kernel releases it on **any** death (SIGKILL, crash, zombie), and pid reuse can't fake liveness. Legacy entries keep the pid probe, now zombie-aware on Linux (`/proc/<pid>/stat` state) and Darwin (`KERN_PROC` `p_stat`), so mixed-version fleets shed corpses too.

## Receipts

Repro on a throwaway daemon (private store/state/socket; script exercised both halves):

Before (p29): SIGKILL the worker with its parent stopped ->
```
-- worker after SIGKILL with stopped parent: Z    <defunct>
-- nix store builds (zombie writer):
build  building .../quiet-sleeper.drv  (pid 3668, ...)   # phantom
-- builder still alive: yes                              # orphaned
```
After (p32): the same zombie-owned entry is pruned on read; a SIGKILLed *client* drains the worker, its builder, and its status entry (now functional tests: `tests/functional/build-status.sh` gains the SIGKILL disconnect case and both staleness cases).

Rollout: fleet hosts on the next pin/deploy cycle; workstations via home-manager switch (p32).

(sent by an AI agent via Claude Code, Fable 5; patches carry Assisted-by trailers per the NixOS/nix#15984 policy -- upstream submission stays a human act, both patches registered `hold`)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Nix daemon patches to abort workers on client disconnect and prune zombie-owned build status entries
> - Adds [patch 0033](https://github.com/indexable-inc/index/pull/3754/files#diff-afa35e34a1741695997e450d48669aaafaecf588cfd6c93da9d389ecc818730e) which introduces a level-triggered wakeup pipe in the libstore worker so the goal loop is interrupted when a client disconnects (SIGKILL).
> - Adds [patch 0034](https://github.com/indexable-inc/index/pull/3754/files#diff-3fa74afab895625b616afeb1090dd001442d4df43370bf904a746b568bbcfa4a) which introduces lifetime file locks for build-status writers and zombie-aware PID checks, allowing stale entries from dead processes to be pruned.
> - Both patches are registered in [dag.json](https://github.com/indexable-inc/index/pull/3754/files#diff-bb8cabe3c8aca5a21a04124e99377308810f2ffd5701104ed528dd747207dc2d) with dependencies on existing patches and tracked as held in [fork-packages.nix](https://github.com/indexable-inc/index/pull/3754/files#diff-35e5ff5b02c2dcd32c93fd770ad2194f9fcbfc9f35fdcbd56821891b6e7452f4).
> - A site update post is added describing both fixes for end users.
> - Updates a clippy DAG closure test to reference the correct patch ID `0012` instead of `0014`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91d5dd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->