### PR TITLE
feat(prompt): add htmlOutput rule, respond as a live HTML page

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -451,6 +451,21 @@
     };
   }
   {
+    htmlOutput = {
+      topics = ["writing" "comms"];
+      text = ''
+        Respond as HTML, not chat text: write each response to one HTML
+        file per session, open it on the first write, and keep rewriting
+        that same file so it always shows the current state of the
+        response.
+      '';
+      reason = ''
+        Requested 2026-07-19: the user reads responses as a live HTML page
+        that updates while the agent works.
+      '';
+    };
+  }
+  {
     answerIntent = {
       topics = ["writing"];
       text = ''


### PR DESCRIPTION
Adds a rendered rule to `packages/agent/prompt/rules.nix`: write each response to one HTML file per session, open it on the first write, and keep rewriting that file so it always shows the current response state.

Closes #3756. Requested by Andrew with explicit force-merge instruction.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `htmlOutput` prompt rule to respond as a live HTML page
> Adds a new `htmlOutput` rule in [rules.nix](https://github.com/indexable-inc/index/pull/3757/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) for the `writing` and `comms` topics. The rule instructs the agent to respond as HTML and manage output by writing to a single HTML file per session, opening it on first write and rewriting it to reflect the current state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b53e93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->