### PR TITLE
keep git auto-maintenance out of nix-internal cache repos -> no more fetch-time git SIGSEGVs on macOS

### DIFF
--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -700,6 +700,20 @@
           upstream = "hold";
           reason = "Submodule metadata for relative path inputs (indexable-inc/index#3737); companion to 0024 in the sparseNodes direction (NixOS/nix#7730). Hold: humans submit Nix patches upstream per NixOS/nix#15984.";
         };
+        # 0031: every GitRepoImpl::fetch targets a nix-internal cache repo
+        # (~/.cache/nix/gitv3/*, tarball-cache-v2) that inherits the user's
+        # global gitconfig. With maintenance.auto=true + gc.autodetach=true
+        # there, each unguarded fetch spawned a detached `git maintenance
+        # run --auto` that SIGSEGVs on macOS (gettext locale init ->
+        # CFLocaleCopyPreferredLanguages -> NULL CF distributed-notification
+        # center -> PAC check at 0x8), so cache maintenance never completed
+        # (tarball-cache-v2: 3700 packs / 932MB). Extends the guard patch
+        # 0013 already applied to packfilesOnly fetches to every cache-repo
+        # fetch.
+        "0031-fix-libfetchers-keep-user-git-auto-maintenance-out-o.patch" = {
+          upstream = "hold";
+          reason = "Keeps user git auto-maintenance out of nix-internal cache repos; fetch-spawned detached `git maintenance run --auto` SIGSEGVs on macOS (indexable-inc/index#3755). Upstream-nix candidate, held: humans submit Nix patches upstream per NixOS/nix#15984.";
+        };
       };
     }
     {

--- a/packages/nix/nix/patches/0031-fix-libfetchers-keep-user-git-auto-maintenance-out-o.patch
+++ b/packages/nix/nix/patches/0031-fix-libfetchers-keep-user-git-auto-maintenance-out-o.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew@ix.dev>
+Date: Sun, 19 Jul 2026 17:32:57 -0700
+Subject: [PATCH] fix: libfetchers: keep user git auto-maintenance out of cache
+ fetches
+
+Every GitRepoImpl::fetch targets a Nix-internal cache repository (the
+per-URL caches under ~/.cache/nix/gitv3/*, or the tarball cache), and
+those repos inherit the user's global gitconfig. The tarball-cache
+(packfilesOnly) fetch already passed `-c gc.auto=0
+-c maintenance.auto=false`, but the gitv3 fetches did not: with
+`maintenance.auto=true` plus `gc.autodetach=true` in the user's global
+config, every such fetch spawned a detached `git maintenance run
+--auto` (double-forked, reparented to launchd). On macOS that detached,
+session-less process crashes in gettext locale initialization --
+CFLocaleCopyPreferredLanguages hits a NULL CoreFoundation
+distributed-notification center and dies on the PAC check at offset
+0x8 -- so maintenance never completes: 65 git SIGSEGV reports on
+2026-07-19 alone on one workstation, and the caches never got
+consolidated (tarball-cache-v2 had accumulated 3700 packs / 932MB).
+Full forensics: indexable-inc/index#3755.
+
+Hoist the guard out of the packfilesOnly branch so every cache-repo
+fetch runs with `-c maintenance.auto=false -c gc.auto=0`, keeping
+`fetch.unpackLimit=1` packfilesOnly-specific. `fetch` is the only git
+subprocess Nix runs against its cache repos that can trigger
+auto-maintenance (ls-remote, symbolic-ref, and verify-commit cannot),
+so this closes the whole class: tool-internal repos never run the
+user's background maintenance.
+
+Refs indexable-inc/index#3755
+
+diff --git a/src/libfetchers/git-utils.cc b/src/libfetchers/git-utils.cc
+index e1bcb0bdf..51e239dd0 100644
+--- a/src/libfetchers/git-utils.cc
++++ b/src/libfetchers/git-utils.cc
+@@ -966,15 +966,25 @@ struct GitRepoImpl : GitRepo, std::enable_shared_from_this<GitRepoImpl>
+             OS_STR("--git-dir"),
+             OS_STR("."),
+         };
++        /* This fetch always targets a Nix-internal cache repository (the
++           per-URL git cache or the tarball cache), which inherits the
++           user's global gitconfig. Never let it start the user's
++           background maintenance there: a background gc could prune
++           objects the cache still wants (most objects in the tarball
++           cache are unreferenced by design), and on macOS the detached
++           `git maintenance run --auto` that `maintenance.auto=true`
++           spawns crashes outright (gettext locale init calls
++           CFLocaleCopyPreferredLanguages, which dereferences a null
++           CoreFoundation notification center in the session-less,
++           launchd-reparented context). */
++        for (auto opt : {OS_STR("gc.auto=0"), OS_STR("maintenance.auto=false")}) {
++            gitArgs.push_back(OS_STR("-c"));
++            gitArgs.push_back(opt);
++        }
+         if (packfilesOnly) {
+-            /* Keep the fetched objects packed however few they are, and
+-               don't let the fetch trigger an auto-gc: most objects in the
+-               tarball cache are unreferenced by design, so a gc would
+-               prune them. */
+-            for (auto opt : {OS_STR("fetch.unpackLimit=1"), OS_STR("gc.auto=0"), OS_STR("maintenance.auto=false")}) {
+-                gitArgs.push_back(OS_STR("-c"));
+-                gitArgs.push_back(opt);
+-            }
++            /* Keep the fetched objects packed however few they are. */
++            gitArgs.push_back(OS_STR("-c"));
++            gitArgs.push_back(OS_STR("fetch.unpackLimit=1"));
+         }
+         gitArgs.push_back(OS_STR("fetch"));
+         gitArgs.push_back(OS_STR("--progress"));

--- a/packages/nix/nix/patches/dag.json
+++ b/packages/nix/nix/patches/dag.json
@@ -139,6 +139,12 @@
     {
       "patch": "0030-libflake-stamp-submodule-metadata-on-relative-path-f.patch",
       "deps": []
+    },
+    {
+      "patch": "0031-fix-libfetchers-keep-user-git-auto-maintenance-out-o.patch",
+      "deps": [
+        "0013-libfetchers-opt-in-incremental-fetching-of-forge-inp.patch"
+      ]
     }
   ]
 }

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -1408,7 +1408,6 @@ in {
           writeCommitGraph = true;
           auto = 256;
           autopacklimit = 10;
-          autodetach = true;
           pruneExpire = "2.weeks.ago";
           reflogExpire = "90.days.ago";
           reflogExpireUnreachable = "30.days.ago";
@@ -1527,6 +1526,24 @@ in {
             update = "merge";
           };
         });
+        # Fetch-time background maintenance is for real project repos only.
+        # Nix-internal git cache repos (~/.cache/nix/tarball-cache-v2,
+        # ~/.cache/nix/gitv3/*) inherit this global file, and with
+        # maintenance.auto + gc.autodetach set every fetch spawned a
+        # detached `git maintenance run --auto` that SIGSEGVs on macOS
+        # (gettext locale init -> CFLocaleCopyPreferredLanguages -> NULL CF
+        # distributed-notification center), so the caches never got
+        # maintained (#3755). Scoping by gitdir keeps today's behavior for
+        # everything under ~/Projects/ (linked worktrees too: their gitdir
+        # resolves into the main checkout's .git) while ~/.cache repos fall
+        # back to git defaults.
+        "includeIf \"gitdir:~/Projects/\"".path = pkgs.writeText "projects-git-maintenance" (lib.generators.toGitINI {
+          gc.autodetach = true;
+          maintenance = {
+            auto = true;
+            strategy = "incremental";
+          };
+        });
         push = {
           default = "simple";
           autoSetupRemote = true;
@@ -1554,15 +1571,6 @@ in {
           allowAnySHA1InWant = true;
         };
         feature.manyFiles = true;
-        maintenance =
-          {
-            auto = true;
-            strategy = "incremental";
-          }
-          # Registered maintenance repo lives on the workstation only.
-          // lib.optionalAttrs pkgs.stdenv.isDarwin {
-            repo = cfg.paths.ixCheckout;
-          };
         sparse.expectFilesOutsideOfPatterns = true;
         "branchless.restack" = {
           preserveTimestamps = false;
@@ -1572,6 +1580,14 @@ in {
         pager.log = true;
       }
       // gitCredentialHelpers
+      # Registered maintenance repo lives on the workstation only. The
+      # maintenance scheduling knobs (maintenance.auto/strategy,
+      # gc.autodetach) live in the ~/Projects/ includeIf above: they are
+      # for real project repos, not the git cache repos tools keep under
+      # ~/.cache (#3755).
+      // lib.optionalAttrs pkgs.stdenv.isDarwin {
+        maintenance.repo = cfg.paths.ixCheckout;
+      }
     );
 
   programs.ssh = let


### PR DESCRIPTION
Two commits, one per layer, closing the fetch-time git crash storm from #3755 (full forensics: [the analysis comment](https://github.com/indexable-inc/index/issues/3755#issuecomment-5017903784)).

Crash chain, short form: nix's fetcher shells out to real `git` in its cache repos (`~/.cache/nix/gitv3/*`, `tarball-cache-v2`), which inherit the user's global gitconfig; with `maintenance.auto=true` + `gc.autodetach=true` every fetch spawns a detached `git maintenance run --auto` (reparented to launchd) that SIGSEGVs on macOS in gettext locale init (`CFLocaleCopyPreferredLanguages` -> NULL CF distributed-notification center -> PAC check at 0x8), so maintenance never completes -- 65 crashes on 2026-07-19, tarball-cache-v2 at 3700 packs / 932MB.

**Commit 1 -- nix fork patch `0031-fix-libfetchers-keep-user-git-auto-maintenance-out-o.patch`:** every `GitRepoImpl::fetch` targets a nix-internal cache repo, so hoist the `-c gc.auto=0 -c maintenance.auto=false` guard that patch 0013 applied only to `packfilesOnly` (tarball-cache) fetches out to every cache-repo fetch (`fetch.unpackLimit=1` stays packfilesOnly-only). `fetch` is the only git subprocess nix runs against its cache repos that can trigger auto-maintenance. Registered in `lib/fork-packages.nix` as an upstream-nix candidate, held per NixOS/nix#15984 (humans submit nix patches). Gates: `checks.aarch64-darwin.patched-src-nix` and `patch-dag-nix` pass locally; dag regenerated by rebase-patches (31 nodes, 0031 depends on 0013).

**Commit 2 -- gitconfig scoping (`users/andrewgazelka/profiles/workstation.nix`):** move exactly `maintenance.auto`, `maintenance.strategy`, `gc.autodetach` under `includeIf "gitdir:~/Projects/"` (the same `pkgs.writeText` + `toGitINI` include pattern as the #3746 private-config include), so tool-internal cache repos never inherit fetch-time maintenance while `~/Projects/` repos -- linked worktrees included -- keep today's behavior. Verified by evaluating the rendered `.gitconfig` from the private HM flake with `--override-input index` on this branch, plus a live-git behavioral test: all three keys unset in a `~/.cache` repo, all three intact in the main checkout and a linked worktree.

Not covered here: the one-time foreground `git gc` on tarball-cache-v2 to collapse the accumulated packs (imperative, on hydra).

Fixes #3755

---
Authored by an AI agent (Claude Code, Fable 5); Andrew reviews before merge.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix fetch-time git SIGSEGVs on macOS by keeping auto-maintenance out of Nix-internal cache repos
> - Moves `-c gc.auto=0` and `-c maintenance.auto=false` in [`GitRepoImpl::fetch`](https://github.com/indexable-inc/index/pull/3758/files#diff-2d33f23e8c596aade4b9362b0cc778a1493e35febca90617978ff361ef3aa85e) so they apply to all cache-repo fetches, not just `packfilesOnly` fetches — previously git auto-maintenance could trigger inside Nix-internal cache repos and cause SIGSEGVs on macOS.
> - Registers the fix as patch `0031` in [lib/fork-packages.nix](https://github.com/indexable-inc/index/pull/3758/files#diff-35e5ff5b02c2dcd32c93fd770ad2194f9fcbfc9f35fdcbd56821891b6e7452f4) and [dag.json](https://github.com/indexable-inc/index/pull/3758/files#diff-bb8cabe3c8aca5a21a04124e99377308810f2ffd5701104ed528dd747207dc2d), ordered after patch `0013`.
> - Scopes `gc.autodetach` and `maintenance.auto` in [workstation.nix](https://github.com/indexable-inc/index/pull/3758/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962) to repos under `~/Projects/` via `includeIf`, so global git no longer enables auto-maintenance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8099c32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->