### PR TITLE
nix fork: snapshot mutable source trees at mount time under lazy-trees

### DIFF
--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -714,6 +714,16 @@
           upstream = "hold";
           reason = "Keeps user git auto-maintenance out of nix-internal cache repos; fetch-spawned detached `git maintenance run --auto` SIGSEGVs on macOS (indexable-inc/index#3755). Upstream-nix candidate, held: humans submit Nix patches upstream per NixOS/nix#15984.";
         };
+        # With lazy-trees on, path inputs and dirty git worktrees are read
+        # from the live filesystem for the whole eval, so a concurrent
+        # writer kills long evals with "contents have changed" (exit 102).
+        # Snapshot such trees at mount time via clonefile(2) (~70ms) and
+        # evaluate from the snapshot; fall back to an eager copy where
+        # cloning is unavailable.
+        "0032-libexpr-snapshot-mutable-source-trees-at-mount-time-.patch" = {
+          upstream = "hold";
+          reason = "Fixes the lazy-trees mid-eval mutation race for mutable local trees (indexable-inc/index#3749). Upstream-nix candidate once lazy trees settle there, held: humans submit Nix patches upstream per NixOS/nix#15984.";
+        };
       };
     }
     {

--- a/packages/nix/nix/patches/0032-libexpr-snapshot-mutable-source-trees-at-mount-time-.patch
+++ b/packages/nix/nix/patches/0032-libexpr-snapshot-mutable-source-trees-at-mount-time-.patch
@@ -1,0 +1,153 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew@ix.dev>
+Date: Sun, 19 Jul 2026 19:19:39 -0700
+Subject: [PATCH] libexpr: snapshot mutable source trees at mount time
+ (lazy-trees)
+
+With lazy-trees enabled, a path input or dirty git worktree is read
+from the live filesystem for the entire evaluation. Another process
+writing into the tree mid-eval makes the on-demand copy hash
+differently from the mount-time dry-run hash, killing long evals with
+"contents have changed" (exit 102): on hydra, agent sessions journaling
+into ~/.config/nix took down two home-manager switches on 2026-07-19.
+
+Snapshot such trees at mount time with an in-kernel APFS directory
+clone and evaluate from the snapshot, so hash and content agree by
+construction. clonefile(2) on the 4k-file/59 MB index worktree takes
+63-77 ms (vs 1.3 s for a userland cp -c walk and 3.0 s for an eager
+store copy of a changed tree); content verified identical. Where
+cloning is unavailable (non-Darwin, cross-volume EXDEV, non-APFS) fall
+back to copying the tree to the store eagerly at mount, i.e. the
+pre-lazy-trees base behavior with its historical seconds-wide window.
+
+Only path and git inputs are treated as mutable; other accessors with
+physical paths (archives extracted into the fetcher cache) are owned by
+Nix and stay lazily mounted. The tree root comes from the input attrs
+(for git the accessor root omits .git, which the snapshot re-fetch
+needs); lock-identity attrs are stripped from the redirected input and
+mountInput's existing narHash check still validates the snapshot
+against the original lock.
+
+Race repro (writer appends to a tracked file 2 s into a ~7 s eval):
+baseline fails 2/5 with exit 102; patched passes 10/10 lazily and 5/5
+via the EXDEV fallback; drvPaths byte-identical on a quiescent tree.
+
+Refs indexable-inc/index#3749
+
+Assisted-by: Claude <noreply@anthropic.com>
+
+diff --git a/src/libexpr/paths.cc b/src/libexpr/paths.cc
+index a4316c8..ffb85d3 100644
+--- a/src/libexpr/paths.cc
++++ b/src/libexpr/paths.cc
+@@ -2,9 +2,53 @@
+ #include "nix/expr/eval.hh"
+ #include "nix/util/mounted-source-accessor.hh"
+ #include "nix/fetchers/fetch-to-store.hh"
++#include "nix/fetchers/fetchers.hh"
++#include "nix/util/file-system.hh"
++#include "nix/util/sync.hh"
++
++#ifdef __APPLE__
++#  include <sys/clonefile.h>
++#endif
+ 
+ namespace nix {
+ 
++/* Snapshot a mutable source tree with an in-kernel APFS directory clone.
++
++   A lazily mounted input is read from the live filesystem for the whole
++   evaluation, so a `path:` input or a dirty git worktree that another
++   process writes to mid-eval makes the on-demand copy hash differently
++   from the mount-time dry-run hash and the evaluation dies in
++   ensureLazyPathCopied (indexable-inc/index#3749). Cloning the tree at
++   mount time (clonefile(2): one blocking syscall, ~70 ms for a
++   4k-file/59 MB worktree, content verified identical) and evaluating
++   from the clone makes hash and content agree by construction.
++
++   Returns std::nullopt when cloning is unavailable (non-Darwin,
++   cross-volume EXDEV, non-APFS); the caller then falls back to copying
++   the tree to the store eagerly, which is the pre-lazy-trees base
++   behavior. Snapshots are deduplicated per source path and live until
++   process exit. */
++static std::optional<std::filesystem::path> cloneTreeSnapshot(const std::filesystem::path & src)
++{
++#ifdef __APPLE__
++    static std::filesystem::path snapRoot = createTempDir("", "nix-eval-snapshot");
++    static AutoDelete snapRootDelete(snapRoot, true);
++    static Sync<std::map<std::filesystem::path, std::filesystem::path>> snapshots_;
++
++    auto snapshots(snapshots_.lock());
++    if (auto it = snapshots->find(src); it != snapshots->end())
++        return it->second;
++    auto dst = snapRoot / fmt("snapshot-%d", snapshots->size());
++    if (clonefile(src.c_str(), dst.c_str(), 0) != 0)
++        return std::nullopt;
++    snapshots->emplace(src, dst);
++    return dst;
++#else
++    (void) src;
++    return std::nullopt;
++#endif
++}
++
+ SourcePath EvalState::rootPath(CanonPath path)
+ {
+     return {rootFS, std::move(path)};
+@@ -77,8 +121,54 @@ EvalState::mountInput(fetchers::Input & input, const fetchers::Input & originalI
+        would require having a special "LazyStorePathString" thunk. narHash also doesn't need to be computed eagerly in
+        case it's not actually specified (like during local development with a dirty tree) - in that case narHash could
+        also become a lazy app/thunk that shares the state with the storePath delayed computation. */
+-    auto [storePath, narHash] = fetchToStore2(
+-        fetchSettings, *store, accessor, settings.lazyTrees ? FetchMode::DryRun : FetchMode::Copy, input.getName());
++    auto mode = settings.lazyTrees ? FetchMode::DryRun : FetchMode::Copy;
++
++    /* Only `path` and `git` (workdir) inputs are backed by trees that
++       other processes can mutate; anything else with a physical path
++       (say, an archive extracted into the fetcher cache) is owned by
++       Nix and stays lazily mounted as-is. The tree root comes from the
++       input attrs, not the accessor's physical path: for a git workdir
++       the accessor root omits .git, which the re-fetch of the snapshot
++       needs. */
++    if (mode == FetchMode::DryRun && (input.getType() == "path" || input.getType() == "git")
++        && accessor->getPhysicalPath(CanonPath::root)) {
++        std::optional<std::filesystem::path> treeRoot;
++        if (input.getType() == "path") {
++            if (auto phys = accessor->getPhysicalPath(CanonPath::root); phys && phys->is_absolute())
++                treeRoot = *phys;
++        } else if (auto url = fetchers::maybeGetStrAttr(input.attrs, "url");
++                   url && hasPrefix(*url, "file://") && url->size() > 7 && (*url)[7] == '/')
++            treeRoot = url->substr(7);
++        if (treeRoot && !store->isInStore(treeRoot->string())) {
++            bool snapshotted = false;
++            if (auto snapshot = cloneTreeSnapshot(*treeRoot)) {
++                try {
++                    auto attrs = input.attrs;
++                    /* Identity and lock attrs describe the original
++                       location; mountInput below re-checks the snapshot
++                       against the original lock via its narHash. */
++                    for (auto & attr : {"narHash", "lastModified", "rev", "revCount", "dirtyRev", "dirtyShortRev", "__final"})
++                        attrs.erase(attr);
++                    if (input.getType() == "path")
++                        attrs.insert_or_assign("path", snapshot->string());
++                    else
++                        attrs.insert_or_assign("url", "file://" + snapshot->string());
++                    accessor = fetchers::Input::fromAttrs(fetchSettings, std::move(attrs))
++                                   .getAccessor(fetchSettings, *store)
++                                   .first;
++                    snapshotted = true;
++                } catch (Error & e) {
++                    /* e.g. a worktree whose .git file points outside the
++                       cloned tree; fall through to the eager copy. */
++                    debug("cannot re-fetch snapshot of '%s': %s", treeRoot->string(), e.what());
++                }
++            }
++            if (!snapshotted)
++                mode = FetchMode::Copy;
++        }
++    }
++
++    auto [storePath, narHash] = fetchToStore2(fetchSettings, *store, accessor, mode, input.getName());
+ 
+     allowPath(storePath); // FIXME: should just whitelist the entire virtual store
+ 

--- a/packages/nix/nix/patches/dag.json
+++ b/packages/nix/nix/patches/dag.json
@@ -145,6 +145,12 @@
       "deps": [
         "0013-libfetchers-opt-in-incremental-fetching-of-forge-inp.patch"
       ]
+    },
+    {
+      "patch": "0032-libexpr-snapshot-mutable-source-trees-at-mount-time-.patch",
+      "deps": [
+        "0029-libexpr-gate-lazy-input-mounting-behind-an-off-by-de.patch"
+      ]
     }
   ]
 }


### PR DESCRIPTION
With `lazy-trees = true`, `path:` inputs and dirty git worktrees are read from the live filesystem for the entire evaluation. A concurrent writer breaks the mount-time hash promise and kills the eval with exit 102 (`store path ... was hashed to avoid a full copy at first, but upon reading it again, the contents have changed`). On hydra, agent sessions journaling into `~/.config/nix/claude/auto-memory/` killed two home-manager switches on 2026-07-19, and one of the four benchmark evals for this very PR.

Patch 0032: at mount time, snapshot mutable local trees with an in-kernel APFS directory clone (`clonefile(2)`) and evaluate from the snapshot, so the dry-run hash and the on-demand copy agree by construction. Immutable inputs (git revs, tarballs, github zips) have no physical path and stay fully lazy. Where cloning is unavailable (non-Darwin, cross-volume EXDEV, non-APFS), fall back to `FetchMode::Copy` at mount, which is the pre-lazy-trees base behavior.

Benchmarks (hydra, M-series, APFS, load 20-30):

| operation | time |
|---|---|
| dry-run narHash, index worktree (3,900 files / 52 MB) | 0.26 s |
| `clonefile(2)` directory clone of the same tree | 0.063-0.077 s |
| `cp -c` userland clone walk (rejected) | 1.3 s |
| eager store copy, changed tree (fallback path) | 3.0 s |
| eager store copy, unchanged tree | 0.30 s |

Steady-state cost of the fix: ~0.07 s per mutable input per eval, on evals measured at 66-81 s.

Validation:
- Race repro (writer appends to a tracked file 2 s into a ~7 s eval): baseline fails 2/5 with exit 102; patched 0/10; EXDEV fallback (TMPDIR on the /nix volume) 0/5.
- Real config, cold cache, interleaved: baseline 78.7 s OK then FAILED on a live agent write; patched 66.2 s / 80.6 s both OK.
- drvPaths byte-identical to baseline on quiescent trees, including the full home-manager generation drv (`7w5ygdyd...-home-manager-generation.drv` from both binaries).
- Fast gates `patched-src-nix` and `patch-dag-nix` pass locally.

Closes #3749

(opened by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Snapshot mutable source trees at mount time under lazy-trees in forked Nix
> - Adds [0032-libexpr-snapshot-mutable-source-trees-at-mount-time-.patch](https://github.com/indexable-inc/index/pull/3760/files#diff-b03590d7e36cf53b8717e4e032c060730fbe322054ee9cb96c59e7b16f7f4f50) to fix a race condition where mutable local trees could be mutated between lazy-trees mount and evaluation.
> - When `lazyTrees` is enabled and the input is a mutable `path` or `git` type with a physical path on macOS, `EvalState::mountInput` now snapshots the tree via `clonefile(2)` into a temporary directory, caching snapshots per source path.
> - If snapshotting is unavailable or fails, the code falls back to `FetchMode::Copy` (eager copy), preserving existing behavior on non-macOS platforms and non-mutable inputs.
> - Risk: snapshot cache and temp directory are process-global static state; snapshots are not cleaned up within a single Nix invocation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a9a60a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->