### PR TITLE
nushell: memoize prompt repo lookup per directory

### DIFF
--- a/users/andrewgazelka/config/nushell/functions/github.nu
+++ b/users/andrewgazelka/config/nushell/functions/github.nu
@@ -269,11 +269,27 @@ export def github-pr-prompt-refresh [
     rm --force $lock_file
 }
 
-export def github-pr-prompt-refresh-current-if-stale [
+# Memoize the repo lookup per directory. Prompt hooks call the refresh check on
+# every REPL iteration, and `github-current-repo` forks git twice; unmemoized,
+# a runaway prompt loop turns that into a machine-wide fork storm
+# (andrewgazelka/nix#116). Closure hooks preserve env via redirect_env
+# (nu crates/nu-cmd-base/src/hook.rs), so $env memoization sticks across
+# prompts. Goes stale only if the repo changes under an unchanged PWD.
+export def --env github-current-repo-for-prompt [] {
+    if ($env.__GITHUB_PROMPT_REPO_PWD? | default "") == $env.PWD {
+        return ($env.__GITHUB_PROMPT_REPO? | default "")
+    }
+    let repo = (github-current-repo)
+    $env.__GITHUB_PROMPT_REPO_PWD = $env.PWD
+    $env.__GITHUB_PROMPT_REPO = $repo
+    $repo
+}
+
+export def --env github-pr-prompt-refresh-current-if-stale [
     --max-age: duration = 1min
     --lock-max-age: duration = 2min
 ] {
-    let repo = (github-current-repo)
+    let repo = (github-current-repo-for-prompt)
     if ($repo | is-empty) {
         return
     }


### PR DESCRIPTION
Fixes #3763. `github-current-repo` forks `git rev-parse` + `git config` on every prompt, before the staleness gate. This memoizes the lookup per `$env.PWD` so steady-state prompts fork no git. Verified: module parses and resolves the repo under system nu 0.114.0.

Amplifier for andrewgazelka/nix#116 (orphaned ghostty shells fork-looping).

(PR by an AI agent via Claude Code, model Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Memoize prompt repo lookup per directory in nushell config
> - Adds `github-current-repo-for-prompt` in [github.nu](https://github.com/indexable-inc/index/pull/3765/files#diff-9e7980c1ddc5ce44c8a40bd63093fd97957521440f89b5171d5475777c11c60f), which caches the result of `github-current-repo` in `$env.__GITHUB_PROMPT_REPO` keyed by `$env.__GITHUB_PROMPT_REPO_PWD`, skipping the lookup when the cached PWD matches the current directory.
> - Updates `github-pr-prompt-refresh-current-if-stale` to use `--env` and call `github-current-repo-for-prompt` so memoization variables persist across prompt iterations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aebdfe6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->