### PR TITLE
ghostty: check in config.ghostty, deploy it as an out-of-store symlink

### DIFF
--- a/users/andrewgazelka/config/ghostty/config.ghostty
+++ b/users/andrewgazelka/config/ghostty/config.ghostty
@@ -1,0 +1,108 @@
+# Ghostty configuration. Deployed as an out-of-store symlink to this file
+# (users/andrewgazelka/config/home/ghostty.nix), so an edit here is live after
+# `cmd+shift+r` with no switch. Ghostty expands `~/` in path-valued keys, and
+# the `cd` keybinds type text into a shell that expands `~` itself, so nothing
+# here needs Nix interpolation.
+#
+# Themes (custom-dark/custom-light) and shaders are shared, and live in
+# modules/home/ghostty/{themes,shaders}; profiles/workstation.nix links them
+# into ~/.config/ghostty. This file only references them by name and path.
+
+font-family = Berkeley Mono
+font-size = 10
+theme = dark:custom-dark,light:custom-light
+
+split-divider-color = 2a2a2a
+scrollback-limit = 4294967295
+scrollbar = never
+link-previews = true
+
+clipboard-paste-protection = false
+clipboard-read = allow
+
+macos-icon = custom-style
+macos-icon-ghost-color = 111111
+macos-icon-screen-color = 222222
+macos-icon-frame = chrome
+macos-titlebar-proxy-icon = hidden
+macos-option-as-alt = true
+macos-window-buttons = hidden
+
+window-padding-x = 5
+window-padding-y = 5
+window-decoration = none
+
+cursor-style = block
+cursor-style-blink = false
+
+background-blur = 20
+background-opacity = 1.0
+background-opacity-cells = true
+
+confirm-close-surface = false
+
+# Track Ghostty nightlies. The declared Homebrew cask is `ghostty@tip`, so keep
+# the in-app Sparkle updater OFF but pinned to the matching `tip` channel so any
+# reload reports the right track. Updates come from the cask
+# (`brew upgrade --cask ghostty@tip`), not the in-app updater.
+auto-update = off
+auto-update-channel = tip
+
+# Applied in order: subtle CRT look, then a static dim-white outline on the
+# focused pane (gated by iFocus).
+custom-shader = ~/.config/ghostty/shaders/crt.glsl
+custom-shader = ~/.config/ghostty/shaders/focus-border.glsl
+custom-shader-animation = true
+
+# Send Ctrl+U for Cmd+Backspace (delete to start of line).
+keybind = cmd+backspace=text:\x15
+
+keybind = cmd+n=new_window
+keybind = cmd+t=new_tab
+keybind = cmd+shift+]=next_tab
+keybind = cmd+shift+[=previous_tab
+keybind = cmd+w=close_surface
+
+# Copy entire scrollback: select all, then copy.
+keybind = cmd+shift+c=select_all
+keybind = chain=copy_to_clipboard
+keybind = cmd+shift+v=paste_from_clipboard
+
+keybind = cmd+0=reset_font_size
+keybind = cmd+plus=increase_font_size:1
+keybind = cmd+minus=decrease_font_size:1
+keybind = cmd+shift+r=reload_config
+
+# Split focus: sequential, then directional.
+keybind = cmd+]=goto_split:next
+keybind = cmd+[=goto_split:previous
+keybind = alt+tab=goto_split:next
+keybind = shift+alt+tab=goto_split:previous
+keybind = cmd+shift+left=goto_split:left
+keybind = cmd+shift+right=goto_split:right
+keybind = cmd+shift+up=goto_split:up
+keybind = cmd+shift+down=goto_split:down
+
+# Copy file path/URL to clipboard.
+keybind = performable:cmd+shift+u=copy_url_to_clipboard
+
+# Scrollback navigation.
+keybind = cmd+up=scroll_to_top
+keybind = cmd+down=scroll_to_bottom
+
+keybind = shift+enter=text:\x1b\r
+keybind = cmd+enter=text:\x1b[13;9u
+keybind = cmd+a=unbind
+keybind = cmd+shift+a=toggle_command_palette
+keybind = cmd+shift+s=write_screen_file:copy
+
+# cmd+<n> clears the half-typed line (Ctrl-U = \x15) then types `cd <repo>\r`.
+# Native Ghostty text injection, so no Accessibility permission and no leaking
+# keys to other apps. MUST bind the physical `digit_N` position: since Ghostty
+# 1.2.0 the default `cmd+digit_N=goto_tab:N` (physical) wins over a logical
+# `cmd+1`, so binding `cmd+digit_N` is what overrides the tab switch. AeroSpace
+# must NOT bind cmd-1/2/3 or its global tap swallows them before Ghostty sees
+# the keys (see profiles/workstation.nix).
+keybind = cmd+digit_1=text:\x15cd ~/Projects/indexable-inc/ix\r
+keybind = cmd+digit_2=text:\x15cd ~/Projects/indexable-inc/index\r
+keybind = cmd+digit_3=text:\x15cd ~/.config/nix\r

--- a/users/andrewgazelka/config/home/ghostty.nix
+++ b/users/andrewgazelka/config/home/ghostty.nix
@@ -1,170 +1,35 @@
-# Ghostty terminal configuration, generated entirely from Nix.
+# Ghostty terminal configuration.
 #
-# Single source of truth: the `settings` attrset below. It is rendered in-store
-# by pkgs.formats.keyValue (the same generator home-manager's programs.ghostty
-# uses) and seeded to the macOS config path as a plain writable file
-# (`mutable.files`, ephemeral): tweak the live file to experiment, and every
-# switch/login resets it to this render with the drift journaled. Edit Nix,
-# switch, done — or scribble on the deployed file and lift the keepers here.
+# The config is a real Ghostty file, checked in at
+# users/andrewgazelka/config/ghostty/config.ghostty, and the macOS config path
+# is an out-of-store symlink to it in the checkout. Edit the file, hit
+# `cmd+shift+r`, done — no switch, and no drift to lift back into Nix.
 #
-# Repeated keybind/shader families (repo `cd` shortcuts, directional split
-# focus, shader stack) are built algebraically by mapping over data, so adding
-# one is a one-line data edit rather than a hand-copied config line.
-#
-# Themes (custom-dark/custom-light) and shaders live in the shared
-# modules/home/ghostty/{themes,shaders} and are linked into ~/.config/ghostty
-# separately in profiles/workstation.nix; this file only references them by
-# name / absolute path.
+# Only one config path is written, so cumulative settings (custom-shader) are
+# not double-applied. Themes and shaders stay under ~/.config/ghostty, linked
+# from the shared modules/home/ghostty in profiles/workstation.nix.
 {
   config,
   lib,
-  pkgs,
   ...
 }: let
   cfg = config.users.andrewgazelka;
-  home = config.home.homeDirectory;
-  projects = "${home}/Projects/indexable-inc";
-  shaderDir = "${home}/.config/ghostty/shaders";
-
-  # cmd+<n> clears the half-typed line (Ctrl-U = \x15) then types `cd <repo>\r`.
-  # Native Ghostty text injection, so no Accessibility/System-Events permission
-  # and no leaking keys to other apps. MUST bind the physical `digit_N`
-  # position: since Ghostty 1.2.0 the default `cmd+digit_N=goto_tab:N` (physical)
-  # wins over a logical `cmd+1`, so binding `cmd+digit_N` is what overrides the
-  # tab switch. AeroSpace must NOT bind cmd-1/2/3 or its global tap swallows them
-  # before Ghostty sees the keys (see profiles/workstation.nix).
-  repoShortcuts = lib.mapAttrsToList (n: path: ''cmd+digit_${n}=text:\x15cd ${path}\r'') {
-    "1" = "${projects}/ix";
-    "2" = "${projects}/index";
-    "3" = cfg.paths.indexCheckout;
-  };
-
-  # Directional split focus: same shape for all four arrows.
-  splitNav = map (d: "cmd+shift+${d}=goto_split:${d}") [
-    "left"
-    "right"
-    "up"
-    "down"
-  ];
-
-  # Shader stack, applied in order.
-  shaders = map (s: "${shaderDir}/${s}") [
-    "crt.glsl" # subtle CRT look
-    "focus-border.glsl" # static dim-white outline on the focused pane (gated by iFocus)
-  ];
-
-  settings = {
-    font-size = 10;
-    font-family = "Berkeley Mono";
-    theme = "dark:custom-dark,light:custom-light";
-
-    split-divider-color = "2a2a2a";
-    scrollback-limit = 4294967295;
-    scrollbar = "never";
-    link-previews = true;
-
-    clipboard-paste-protection = false;
-    clipboard-read = "allow";
-
-    macos-icon = "custom-style";
-    macos-icon-ghost-color = "111111";
-    macos-icon-screen-color = "222222";
-    macos-icon-frame = "chrome";
-    macos-titlebar-proxy-icon = "hidden";
-    macos-option-as-alt = true;
-    macos-window-buttons = "hidden";
-
-    window-padding-x = 5;
-    window-padding-y = 5;
-    window-decoration = "none";
-
-    cursor-style = "block";
-    cursor-style-blink = false;
-
-    background-blur = 20;
-    background-opacity = "1.0";
-    background-opacity-cells = true;
-
-    # Track Ghostty nightlies. The declared Homebrew cask is `ghostty@tip`, so
-    # keep the in-app Sparkle updater OFF but pinned to the matching `tip`
-    # channel so any reload reports the right track. Updates come from the cask
-    # (`brew upgrade --cask ghostty@tip`), not the in-app updater.
-    auto-update = "off";
-    auto-update-channel = "tip";
-
-    confirm-close-surface = false;
-
-    custom-shader = shaders;
-    custom-shader-animation = true;
-
-    keybind =
-      [
-        # Send Ctrl+U for Cmd+Backspace (delete to start of line).
-        ''cmd+backspace=text:\x15''
-
-        "cmd+n=new_window"
-        "cmd+t=new_tab"
-        "cmd+shift+]=next_tab"
-        "cmd+shift+[=previous_tab"
-        "cmd+w=close_surface"
-
-        # Copy entire scrollback: select all, then copy.
-        "cmd+shift+c=select_all"
-        "chain=copy_to_clipboard"
-        "cmd+shift+v=paste_from_clipboard"
-
-        "cmd+0=reset_font_size"
-        "cmd+plus=increase_font_size:1"
-        "cmd+minus=decrease_font_size:1"
-        "cmd+shift+r=reload_config"
-
-        # Sequential split focus.
-        "cmd+]=goto_split:next"
-        "cmd+[=goto_split:previous"
-        "alt+tab=goto_split:next"
-        "shift+alt+tab=goto_split:previous"
-
-        # Copy file path/URL to clipboard.
-        "performable:cmd+shift+u=copy_url_to_clipboard"
-
-        # Scrollback navigation.
-        "cmd+up=scroll_to_top"
-        "cmd+down=scroll_to_bottom"
-
-        ''shift+enter=text:\x1b\r''
-        ''cmd+enter=text:\x1b[13;9u''
-        "cmd+a=unbind"
-        "cmd+shift+a=toggle_command_palette"
-        "cmd+shift+s=write_screen_file:copy"
-      ]
-      ++ repoShortcuts
-      ++ splitNav;
-  };
-
-  configFile =
-    (pkgs.formats.keyValue {
-      listsAsDuplicateKeys = true;
-      mkKeyValue = lib.generators.mkKeyValueDefault {} " = ";
-    }).generate
-    "ghostty-config"
-    settings;
+  target = "${cfg.paths.indexCheckout}/users/andrewgazelka/config/ghostty/config.ghostty";
+  deployed = "Library/Application Support/com.mitchellh.ghostty/config";
 in {
-  # Written to the macOS Application Support path Ghostty already loads;
-  # shaders/themes stay under ~/.config/ghostty (linked in
-  # profiles/workstation.nix). Only one config path is written so cumulative
-  # settings (e.g. custom-shader) are not double-applied.
-  #
-  # Deployed as a writable mutable file (module imported in
-  # profiles/workstation.nix), NOT a store symlink: edit the live config to
-  # experiment (`cmd+shift+r` reloads it in place), and every activation and
-  # login resets it to this declared render — ephemeral, with the drift's
-  # logical keyvalue diff archived to `index-delta journal` first, so a tweak
-  # worth keeping can be lifted back into this file instead of being lost.
-  mutable.files."Library/Application Support/com.mitchellh.ghostty/config" = {
-    source = configFile;
-    format = "keyvalue";
-    # No `sourceFile`: the declaration is Nix, not raw keyvalue, so
-    # `apply-ops` cannot absorb drift mechanically — lift keepers by hand.
-    declaredAt = "users/andrewgazelka/config/home/ghostty.nix";
+  home = {
+    file."${deployed}".source = config.lib.file.mkOutOfStoreSymlink target;
+
+    # The config used to be deployed by `mutable.files` as a plain writable
+    # file, which Home Manager will not overwrite with a link. index-delta
+    # forgets undeclared files but leaves them on disk, so drop the regular
+    # file (never a link: an existing generation link is Home Manager's to
+    # replace) before checkLinkTargets runs.
+    activation.migrateGhosttyConfig = config.lib.dag.entryBefore ["checkLinkTargets"] ''
+      configFile=${lib.escapeShellArg "${config.home.homeDirectory}/${deployed}"}
+      if [[ -f "$configFile" ]] && [[ ! -L "$configFile" ]]; then
+        run rm "$configFile"
+      fi
+    '';
   };
 }

--- a/users/andrewgazelka/profiles/darwin-home.nix
+++ b/users/andrewgazelka/profiles/darwin-home.nix
@@ -109,8 +109,8 @@ in {
     ./infra.nix
     optionsModule
     raycastModule
-    # Ghostty config, generated from Nix (home/ghostty.nix). Replaces the former
-    # out-of-store symlink to ghostty/config.
+    # Ghostty config: out-of-store symlink to config/ghostty/config.ghostty
+    # (home/ghostty.nix).
     ghosttyModule
     # vmkit macOS guests: general push machinery + the personal guest specs
     # (macos-primary / the Beeper iMessage bridge, ENG-7746).
@@ -303,7 +303,7 @@ in {
   # macOS-specific paths (Library/Application Support)
   # ============================================
 
-  # Ghostty main config: generated from Nix in home/ghostty.nix (imported above).
+  # Ghostty main config: symlinked to the checkout in home/ghostty.nix (imported above).
 
   # Claude Desktop rewrites its config file and carries a runtime
   # Authorization header. The `mutable.files` declaration below seeds only


### PR DESCRIPTION
Closes #3764.

The Ghostty config is now a real Ghostty file, `users/andrewgazelka/config/ghostty/config.ghostty`,
and `~/Library/Application Support/com.mitchellh.ghostty/config` is an out-of-store symlink to it
in the index checkout (`mkOutOfStoreSymlink`, the idiom `profiles/nushell.nix` already uses).
Edit the file, hit `cmd+shift+r`, no switch, no drift to lift back into Nix.

Nothing in the config needed Nix: Ghostty expands `~/` in path-valued keys (`src/config/path.zig`),
so the shader paths carry over verbatim, and the `cd` keybinds type text into a shell that expands
`~` itself.

Also fixes a dup from the move to index-owned profiles: `cmd+digit_2` and `cmd+digit_3` both
resolved to `~/Projects/indexable-inc/index`, because `cfg.paths.indexCheckout` defaults to the
path shortcut 2 already hardcodes. Shortcut 3 goes back to `~/.config/nix`, its pre-migration
target.

Dropping the `mutable.files` declaration leaves the old plain file on disk (index-delta forgets
undeclared files but does not delete them), and Home Manager will not replace a regular file with
a link, so activation removes it before `checkLinkTargets`.

Verified by building the private Home Manager generation against this branch
(`--override-input index git+file://...`):
- `home-files/Library/Application Support/com.mitchellh.ghostty/config` resolves to
  `.../index/users/andrewgazelka/config/ghostty/config.ghostty`
- `migrateGhosttyConfig` is ordered at activation step 310, before `checkLinkTargets` at 359
- the ghostty entry is gone from `index-delta-manifest.json` (14 files left, none ghostty)

Not verified: a real `home-manager switch` and a Ghostty reload against the new file. Order matters
when landing, since the symlink points at the primary checkout: merge, `git pull` there, then switch.
Switching first leaves a dangling link and Ghostty falls back to defaults until the pull.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deploy Ghostty config as an out-of-store symlink to the checked-in repo file
> - Replaces the Nix-generated `keyValue`-based Ghostty config in [ghostty.nix](https://github.com/indexable-inc/index/pull/3767/files#diff-c93e0cf9c42acb0877d190356dbea7b234a7b69e5c2b17216de3cbc27ee7e232) with a `mkOutOfStoreSymlink` pointing to the checked-in [config.ghostty](https://github.com/indexable-inc/index/pull/3767/files#diff-042d64d0cd50f2ab4d74d24cf6a2f7a455facaefee5b4024e68c5f8b2cfd6964).
> - Adds an activation step (`migrateGhosttyConfig`) that removes any existing regular file at `Library/Application Support/com.mitchellh.ghostty/config` before Home Manager creates the symlink.
> - The checked-in config includes font settings, theme, window preferences, shader declarations, and keybindings (split navigation, clipboard, scrollback, and `cmd+digit` repo shortcuts).
> - Behavioral Change: the deployed config is now a live symlink to the repo, so edits to the file take effect without a Home Manager rebuild.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39a9909.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->