### PR TITLE
ast-merge: replace positional zip in lines::based with real diff3 alignment

### DIFF
--- a/packages/code/ast-merge/diff/src/lines.rs
+++ b/packages/code/ast-merge/diff/src/lines.rs
@@ -161,6 +161,57 @@ fn push_lines(output: &mut String, lines: &[&str]) {
     }
 }
 
+/// Walks one side's hunks in lockstep with the shared base cursor. Left and
+/// right are structurally symmetric (each just diffs its own lines against
+/// the same base), so `based()` drives two of these instead of duplicating
+/// the grow-and-measure logic per side.
+struct SideCursor<'a> {
+    hunks: &'a [Hunk],
+    next: usize,
+    last: Option<&'a Hunk>,
+    pos: usize,
+}
+
+impl<'a> SideCursor<'a> {
+    fn new(hunks: &'a [Hunk]) -> Self {
+        Self {
+            hunks,
+            next: 0,
+            last: None,
+            pos: 0,
+        }
+    }
+
+    fn peek_start(&self) -> Option<usize> {
+        self.hunks.get(self.next).map(|hunk| hunk.base.start)
+    }
+
+    /// Consumes every not-yet-seen hunk starting at or before `end`, growing
+    /// `end` to cover it. Returns whether it consumed anything, so the
+    /// caller can alternate sides until neither grows the region further.
+    fn consume(&mut self, end: &mut usize) -> bool {
+        let mut grew = false;
+        while let Some(hunk) = self.hunks.get(self.next)
+            && hunk.base.start <= *end
+        {
+            *end = (*end).max(hunk.base.end);
+            self.last = Some(hunk);
+            self.next += 1;
+            grew = true;
+        }
+        grew
+    }
+
+    /// This side's text end for the region `[region_start, end)`: the last
+    /// consumed hunk's replacement end plus any stable tail up to `end`, or
+    /// (no hunk touched this region) `pos` tracking the base 1:1.
+    fn region_end(&self, region_start: usize, end: usize) -> usize {
+        self.last.map_or(self.pos + (end - region_start), |hunk| {
+            hunk.side.end + (end - hunk.base.end)
+        })
+    }
+}
+
 /// Three-way line merge with diff3 alignment.
 ///
 /// Each side is diffed against the base (patience diff), so an insertion
@@ -192,68 +243,39 @@ pub fn based(base: &str, left: &str, right: &str) -> Result {
     let mut output = String::new();
     let mut conflicts = Vec::new();
 
-    // `cursor` walks base lines; `left_pos`/`right_pos` are the side line
-    // indices aligned with `cursor` whenever `cursor` sits outside any hunk.
+    // `cursor` walks base lines; each side's cursor tracks `pos`, its own
+    // line index, staying aligned with `cursor` whenever `cursor` sits
+    // outside any hunk.
     let mut cursor = 0;
-    let mut left_pos = 0;
-    let mut right_pos = 0;
-    let mut li = 0;
-    let mut ri = 0;
+    let mut left = SideCursor::new(&left_hunks);
+    let mut right = SideCursor::new(&right_hunks);
 
     loop {
-        let next = [left_hunks.get(li), right_hunks.get(ri)]
+        let next = [left.peek_start(), right.peek_start()]
             .into_iter()
             .flatten()
-            .map(|hunk| hunk.base.start)
             .min();
         let Some(next) = next else { break };
 
         push_lines(&mut output, &base_lines[cursor..next]);
-        left_pos += next - cursor;
-        right_pos += next - cursor;
+        left.pos += next - cursor;
+        right.pos += next - cursor;
         let region_start = next;
 
         // Grow the unstable region to a maximal chunk: consuming a hunk from
         // one side can extend `end` into range of the other side's next hunk,
         // so repeat until neither side adds one.
         let mut end = region_start;
-        let mut last_left: Option<&Hunk> = None;
-        let mut last_right: Option<&Hunk> = None;
-        loop {
-            let mut grew = false;
-            while let Some(hunk) = left_hunks.get(li)
-                && hunk.base.start <= end
-            {
-                end = end.max(hunk.base.end);
-                last_left = Some(hunk);
-                li += 1;
-                grew = true;
-            }
-            while let Some(hunk) = right_hunks.get(ri)
-                && hunk.base.start <= end
-            {
-                end = end.max(hunk.base.end);
-                last_right = Some(hunk);
-                ri += 1;
-                grew = true;
-            }
-            if !grew {
-                break;
-            }
-        }
+        left.last = None;
+        right.last = None;
+        while left.consume(&mut end) | right.consume(&mut end) {}
 
-        // A side's region text ends at its last hunk's replacement plus the
-        // stable tail up to `end`; a side with no hunk here tracks the base.
-        let left_end = last_left.map_or(left_pos + (end - region_start), |hunk| {
-            hunk.side.end + (end - hunk.base.end)
-        });
-        let right_end = last_right.map_or(right_pos + (end - region_start), |hunk| {
-            hunk.side.end + (end - hunk.base.end)
-        });
+        let left_end = left.region_end(region_start, end);
+        let right_end = right.region_end(region_start, end);
 
         let base_seg = &base_lines[region_start..end];
-        let left_seg = &left_lines[left_pos..left_end];
-        let right_seg = &right_lines[right_pos..right_end];
+        let left_seg = &left_lines[left.pos..left_end];
+        let right_seg = &right_lines[right.pos..right_end];
 
         if left_seg == right_seg {
             push_lines(&mut output, left_seg);
@@ -272,14 +294,14 @@ pub fn based(base: &str, left: &str, right: &str) -> Result {
             conflicts.push(Conflict {
                 base: (!base_seg.is_empty())
                     .then(|| Region::new(region_start, end, base_seg.join("\n"))),
-                left: Region::new(left_pos, left_end, left_seg.join("\n")),
-                right: Region::new(right_pos, right_end, right_seg.join("\n")),
+                left: Region::new(left.pos, left_end, left_seg.join("\n")),
+                right: Region::new(right.pos, right_end, right_seg.join("\n")),
             });
         }
 
         cursor = end;
-        left_pos = left_end;
-        right_pos = right_end;
+        left.pos = left_end;
+        right.pos = right_end;
     }
 
     push_lines(&mut output, &base_lines[cursor..]);

--- a/packages/code/ast-merge/diff/src/lines.rs
+++ b/packages/code/ast-merge/diff/src/lines.rs
@@ -134,81 +134,155 @@ pub fn inner(base: &str, left: &str, right: &str) -> Outcome {
     }
 }
 
+/// One side's edit to the base: the base line range it replaces and the
+/// replacement line range in that side's file.
+struct Hunk {
+    base: std::ops::Range<usize>,
+    side: std::ops::Range<usize>,
+}
+
+fn hunks(base: &[&str], side: &[&str]) -> Vec<Hunk> {
+    use similar::{Algorithm, DiffOp, capture_diff_slices};
+
+    capture_diff_slices(Algorithm::Patience, base, side)
+        .into_iter()
+        .filter(|op| !matches!(op, DiffOp::Equal { .. }))
+        .map(|op| Hunk {
+            base: op.old_range(),
+            side: op.new_range(),
+        })
+        .collect()
+}
+
+fn push_lines(output: &mut String, lines: &[&str]) {
+    for line in lines {
+        output.push_str(line);
+        output.push('\n');
+    }
+}
+
+/// Three-way line merge with diff3 alignment.
+///
+/// Each side is diffed against the base (patience diff), so an insertion
+/// early in one side shifts nothing: disjoint edits apply cleanly and only
+/// overlapping or touching edits that disagree become conflicts. Touching
+/// edit regions coalesce into one conflict, matching GNU diff3 / `git
+/// merge-file`, because their relative order is ambiguous (index#3762: the
+/// previous positional walk conflicted nearly every line of a file after a
+/// single early insertion).
 #[must_use]
 pub fn based(base: &str, left: &str, right: &str) -> Result {
-    let base_lines: Vec<_> = base.lines().collect();
-    let left_lines: Vec<_> = left.lines().collect();
-    let right_lines: Vec<_> = right.lines().collect();
+    if left == right {
+        return Result::success(left.to_owned());
+    }
+    if base == left {
+        return Result::success(right.to_owned());
+    }
+    if base == right {
+        return Result::success(left.to_owned());
+    }
+
+    let base_lines: Vec<&str> = base.lines().collect();
+    let left_lines: Vec<&str> = left.lines().collect();
+    let right_lines: Vec<&str> = right.lines().collect();
+
+    let left_hunks = hunks(&base_lines, &left_lines);
+    let right_hunks = hunks(&base_lines, &right_lines);
 
     let mut output = String::new();
     let mut conflicts = Vec::new();
-    let mut i = 0;
 
-    while i < base_lines.len() || i < left_lines.len() || i < right_lines.len() {
-        let base_line = base_lines.get(i).copied();
-        let left_line = left_lines.get(i).copied();
-        let right_line = right_lines.get(i).copied();
+    // `cursor` walks base lines; `left_pos`/`right_pos` are the side line
+    // indices aligned with `cursor` whenever `cursor` sits outside any hunk.
+    let mut cursor = 0;
+    let mut left_pos = 0;
+    let mut right_pos = 0;
+    let mut li = 0;
+    let mut ri = 0;
 
-        match (base_line, left_line, right_line) {
-            (Some(_), Some(l), Some(r)) if l == r => {
-                output.push_str(l);
-                output.push('\n');
+    loop {
+        let next = [left_hunks.get(li), right_hunks.get(ri)]
+            .into_iter()
+            .flatten()
+            .map(|hunk| hunk.base.start)
+            .min();
+        let Some(next) = next else { break };
+
+        push_lines(&mut output, &base_lines[cursor..next]);
+        left_pos += next - cursor;
+        right_pos += next - cursor;
+        let region_start = next;
+
+        // Grow the unstable region to a maximal chunk: consuming a hunk from
+        // one side can extend `end` into range of the other side's next hunk,
+        // so repeat until neither side adds one.
+        let mut end = region_start;
+        let mut last_left: Option<&Hunk> = None;
+        let mut last_right: Option<&Hunk> = None;
+        loop {
+            let mut grew = false;
+            while let Some(hunk) = left_hunks.get(li)
+                && hunk.base.start <= end
+            {
+                end = end.max(hunk.base.end);
+                last_left = Some(hunk);
+                li += 1;
+                grew = true;
             }
-            (Some(b), Some(l), Some(r)) if l == b => {
-                output.push_str(r);
-                output.push('\n');
+            while let Some(hunk) = right_hunks.get(ri)
+                && hunk.base.start <= end
+            {
+                end = end.max(hunk.base.end);
+                last_right = Some(hunk);
+                ri += 1;
+                grew = true;
             }
-            (Some(b), Some(l), Some(r)) if r == b => {
-                output.push_str(l);
-                output.push('\n');
+            if !grew {
+                break;
             }
-            (Some(b), Some(l), Some(r)) => {
-                output.push_str("<<<<<<< LEFT\n");
-                output.push_str(l);
-                output.push('\n');
-                output.push_str("||||||| BASE\n");
-                output.push_str(b);
-                output.push('\n');
-                output.push_str("=======\n");
-                output.push_str(r);
-                output.push('\n');
-                output.push_str(">>>>>>> RIGHT\n");
-                conflicts.push(Conflict {
-                    base: Some(Region::new(0, b.len(), b.to_owned())),
-                    left: Region::new(0, l.len(), l.to_owned()),
-                    right: Region::new(0, r.len(), r.to_owned()),
-                });
-            }
-            (None, Some(l), Some(r)) if l == r => {
-                output.push_str(l);
-                output.push('\n');
-            }
-            (None, Some(l), Some(r)) => {
-                output.push_str("<<<<<<< LEFT\n");
-                output.push_str(l);
-                output.push('\n');
-                output.push_str("=======\n");
-                output.push_str(r);
-                output.push('\n');
-                output.push_str(">>>>>>> RIGHT\n");
-                conflicts.push(Conflict {
-                    base: None,
-                    left: Region::new(0, l.len(), l.to_owned()),
-                    right: Region::new(0, r.len(), r.to_owned()),
-                });
-            }
-            (Some(_) | None, None, Some(r)) => {
-                output.push_str(r);
-                output.push('\n');
-            }
-            (Some(_) | None, Some(l), None) => {
-                output.push_str(l);
-                output.push('\n');
-            }
-            _ => {}
         }
-        i += 1;
+
+        // A side's region text ends at its last hunk's replacement plus the
+        // stable tail up to `end`; a side with no hunk here tracks the base.
+        let left_end = last_left.map_or(left_pos + (end - region_start), |hunk| {
+            hunk.side.end + (end - hunk.base.end)
+        });
+        let right_end = last_right.map_or(right_pos + (end - region_start), |hunk| {
+            hunk.side.end + (end - hunk.base.end)
+        });
+
+        let base_seg = &base_lines[region_start..end];
+        let left_seg = &left_lines[left_pos..left_end];
+        let right_seg = &right_lines[right_pos..right_end];
+
+        if left_seg == right_seg {
+            push_lines(&mut output, left_seg);
+        } else if left_seg == base_seg {
+            push_lines(&mut output, right_seg);
+        } else if right_seg == base_seg {
+            push_lines(&mut output, left_seg);
+        } else {
+            output.push_str("<<<<<<< LEFT\n");
+            push_lines(&mut output, left_seg);
+            output.push_str("||||||| BASE\n");
+            push_lines(&mut output, base_seg);
+            output.push_str("=======\n");
+            push_lines(&mut output, right_seg);
+            output.push_str(">>>>>>> RIGHT\n");
+            conflicts.push(Conflict {
+                base: (!base_seg.is_empty())
+                    .then(|| Region::new(region_start, end, base_seg.join("\n"))),
+                left: Region::new(left_pos, left_end, left_seg.join("\n")),
+                right: Region::new(right_pos, right_end, right_seg.join("\n")),
+            });
+        }
+
+        cursor = end;
+        left_pos = left_end;
+        right_pos = right_end;
     }
+
+    push_lines(&mut output, &base_lines[cursor..]);
 
     if conflicts.is_empty() {
         Result::success(output)

--- a/packages/code/ast-merge/diff/src/tests.rs
+++ b/packages/code/ast-merge/diff/src/tests.rs
@@ -189,6 +189,89 @@ fn test_line_based_same_change() {
     assert!(result.content.contains("changed"));
 }
 
+#[test]
+fn line_based_disjoint_inserts_merge_clean() {
+    // index#3762: an early insertion on one side used to desync the
+    // positional walk and conflict nearly every following line.
+    let base = "a\nb\nc\nd\ne\nf\ng\nh\n";
+    let left = "top\na\nb\nc\nd\ne\nf\ng\nh\n";
+    let right = "a\nb\nc\nd\nmid\ne\nf\ng\nh\ntail\n";
+
+    let result = based(base, left, right);
+    assert!(
+        result.success,
+        "disjoint inserts must merge clean, got:\n{}",
+        result.content
+    );
+    assert_eq!(result.content, "top\na\nb\nc\nd\nmid\ne\nf\ng\nh\ntail\n");
+}
+
+#[test]
+fn line_based_overlapping_edits_conflict_with_context() {
+    let base = "a\nb\nc\n";
+    let left = "a\nB1\nc\n";
+    let right = "a\nB2\nc\n";
+
+    let result = based(base, left, right);
+    assert!(!result.success);
+    assert_eq!(
+        result.content,
+        "a\n<<<<<<< LEFT\nB1\n||||||| BASE\nb\n=======\nB2\n>>>>>>> RIGHT\nc\n"
+    );
+    assert_eq!(result.conflicts.len(), 1);
+}
+
+#[test]
+fn line_based_delete_vs_edit_conflicts() {
+    let base = "a\nb\nc\n";
+    let left = "a\nc\n";
+    let right = "a\nB\nc\n";
+
+    let result = based(base, left, right);
+    assert!(!result.success);
+    assert_eq!(
+        result.content,
+        "a\n<<<<<<< LEFT\n||||||| BASE\nb\n=======\nB\n>>>>>>> RIGHT\nc\n"
+    );
+}
+
+#[test]
+fn line_based_same_insert_plus_one_sided_tail_merges_clean() {
+    let base = "a\nb\n";
+    let left = "a\nx\nb\n";
+    let right = "a\nx\nb\nz\n";
+
+    let result = based(base, left, right);
+    assert!(result.success);
+    assert_eq!(result.content, "a\nx\nb\nz\n");
+}
+
+#[test]
+fn line_based_adjacent_edits_conflict() {
+    // Touching edit regions coalesce into one conflict (GNU diff3 / `git
+    // merge-file` semantics): with no stable line between them, their
+    // relative order is ambiguous.
+    let base = "a\nb\nc\nd\n";
+    let left = "a\nB\nc\nd\n";
+    let right = "a\nb\nC\nd\n";
+
+    let result = based(base, left, right);
+    assert!(!result.success);
+    assert_eq!(result.conflicts.len(), 1);
+}
+
+#[test]
+fn line_based_one_sided_change_passes_through_verbatim() {
+    // Fast path: byte-exact passthrough, trailing-newline-less input stays so.
+    let base = "a\nb";
+    let left = "a\nb";
+    let right = "a\nB";
+
+    let result = based(base, left, right);
+    assert!(result.success);
+    assert_eq!(result.content, "a\nB");
+}
+
 fn rust(base: &str, left: &str, right: &str) -> Result {
     let ts_lang = ast_merge_langs::Lang::Rust.to_tree_sitter();
 


### PR DESCRIPTION
Fixes #3762.

`lines::based` compared base/left/right **by raw line index** -- no alignment. One early insertion desynced every following line into a conflict. Every conflict path funnels through it: the no-language git-driver case (git's `.merge_file_*` temp names have no extension, so detection always fails there) and the AST merge's structural-conflict fallback.

Rewrote it as a real diff3: each side patience-diffed against base, disjoint edits apply cleanly, only maximal unstable chunks that disagree conflict (GNU diff3 / `git merge-file` semantics, including coalescing touching regions).

Measured on the incident files (test-ide `server/main.ts`, disjoint 9- vs 8-line additions):

| | conflicts | output |
|---|---|---|
| before | 674 blocks | 4773 lines of marker soup |
| after | 0 | 753 lines, **byte-identical to `git merge-file -p`** |

Both the line path and the AST-structural-fallback path verified. 45/45 crate tests pass incl. 6 new regressions (disjoint inserts, delete-vs-edit, adjacent-edit coalescing, byte-exact one-sided passthrough).

(sent by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace positional zip in `lines::based` with diff3-aligned patience diff merge
> - Rewrites the three-way line merge in [lines.rs](https://github.com/indexable-inc/index/pull/3770/files#diff-41692fa572a9a99ae2d84619205dbcafa7fbc69dcfa97a23bb9859bfe2eba46e) to use a proper diff3 algorithm instead of a positional zip, computing patience diff hunks for each side against the base.
> - Adds `SideCursor` to walk each side's hunks in lockstep with a shared base cursor, coalescing touching or overlapping edit regions into single conflict blocks with base context.
> - Adds fast paths: if left==right return left; if base==left return right; if base==right return left, preserving exact bytes including absent trailing newlines.
> - New tests cover disjoint inserts, overlapping edits, adjacent edits, delete-vs-edit, identical inserts, and the fast-path verbatim passthrough.
> - Behavioral Change: disjoint edits that previously conflicted now merge cleanly; overlapping or touching edits are emitted as a single conflict block with a BASE section instead of multiple separate conflicts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19056d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->