### PR TITLE
ghostty: vendor as a fork, build the VT engine from patchable source (index#3768)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -169,6 +169,23 @@
         "type": "github"
       }
     },
+    "ghostty-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1774297202,
+        "narHash": "sha256-zJwCCkqH/4TNwzxidiCLmj9hhkTiUMvQoIKFgGNPuHM=",
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "rev": "fd49716ea2084108aa098db390931c007495a1ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "rev": "fd49716ea2084108aa098db390931c007495a1ab",
+        "type": "github"
+      }
+    },
     "git-src": {
       "flake": false,
       "locked": {
@@ -618,6 +635,7 @@
         "examples": "examples",
         "fff-src": "fff-src",
         "ghostty": "ghostty",
+        "ghostty-src": "ghostty-src",
         "git-src": "git-src",
         "hermes-agent": "hermes-agent",
         "home-manager": "home-manager",

--- a/flake.nix
+++ b/flake.nix
@@ -325,6 +325,34 @@
       flake = false;
     };
 
+    # Ghostty's terminal application, patched in-repo (packages/ghostty/patches,
+    # empty for now: index#3768 vendors the fork source and build; the
+    # surface-teardown fix -- killing the child process group on close_surface
+    # -- lands as a follow-up patch in this series). Distinct from the
+    # `ghostty` input above: that one pins a single rev unpatched, consumed
+    # only by `packages/tui/vt/libghostty-vt` for the VT-engine-only
+    # `-Demit-lib-vt` build. This input is the full application source that
+    # `packages/ghostty` builds against -- currently the same recipe, since
+    # the rest of ghostty's darwin core is not buildable in the sandbox (see
+    # `lib/build/libghostty-vt.nix`'s doc comment).
+    #
+    # Pinned BY REV (autoUpdate = false in lib/fork-packages.nix), same as
+    # `nix-src`/`clippy-src`: ghostty's own `build.zig` changed, somewhere
+    # after this rev, to unconditionally attempt a fat-archive combine for
+    # the VT static lib via hardcoded `/usr/bin/ranlib`/`/bin/cp` (absolute
+    # paths, so not PATH-shimmable), which the Nix darwin sandbox correctly
+    # denies. Confirmed by building this exact rev (succeeds) versus
+    # upstream main as of 2026-07-20 (fails at that step). ghostty is
+    # darwin-only and darwin has no CI (index-workstation-profile-no-ci-eval,
+    # zed-src-patch-lock-drift-darwin-only-guard document the same class of
+    # silent-drift risk for zed), so nothing catches a routine bump breaking
+    # this build; move this rev only with `nix run .#rebase-patches --
+    # ghostty` followed by a manual `nix build .#ghostty` on darwin.
+    ghostty-src = {
+      url = "github:ghostty-org/ghostty/fd49716ea2084108aa098db390931c007495a1ab";
+      flake = false;
+    };
+
     # Upstream mesa (gitlab.freedesktop.org), patched in-repo for the panes GPU
     # guest (packages/vm/panes/guest-image/mesa/patches): the venus driver-side
     # external-semaphore delta (index#1742). De-forking replacement for the old
@@ -377,6 +405,7 @@
     rnix-0-12-src,
     rnix-0-14-src,
     ghostty,
+    ghostty-src,
     mesa-src,
     skills,
     examples,
@@ -456,6 +485,7 @@
         rnix-0-12-src
         rnix-0-14-src
         ghostty
+        ghostty-src
         mesa-src
         ;
     };

--- a/lib/build/darwin-xcrun-shim.nix
+++ b/lib/build/darwin-xcrun-shim.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  writeNushellApplication,
+}:
+/**
+Shim `xcrun`/`xcode-select` to a pinned nixpkgs `apple-sdk` for zig builds on
+darwin.
+
+zig 0.15's darwin SDK probe (`std.zig.system.darwin.getSdk` /
+`isSdkInstalled`) shells out to `xcrun --show-sdk-path` and `xcode-select
+--print-path`, neither of which exists in the Nix build sandbox. Every
+zig-built ghostty artifact (`libghostty-vt`, the `ghostty` package) needs the
+same two-command shim pointed at the same pinned SDK, so it lives here once
+rather than copied per package.
+
+Returns `{ appleSdk, appleSdkRoot, darwinSdkInputs }`: `darwinSdkInputs` is
+the shim packages to add to `nativeBuildInputs` on darwin (empty list
+elsewhere), `appleSdk`/`appleSdkRoot` are the pinned SDK derivation and its
+`MacOSX.sdk` path for `SDKROOT`/`DEVELOPER_DIR` and `buildInputs`.
+*/
+pkgs: let
+  isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
+  appleSdk = pkgs.apple-sdk_14;
+  appleSdkRoot = "${appleSdk}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk";
+
+  # `--wrapped main [...args]` lets the shim swallow every flag zig passes
+  # (`xcrun --sdk macosx --show-sdk-path`, `xcode-select --print-path`) and
+  # just echo the pinned path. writeShellScriptBin is banned (no nu-check, no
+  # declared deps), so these go through the checked Nushell writer.
+  xcrunShim = writeNushellApplication pkgs {
+    name = "xcrun";
+    text = ''
+      # nu
+      def --wrapped main [...args] { print "${appleSdkRoot}" }
+    '';
+  };
+  xcodeSelectShim = writeNushellApplication pkgs {
+    name = "xcode-select";
+    text = ''
+      # nu
+      def --wrapped main [...args] { print "${appleSdk}" }
+    '';
+  };
+in {
+  inherit appleSdk appleSdkRoot;
+  darwinSdkInputs = lib.optionals isDarwin [xcrunShim xcodeSelectShim];
+}

--- a/lib/build/libghostty-vt.nix
+++ b/lib/build/libghostty-vt.nix
@@ -1,150 +1,217 @@
 {
   lib,
   writeNushellApplication,
-}:
-/**
-Build libghostty-vt: ghostty's terminal VT engine as a standalone C library.
-
-Ghostty's `build.zig` exposes a VT-only artifact through `-Demit-lib-vt=true`,
-which skips the GUI app, xcframework, and docs and emits just the parser,
-screen model, and render-state API. The result is a static `libghostty-vt.a`
-plus a self-contained `libghostty-vt.<ver>.dylib`/`.so`, the `ghostty/` C
-headers, and a pkg-config file.
-
-Arguments:
-- `pkgs`: package set to build against; the artifact is host-system specific.
-- `ghosttySource`: ghostty source tree (the `ghostty` flake input). Must ship
-  `build.zig`, `build.zig.zon`, and `build.zig.zon.nix` (the zon2nix output
-  that vendors every lazy Zig dependency with SRI hashes for a network-free
-  build).
-- `version`: derivation version. Defaults to the value in `build.zig.zon`.
-
-The static archive does not bundle its C++ dependencies (`libhighway`,
-`libsimdutf`, `libutfcpp`) and needs `-lc++`; the dylib is self-contained, so
-`ix-vt-sys` links the dylib to avoid that archive dance.
-*/
-pkgs: {
-  ghosttySource,
-  version ? "1.3.2-dev",
 }: let
-  inherit (pkgs) stdenv;
-
-  # zon2nix output checked into the ghostty tree. It materializes a link farm of
-  # `<zig-hash> -> source` for every dependency, populated into the Zig global
-  # cache `p/` directory below so `zig build` resolves deps offline.
-  deps = pkgs.callPackage (ghosttySource + "/build.zig.zon.nix") {
-    inherit (pkgs) zig_0_15;
-    name = "libghostty-vt-deps-${version}";
-  };
-
-  isDarwin = stdenv.hostPlatform.isDarwin;
-
-  # The apple-sdk that zig links against inside the sandbox. zig 0.15.2 finds
-  # the SDK by shelling out to `xcode-select` / `xcrun`, which do not exist in
-  # the Nix build sandbox, so the SDK detection is shimmed below to point at
-  # this pinned SDK rather than a host install.
-  appleSdk = pkgs.apple-sdk_14;
-  appleSdkRoot = "${appleSdk}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk";
-
-  # Shim zig's darwin SDK probe. ghostty's vendored C/C++ deps (`zlib`,
-  # `simdutf`, `highway`, `utfcpp`) call `apple_sdk.addPaths`, which runs
-  # `std.zig.system.darwin.getSdk` -> `xcrun --show-sdk-path` and
-  # `isSdkInstalled` -> `xcode-select --print-path`. Neither tool is in the
-  # sandbox, so without these shims the build crashes with `DarwinSdkNotFound`.
-  # Returning the pinned Nix SDK path keeps the build hermetic.
-  # `--wrapped main [...args]` lets the shim swallow every flag zig passes
-  # (`xcrun --sdk macosx --show-sdk-path`, `xcode-select --print-path`) and just
-  # echo the pinned path. writeShellScriptBin is banned (no nu-check, no declared
-  # deps), so these go through the checked Nushell writer.
-  xcrunShim = writeNushellApplication pkgs {
-    name = "xcrun";
-    text = ''
-      # nu
-      def --wrapped main [...args] { print "${appleSdkRoot}" }
-    '';
-  };
-  xcodeSelectShim = writeNushellApplication pkgs {
-    name = "xcode-select";
-    text = ''
-      # nu
-      def --wrapped main [...args] { print "${appleSdk}" }
-    '';
-  };
-
-  darwinSdkInputs = lib.optionals isDarwin [
-    xcrunShim
-    xcodeSelectShim
-  ];
+  darwinXcrunShimFor = import ./darwin-xcrun-shim.nix {inherit lib writeNushellApplication;};
 in
-  stdenv.mkDerivation {
-    pname = "libghostty-vt";
-    inherit version;
+  /**
+  Build libghostty-vt: ghostty's terminal VT engine as a standalone C library.
 
-    src = builtins.path {
-      name = "ghostty-source";
-      path = ghosttySource;
+  Ghostty's `build.zig` exposes a VT-only artifact through `-Demit-lib-vt=true`,
+  which skips the GUI app, xcframework, and docs and emits just the parser,
+  screen model, and render-state API. The result is a static `libghostty-vt.a`
+  plus a self-contained `libghostty-vt.<ver>.dylib`/`.so`, the `ghostty/` C
+  headers, and a pkg-config file.
+
+  This is also, as of index#3768, the ONLY subtree of ghostty's darwin build
+  that is buildable purely inside the Nix sandbox. Every other artifact --
+  `GhosttyLib` (the macOS app's Zig glue library), `GhosttyKit.xcframework`,
+  and the `.app` bundle -- reaches, unconditionally, for real Apple toolchain
+  binaries at hardcoded absolute paths ghostty's own `build.zig` never routes
+  through `PATH`:
+
+  - `SharedDeps.initTarget` unconditionally creates a `MetallibStep` for any
+    darwin target and every artifact built through `deps.add()` (the exe, the
+    test binary, `GhosttyLib`) depends on it; `MetallibStep` shells out to
+    `/usr/bin/xcrun -sdk macosx metal`, the proprietary Metal shader compiler,
+    with no nixpkgs package and no OSS equivalent. This does not depend on the
+    selected renderer (`-Drenderer=opengl` does not skip it) -- confirmed by
+    attempting a `-Demit-test-exe=true` build against this recipe's darwin SDK
+    shim, which reached `metallib Ghostty (Ghostty.ir)` and failed with
+    `PermissionDenied` on `/usr/bin/xcrun` (the sandbox correctly denies execing
+    an undeclared host binary).
+  - `GhosttyLibVt.initLib`'s SIMD-dependency fat-archive path (and
+    `GhosttyLib.initStatic`'s always-taken one) shell to `/bin/cp` and
+    `/usr/bin/ranlib` to combine archives, hit in that same attempt right after
+    the metallib failure.
+  - `GhosttyXCFramework`/the macOS app additionally need
+    `xcodebuild -create-xcframework` (`src/build/XCFrameworkStep.zig`).
+
+  `-Demit-lib-vt=true` avoids all three: `GhosttyLibVt.initStatic`/`initShared`
+  build directly off the `vt`/`vt_c` Zig modules, which never calls
+  `deps.add()` and has no SIMD dependencies to fat-archive. That is a real
+  structural boundary, not a flag we chose for convenience: the VT engine
+  (parser, screen model) is deliberately renderer- and app-independent.
+
+  Consequence: `packages/ghostty`, index#3768's vendored fork, builds and
+  validates this same VT-only subtree from the *patchable* fork source. It
+  does not reach the `Surface`/`apprt` process-lifecycle code the follow-up
+  teardown-fix patch touches -- getting there is real, separate follow-up work
+  (likely: patch `build.zig` to route its tool calls through `PATH` so a
+  future Nix recipe can substitute `xcrun`/`ranlib`, which unblocks the second
+  bullet above but not the first; the Metal compiler has no substitute short of
+  a real macOS builder outside the sandbox).
+
+  Arguments:
+  - `pkgs`: package set to build against; the artifact is host-system specific.
+  - `ghosttySource`: ghostty source tree (the `ghostty` flake input, or a
+    patched fork source). Must ship `build.zig`, `build.zig.zon`, and
+    `build.zig.zon.nix` (the zon2nix output that vendors every lazy Zig
+    dependency with SRI hashes for a network-free build).
+  - `baseSource`: optional. When set, zig's own `--cache-dir` (a
+    content-addressed cache keyed by each file's digest, its `Manifest`
+    system) is warmed once from this UNPATCHED base and copied into the real
+    build as a starting point, so a patch-series edit to `ghosttySource`
+    recompiles only what it touches instead of the whole tree -- the same
+    "small delta, small rebuild" property cargo-unit gets by splitting Cargo
+    builds per-crate, without needing a per-translation-unit Nix decomposition
+    zig's build graph has no boundary for. `warmCache` is keyed on `baseSource`
+    alone, so it survives every patch-series change and rebuilds only when the
+    upstream pin moves. Omit (the default) when `ghosttySource` never diverges
+    from `baseSource` -- the existing unpatched `packages/tui/vt/libghostty-vt`
+    consumer -- where warming a separate cache buys nothing.
+  - `version`: derivation version. Defaults to the value in `build.zig.zon`.
+
+  The static archive does not bundle its C++ dependencies (`libhighway`,
+  `libsimdutf`, `libutfcpp`) and needs `-lc++`; the dylib is self-contained, so
+  `ix-vt-sys` links the dylib to avoid that archive dance.
+  */
+  pkgs: {
+    ghosttySource,
+    baseSource ? ghosttySource,
+    version ? "1.3.2-dev",
+  }: let
+    inherit (pkgs) stdenv;
+
+    # zon2nix output checked into the ghostty tree. Keyed on `baseSource` (equal
+    # to `ghosttySource` when the caller omits it) so a patch-series edit never
+    # invalidates the dependency fetch, matching `warmCache` below.
+    deps = pkgs.callPackage (baseSource + "/build.zig.zon.nix") {
+      inherit (pkgs) zig_0_15;
+      name = "libghostty-vt-deps-${version}";
     };
 
-    strictDeps = true;
+    isDarwin = stdenv.hostPlatform.isDarwin;
 
-    nativeBuildInputs =
-      [
-        pkgs.zig_0_15
-        pkgs.pkg-config
-      ]
-      ++ darwinSdkInputs;
+    # zig 0.15's darwin SDK probe shells out to `xcrun`/`xcode-select` via
+    # `PATH` (unlike the hardcoded-absolute-path calls documented above), so
+    # this one is shimmable to the pinned nixpkgs apple-sdk.
+    inherit (darwinXcrunShimFor pkgs) appleSdk appleSdkRoot darwinSdkInputs;
 
-    # `zlib` is consumed through `-fsys=zlib` so ghostty's framegen tool links the
-    # nixpkgs zlib instead of building the vendored copy (which would re-trigger
-    # the apple-sdk probe). `apple-sdk` is a buildInput on darwin so the linker
-    # resolves the system frameworks the C++ deps pull in.
-    buildInputs =
-      [
-        pkgs.zlib
-      ]
-      ++ lib.optional isDarwin appleSdk;
+    commonNativeBuildInputs = [pkgs.zig_0_15 pkgs.pkg-config] ++ darwinSdkInputs;
+    commonBuildInputs = [pkgs.zlib] ++ lib.optional isDarwin appleSdk;
 
-    dontConfigure = true;
-    dontBuild = true;
-
-    installPhase = ''
-      # shell
-      runHook preInstall
-
+    seedGlobalCache = ''
       export ZIG_GLOBAL_CACHE_DIR="$TMPDIR/zig-cache"
       mkdir -p "$ZIG_GLOBAL_CACHE_DIR/p"
       cp -R --no-preserve=mode ${deps}/. "$ZIG_GLOBAL_CACHE_DIR/p/"
-
       ${lib.optionalString isDarwin ''
         export SDKROOT="${appleSdkRoot}"
         export DEVELOPER_DIR="${appleSdk}"
       ''}
-
-      buildCores=1
-      if [ "''${enableParallelBuilding-1}" ]; then
-        buildCores="$NIX_BUILD_CORES"
-      fi
-
-      zig build \
-        "-j$buildCores" \
-        --global-cache-dir "$ZIG_GLOBAL_CACHE_DIR" \
-        --cache-dir "$TMPDIR/zig-local-cache" \
-        -Demit-lib-vt=true \
-        -Dcpu=baseline \
-        -Doptimize=ReleaseFast \
-        -fsys=zlib --search-prefix ${pkgs.zlib} \
-        --prefix "$out" \
-        --summary all
-
-      runHook postInstall
     '';
 
-    doCheck = false;
+    zigInstallArgs = ''
+      -Demit-lib-vt=true \
+      -Dcpu=baseline \
+      -Doptimize=ReleaseFast \
+      -fsys=zlib --search-prefix ${pkgs.zlib}'';
 
-    meta = {
-      description = "Ghostty's terminal VT engine as a standalone C library (parser, screen, render state)";
-      homepage = "https://ghostty.org/";
-      license = lib.licenses.mit;
-      platforms = lib.platforms.unix;
-    };
-  }
+    warmCache =
+      if baseSource == ghosttySource
+      then null
+      else
+        stdenv.mkDerivation {
+          pname = "libghostty-vt-warm-cache";
+          inherit version;
+
+          src = builtins.path {
+            name = "ghostty-base-source";
+            path = baseSource;
+          };
+
+          strictDeps = true;
+          nativeBuildInputs = commonNativeBuildInputs;
+          buildInputs = commonBuildInputs;
+
+          dontConfigure = true;
+          dontBuild = true;
+
+          installPhase = ''
+            # shell
+            runHook preInstall
+
+            ${seedGlobalCache}
+            mkdir -p "$TMPDIR/zig-local-cache"
+
+            zig build \
+              --global-cache-dir "$ZIG_GLOBAL_CACHE_DIR" \
+              --cache-dir "$TMPDIR/zig-local-cache" \
+              ${zigInstallArgs} \
+              --prefix "$TMPDIR/warm-install" \
+              --summary all
+
+            cp -R "$TMPDIR/zig-local-cache" "$out"
+
+            runHook postInstall
+          '';
+
+          doCheck = false;
+
+          meta.description = "Warm zig incremental-compile cache for libghostty-vt, keyed on the unpatched base source";
+        };
+  in
+    stdenv.mkDerivation {
+      pname = "libghostty-vt";
+      inherit version;
+
+      src = builtins.path {
+        name = "ghostty-source";
+        path = ghosttySource;
+      };
+
+      strictDeps = true;
+      nativeBuildInputs = commonNativeBuildInputs;
+      buildInputs = commonBuildInputs;
+
+      dontConfigure = true;
+      dontBuild = true;
+
+      installPhase = ''
+        # shell
+        runHook preInstall
+
+        ${seedGlobalCache}
+        mkdir -p "$TMPDIR/zig-local-cache"
+        ${lib.optionalString (warmCache != null) ''
+          cp -R --no-preserve=mode ${warmCache}/. "$TMPDIR/zig-local-cache/"
+          chmod -R u+w "$TMPDIR/zig-local-cache"
+        ''}
+
+        buildCores=1
+        if [ "''${enableParallelBuilding-1}" ]; then
+          buildCores="$NIX_BUILD_CORES"
+        fi
+
+        zig build \
+          "-j$buildCores" \
+          --global-cache-dir "$ZIG_GLOBAL_CACHE_DIR" \
+          --cache-dir "$TMPDIR/zig-local-cache" \
+          ${zigInstallArgs} \
+          --prefix "$out" \
+          --summary all
+
+        runHook postInstall
+      '';
+
+      doCheck = false;
+
+      passthru = lib.optionalAttrs (warmCache != null) {inherit warmCache;};
+
+      meta = {
+        description = "Ghostty's terminal VT engine as a standalone C library (parser, screen, render state)";
+        homepage = "https://ghostty.org/";
+        license = lib.licenses.mit;
+        platforms = lib.platforms.unix;
+      };
+    }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -29,6 +29,7 @@
   rnix-0-12-src,
   rnix-0-14-src,
   ghostty,
+  ghostty-src,
   mesa-src,
   # The flake's own source (`self`), carrying `.outPath` (a `-source` store
   # path with string context, so it roots into a closure like `nixpkgs`) and
@@ -783,6 +784,7 @@
     launchkSrc = launchk-src;
     nixNinjaSrc = nix-ninja-src;
     snixSrc = snix-src;
+    ghosttySrc = ghostty-src;
     mesaSrc = mesa-src;
     # Pinned toolchain evaluation context for the prebuilt public-SDK rlib:
     # the exact nixpkgs + rust-overlay sources whose evaluation reproduces the

--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -291,6 +291,33 @@
       };
     }
     {
+      # Full ghostty application source (index#3768), distinct from the bare
+      # `ghostty` input `packages/tui/vt/libghostty-vt` consumes unpatched: this
+      # is the fork's actual patch point. No patches yet -- `packages/ghostty`
+      # builds the pinned base as-is; the surface-teardown fix (kill the child
+      # process group and waitpid-reap on close_surface) lands here as a
+      # follow-up patch.
+      name = "ghostty";
+      input = "ghostty-src";
+      url = "https://github.com/ghostty-org/ghostty.git";
+      patchDir = "packages/ghostty/patches";
+      # Pinned by rev (see flake.nix's ghostty-src comment): a routine bump
+      # can silently break the darwin-only build with no CI to catch it.
+      autoUpdate = false;
+      upstreamPolicy = {
+        prsWelcome = true;
+        # AI_POLICY.md: AI-assisted contributions are welcome with full
+        # disclosure and human review. CONTRIBUTING.md additionally runs a
+        # vouch system: any first-time contributor's PR is auto-closed until
+        # a maintainer comments `!vouch` on a "Vouch Request" discussion, so
+        # `upstream-sync` cannot open a PR here until that human step happens.
+        aiPrsAllowed = "true";
+        citation = "https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md";
+        notes = "AI-assisted PRs welcome with disclosure (AI_POLICY.md) but gated by CONTRIBUTING.md's vouch system: unvouched contributors are auto-closed, so a human must request and receive a maintainer's `!vouch` before upstream-sync can open a PR.";
+      };
+      patches = {};
+    }
+    {
       # clippy is nightly-toolchain-coupled: its input is pinned by rev and must
       # move only with the pinned nightly, so `rebase-patches` is run explicitly
       # alongside a toolchain bump, never under a blanket `nix flake update` or

--- a/packages/ghostty/default.nix
+++ b/packages/ghostty/default.nix
@@ -1,0 +1,48 @@
+# ghostty: the full terminal application source, vendored as a fork
+# (index#3768). Today this builds only the VT-engine subtree
+# (`-Demit-lib-vt=true`, via the shared `lib/build/libghostty-vt.nix`
+# recipe) from the *patchable* fork source, proving the fork/patch pipeline
+# end-to-end. It deliberately does not (yet) reach the rest of ghostty's
+# darwin core -- see the doc comment on `ix.buildLibghosttyVt` for exactly
+# which absolute-path Xcode-toolchain calls block that, unconditionally,
+# inside the Nix sandbox. Closing that gap (so the follow-up
+# surface-teardown patch's `Surface`/`apprt` code actually gets built and
+# tested here) is the concrete follow-up work index#3768 calls for.
+{
+  ix,
+  pkgs,
+  ...
+}: let
+  source = ix.patchedSrc {
+    name = "ghostty";
+    src = ix.ghosttySrc;
+    patchDir = ./patches;
+  };
+
+  package = ix.buildLibghosttyVt pkgs {
+    ghosttySource = source;
+    baseSource = ix.ghosttySrc;
+  };
+
+  # Confirm the build actually reached the artifacts the package claims
+  # rather than re-asserting the recipe.
+  layout = pkgs.runCommand "ghostty-layout" {strictDeps = true;} ''
+    test -f ${package}/lib/libghostty-vt.a
+    test -f ${package}/include/ghostty/vt.h
+
+    mkdir -p "$out"
+  '';
+in
+  package.overrideAttrs (old: {
+    pname = "ghostty";
+
+    passthru =
+      (old.passthru or {})
+      // {
+        tests =
+          (old.passthru.tests or {})
+          // {
+            inherit layout;
+          };
+      };
+  })

--- a/packages/ghostty/package.nix
+++ b/packages/ghostty/package.nix
@@ -1,0 +1,11 @@
+{
+  id = "ghostty";
+  packageSet = {
+    systems = ["aarch64-darwin"];
+  };
+  flake = {
+    systems = ["aarch64-darwin"];
+  };
+  overlay = false;
+  updateScript = true;
+}

--- a/packages/ghostty/patches/README.md
+++ b/packages/ghostty/patches/README.md
@@ -1,0 +1,6 @@
+# ghostty patches
+
+Empty for now (index#3768 vendors the fork source and darwin build only).
+The surface-teardown fix -- kill the child process group and `waitpid`-reap
+on `close_surface`, honoring `undo-timeout` -- lands here as a follow-up
+patch in this series, generated with `nix run .#rebase-patches -- ghostty`.


### PR DESCRIPTION
## Summary

Vendors ghostty as a de-forked package (`ghostty-src`, `lib/fork-packages.nix`, same shape as nushell) and builds it from the patchable fork source on darwin, closing (part of) index#3768.

## What's here

1. **Fork input + entry**: `ghostty-src` flake input, `lib/fork-packages.nix` entry mirroring nushell's (name/input/url/patchDir/citation/reason). `packages/ghostty/patches/` is empty for now -- the surface-teardown fix (kill the child process group, `waitpid`-reap on `close_surface`) lands there as a follow-up patch, per the issue's own scoping.

2. **The darwin build, and its real ceiling**: `packages/ghostty` builds the fork source through the existing `-Demit-lib-vt=true` recipe (`lib/build/libghostty-vt.nix`, which I refactored to share its darwin `xcrun`/`xcode-select` shim with the new package via `lib/build/darwin-xcrun-shim.nix`). I want to be plain about what I found rather than paper over it: **this is not just "GhosttyKit + CLI, .app assembly as follow-up."** I tried building further -- the shared core via `-Demit-test-exe=true` against this recipe's SDK shim -- and it compiles the bulk of ghostty's Zig source, then hits two separate hard blockers before ever reaching xcodebuild:
   - `SharedDeps.initTarget` unconditionally wires a `MetallibStep` into every darwin artifact built through `deps.add()` (the exe, the test binary, the macOS glue library). It shells to `/usr/bin/xcrun -sdk macosx metal` -- the proprietary Metal shader compiler, no nixpkgs package, no OSS equivalent, and *not* gated by the selected renderer (`-Drenderer=opengl` doesn't skip it).
   - Right after that: `GhosttyLibVt`'s SIMD-dependency fat-archive step shells to `/bin/cp` and `/usr/bin/ranlib`.

   Both are hardcoded absolute host paths in ghostty's own `build.zig` (not routed through `PATH`), so the Nix sandbox correctly denies them and there's no way to substitute around it the way the SDK shim substitutes `xcrun`'s SDK-path probe. `-Demit-lib-vt=true` is a real structural boundary, not a flag of convenience: the VT engine never calls `deps.add()` and has no SIMD deps to fat-archive. Consequence: **this package does not yet reach the `Surface`/`apprt` code the follow-up teardown-fix patch touches.** Getting there is real follow-up work -- likely patching `build.zig` to route its tool calls through `PATH` (fixes the ranlib/cp blocker, not the Metal one, which has no substitute short of a real macOS builder outside the sandbox).

3. **A live upstream regression, found and worked around**: `ghostty-src` is pinned by rev rather than tracking `main` (`autoUpdate = false`). Somewhere after the pinned commit, ghostty's `build.zig` changed to *unconditionally* attempt that same fat-archive combine for the VT-only static lib too -- I confirmed the pinned rev builds clean and current upstream `main` does not, hitting the identical `ranlib`/`cp` sandbox denial. ghostty is darwin-only and darwin has no CI, so nothing would catch a routine bump breaking this (same risk class documented for zed in `zed-src-patch-lock-drift-darwin-only-guard`).

4. **Incremental builds**: added an optional `baseSource` parameter to `buildLibghosttyVt`. When set, it warms zig's own `--cache-dir` (already a content-addressed cache, keyed by each file's digest) from the unpatched pinned base once, then seeds the patched build from that. Since the warm cache is keyed on the base source alone, it's a cache hit across the whole patch series and only rebuilds when the upstream pin moves -- so a future one-file patch recompiles only what it touches. This is the "small delta, small rebuild" property cargo-unit gets by splitting Cargo builds per-crate; zig's build graph has no per-translation-unit boundary for Nix to intercept the way rustc's does, so I reused zig's own cache instead of reimplementing that decomposition. Documented in `lib/build/libghostty-vt.nix`.

## Not in this PR (explicit follow-ups)

- The actual surface-teardown fix.
- Reaching the `Surface`/`apprt` code that fix touches at all (see the blockers above).
- Wiring the workstation profile off the `ghostty@tip` brew cask onto this package.

## Validation

- `nix build .#packages.aarch64-darwin.ghostty` -- succeeds, produces `libghostty-vt.a`/`.dylib` + headers.
- `nix build .#packages.aarch64-darwin.ghostty.passthru.tests.layout` -- succeeds.
- `nix build .#checks.aarch64-darwin.patched-src-ghostty` -- succeeds (fast conflict gate).
- `nix run .#lint` and `nix fmt` -- clean.

*(sent by an AI agent via Claude Code, model Claude Opus 4.5)*


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Vendor ghostty as a patchable fork and build its VT engine from source
> - Adds a new `ghostty` package (aarch64-darwin only) that fetches the ghostty source via a pinned fork input (`ghostty-src`), applies patches from [packages/ghostty/patches/](https://github.com/indexable-inc/index/pull/3771/files#diff-7c16a7b57ba9b24bf258615a87fbc19ff9caee2edacfa8c873d34a08afb43da8), and builds only the VT-engine subtree using `buildLibghosttyVt`.
> - Introduces a `darwin-xcrun-shim` helper in [lib/build/darwin-xcrun-shim.nix](https://github.com/indexable-inc/index/pull/3771/files#diff-55f3190f15e79693bf63bbcd9d60c11d86de2b048d43cc250211825eaa947680) that exposes Nushell-based `xcrun`/`xcode-select` shims pointing at a pinned `apple-sdk_14`, so Zig SDK probes resolve correctly inside the sandbox.
> - Extends `buildLibghosttyVt` in [lib/build/libghostty-vt.nix](https://github.com/indexable-inc/index/pull/3771/files#diff-b7fb92f2cb27bd4449e20e4354714f07661f87d536349f0905c1b76fec8cbd0a) with an optional `baseSource` parameter that pre-warms Zig's incremental cache from the upstream source before building the patched fork.
> - Auto-updates are disabled for the fork; the patches directory is currently empty, with a planned surface-teardown fix noted in [packages/ghostty/patches/README.md](https://github.com/indexable-inc/index/pull/3771/files#diff-053def01e0d79d8bfcb5aaf319a7a5bd0977992be98a86f90d40727fcc5f14f1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6928b5b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->