### PR TITLE
ghostty: disable undo-close retention until teardown patch lands

### DIFF
--- a/users/andrewgazelka/config/ghostty/config.ghostty
+++ b/users/andrewgazelka/config/ghostty/config.ghostty
@@ -41,6 +41,13 @@ background-opacity-cells = true
 
 confirm-close-surface = false
 
+# Interim mitigation for index#3768: tip's undo-close retention (upstream
+# ghostty#7535) fails to expire, so closed surfaces stay fully alive -
+# measured 69 live sessions vs 6 visible windows, some 21h old. 0 skips undo
+# registration so close tears the surface down immediately. Remove once the
+# vendored ghostty teardown patch lands.
+undo-timeout = 0
+
 # Track Ghostty nightlies. The declared Homebrew cask is `ghostty@tip`, so keep
 # the in-app Sparkle updater OFF but pinned to the matching `tip` channel so any
 # reload reports the right track. Updates come from the cask


### PR DESCRIPTION
Interim for #3768: tip ghostty fails to expire undo-close retention (5s configured, 21h observed, 69 live surfaces vs 6 visible windows), so every cmd-w leaks a full session stack (nu + Claude Code + BEAM kernel, ~570M each). `undo-timeout = 0` skips retention; close kills immediately. Applies on config reload, no switch needed. Revert when the vendored teardown patch from #3768 lands.

(PR by an AI agent via Claude Code, model Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable undo-close retention in Ghostty by setting `undo-timeout` to 0
> Sets `undo-timeout = 0` in [config.ghostty](https://github.com/indexable-inc/index/pull/3772/files#diff-042d64d0cd50f2ab4d74d24cf6a2f7a455facaefee5b4024e68c5f8b2cfd6964) so closing a surface tears it down immediately instead of being retained for undo-close. This is an interim workaround until an upstream teardown patch lands, at which point the setting should be removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b597d77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->