### PR TITLE
workstation: drop the verbose = true Claude override

### DIFF
--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -115,8 +115,6 @@
 
   claudeSettings = {
     autoMemoryDirectory = "~/.config/nix/claude/auto-memory";
-    # Full tool output in the transcript (house posture defaults verbose = false).
-    verbose = true;
     enabledPlugins = {
       "ix-docs@ix" = true;
       "ix@ix" = true;


### PR DESCRIPTION
The override never held: verbose is runtime-toggleable, so Claude Code
rewrites ~/.claude/settings.json in place and the live value drifted to
false. Take the house default (packages/agent/claude-code) instead.

Closes #3773


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `verbose = true` override from workstation Claude settings
> Drops the explicit `verbose = true` assignment from the `claudeSettings` block in [workstation.nix](https://github.com/indexable-inc/index/pull/3774/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962), leaving the option unset so the default value applies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba27902.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->