### PR TITLE
claude-code: byte-patch out the dev-channels confirmation gate

### DIFF
--- a/packages/agent/claude-code-debug/default.nix
+++ b/packages/agent/claude-code-debug/default.nix
@@ -15,10 +15,12 @@
   claude-code =
     repoPackages.claude-code
       or (throw "claude-code-debug: needs the claude-code sibling (flake package set only)");
-  # The unwrapped upstream binary (unmodified, still Anthropic-signed, so it runs
-  # as-is). Debugging the raw binary keeps the house system-prompt/MCP wrapper out
-  # of the picture while inspecting internals.
-  claudeBin = "${claude-code}/libexec/Claude Code";
+  # The stock upstream binary as Anthropic shipped it (autopatchelfed on Linux),
+  # exposed by claude-code as `passthru.stockCli`. Debugging the stock bytes
+  # keeps both the house wrapper AND the byte patches the wrapped binary now
+  # carries (the dev-channels gate swap) out of the picture while inspecting
+  # internals.
+  claudeBin = "${claude-code.stockCli}/bin/claude";
 in
   writeNushellApplication {
     name = "claude-debug";

--- a/packages/agent/claude-code-rainbow/default.nix
+++ b/packages/agent/claude-code-rainbow/default.nix
@@ -17,63 +17,32 @@
   lib,
   ix,
   stdenv,
-  fetchurl,
   runCommand,
   python3,
   autoPatchelfHook,
   darwin,
   makeBinaryWrapper,
+  repoPackages ? {},
 }: let
-  # Single source of truth for the pin: reuse the stock package's manifest so
-  # the rainbow build tracks the exact same version/hash Anthropic shipped.
-  manifest = lib.importJSON (ix.paths.packagesRoot + "/agent/claude-code/manifest.json");
-  inherit (manifest) version;
-  inherit (stdenv.hostPlatform) system;
-  target =
-    manifest.platforms.${system}
-      or (throw "claude-code-rainbow: no prebuilt binary for ${system}");
+  claude-code =
+    repoPackages.claude-code
+      or (throw "claude-code-rainbow: needs the claude-code sibling (flake package set only)");
+  inherit (claude-code) version;
 
-  # The raw Bun binary, fetched directly (same bytes as the stock package's
-  # `nativeBinary`). Depending on the fetch rather than the wrapped
-  # `claude-code` package keeps each mapping derivation tiny: its only input is
-  # the binary itself, nothing else in the wrapper closure.
-  nativeBinary = fetchurl {
-    urls = [
-      "https://downloads.claude.ai/claude-code-releases/${version}/${target.slug}/claude"
-      "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/${version}/${target.slug}/claude"
-    ];
-    inherit (target) hash;
-  };
+  # The single fetched upstream binary, shared with the stock package: one
+  # `fetchurl` derivation, one download, one store path (claude-code exposes it
+  # as `passthru.nativeBinary`). Depending on this FOD rather than the wrapped
+  # claude-code closure keeps each mapping derivation's input tiny -- just the
+  # binary, nothing else from the wrapper.
+  inherit (claude-code) nativeBinary;
 
-  # Shared equal-length byte patcher, owned by the canonical claude-code
-  # package (which now bakes its own gate patch through it); reached via the
-  # threaded packages root rather than a `../` climb.
-  patcher = ix.paths.packagesRoot + "/agent/claude-code/patch-binary.py";
-
-  # One cacheable derivation per mapping. `input` is a store path to a single
-  # binary file (the fetched binary, or the previous mapping's output); `$out`
-  # is likewise a single patched binary file. `dontStrip`/`dontFixup` because
-  # stripping rewrites the file length and corrupts the Bun trailer.
-  applyMapping = {
-    name,
-    rules,
-    input,
-  }:
-    runCommand "claude-code-rainbow-${name}"
-    {
-      nativeBuildInputs = [python3];
-      dontStrip = true;
-      dontFixup = true;
-      # The mapping rides the derivation env as JSON (the patcher's input
-      # format), so the rules stay typed Nix here instead of a committed
-      # serialized file.
-      mappingJson = builtins.toJSON rules;
-      passAsFile = ["mappingJson"];
-    }
-    ''
-      # shell
-      python3 ${patcher} ${input} "$mappingJsonPath" $out
-    '';
+  # Shared equal-length byte-patch layer primitive, owned by the canonical
+  # claude-code package (which bakes its own dev-channels gate patch through the
+  # same primitive); reached via the threaded packages root rather than a `../`
+  # climb. One cacheable layer per mapping, so the fold below is a DAG.
+  applyBytePatch =
+    import (ix.paths.packagesRoot + "/agent/claude-code/byte-patch.nix")
+    {inherit runCommand python3;};
 
   # The rainbow chain. Order is irrelevant to correctness (finds and replaces
   # are disjoint), but the fold makes the caching layers explicit:
@@ -139,7 +108,7 @@
   patched =
     lib.foldl'
     (input: m:
-      applyMapping {
+      applyBytePatch {
         inherit (m) name rules;
         inherit input;
       })
@@ -239,7 +208,7 @@ in
       # Stripped by `ix.allowVendoredUnfree` above; kept honest here.
       license = lib.licenses.unfree;
       mainProgram = "claude";
-      platforms = builtins.attrNames manifest.platforms;
+      inherit (claude-code.meta) platforms;
       sourceProvenance = [lib.sourceTypes.binaryNativeCode];
     };
   })

--- a/packages/agent/claude-code-rainbow/default.nix
+++ b/packages/agent/claude-code-rainbow/default.nix
@@ -45,7 +45,10 @@
     inherit (target) hash;
   };
 
-  patcher = ./patch-binary.py;
+  # Shared equal-length byte patcher, owned by the canonical claude-code
+  # package (which now bakes its own gate patch through it); reached via the
+  # threaded packages root rather than a `../` climb.
+  patcher = ix.paths.packagesRoot + "/agent/claude-code/patch-binary.py";
 
   # One cacheable derivation per mapping. `input` is a store path to a single
   # binary file (the fetched binary, or the previous mapping's output); `$out`

--- a/packages/agent/claude-code/byte-patch.nix
+++ b/packages/agent/claude-code/byte-patch.nix
@@ -1,0 +1,33 @@
+# One cacheable derivation per equal-length byte mapping applied to the Claude
+# Code Bun single-file binary. `input` is a single binary file (the fetched
+# download or a previous layer's output) and `$out` is the patched file, so a
+# fold of layers forms a DAG in which editing layer N+1 never rebuilds layer N.
+#
+# Layers stay raw (dontStrip/dontFixup): stripping rewrites the file length and
+# corrupts the trailer Bun appends to its single-file executables. Interpreter
+# patching (Linux) and ad-hoc re-signing (darwin -- the byte edit invalidates
+# the vendor's Developer-ID signature, and AMFI SIGKILLs an unsigned Mach-O)
+# happen ONCE at the consuming wrapper leaf, where the binary lands runnable.
+# See ./patch-binary.py for the equal-length + occurrence-count gates every rule
+# must pass.
+{
+  runCommand,
+  python3,
+}: {
+  name,
+  input,
+  rules,
+}:
+runCommand "claude-code-patch-${name}"
+{
+  nativeBuildInputs = [python3];
+  dontStrip = true;
+  dontFixup = true;
+  # The mapping rides the derivation env as JSON (the patcher's input format),
+  # so rules stay typed Nix at the call site instead of a serialized file.
+  mappingJson = builtins.toJSON rules;
+  passAsFile = ["mappingJson"];
+}
+''
+  python3 ${./patch-binary.py} ${input} "$mappingJsonPath" $out
+''

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -7,6 +7,7 @@
   makeBinaryWrapper,
   runCommand,
   autoPatchelfHook,
+  darwin,
   procps,
   ripgrep,
   git,
@@ -576,6 +577,75 @@
     inherit (target) hash;
   };
 
+  # The DevChannelsDialog gate. Because this wrapper bakes our own trusted
+  # `index` stdio server as a `--dangerously-load-development-channels` channel
+  # (see `developmentChannels`), every interactive launch otherwise stops on a
+  # full-screen "WARNING: Loading development channels" confirm before the
+  # session starts. Upstream already loads the channels either way (the dialog
+  # is only a confirmation UI): the onboarding flow renders it solely in the
+  # `else` of
+  #   if(!g()||En()!=="firstParty"||_(y("policySettings"))) <load silently>
+  #   else <show DevChannelsDialog, load on accept>
+  # so forcing that condition true always takes the silent-load branch. The
+  # swap is equal-length (`!g()` -> `true`, both 4 bytes): the only safe edit to
+  # a Bun single-file executable, since it leaves every downstream offset and
+  # the appended trailer byte-identical (see ./patch-binary.py). The `expect`
+  # count gate fails the build loudly if a version bump reminifies the
+  # surrounding identifiers so the anchor no longer lands exactly once; re-derive
+  # the find/replace against the new binary when that happens.
+  devChannelsGatePatch = [
+    {
+      find = ''if(!g()||En()!=="firstParty"||_(y("policySettings")))'';
+      replace = ''if(true||En()!=="firstParty"||_(y("policySettings")))'';
+      expect = 1;
+    }
+  ];
+
+  # The launched helper binary with the gate patch applied. Only the binary the
+  # wrapper actually execs is patched; `stockCli` above keeps the unmodified
+  # download so the system-prompt extractor still probes stock behavior. The
+  # byte edit invalidates Anthropic's Developer-ID signature, so on darwin
+  # `autoSignDarwinBinariesHook` re-signs the Mach-O ad-hoc (else AMFI SIGKILLs
+  # it); on Linux `autoPatchelfHook` fixes the interpreter as it does for the
+  # stock binary.
+  patchedBinary = stdenv.mkDerivation {
+    pname = "claude-code-patched-binary";
+    inherit version;
+    dontUnpack = true;
+    dontStrip = true;
+    strictDeps = true;
+    nativeBuildInputs =
+      [python3]
+      ++ lib.optional stdenv.hostPlatform.isElf autoPatchelfHook
+      ++ lib.optional stdenv.hostPlatform.isDarwin darwin.autoSignDarwinBinariesHook;
+    # The mapping rides the derivation env as JSON (the patcher's input format),
+    # so the rules stay typed Nix here instead of a committed serialized file.
+    mappingJson = builtins.toJSON devChannelsGatePatch;
+    passAsFile = ["mappingJson"];
+    installPhase = ''
+      # shell
+      runHook preInstall
+      mkdir -p $out/libexec
+      python3 ${./patch-binary.py} ${nativeBinary} "$mappingJsonPath" "$out/libexec/claude"
+      chmod +x "$out/libexec/claude"
+      runHook postInstall
+    '';
+    # Byte proof: the silent-load branch must now be forced (`if(true||` present)
+    # and the original gated condition (`if(!g()||`) gone. A grep needs no exec,
+    # so this runs in-sandbox on darwin too (the re-sign-then-exec AMFI caveat
+    # that blocks a runtime smoke does not apply to byte inspection).
+    doInstallCheck = true;
+    installCheckPhase = ''
+      # shell
+      runHook preInstallCheck
+      patched=$(grep -c 'if(true||En()' "$out/libexec/claude" || true)
+      gated=$(grep -c 'if(!g()||En()' "$out/libexec/claude" || true)
+      [ "$patched" -ge 1 ] || { echo "FAIL: gate-disabled bytes not present" >&2; exit 1; }
+      [ "$gated" -eq 0 ] || { echo "FAIL: original gate condition still present ($gated)" >&2; exit 1; }
+      runHook postInstallCheck
+    '';
+  };
+
   stockCli = stdenv.mkDerivation {
     pname = "claude-code-stock";
     inherit version;
@@ -641,7 +711,7 @@ in
       # example, iTerm2 or Terminal)", not the code signature or CFBundleName:
       # https://developer.1password.com/docs/cli/app-integration-security/
       helper="$out/libexec/Claude Code"
-      install -m755 ${nativeBinary} "$helper"
+      install -m755 "${patchedBinary}/libexec/claude" "$helper"
 
       # All flag/env/PATH injection lives in `launchSpec` (see its let-binding and
       # `wrapperFlags` for the per-flag rationale); bake the helper's real path

--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -577,6 +577,11 @@
     inherit (target) hash;
   };
 
+  # Shared equal-length byte-patch layer primitive (also used by
+  # claude-code-rainbow), so patches compose as a cacheable DAG over the single
+  # download. See ./byte-patch.nix.
+  applyBytePatch = import ./byte-patch.nix {inherit runCommand python3;};
+
   # The DevChannelsDialog gate. Because this wrapper bakes our own trusted
   # `index` stdio server as a `--dangerously-load-development-channels` channel
   # (see `developmentChannels`), every interactive launch otherwise stops on a
@@ -601,49 +606,17 @@
     }
   ];
 
-  # The launched helper binary with the gate patch applied. Only the binary the
-  # wrapper actually execs is patched; `stockCli` above keeps the unmodified
-  # download so the system-prompt extractor still probes stock behavior. The
-  # byte edit invalidates Anthropic's Developer-ID signature, so on darwin
-  # `autoSignDarwinBinariesHook` re-signs the Mach-O ad-hoc (else AMFI SIGKILLs
-  # it); on Linux `autoPatchelfHook` fixes the interpreter as it does for the
-  # stock binary.
-  patchedBinary = stdenv.mkDerivation {
-    pname = "claude-code-patched-binary";
-    inherit version;
-    dontUnpack = true;
-    dontStrip = true;
-    strictDeps = true;
-    nativeBuildInputs =
-      [python3]
-      ++ lib.optional stdenv.hostPlatform.isElf autoPatchelfHook
-      ++ lib.optional stdenv.hostPlatform.isDarwin darwin.autoSignDarwinBinariesHook;
-    # The mapping rides the derivation env as JSON (the patcher's input format),
-    # so the rules stay typed Nix here instead of a committed serialized file.
-    mappingJson = builtins.toJSON devChannelsGatePatch;
-    passAsFile = ["mappingJson"];
-    installPhase = ''
-      # shell
-      runHook preInstall
-      mkdir -p $out/libexec
-      python3 ${./patch-binary.py} ${nativeBinary} "$mappingJsonPath" "$out/libexec/claude"
-      chmod +x "$out/libexec/claude"
-      runHook postInstall
-    '';
-    # Byte proof: the silent-load branch must now be forced (`if(true||` present)
-    # and the original gated condition (`if(!g()||`) gone. A grep needs no exec,
-    # so this runs in-sandbox on darwin too (the re-sign-then-exec AMFI caveat
-    # that blocks a runtime smoke does not apply to byte inspection).
-    doInstallCheck = true;
-    installCheckPhase = ''
-      # shell
-      runHook preInstallCheck
-      patched=$(grep -c 'if(true||En()' "$out/libexec/claude" || true)
-      gated=$(grep -c 'if(!g()||En()' "$out/libexec/claude" || true)
-      [ "$patched" -ge 1 ] || { echo "FAIL: gate-disabled bytes not present" >&2; exit 1; }
-      [ "$gated" -eq 0 ] || { echo "FAIL: original gate condition still present ($gated)" >&2; exit 1; }
-      runHook postInstallCheck
-    '';
+  # The one-mapping byte-patch layer that disables the gate: fold it over the
+  # single download. Shared primitive with claude-code-rainbow (./byte-patch.nix)
+  # -- both express their patches as cacheable layers rooted at `nativeBinary`.
+  # The layer is raw bytes; the wrapper leaf below interpreter-patches (Linux)
+  # and ad-hoc re-signs (darwin) the result, since the byte edit invalidates
+  # Anthropic's Developer-ID signature. Only this launched helper is patched;
+  # `stockCli` above keeps the unmodified download for the prompt/env extractors.
+  patchedBinary = applyBytePatch {
+    name = "dev-channels-gate";
+    input = nativeBinary;
+    rules = devChannelsGatePatch;
   };
 
   stockCli = stdenv.mkDerivation {
@@ -694,7 +667,12 @@ in
       [
         makeBinaryWrapper
       ]
-      ++ lib.optional stdenv.hostPlatform.isElf autoPatchelfHook;
+      ++ lib.optional stdenv.hostPlatform.isElf autoPatchelfHook
+      # The helper carries the byte patch, so its vendor signature is invalid;
+      # re-sign ad-hoc on darwin (AMFI SIGKILLs an unsigned Mach-O). The argv
+      # install checks run against a stub and never exec this helper, so the
+      # darwin re-sign-then-exec-in-sandbox AMFI caveat does not bite here.
+      ++ lib.optional stdenv.hostPlatform.isDarwin darwin.autoSignDarwinBinariesHook;
 
     installPhase = ''
       # shell
@@ -711,7 +689,7 @@ in
       # example, iTerm2 or Terminal)", not the code signature or CFBundleName:
       # https://developer.1password.com/docs/cli/app-integration-security/
       helper="$out/libexec/Claude Code"
-      install -m755 "${patchedBinary}/libexec/claude" "$helper"
+      install -m755 ${patchedBinary} "$helper"
 
       # All flag/env/PATH injection lives in `launchSpec` (see its let-binding and
       # `wrapperFlags` for the per-flag rationale); bake the helper's real path
@@ -762,6 +740,32 @@ in
         # JSON file for non-HM consumers and the install checks.
         settings = settingsDefaults;
         settingsFile = settingsDefaultsFile;
+
+        # The single fetched upstream binary (a fixed-output derivation) and its
+        # runnable stock wrapping. Exposed so sibling packages that customize or
+        # inspect the same download -- claude-code-rainbow's byte patches,
+        # claude-code-debug's inspector -- reuse ONE download derivation instead
+        # of re-declaring `fetchurl`. `nativeBinary` is the raw bytes;
+        # `stockCli` is the same bytes, unpatched and unwrapped (autopatchelfed
+        # on Linux), i.e. genuinely stock behavior.
+        inherit nativeBinary stockCli;
+
+        # Byte proof that the dev-channels gate is disabled in the SHIPPED helper
+        # (post-sign, post-fixup): the silent-load branch is forced
+        # (`if(true||En()` present) and the original gated condition
+        # (`if(!g()||En()`) is gone. Grep needs no exec, so it runs on darwin too
+        # (the AMFI re-sign-then-exec caveat that blocks a runtime smoke does not
+        # apply to byte inspection). The patcher's `expect` gate already fails the
+        # build if the swap does not land exactly once; this additionally proves
+        # signing did not disturb the JS region.
+        tests.dev-channels-gate-disabled = pkgs.runCommand "claude-code-dev-channels-gate-disabled" {} ''
+          helper="${finalAttrs.finalPackage}/libexec/Claude Code"
+          patched=$(grep -c 'if(true||En()' "$helper" || true)
+          gated=$(grep -c 'if(!g()||En()' "$helper" || true)
+          [ "$patched" -ge 1 ] || { echo "FAIL: gate-disabled bytes absent" >&2; exit 1; }
+          [ "$gated" -eq 0 ] || { echo "FAIL: original gate condition present ($gated)" >&2; exit 1; }
+          touch "$out"
+        '';
 
         # Machine-readable knob tables for the commented knob reference at
         # the Home Manager consumption site

--- a/packages/agent/claude-code/patch-binary.py
+++ b/packages/agent/claude-code/patch-binary.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 """Equal-length, count-gated byte patcher for the Claude Code Bun binary.
 
-The load-bearing idea behind the whole "rainbow" chain lives here:
+Used to bake small, verifiable edits into the prebuilt binary without
+recompiling Bun: the claude-code package disables the development-channels
+confirmation gate this way, and claude-code-rainbow recolors the theme. The
+load-bearing idea behind every such swap lives here:
 
   * Claude Code ships as a prebuilt Bun single-file executable: a Mach-O/ELF
     with the minified app JS embedded as text inside it, plus a trailer Bun


### PR DESCRIPTION
## What

Byte-patches out the full-screen `WARNING: Loading development channels` confirmation gate that Claude Code shows on every interactive launch.

We bake our own trusted `index` stdio server as a `--dangerously-load-development-channels server:index` channel (see `developmentChannels` in `claude-code/default.nix`), so the gate fires on every start:

```
WARNING: Loading development channels
  --dangerously-load-development-channels is for local channel development only...
  Channels: server:index
  > 1. I am using this for local development
    2. Exit
```

## Why this is safe

Upstream loads the channels either way; the dialog is only a confirmation UI. The onboarding flow renders it solely in the `else` of a single gate condition:

```js
if(!g()||En()!=="firstParty"||_(y("policySettings")))  // load channels silently
  ...load...
else                                                    // show DevChannelsDialog
  ...show dialog, load on accept...
```

Forcing the condition true always takes the silent-load branch. The swap is equal-length (`!g()` -> `true`, both 4 bytes), the only safe edit to a Bun single-file executable: it leaves every downstream offset and the appended trailer byte-identical.

## How

- Moved the equal-length, count-gated `patch-binary.py` from the `claude-code-rainbow` POC to the canonical `claude-code` package (one implementation; rainbow now references it through `ix.paths.packagesRoot`).
- Added a `patchedBinary` derivation that applies the gate swap. Only the launched helper binary is patched; `stockCli` stays unmodified so the system-prompt extractor keeps probing stock behavior. darwin re-signs the Mach-O ad-hoc (`autoSignDarwinBinariesHook`); Linux fixes the interpreter with `autoPatchelfHook`.
- A byte proof gates the build, and `expect = 1` fails loudly if a version bump reminifies the anchor. When that happens, re-derive the find/replace against the new binary.

## Verification

- `nix build .#claude-code` green on darwin, including the patched-binary byte proof and the existing argv/hook install checks.
- Shipped helper: `if(true||En()` present (1), `if(!g()||En()` gone (0); `codesign -v` OK; `claude --version` runs (2.1.215).
- `nix eval .#claude-code-rainbow` green after the patcher relocation.
- Repo lint: my three files pass every check. One pre-existing `deadnix` warning in `lib/build/zig-warm-cache.nix` (`{lib}:` unused, from unrelated commit f4cff2c3) is not in this diff.

The interactive gate repro was not reproduced headlessly (it needs authenticated onboarding state); the fix is a direct control-flow guarantee (the `DevChannelsDialog` else-branch is unreachable) plus the byte proof.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Byte-patch the claude-code dev-channels confirmation gate at build time
> - Adds [byte-patch.nix](https://github.com/indexable-inc/index/pull/3780/files#diff-a550b2aa96ab47fdf7bcfd3289e21ead3046e461d8775abde629525c5830a3a4), a reusable Nix primitive that applies equal-length byte substitutions to a binary via [patch-binary.py](https://github.com/indexable-inc/index/pull/3780/files#diff-621d8fa2731629625fab9584713089d4b041561e6e1ae0b12a1961f350b4e415) (moved from `claude-code-rainbow`).
> - Introduces a `devChannelsGatePatch` ruleset in [claude-code/default.nix](https://github.com/indexable-inc/index/pull/3780/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) that rewrites the condition `if(!g()||En()...` to `if(true||En()...`, bypassing the dev-channels confirmation dialog.
> - Exposes `nativeBinary` and `stockCli` as `passthru` outputs so sibling packages (`rainbow`, `debug`) can consume the original upstream binary directly.
> - On Darwin, adds `darwin.autoSignDarwinBinariesHook` so the patched binary is re-signed after the vendor signature is invalidated.
> - A build-time test derivation greps the installed binary to assert the patch is present and the original condition is absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6d9d2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
---

## Update: one download, one patch DAG across the claude packages

The claude package family now shares a single download derivation and a single patch mechanism, so the graph is a clean DAG rooted at one fetch:

```
claude.drv  (one fetchurl download)
├─ claude-code-stock ─────────────────────► claude-debug, envRegistry, extractStockSystemPrompt
├─ claude-code-patch-dev-channels-gate ────► claude-code          (leaf: autopatchelf + darwin re-sign)
└─ claude-code-patch-banner ─► …-patch-colors ─► claude-code-rainbow  (leaf: same)
```

- `claude-code` exposes `passthru.nativeBinary` (the single `fetchurl` FOD) and `stockCli`. `claude-code-rainbow` and `claude-code-debug` consume those instead of re-declaring `fetchurl`. Verified `claude-code.nativeBinary.drvPath == claude-code-rainbow.nativeBinary.drvPath` (`/nix/store/hb157…-claude.drv`).
- Factored the equal-length byte-patch layer into `byte-patch.nix`, used by both `claude-code` (the gate patch) and rainbow (banner/colors). Layers stay raw; interpreter-patching (Linux) and ad-hoc re-signing (darwin) happen once at each wrapper leaf.
- `claude-code-debug` now inspects `stockCli` (genuinely stock bytes), not the patched helper.
- The gate byte proof moved to `passthru.tests.dev-channels-gate-disabled` (its own DAG node), proving the swap survives signing in the shipped helper.

Verified: `nix build .#claude-code .#claude-code.tests.dev-channels-gate-disabled .#claude-code-rainbow .#claude-code-debug` all green on darwin; `claude --version` runs and `codesign -v` passes on the patched helper.
