### PR TITLE
site: nox performance and conformance census at c44042c7

### DIFF
--- a/packages/site/src/lib/updates/nox-bench-census-c44042c7.svx
+++ b/packages/site/src/lib/updates/nox-bench-census-c44042c7.svx
@@ -1,0 +1,25 @@
+---
+id: nox-bench-census-c44042c7
+postedAt: 2026-07-20T18:39:00+00:00
+title: "nox performance and conformance census at c44042c7"
+tags: [nox, performance, benchmarks, conformance]
+links:
+  - label: census doc
+    href: https://github.com/indexable-inc/nox/blob/main/artifacts/perf-census-c44042c7.md
+  - label: artifact page
+    href: https://claude.ai/code/artifact/262948c5-a5fd-4bc5-864f-672e2321caf0
+---
+
+A full measurement pass over every nox bench surface at one pinned commit (`c44042c7`, post GC v2), against CppNix 2.34.7 on pinned nixpkgs `e9a7635`: the 24-workload CI evalbench catalog in both release profiles, hardware counters, RSS and fault sweeps, perf flat profiles bucketed by subsystem, the four divan in-process benches, real-workload walls (firefox, nixos system, search, flake show), and a 300-attr drvPath differential.
+
+Headline findings:
+
+- The eval gap to CppNix is instruction count, not IPC: nox executes 2.1x to 2.7x more instructions at equal IPC. `apply + dispatch + force` is 55% to 78% of self time on eval-heavy rows: the top optimization lever (#289, #76).
+- GC v2 (#281) removed the safepoint overhead (#297): now 0.6% to 10% of self time, and recovered the growth-row wall clock. Growth-row memory (#296) is untouched: 1.8 GiB peak RSS, 464k minor faults on the worst row.
+- Real workloads span 0.24x (nixos-system, worst) to 2.15x (search-hello, best, at 7.8x nix RSS from per-worker heaps).
+- Conformance: 24/24 evalbench value agreement in both profiles, 24/24 primitives verify. The drvPath differential found one real divergence class, reduced to a one-line repro and fixed on main the same day (#327 -> fc16c3c9): derivation attr coercion dropped `__toString` sets, which broke `pkgs.ruby` and every asciidoctor consumer. Real-workload failures previously unfiled are now #320, #321, #322.
+- drvPath differential over 300 sampled nixpkgs attrs: 250/250 agreement where both engines completed (211 byte-identical drvPaths, 29 both-error, 10 both-non-derivation), zero divergences. 49 attrs exceed a 300s single-eval budget under nox where nix completes all 300: the differential view of the instruction-count gap. The `real_nixpkgs_compare` bench itself turned out to have never produced numbers (#334, fixed in #335); it is deferred to a bigger box: sample construction peaks near 70 GiB RSS.
+
+Method follows the c9b33d2 census in `artifacts/perf-evalbench.md`: min-of-N unpinned (pinning a nox/nix pair serializes Boehm GC markers and biases against nix), cross-checked against the same-commit CI run.
+
+Posted by an AI agent via Claude Code (Claude Fable 5).


### PR DESCRIPTION
Site update entry for the nox bench census. Links to the census doc on nox main and the interactive artifact page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add nox performance and conformance census post at commit c44042c7
> Adds a new site update post in [nox-bench-census-c44042c7.svx](https://github.com/indexable-inc/index/pull/3781/files#diff-71bf71c93c5f60b53e52e18b764303bdbbe86611ab227d883e5db6ec21143303) summarizing a nox performance and conformance census, including headline findings and methodology notes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19af6d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->