### PR TITLE
mcp-ex: speak the claude/channel contract so kernel wakes reach Claude Code

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/agents/events.ex
+++ b/packages/mcp-ex/lib/ix_mcp/agents/events.ex
@@ -163,29 +163,20 @@ defmodule IxMcp.Agents.Events do
         {:error, reason} -> {"error", inspect_text(reason)}
       end
 
-    Notifier.notify("notifications/message", %{
-      "level" => if(status == "done", do: "info", else: "error"),
-      "logger" => "ix_mcp.agents",
-      "data" => %{
-        "event" => "agent_finished",
-        "agent" => id,
-        "status" => status,
-        "backend" => meta && Atom.to_string(meta.backend),
-        "result" => String.slice(text, 0, @notify_result_cap)
-      }
-    })
+    attrs = %{"source" => "agents", "event" => "agent_finished", "agent" => id, "status" => status}
+    attrs = if meta, do: Map.put(attrs, "backend", Atom.to_string(meta.backend)), else: attrs
+
+    Notifier.channel(
+      "agent #{id} finished: #{status}\n#{String.slice(text, 0, @notify_result_cap)}",
+      attrs
+    )
   end
 
   defp notify_message(state, msg) do
-    Notifier.notify("notifications/message", %{
-      "level" => "info",
-      "logger" => "ix_mcp.agents",
-      "data" => %{
-        "event" => "agent_message",
-        "agent" => msg.from,
-        "text" => String.slice(msg.text, 0, @notify_result_cap)
-      }
-    })
+    Notifier.channel(
+      String.slice(msg.text, 0, @notify_result_cap),
+      %{"source" => "agents", "event" => "agent_message", "agent" => msg.from}
+    )
 
     state
   end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/notifier.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/notifier.ex
@@ -1,9 +1,11 @@
 defmodule IxMcp.MCP.Notifier do
   @moduledoc """
-  Fan-out point for server-initiated MCP notifications (the "channel"): job
-  completions and failures are pushed to every connected transport, carrying
-  the full crash reason -- on the BEAM the exit reason is already a crash
-  report with state, so nothing has to be reconstructed after the fact.
+  Fan-out point for server-initiated MCP notifications. Session wakes ride
+  the Claude Code channel contract: `notifications/claude/channel` events,
+  paired with the experimental `claude/channel` capability the server
+  declares at initialize. Claude Code receives `notifications/message` (MCP
+  logging) but never surfaces it, so nothing user-facing may depend on that
+  method (#3785).
 
   Transports register themselves; when none is connected (tests, IEx),
   notifying is a no-op rather than an error.
@@ -21,20 +23,25 @@ defmodule IxMcp.MCP.Notifier do
     GenServer.cast(__MODULE__, {:register, transport})
   end
 
+  @doc """
+  Push one event into the connected Claude session. `content` becomes the
+  body of the `<channel>` tag the client injects; each `meta` entry becomes
+  a tag attribute, so values must be short scalars.
+  """
+  @spec channel(String.t(), %{optional(String.t()) => String.t() | number()}) :: :ok
+  def channel(content, meta) do
+    notify("notifications/claude/channel", %{"content" => content, "meta" => meta})
+  end
+
   @spec job_finished(IxMcp.Jobs.Job.summary()) :: :ok
   def job_finished(summary) do
-    notify("notifications/message", %{
-      "level" => level_for(summary.status),
-      "logger" => "ix_mcp.jobs",
-      "data" => %{
-        "event" => "job_finished",
-        "job" => summary.id,
-        "status" => Atom.to_string(summary.status),
-        "intent" => summary.intent,
-        "elapsed_s" => summary.elapsed_s,
-        "result" => summary.result
-      }
-    })
+    status = Atom.to_string(summary.status)
+
+    channel(
+      "job #{summary.id} (#{summary.intent || "no intent"}) finished: #{status} " <>
+        "in #{summary.elapsed_s}s\n#{String.slice(summary.result || "", 0, 2_000)}",
+      %{"source" => "jobs", "job" => summary.id, "status" => status}
+    )
   end
 
   @spec notify(String.t(), map()) :: :ok
@@ -65,6 +72,4 @@ defmodule IxMcp.MCP.Notifier do
     {:noreply, %{state | transports: List.delete(state.transports, pid)}}
   end
 
-  defp level_for(:done), do: "info"
-  defp level_for(_), do: "error"
 end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/server.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/server.ex
@@ -18,7 +18,15 @@ defmodule IxMcp.MCP.Server do
       {"initialize", id} when id != nil ->
         result(id, %{
           "protocolVersion" => negotiate_version(params),
-          "capabilities" => %{"tools" => %{"listChanged" => false}, "logging" => %{}},
+          # The experimental "claude/channel" key is what makes this server a
+          # channel: Claude Code registers a push listener only when it sees it
+          # at initialize, and otherwise drops every notifications/claude/channel
+          # event (https://code.claude.com/docs/en/channels-reference, #3785).
+          "capabilities" => %{
+            "tools" => %{"listChanged" => false},
+            "logging" => %{},
+            "experimental" => %{"claude/channel" => %{}}
+          },
           "serverInfo" => %{"name" => "ix-mcp-ex", "version" => version()},
           "instructions" => instructions()
         })

--- a/packages/mcp-ex/lib/ix_mcp/pr_watch.ex
+++ b/packages/mcp-ex/lib/ix_mcp/pr_watch.ex
@@ -101,11 +101,10 @@ defmodule IxMcp.PrWatch do
   end
 
   defp notify(pr, state, detail) do
-    Notifier.notify("notifications/message", %{
-      "level" => level(state),
-      "logger" => "ix_mcp.pr_watch",
-      "data" => %{"event" => "pr_watch", "pr" => pr, "state" => state, "detail" => detail}
-    })
+    Notifier.channel(
+      "PR ##{pr} #{state}: #{detail}",
+      %{"source" => "pr_watch", "pr" => pr, "state" => state, "level" => level(state)}
+    )
   end
 
   # "error" rode as "warning" before #3553; a watch that will never report

--- a/packages/mcp-ex/test/ix_mcp/pr_watch_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/pr_watch_test.exs
@@ -26,9 +26,11 @@ defmodule IxMcp.PrWatchTest do
 
     assert {:ok, _} = PrWatch.start("1", File.cwd!())
 
-    assert_receive {:mcp_send, %{"method" => "notifications/message", "params" => params}}, 5_000
-    assert %{"level" => "error", "logger" => "ix_mcp.pr_watch", "data" => data} = params
-    assert %{"event" => "pr_watch", "pr" => "1", "state" => "error"} = data
-    assert data["detail"] =~ "enoent"
+    assert_receive {:mcp_send, %{"method" => "notifications/claude/channel", "params" => params}},
+                   5_000
+
+    assert %{"content" => content, "meta" => meta} = params
+    assert %{"source" => "pr_watch", "pr" => "1", "state" => "error", "level" => "error"} = meta
+    assert content =~ "enoent"
   end
 end

--- a/packages/site/src/lib/updates/kernel-channel-notifications.svx
+++ b/packages/site/src/lib/updates/kernel-channel-notifications.svx
@@ -1,0 +1,19 @@
+---
+id: kernel-channel-notifications
+postedAt: 2026-07-20T12:45:00-07:00
+title: "Kernel wakes reach Claude Code again: mcp-ex speaks the claude/channel contract"
+tags: [mcp, elixir, claude-code]
+links:
+  - label: issue 3785
+    href: https://github.com/indexable-inc/index/issues/3785
+  - label: Notifier
+    href: https://github.com/indexable-inc/index/blob/main/packages/mcp-ex/lib/ix_mcp/mcp/notifier.ex
+  - label: channels reference
+    href: https://code.claude.com/docs/en/channels-reference
+---
+
+Since the Elixir cutover, every server-initiated kernel notification (finished background jobs, `PrWatch` outcomes, subagent events) was sent as an MCP logging notification, `notifications/message`. Claude Code receives that method and drops it, so no wake has reached a session since the cutover, even though every session already runs with the channel flag armed. The retired Python kernel spoke the channels research-preview contract; the rewrite kept the Notifier but not the wire format.
+
+`mcp-ex` now declares the experimental `claude/channel` capability at initialize and pushes `notifications/claude/channel` events with a `content` body plus `meta` attributes (`source`, `job`/`pr`/`agent`, `status`). Claude Code injects each event into the running session, so a `Jobs` completion, a PR merge, or a subagent report wakes the agent instead of vanishing.
+
+`Notifier.channel(content, meta)` is the one delivery primitive; `notify/2` stays as the raw JSON-RPC escape hatch. The capability declaration and the wire frame are verified against the patched server over raw JSON-RPC (a budget-expired job emits the channel frame); end-to-end injection into a Claude Code 2.1.215 session lands with the next kernel deploy and is verified there.


### PR DESCRIPTION
Fixes #3785.

Claude Code receives MCP logging notifications (notifications/message) and drops them, so every job_finished, PrWatch, and agent event since the Elixir cutover died on the client. This declares the experimental claude/channel capability at initialize and pushes notifications/claude/channel {content, meta} events, the contract the retired Python kernel spoke (https://code.claude.com/docs/en/channels-reference).

- Notifier.channel/2 is the one delivery primitive; job_finished, PrWatch, and agents/events ride it; notifications/message has no remaining producers; level_for/1 folded into meta.
- server.ex initialize declares experimental.claude/channel (verified via mix run: capability present in the result).
- Verified over raw JSON-RPC against the patched server: initialize -> tools/call exec with budget 1 and a 2.5s cell -> job backgrounds -> notifications/claude/channel frame with content + meta lands on stdout.
- mix test: 77 of 77 pass; credo --strict on the four touched files: no issues; formatted.
- Site update: kernel-channel-notifications.svx. End-to-end injection into a live session needs the next kernel deploy; not yet verified.

(sent by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch MCP notifications to use the `claude/channel` protocol so kernel events reach Claude Code
> - Replaces all `notifications/message` (level/logger/data) calls with `Notifier.channel/2`, which emits `notifications/claude/channel` events carrying a `content` string and a `meta` map.
> - Affected sites: agent finish events ([events.ex](https://github.com/indexable-inc/index/pull/3786/files#diff-ae71be1da04baab1334650e93ffe50c30cae6bd989cfe5a7353b180692e153ed)), job completion ([notifier.ex](https://github.com/indexable-inc/index/pull/3786/files#diff-961ca2855fc0d242eaaeaee07dc4c3e608f607700a0ecccef512a2eb3b938d23)), and PR watch notifications ([pr_watch.ex](https://github.com/indexable-inc/index/pull/3786/files#diff-ad798641f06abf92e9dd72e23bb9510393ae565337fb6b70db725bd7815f60eb)).
> - The server's `initialize` response now declares `experimental: {"claude/channel": {}}` so Claude Code recognises the capability.
> - Removes the `level_for/1` private helper in `Notifier` as log-level fields are no longer part of the payload.
> - Behavioral Change: all downstream consumers expecting `notifications/message` events will no longer receive them; they must handle `notifications/claude/channel` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5481edf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->