### PR TITLE
agent: open response HTML as a cmux browser split; add cmux cask

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -455,9 +455,11 @@
       topics = ["writing" "comms"];
       text = ''
         Respond as HTML, not chat text: write each response to one HTML
-        file per session, open it on the first write, and keep rewriting
-        that same file so it always shows the current state of the
-        response.
+        file per session and keep rewriting that same file so it always
+        shows the current state of the response. On the first write open
+        it as a cmux browser split (`cmux browser open-split
+        "file://<path>"`); fall back to plain `open` when there is no
+        cmux socket.
       '';
       reason = ''
         Requested 2026-07-19: the user reads responses as a live HTML page

--- a/users/andrewgazelka/darwin.nix
+++ b/users/andrewgazelka/darwin.nix
@@ -44,6 +44,9 @@ in {
       # broken-IPv4 network (e.g. hotel wifi with dead DHCPv4) can still reach
       # IPv4-only hosts like github and Apple's APNs. Needs UDP egress to work.
       "cloudflare-warp"
+      # Ghostty-based terminal with programmable browser panes (cmux.com);
+      # the agent rules open response HTML as a cmux browser split.
+      "cmux"
       "codex-app"
       "contexts"
       "cursor"


### PR DESCRIPTION
Fixes #3791. Adds the cmux cask to the declarative Homebrew set and changes the respond-as-HTML rule to open the session page as a cmux browser split (cmux browser open-split), plain open as fallback without a cmux socket. nix fmt run on both files.

(sent by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open agent HTML responses as a cmux browser split with fallback to `open`
> - Updates the agent prompt rules in [rules.nix](https://github.com/indexable-inc/index/pull/3792/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to instruct the agent to open the first HTML output via `cmux browser open-split "file://<path>"` instead of a generic `open` call, with a fallback to plain `open` when no cmux socket is available.
> - Adds `cmux` (a Ghostty-based terminal with programmable browser panes) to the darwin system config in [darwin.nix](https://github.com/indexable-inc/index/pull/3792/files#diff-8e50939d75ca47b003564ea6eb7afcd3cd3ab9bfa6b8876d3c079c94862fb7bc) so the package is available for the agent to use.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a502207.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->