### PR TITLE
ci: disable the hourly flake.lock self-bump for index

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -46,8 +46,15 @@ on:
       slack-bot-token:
         description: "Slack bot token (chat:write) for escalation posts; empty escalates through the tracking issue only."
         required: false
-  schedule:
-    - cron: "17 * * * *"
+  # Scheduled self-bumps are DISABLED for index (operator decision,
+  # 2026-07-20): an unattended nixpkgs/input bump invalidates huge build
+  # closures (fork patch DAGs, the znver5 base, every dependent check) and,
+  # done often, drifts CI ahead of the nix-controlled workstation and fleet
+  # pins, so local funs/builds fall out of sync with what main expects.
+  # Bump deliberately via workflow_dispatch instead; may be re-enabled once
+  # the rebuild cost and pin-sync story are solved.
+  # schedule:
+  #   - cron: "17 * * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
Operator decision (2026-07-20): stop the hourly flake.lock self-bump on index. An unattended input bump invalidates huge closures and drifts CI ahead of the nix-controlled workstation/fleet pins; today's main breakage stack included three stale fork dag.json failures from exactly this. `workflow_dispatch` stays for deliberate bumps and the reusable `workflow_call` surface (used by ix) is unchanged. May be re-enabled later.

(sent by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable the hourly cron schedule for the `update-flake-lock` workflow
> Comments out the `schedule` trigger in [update-flake-lock.yml](.github/workflows/update-flake-lock.yml) so the workflow no longer runs automatically. It can still be triggered manually via `workflow_dispatch` or called by other workflows via `workflow_call`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ae6f17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->