### PR TITLE
ix-term: tailnet web terminal on server-side libghostty-vt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5701,6 +5701,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ix-term-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "futures",
+ "ix-vt",
+ "libc",
+ "pty-process",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tower-http 0.7.0",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "ix-vt"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
   "packages/indexbench",
   "packages/indexbench/filesystem",
   "packages/ix-dev-diagnose",
+  "packages/ix-term/server",
   "packages/ix-windows",
   "packages/ixterm",
   "packages/mcp/server-info",

--- a/lib/rust/workspace.nix
+++ b/lib/rust/workspace.nix
@@ -317,6 +317,9 @@
           # ix-vt's tests dlopen the libghostty-vt dylib at runtime; make its lib
           # dir available so the loader resolves `@rpath`/`-l ghostty-vt`.
           ix-vt = [libghosttyVt];
+          # ix-term-server's test binaries link the same dylib (its VT engine
+          # is ix-vt), so the loader needs the lib dir at test runtime too.
+          ix-term-server = [libghosttyVt];
           # clone-cli's diff-gate integration tests build temp git repos and run
           # `git` (directly and via the `clone` binary's diff gate). The test
           # sandbox has no git otherwise, so the tests panic spawning it.

--- a/modules/services/ix-term/default.nix
+++ b/modules/services/ix-term/default.nix
@@ -1,0 +1,117 @@
+# ix-term: tailnet-internal web terminal (index#3797).
+#
+# Runs the ix-term server as a long-lived systemd service: server-side
+# libghostty-vt terminal state per session, PTY login shells spawned as
+# {option}`user`, and the browser UI served from the packaged Svelte site.
+# The `ixterm` CLI in a session resolves its pts through
+# `/run/ix-term/sessions/<id>/pts` (the service's runtime directory).
+#
+# Auth: the server binds {option}`listenAddress` (loopback by default) and
+# trusts whatever sits in front of it. The intended deployment terminates
+# term.ix.dev on the tailnet with a reverse proxy on the same host; per-request
+# Tailscale WhoIs identity is a TODO tracked in index#3797. There is no login
+# UI by design, so never point this at a non-loopback address without a
+# tailnet-scoped proxy in front. Host wiring (term.ix.dev DNS, the proxy, and
+# which fleet host serves it) lands in the ix repo, not here.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit
+    (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    types
+    ;
+  cfg = config.services.ix-term;
+in {
+  options.services.ix-term = {
+    enable = mkEnableOption "the ix-term web terminal server";
+
+    package = mkPackageOption pkgs "ix-term-server" {};
+
+    listenAddress = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = ''
+        Address the server binds. Keep it loopback and let the tailnet
+        reverse proxy terminate term.ix.dev; the server itself performs no
+        authentication.
+      '';
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 7533;
+      description = "TCP port for the UI, the REST API, and the websockets.";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "ix-term";
+      description = ''
+        User the server (and therefore every session's login shell) runs as.
+        The default system user is created with a bash login shell and a home
+        under /var/lib/ix-term; point this at a real account instead when
+        sessions should be that person's environment.
+      '';
+    };
+
+    scrollback = mkOption {
+      type = types.ints.positive;
+      default = 10000;
+      description = "Scrollback lines kept per session by the VT engine.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.ix-term = mkIf (cfg.user == "ix-term") {
+      isSystemUser = true;
+      group = "ix-term";
+      # Sessions are login shells; the default user needs a real shell and a
+      # writable home for one to start in.
+      shell = pkgs.bashInteractive;
+      home = "/var/lib/ix-term";
+      createHome = true;
+    };
+    users.groups.ix-term = mkIf (cfg.user == "ix-term") {};
+
+    ix.networking.portClaims.ix-term = {
+      protocol = "tcp";
+      inherit (cfg) port;
+      address = cfg.listenAddress;
+      description = "ix-term web terminal";
+    };
+
+    systemd.services.ix-term = {
+      description = "ix-term web terminal server";
+      wantedBy = ["multi-user.target"];
+      after = ["network.target"];
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        # /run/ix-term is the pts-mapping contract with the `ixterm` CLI, so
+        # the service owns it for its whole life (no DynamicUser: the path and
+        # the session shells must belong to a stable account).
+        RuntimeDirectory = "ix-term";
+        RuntimeDirectoryMode = "0755";
+        ExecStart = lib.escapeShellArgs [
+          (lib.getExe cfg.package)
+          "--listen"
+          "${cfg.listenAddress}:${toString cfg.port}"
+          "--scrollback"
+          (toString cfg.scrollback)
+        ];
+        Restart = "on-failure";
+        RestartSec = 2;
+        # Deliberately no ix.systemdHardening: sessions are real login shells
+        # for cfg.user, so ProtectHome/ProtectSystem would gut the product.
+      };
+      environment.IX_TERM_RUNTIME_DIR = "/run/ix-term";
+    };
+  };
+}

--- a/packages/ix-term/server/Cargo.toml
+++ b/packages/ix-term/server/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ix-term-server"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Tailnet-internal web terminal: server-side libghostty-vt sessions streamed to the browser as dirty rows"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+axum = { workspace = true, features = ["ws"] }
+clap = { workspace = true, features = ["derive", "env"] }
+futures.workspace = true
+ix-vt.workspace = true
+libc.workspace = true
+pty-process.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
+tower-http = { workspace = true, features = ["fs"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
+uuid = { workspace = true, features = ["v4"] }
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }

--- a/packages/ix-term/server/default.nix
+++ b/packages/ix-term/server/default.nix
@@ -1,0 +1,38 @@
+{
+  ix,
+  pkgs,
+}: let
+  site = ix.buildSvelteSite pkgs {
+    sourceRoot = ./site;
+    serve.enable = false;
+  };
+
+  server = ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+    binary = "ix-term-server";
+    meta.mainProgram = "ix-term-server";
+  };
+in
+  # The Rust server and the Svelte site are built independently, then composed:
+  # the site is installed as a resource and its path is handed to the server via
+  # `IX_TERM_SITE_DIR` (the same shape as nix-web-monitor).
+  ix.wrapPackage pkgs {
+    package = server;
+    resources.site = {
+      source = site;
+      from = "share/ix-term-site";
+      to = "share/ix-term";
+      env = "IX_TERM_SITE_DIR";
+    };
+    passthru = {
+      tests =
+        server.passthru.tests
+        // {
+          inherit site;
+        };
+      inherit site;
+    };
+    meta = {
+      description = "Tailnet-internal web terminal on server-side libghostty-vt";
+      mainProgram = "ix-term-server";
+    };
+  }

--- a/packages/ix-term/server/package.nix
+++ b/packages/ix-term/server/package.nix
@@ -1,0 +1,13 @@
+{
+  id = "ix-term-server";
+  # The server spawns PTY login shells and publishes pts paths under
+  # /run/ix-term for the `ixterm` CLI, so the packaged artifact is linux-only
+  # (the crate itself stays in the cargo workspace on darwin for local dev).
+  # `overlay` is on so the NixOS module can reference `pkgs.ix-term-server`
+  # via `mkPackageOption`.
+  packageSet.systems = ["x86_64-linux" "aarch64-linux"];
+  flake.systems = ["x86_64-linux" "aarch64-linux"];
+  overlay.systems = ["x86_64-linux" "aarch64-linux"];
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/ix-term/server/site/.gitignore
+++ b/packages/ix-term/server/site/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/packages/ix-term/server/site/eslint.config.js
+++ b/packages/ix-term/server/site/eslint.config.js
@@ -1,0 +1,51 @@
+import js from '@eslint/js';
+import svelte from 'eslint-plugin-svelte';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+const typedFiles = ['src/**/*.{ts,svelte}'];
+
+export default tseslint.config(
+  {
+    ignores: ['dist']
+  },
+  js.configs.recommended,
+  ...tseslint.configs.strictTypeChecked.map((config) => ({
+    ...config,
+    files: typedFiles
+  })),
+  ...svelte.configs['flat/recommended'],
+  {
+    files: typedFiles,
+    languageOptions: {
+      parserOptions: {
+        extraFileExtensions: ['.svelte'],
+        parser: tseslint.parser,
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname
+      }
+    }
+  },
+  {
+    files: typedFiles,
+    languageOptions: {
+      globals: {
+        ...globals.browser
+      }
+    }
+  },
+  {
+    files: ['*.config.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node
+      }
+    }
+  },
+  {
+    files: typedFiles,
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error'
+    }
+  }
+);

--- a/packages/ix-term/server/site/index.html
+++ b/packages/ix-term/server/site/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ix-term</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/ix-term/server/site/package-lock.json
+++ b/packages/ix-term/server/site/package-lock.json
@@ -1,0 +1,2903 @@
+{
+  "name": "ix-term-site",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ix-term-site",
+      "version": "0.1.0",
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte": "^6.2.1",
+        "svelte": "^5.55.7",
+        "vite": "^7.1.7"
+      },
+      "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "eslint": "^10.3.0",
+        "eslint-plugin-svelte": "^3.17.1",
+        "globals": "^17.6.0",
+        "svelte-check": "^4.3.2",
+        "typescript": "^5.9.2",
+        "typescript-eslint": "^8.59.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.11.tgz",
+      "integrity": "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.0.tgz",
+      "integrity": "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-6.2.4.tgz",
+      "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
+        "deepmerge": "^4.3.1",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.0",
+        "vitefu": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite": "^6.3.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-5.0.2.tgz",
+      "integrity": "sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "obug": "^2.1.0"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^6.0.0-next.0",
+        "svelte": "^5.0.0",
+        "vite": "^6.3.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.2.tgz",
+      "integrity": "sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-svelte": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.22.0.tgz",
+      "integrity": "sha512-O3qn0NePTWta+1o25dIThqeEP/hEQ3VxDK2LVO8SQ5wG9umLMvulK+m1yQ4JGOb2Pkl8IB0G1lpRV/HXDXSLTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.6.1",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "esutils": "^2.0.3",
+        "globals": "^16.0.0",
+        "known-css-properties": "^0.37.0",
+        "postcss": "^8.4.49",
+        "postcss-load-config": "^3.1.4",
+        "postcss-safe-parser": "^7.0.0",
+        "semver": "^7.6.3",
+        "svelte-eslint-parser": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.1 || ^9.0.0 || ^10.0.0",
+        "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-svelte/node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrap": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.0.tgz",
+      "integrity": "sha512-GQ/7RN8uOtEfNpzZzBMTzW9JBcX42oaSVtPzdF+6cEL8pqIL094iUpr9jzYGn4O4P/1S60dJ6izyT8F4LYARng==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/known-css-properties": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+      "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
+      "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^2.0.5",
+        "yaml": "^1.10.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-scss": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
+      "integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-scss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.29"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.56.7",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.7.tgz",
+      "integrity": "sha512-5qERUZX80oQj6XrDMUmD2Uhd/cIpCPDWWKBK3ZHmyRUC9apPyamWM8xMo31mbWsIQxwG2hVoSnOJ/EcnhVkkzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.12",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.3.tgz",
+      "integrity": "sha512-DHdTCGX62R0fCxBEaT+USdASAnoaRBaaNczkRJl0K7o3WyoCeVUbVxo6fKqpOll/B+WMWCsiFK0eFrJSNBKZIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "^0.2.0",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/svelte-eslint-parser": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.8.0.tgz",
+      "integrity": "sha512-mikR1qwIVy3t5WthUoAXkMwxkXvabZP9FJgdx35Ei7EbGWmctva1Pih16Koeor/bdNNq8NXHlwKGS6NkYTawLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-scope": "^8.2.0",
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.0.0",
+        "postcss": "^8.4.49",
+        "postcss-scss": "^4.0.9",
+        "postcss-selector-parser": "^7.0.0",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0",
+        "pnpm": "10.34.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/svelte-eslint-parser/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/svelte-eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/svelte-eslint-parser/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "extraneous": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/ix-term/server/site/package.json
+++ b/packages/ix-term/server/site/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ix-term-site",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "npm run check && npm run lint && vite build",
+    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "dev": "vite dev",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@sveltejs/vite-plugin-svelte": "^6.2.1",
+    "svelte": "^5.55.7",
+    "vite": "^7.1.7"
+  },
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.3.0",
+    "eslint-plugin-svelte": "^3.17.1",
+    "globals": "^17.6.0",
+    "svelte-check": "^4.3.2",
+    "typescript": "^5.9.2",
+    "typescript-eslint": "^8.59.3"
+  }
+}

--- a/packages/ix-term/server/site/src/App.svelte
+++ b/packages/ix-term/server/site/src/App.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import SessionView from '$components/SessionView.svelte';
+  import TabBar from '$components/TabBar.svelte';
+  import { createSession, deleteSession, renameSession } from '$lib/api';
+  import { SessionsStore } from '$lib/sessions.svelte';
+  import { TermConnection } from '$lib/term.svelte';
+
+  const store = new SessionsStore();
+
+  let activeId = $state<string | null>(null);
+  let conn = $state<TermConnection | null>(null);
+
+  $effect(() => {
+    store.start();
+    return () => {
+      store.dispose();
+    };
+  });
+
+  // Keep the selection valid: fall back to the first session when the active
+  // one disappears (or nothing is selected yet).
+  $effect(() => {
+    const list = store.sessions;
+    if (activeId !== null && list.some((s) => s.id === activeId)) {
+      return;
+    }
+    activeId = list.length > 0 ? list[0].id : null;
+  });
+
+  // One live terminal socket: the active session's.
+  $effect(() => {
+    const id = activeId;
+    if (id === null) {
+      conn = null;
+      return;
+    }
+    const next = new TermConnection(id);
+    conn = next;
+    return () => {
+      next.dispose();
+    };
+  });
+
+  async function create(): Promise<void> {
+    const meta = await createSession();
+    activeId = meta.id;
+  }
+
+  const active = $derived(store.sessions.find((s) => s.id === activeId) ?? null);
+</script>
+
+<div class="app">
+  <TabBar
+    sessions={store.sessions}
+    {activeId}
+    onselect={(id: string) => {
+      activeId = id;
+    }}
+    oncreate={() => {
+      void create();
+    }}
+    onrename={(id: string, name: string) => {
+      void renameSession(id, name);
+    }}
+    onclose={(id: string) => {
+      void deleteSession(id);
+    }}
+  />
+  <main class="main">
+    {#if conn !== null && active !== null}
+      {#key conn.sessionId}
+        <SessionView {conn} name={active.name} />
+      {/key}
+    {:else}
+      <div class="empty">
+        <p>no sessions yet</p>
+        <button
+          onclick={() => {
+            void create();
+          }}>new session</button
+        >
+      </div>
+    {/if}
+  </main>
+</div>
+
+<style>
+  .app {
+    display: flex;
+    height: 100vh;
+  }
+
+  .main {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+  }
+
+  .empty {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    color: #888;
+  }
+
+  .empty button {
+    background: #222;
+    color: #ddd;
+    border: 1px solid #333;
+    border-radius: 4px;
+    padding: 6px 14px;
+    cursor: pointer;
+  }
+
+  .empty button:hover {
+    background: #2a2a2a;
+  }
+</style>

--- a/packages/ix-term/server/site/src/components/SessionView.svelte
+++ b/packages/ix-term/server/site/src/components/SessionView.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+  import Terminal from '$components/Terminal.svelte';
+  import type { TermConnection } from '$lib/term.svelte';
+
+  const { conn, name }: { conn: TermConnection; name: string } = $props();
+
+  const docSrc = $derived(
+    conn.doc === null
+      ? null
+      : `/api/sessions/${encodeURIComponent(conn.sessionId)}/doc?nonce=${String(conn.doc.nonce)}`
+  );
+</script>
+
+<div class="session">
+  <header class="bar">
+    <span class="title">{name}</span>
+    <span class="chip" class:driving={conn.isDriver}>
+      {conn.isDriver ? 'driving' : 'viewing'}
+    </span>
+    {#if !conn.connected}
+      <span class="chip offline">reconnecting...</span>
+    {/if}
+  </header>
+
+  {#if conn.openError !== null}
+    <div class="banner error">
+      <span>{conn.openError}</span>
+      <button
+        onclick={() => {
+          conn.dismissError();
+        }}>dismiss</button
+      >
+    </div>
+  {/if}
+
+  {#if conn.exit !== null}
+    <div class="banner exit">
+      process exited{conn.exit.code === null
+        ? ''
+        : ` (code ${String(conn.exit.code)})`}
+    </div>
+  {/if}
+
+  <div class="panes">
+    <div class="term-pane">
+      <Terminal {conn} />
+    </div>
+    {#if conn.doc !== null && docSrc !== null}
+      <div class="doc-pane">
+        <div class="doc-header">
+          <span class="doc-path" title={conn.doc.path}>{conn.doc.path}</span>
+          <button
+            aria-label="close document"
+            onclick={() => {
+              conn.closeDoc();
+            }}>x</button
+          >
+        </div>
+        <iframe sandbox="allow-scripts" src={docSrc} title={conn.doc.path}
+        ></iframe>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .session {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border-bottom: 1px solid #262626;
+    background: #171717;
+  }
+
+  .title {
+    color: #ccc;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .chip {
+    font-size: 11px;
+    padding: 1px 8px;
+    border-radius: 9px;
+    background: #262626;
+    color: #999;
+  }
+
+  .chip.driving {
+    background: #1d3324;
+    color: #7fc98b;
+  }
+
+  .chip.offline {
+    background: #3a2a1a;
+    color: #d9a05b;
+  }
+
+  .banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 5px 10px;
+    font-size: 12px;
+  }
+
+  .banner.error {
+    background: #3a1d1d;
+    color: #e39a9a;
+  }
+
+  .banner.error button {
+    background: none;
+    border: 1px solid #5a3333;
+    border-radius: 3px;
+    color: #e39a9a;
+    cursor: pointer;
+    padding: 1px 8px;
+  }
+
+  .banner.exit {
+    background: #26262e;
+    color: #a9a9c9;
+  }
+
+  .panes {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+  }
+
+  .term-pane {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+  }
+
+  .doc-pane {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    border-left: 1px solid #262626;
+    background: #141414;
+  }
+
+  .doc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 4px 8px;
+    border-bottom: 1px solid #262626;
+    font-size: 12px;
+    color: #999;
+  }
+
+  .doc-path {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .doc-header button {
+    background: none;
+    border: none;
+    color: #777;
+    cursor: pointer;
+    padding: 0 4px;
+  }
+
+  .doc-header button:hover {
+    color: #ddd;
+  }
+
+  iframe {
+    flex: 1;
+    border: none;
+    background: #fff;
+  }
+</style>

--- a/packages/ix-term/server/site/src/components/TabBar.svelte
+++ b/packages/ix-term/server/site/src/components/TabBar.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+  import type { SessionMeta } from '$lib/types';
+
+  interface Props {
+    sessions: SessionMeta[];
+    activeId: string | null;
+    onselect: (id: string) => void;
+    oncreate: () => void;
+    onrename: (id: string, name: string) => void;
+    onclose: (id: string) => void;
+  }
+
+  const { sessions, activeId, onselect, oncreate, onrename, onclose }: Props =
+    $props();
+
+  let editingId = $state<string | null>(null);
+  let editValue = $state('');
+
+  function beginRename(s: SessionMeta): void {
+    editingId = s.id;
+    editValue = s.name;
+  }
+
+  function commitRename(): void {
+    if (editingId === null) {
+      return;
+    }
+    const id = editingId;
+    const name = editValue.trim();
+    editingId = null;
+    const current = sessions.find((s) => s.id === id);
+    if (name.length > 0 && current !== undefined && name !== current.name) {
+      onrename(id, name);
+    }
+  }
+
+  function cancelRename(): void {
+    editingId = null;
+  }
+
+  function focusSelect(node: HTMLInputElement): void {
+    node.focus();
+    node.select();
+  }
+
+  function createdTooltip(s: SessionMeta): string {
+    return `created ${new Date(s.created_at_ms).toLocaleString()}`;
+  }
+</script>
+
+<nav class="tabbar">
+  <div class="tabs" role="tablist" aria-label="sessions" aria-orientation="vertical">
+    {#each sessions as s (s.id)}
+      <div
+        class="tab"
+        class:active={s.id === activeId}
+        role="tab"
+        aria-selected={s.id === activeId}
+        tabindex="0"
+        title={createdTooltip(s)}
+        onclick={() => {
+          onselect(s.id);
+        }}
+        onkeydown={(ev) => {
+          if (ev.key === 'Enter') {
+            onselect(s.id);
+          }
+        }}
+        ondblclick={() => {
+          beginRename(s);
+        }}
+      >
+        {#if editingId === s.id}
+          <input
+            class="rename"
+            bind:value={editValue}
+            use:focusSelect
+            onblur={commitRename}
+            onkeydown={(ev) => {
+              if (ev.key === 'Enter') {
+                commitRename();
+              } else if (ev.key === 'Escape') {
+                cancelRename();
+              }
+              ev.stopPropagation();
+            }}
+            onclick={(ev) => {
+              ev.stopPropagation();
+            }}
+            ondblclick={(ev) => {
+              ev.stopPropagation();
+            }}
+          />
+        {:else}
+          <span class="name">{s.name}</span>
+          <button
+            class="close"
+            aria-label="close session"
+            onclick={(ev) => {
+              ev.stopPropagation();
+              onclose(s.id);
+            }}>x</button
+          >
+        {/if}
+      </div>
+    {/each}
+  </div>
+  <button class="create" aria-label="new session" onclick={oncreate}>+</button>
+</nav>
+
+<style>
+  .tabbar {
+    width: 200px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    background: #171717;
+    border-right: 1px solid #262626;
+    padding: 8px 6px;
+    gap: 6px;
+    overflow-y: auto;
+  }
+
+  .tabs {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .tab {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 8px;
+    border-radius: 5px;
+    color: #aaa;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .tab:hover {
+    background: #222;
+  }
+
+  .tab.active {
+    background: #2b2b2b;
+    color: #eee;
+  }
+
+  .name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .close {
+    visibility: hidden;
+    background: none;
+    border: none;
+    color: #777;
+    cursor: pointer;
+    padding: 0 3px;
+    border-radius: 3px;
+    line-height: 1;
+  }
+
+  .tab:hover .close {
+    visibility: visible;
+  }
+
+  .close:hover {
+    color: #ddd;
+    background: #333;
+  }
+
+  .rename {
+    flex: 1;
+    min-width: 0;
+    background: #111;
+    color: #eee;
+    border: 1px solid #444;
+    border-radius: 3px;
+    padding: 2px 4px;
+    font: inherit;
+  }
+
+  .create {
+    background: none;
+    border: 1px dashed #333;
+    border-radius: 5px;
+    color: #888;
+    cursor: pointer;
+    padding: 4px 0;
+  }
+
+  .create:hover {
+    color: #ddd;
+    border-color: #555;
+  }
+</style>

--- a/packages/ix-term/server/site/src/components/Terminal.svelte
+++ b/packages/ix-term/server/site/src/components/Terminal.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+  import { encodeKey } from '$lib/keys';
+  import { spanStyle } from '$lib/render';
+  import type { TermConnection } from '$lib/term.svelte';
+
+  const { conn }: { conn: TermConnection } = $props();
+
+  let containerEl = $state<HTMLDivElement | undefined>();
+  let probeEl = $state<HTMLSpanElement | undefined>();
+  let cellW = $state(0);
+  let cellH = $state(0);
+  let availW = $state(0);
+  let availH = $state(0);
+
+  function px(n: number): string {
+    return `${String(n)}px`;
+  }
+
+  // Measure one cell from a 10-glyph probe for sub-pixel accuracy.
+  $effect(() => {
+    const el = probeEl;
+    if (el === undefined) {
+      return;
+    }
+    const rect = el.getBoundingClientRect();
+    cellW = rect.width / 10;
+    cellH = rect.height;
+  });
+
+  $effect(() => {
+    const el = containerEl;
+    if (el === undefined) {
+      return;
+    }
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        availW = entry.contentRect.width;
+        availH = entry.contentRect.height;
+      }
+    });
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+    };
+  });
+
+  // Grab keyboard focus on mount (i.e. on every session switch).
+  $effect(() => {
+    containerEl?.focus();
+  });
+
+  // Driver-owns-size: only the driver translates its container size into a
+  // resize request, debounced so drags do not spam the PTY.
+  $effect(() => {
+    const driving = conn.isDriver;
+    const w = availW;
+    const h = availH;
+    const cw = cellW;
+    const ch = cellH;
+    if (!driving || cw <= 0 || ch <= 0 || w <= 0 || h <= 0) {
+      return;
+    }
+    const cols = Math.max(2, Math.floor(w / cw));
+    const rows = Math.max(2, Math.floor(h / ch));
+    const timer = setTimeout(() => {
+      if (cols !== conn.seatCols || rows !== conn.seatRows) {
+        conn.sendResize(cols, rows);
+      }
+    }, 200);
+    return () => {
+      clearTimeout(timer);
+    };
+  });
+
+  const gridW = $derived(conn.cols * cellW);
+  const gridH = $derived(conn.rows * cellH);
+  // Viewers see the driver-sized grid scaled down to fit; never scaled up.
+  const scale = $derived(
+    conn.isDriver || gridW <= 0 || gridH <= 0 || availW <= 0 || availH <= 0
+      ? 1
+      : Math.min(1, availW / gridW, availH / gridH)
+  );
+
+  function onKeydown(ev: KeyboardEvent): void {
+    const data = encodeKey(ev, conn.appCursor);
+    if (data !== null) {
+      ev.preventDefault();
+      conn.sendInput(data);
+    }
+  }
+
+  function onPaste(ev: ClipboardEvent): void {
+    const text = ev.clipboardData?.getData('text') ?? '';
+    if (text.length > 0) {
+      ev.preventDefault();
+      conn.sendInput(text);
+    }
+  }
+</script>
+
+<div
+  class="terminal"
+  bind:this={containerEl}
+  tabindex="0"
+  role="textbox"
+  aria-multiline="true"
+  aria-label="terminal"
+  onkeydown={onKeydown}
+  onpaste={onPaste}
+  onclick={() => {
+    containerEl?.focus();
+  }}
+>
+  <span class="probe" bind:this={probeEl} aria-hidden="true">WWWWWWWWWW</span>
+  <div
+    class="grid"
+    style:width={px(gridW)}
+    style:height={px(gridH)}
+    style:transform={`scale(${String(scale)})`}
+  >
+    {#each conn.lines as spans, y (y)}
+      <div class="row" style:top={px(y * cellH)} style:height={px(cellH)}>
+        {#each spans as span, i (i)}
+          <span style={spanStyle(span)}>{span.text}</span>
+        {/each}
+      </div>
+    {/each}
+    {#if conn.cursor !== null && conn.cursor.visible}
+      <div
+        class="cursor {conn.cursor.shape}"
+        style:left={px(conn.cursor.x * cellW)}
+        style:top={px(conn.cursor.y * cellH)}
+        style:width={px(cellW)}
+        style:height={px(cellH)}
+      ></div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .terminal {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    background: #111;
+    outline: none;
+    padding: 0;
+    line-height: 1.25;
+    cursor: text;
+  }
+
+  .probe {
+    position: absolute;
+    visibility: hidden;
+    white-space: pre;
+  }
+
+  .grid {
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform-origin: top left;
+  }
+
+  .row {
+    position: absolute;
+    left: 0;
+    white-space: pre;
+    color: #ddd;
+    overflow: hidden;
+  }
+
+  .cursor {
+    position: absolute;
+    pointer-events: none;
+  }
+
+  .cursor.block {
+    background: #ddd;
+    mix-blend-mode: difference;
+  }
+
+  .cursor.bar {
+    border-left: 2px solid #ddd;
+  }
+
+  .cursor.underline {
+    border-bottom: 2px solid #ddd;
+  }
+
+  .cursor.hollow {
+    border: 1px solid #ddd;
+  }
+</style>

--- a/packages/ix-term/server/site/src/lib/api.ts
+++ b/packages/ix-term/server/site/src/lib/api.ts
@@ -1,0 +1,41 @@
+import type { SessionMeta } from '$lib/types';
+
+export async function listSessions(): Promise<SessionMeta[]> {
+  const res = await fetch('/api/sessions');
+  if (!res.ok) {
+    throw new Error(`listing sessions failed: ${String(res.status)}`);
+  }
+  return (await res.json()) as SessionMeta[];
+}
+
+export async function createSession(name?: string): Promise<SessionMeta> {
+  const res = await fetch('/api/sessions', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(name === undefined ? {} : { name })
+  });
+  if (!res.ok) {
+    throw new Error(`creating session failed: ${String(res.status)}`);
+  }
+  return (await res.json()) as SessionMeta;
+}
+
+export async function renameSession(id: string, name: string): Promise<void> {
+  const res = await fetch(`/api/sessions/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ name })
+  });
+  if (!res.ok) {
+    throw new Error(`renaming session failed: ${String(res.status)}`);
+  }
+}
+
+export async function deleteSession(id: string): Promise<void> {
+  const res = await fetch(`/api/sessions/${encodeURIComponent(id)}`, {
+    method: 'DELETE'
+  });
+  if (!res.ok) {
+    throw new Error(`deleting session failed: ${String(res.status)}`);
+  }
+}

--- a/packages/ix-term/server/site/src/lib/keys.ts
+++ b/packages/ix-term/server/site/src/lib/keys.ts
@@ -1,0 +1,66 @@
+/**
+ * Encode a keydown event into the byte string the PTY expects, or null when
+ * the event is not ours to handle (bare modifiers, browser shortcuts, ...).
+ */
+export function encodeKey(ev: KeyboardEvent, appCursor: boolean): string | null {
+  const key = ev.key;
+  if (
+    key === 'Shift' ||
+    key === 'Control' ||
+    key === 'Alt' ||
+    key === 'Meta' ||
+    key === 'CapsLock' ||
+    key === 'Dead' ||
+    key === 'Unidentified'
+  ) {
+    return null;
+  }
+  // Leave meta combos (cmd+c, cmd+t, ...) to the browser.
+  if (ev.metaKey) {
+    return null;
+  }
+  if (ev.ctrlKey) {
+    if (key.length === 1) {
+      const code = key.toUpperCase().charCodeAt(0);
+      // @ A-Z [ \ ] ^ _ map onto C0 controls.
+      if (code >= 64 && code <= 95) {
+        return String.fromCharCode(code & 31);
+      }
+    }
+    return null;
+  }
+  switch (key) {
+    case 'Enter':
+      return '\r';
+    case 'Backspace':
+      return '\x7f';
+    case 'Tab':
+      return '\t';
+    case 'Escape':
+      return '\x1b';
+    case 'ArrowUp':
+      return appCursor ? '\x1bOA' : '\x1b[A';
+    case 'ArrowDown':
+      return appCursor ? '\x1bOB' : '\x1b[B';
+    case 'ArrowRight':
+      return appCursor ? '\x1bOC' : '\x1b[C';
+    case 'ArrowLeft':
+      return appCursor ? '\x1bOD' : '\x1b[D';
+    case 'Home':
+      return '\x1b[H';
+    case 'End':
+      return '\x1b[F';
+    case 'PageUp':
+      return '\x1b[5~';
+    case 'PageDown':
+      return '\x1b[6~';
+    case 'Delete':
+      return '\x1b[3~';
+    default:
+      break;
+  }
+  if (key.length === 1) {
+    return ev.altKey ? `\x1b${key}` : key;
+  }
+  return null;
+}

--- a/packages/ix-term/server/site/src/lib/render.ts
+++ b/packages/ix-term/server/site/src/lib/render.ts
@@ -1,0 +1,39 @@
+import type { Span } from '$lib/types';
+
+export const DEFAULT_FG = '#ddd';
+export const DEFAULT_BG = '#111';
+
+export function spanStyle(span: Span): string {
+  let fg = span.fg ?? DEFAULT_FG;
+  let bg = span.bg ?? DEFAULT_BG;
+  if (span.inverse) {
+    const swap = fg;
+    fg = bg;
+    bg = swap;
+  }
+  const parts = [`color:${fg}`];
+  // Skip painting the default background so the page background shows through.
+  if (bg !== DEFAULT_BG || span.inverse) {
+    parts.push(`background-color:${bg}`);
+  }
+  if (span.bold) {
+    parts.push('font-weight:bold');
+  }
+  if (span.italic) {
+    parts.push('font-style:italic');
+  }
+  const deco: string[] = [];
+  if (span.underline) {
+    deco.push('underline');
+  }
+  if (span.strikethrough) {
+    deco.push('line-through');
+  }
+  if (deco.length > 0) {
+    parts.push(`text-decoration-line:${deco.join(' ')}`);
+  }
+  if (span.dim) {
+    parts.push('opacity:0.6');
+  }
+  return parts.join(';');
+}

--- a/packages/ix-term/server/site/src/lib/sessions.svelte.ts
+++ b/packages/ix-term/server/site/src/lib/sessions.svelte.ts
@@ -1,0 +1,72 @@
+import { listSessions } from '$lib/api';
+import type { SessionsMsg } from '$lib/types';
+import type { SessionMeta } from '$lib/types';
+import { wsUrl } from '$lib/ws';
+
+const MAX_BACKOFF_MS = 8000;
+
+/** Live session list, fed by /api/ws with a REST fallback while it is down. */
+export class SessionsStore {
+  sessions = $state<SessionMeta[]>([]);
+
+  private ws: WebSocket | null = null;
+  private attempts = 0;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+
+  start(): void {
+    // Seed from REST so the tab bar is useful before the socket settles.
+    void this.refreshFromRest();
+    this.connect();
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+    }
+    this.ws?.close();
+  }
+
+  private async refreshFromRest(): Promise<void> {
+    try {
+      this.sessions = await listSessions();
+    } catch {
+      // Server unreachable; the reconnect loop will retry.
+    }
+  }
+
+  private connect(): void {
+    if (this.disposed) {
+      return;
+    }
+    const ws = new WebSocket(wsUrl('/api/ws'));
+    this.ws = ws;
+    ws.onopen = () => {
+      this.attempts = 0;
+    };
+    ws.onmessage = (ev: MessageEvent) => {
+      const raw: unknown = ev.data;
+      if (typeof raw !== 'string') {
+        return;
+      }
+      const msg = JSON.parse(raw) as SessionsMsg;
+      this.sessions = msg.sessions;
+    };
+    ws.onclose = () => {
+      this.scheduleReconnect();
+    };
+  }
+
+  private scheduleReconnect(): void {
+    if (this.disposed) {
+      return;
+    }
+    void this.refreshFromRest();
+    const delay = Math.min(500 * 2 ** this.attempts, MAX_BACKOFF_MS);
+    this.attempts = Math.min(this.attempts + 1, 6);
+    this.timer = setTimeout(() => {
+      this.connect();
+    }, delay);
+  }
+}

--- a/packages/ix-term/server/site/src/lib/term.svelte.ts
+++ b/packages/ix-term/server/site/src/lib/term.svelte.ts
@@ -1,0 +1,176 @@
+import type {
+  ClientMsg,
+  Cursor,
+  GridMsg,
+  ServerMsg,
+  Span
+} from '$lib/types';
+import { wsUrl } from '$lib/ws';
+
+const MAX_BACKOFF_MS = 8000;
+
+export interface OpenDoc {
+  path: string;
+  nonce: number;
+}
+
+export interface ExitInfo {
+  code: number | null;
+}
+
+/** One terminal websocket: grid state, driver seat, doc pane, lifecycle. */
+export class TermConnection {
+  readonly sessionId: string;
+
+  connected = $state(false);
+  connId = $state<string | null>(null);
+  cols = $state(0);
+  rows = $state(0);
+  lines = $state<Span[][]>([]);
+  cursor = $state<Cursor | null>(null);
+  appCursor = $state(false);
+  seatConn = $state<string | null>(null);
+  seatCols = $state(0);
+  seatRows = $state(0);
+  doc = $state<OpenDoc | null>(null);
+  openError = $state<string | null>(null);
+  exit = $state<ExitInfo | null>(null);
+
+  private ws: WebSocket | null = null;
+  private attempts = 0;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+  // After (re)connect, ignore incremental frames until a full grid arrives so
+  // we never patch rows onto a stale or differently sized grid.
+  private awaitingFull = true;
+
+  constructor(sessionId: string) {
+    this.sessionId = sessionId;
+    this.connect();
+  }
+
+  get isDriver(): boolean {
+    return this.connId !== null && this.seatConn === this.connId;
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+    }
+    this.ws?.close();
+  }
+
+  sendInput(data: string): void {
+    this.send({ type: 'input', data });
+  }
+
+  sendResize(cols: number, rows: number): void {
+    this.send({ type: 'resize', cols, rows });
+  }
+
+  closeDoc(): void {
+    this.send({ type: 'close_doc' });
+  }
+
+  dismissError(): void {
+    this.openError = null;
+  }
+
+  private send(msg: ClientMsg): void {
+    if (this.ws !== null && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(msg));
+    }
+  }
+
+  private connect(): void {
+    if (this.disposed) {
+      return;
+    }
+    const path = `/api/sessions/${encodeURIComponent(this.sessionId)}/ws`;
+    const ws = new WebSocket(wsUrl(path));
+    this.ws = ws;
+    ws.onopen = () => {
+      this.attempts = 0;
+      this.connected = true;
+      this.awaitingFull = true;
+      this.send({ type: 'refresh' });
+    };
+    ws.onmessage = (ev: MessageEvent) => {
+      const raw: unknown = ev.data;
+      if (typeof raw !== 'string') {
+        return;
+      }
+      this.handle(JSON.parse(raw) as ServerMsg);
+    };
+    ws.onclose = () => {
+      this.connected = false;
+      this.scheduleReconnect();
+    };
+  }
+
+  private scheduleReconnect(): void {
+    if (this.disposed) {
+      return;
+    }
+    const delay = Math.min(500 * 2 ** this.attempts, MAX_BACKOFF_MS);
+    this.attempts = Math.min(this.attempts + 1, 6);
+    this.timer = setTimeout(() => {
+      this.connect();
+    }, delay);
+  }
+
+  private handle(msg: ServerMsg): void {
+    switch (msg.type) {
+      case 'hello':
+        this.connId = msg.conn;
+        break;
+      case 'grid':
+        this.applyGrid(msg);
+        break;
+      case 'driver':
+        this.seatConn = msg.conn;
+        this.seatCols = msg.cols;
+        this.seatRows = msg.rows;
+        break;
+      case 'open':
+        this.doc = msg.path === null ? null : { path: msg.path, nonce: msg.nonce };
+        break;
+      case 'open_error':
+        this.openError = msg.message;
+        break;
+      case 'exit':
+        this.exit = { code: msg.code };
+        break;
+    }
+  }
+
+  private applyGrid(msg: GridMsg): void {
+    if (msg.full) {
+      const next: Span[][] = Array.from({ length: msg.rows }, () => []);
+      for (const row of msg.changed) {
+        if (row.y >= 0 && row.y < msg.rows) {
+          next[row.y] = row.spans;
+        }
+      }
+      this.cols = msg.cols;
+      this.rows = msg.rows;
+      this.lines = next;
+      this.awaitingFull = false;
+    } else {
+      if (this.awaitingFull) {
+        return;
+      }
+      if (msg.cols !== this.cols || msg.rows !== this.rows) {
+        return;
+      }
+      for (const row of msg.changed) {
+        if (row.y >= 0 && row.y < this.lines.length) {
+          this.lines[row.y] = row.spans;
+        }
+      }
+    }
+    this.cursor = msg.cursor;
+    this.appCursor = msg.app_cursor;
+  }
+}

--- a/packages/ix-term/server/site/src/lib/types.ts
+++ b/packages/ix-term/server/site/src/lib/types.ts
@@ -1,0 +1,90 @@
+export interface SessionMeta {
+  id: string;
+  name: string;
+  created_at_ms: number;
+}
+
+export interface Span {
+  text: string;
+  fg?: string;
+  bg?: string;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  inverse?: boolean;
+  dim?: boolean;
+  strikethrough?: boolean;
+}
+
+export type CursorShape = 'block' | 'bar' | 'underline' | 'hollow';
+
+export interface Cursor {
+  x: number;
+  y: number;
+  visible: boolean;
+  shape: CursorShape;
+}
+
+export interface RowUpdate {
+  y: number;
+  spans: Span[];
+}
+
+export interface HelloMsg {
+  type: 'hello';
+  conn: string;
+  session: { id: string; name: string };
+}
+
+export interface GridMsg {
+  type: 'grid';
+  seq: number;
+  cols: number;
+  rows: number;
+  full: boolean;
+  changed: RowUpdate[];
+  cursor: Cursor | null;
+  app_cursor: boolean;
+}
+
+export interface DriverMsg {
+  type: 'driver';
+  conn: string | null;
+  cols: number;
+  rows: number;
+}
+
+export interface OpenMsg {
+  type: 'open';
+  path: string | null;
+  nonce: number;
+}
+
+export interface OpenErrorMsg {
+  type: 'open_error';
+  message: string;
+}
+
+export interface ExitMsg {
+  type: 'exit';
+  code: number | null;
+}
+
+export type ServerMsg =
+  | HelloMsg
+  | GridMsg
+  | DriverMsg
+  | OpenMsg
+  | OpenErrorMsg
+  | ExitMsg;
+
+export interface SessionsMsg {
+  type: 'sessions';
+  sessions: SessionMeta[];
+}
+
+export type ClientMsg =
+  | { type: 'input'; data: string }
+  | { type: 'resize'; cols: number; rows: number }
+  | { type: 'refresh' }
+  | { type: 'close_doc' };

--- a/packages/ix-term/server/site/src/lib/ws.ts
+++ b/packages/ix-term/server/site/src/lib/ws.ts
@@ -1,0 +1,4 @@
+export function wsUrl(path: string): string {
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${proto}//${location.host}${path}`;
+}

--- a/packages/ix-term/server/site/src/main.ts
+++ b/packages/ix-term/server/site/src/main.ts
@@ -1,0 +1,13 @@
+import './style.css';
+import { mount } from 'svelte';
+import App from './App.svelte';
+
+const target = document.getElementById('app');
+
+if (!(target instanceof HTMLElement)) {
+  throw new Error('missing #app mount target');
+}
+
+const app = mount(App, { target });
+
+export default app;

--- a/packages/ix-term/server/site/src/style.css
+++ b/packages/ix-term/server/site/src/style.css
@@ -1,0 +1,31 @@
+:root {
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+
+body {
+  background: #111;
+  color: #ddd;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, 'Cascadia Mono', 'Fira Code',
+    monospace;
+  font-size: 13px;
+}
+
+#app {
+  height: 100vh;
+}
+
+button {
+  font: inherit;
+}

--- a/packages/ix-term/server/site/src/vite-env.d.ts
+++ b/packages/ix-term/server/site/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/packages/ix-term/server/site/svelte.config.ts
+++ b/packages/ix-term/server/site/svelte.config.ts
@@ -1,0 +1,8 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import type { SvelteConfig } from '@sveltejs/vite-plugin-svelte';
+
+const config: SvelteConfig = {
+  preprocess: [vitePreprocess()]
+};
+
+export default config;

--- a/packages/ix-term/server/site/tsconfig.json
+++ b/packages/ix-term/server/site/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "allowJs": false,
+    "baseUrl": ".",
+    "checkJs": false,
+    "isolatedModules": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "paths": {
+      "$lib/*": ["src/lib/*"],
+      "$components/*": ["src/components/*"]
+    },
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2023",
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte"]
+}

--- a/packages/ix-term/server/site/vite.config.js
+++ b/packages/ix-term/server/site/vite.config.js
@@ -1,0 +1,18 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+
+const src = fileURLToPath(new URL('./src', import.meta.url));
+
+export default defineConfig({
+  build: {
+    target: 'esnext'
+  },
+  resolve: {
+    alias: {
+      $lib: `${src}/lib`,
+      $components: `${src}/components`
+    }
+  },
+  plugins: [svelte()]
+});

--- a/packages/ix-term/server/src/main.rs
+++ b/packages/ix-term/server/src/main.rs
@@ -1,0 +1,392 @@
+//! ix-term server: a tailnet-internal web terminal (index#3797).
+//!
+//! One server-side libghostty-vt state per session is the single source of
+//! truth; browsers are thin views over a dirty-row websocket protocol. PTYs
+//! are spawned on the serving host; the `ixterm` CLI opens HTML files in a
+//! session by writing OSC 5522 to the session pts.
+//!
+//! Auth: the server binds localhost and trusts its reverse proxy / tailnet
+//! (term.ix.dev terminates on tailscale). Tailscale `WhoIs` identity per
+//! request is a documented TODO; there is deliberately no login UI.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::Context as _;
+use axum::Router;
+use axum::extract::ws::WebSocketUpgrade;
+use axum::extract::{Path, State};
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use clap::{Parser, Subcommand};
+use tower_http::services::ServeDir;
+use uuid::Uuid;
+
+mod osc;
+mod proto;
+mod session;
+mod vt;
+mod ws;
+
+use session::{ServerConfig, SessionManager};
+
+#[derive(Parser)]
+#[command(about = "Tailnet-internal web terminal on server-side libghostty-vt")]
+struct Args {
+    /// Address to bind. Defaults to loopback: the tailnet reverse proxy is
+    /// the trust boundary, so the server itself never listens publicly.
+    #[arg(long, env = "IX_TERM_LISTEN", default_value = "127.0.0.1:7533")]
+    listen: SocketAddr,
+
+    /// Static UI directory. The Nix package wrapper sets this; unset means
+    /// API-only (useful in development with `vite dev` proxying).
+    #[arg(long, env = "IX_TERM_SITE_DIR")]
+    site_dir: Option<PathBuf>,
+
+    /// Runtime directory for the `ixterm` CLI contract
+    /// (`<dir>/sessions/<id>/pts`).
+    #[arg(long, env = "IX_TERM_RUNTIME_DIR", default_value = "/run/ix-term")]
+    runtime_dir: PathBuf,
+
+    /// Shell for new sessions; defaults to `$SHELL` then `/bin/sh`.
+    #[arg(long, env = "IX_TERM_SHELL")]
+    shell: Option<String>,
+
+    /// Scrollback lines kept per session.
+    #[arg(long, default_value_t = 10_000)]
+    scrollback: usize,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Measure the dirty-row pipeline under a synthetic redraw storm and
+    /// print rows/sec (the index#3797 pre-freeze benchmark).
+    BenchFlood {
+        /// Grid height.
+        #[arg(long, default_value_t = 40)]
+        rows: u16,
+        /// Grid width.
+        #[arg(long, default_value_t = 120)]
+        cols: u16,
+        /// Measurement duration per phase.
+        #[arg(long, default_value_t = 5)]
+        seconds: u64,
+    },
+}
+
+/// Shared handler state.
+#[derive(Clone)]
+struct App {
+    manager: Arc<SessionManager>,
+    site_dir: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt().init();
+    let args = Args::parse();
+
+    if let Some(Command::BenchFlood {
+        rows,
+        cols,
+        seconds,
+    }) = args.command
+    {
+        return bench_flood(rows, cols, Duration::from_secs(seconds)).await;
+    }
+
+    let manager = Arc::new(SessionManager::new(ServerConfig {
+        runtime_dir: args.runtime_dir,
+        shell: args.shell,
+        scrollback: args.scrollback,
+    })?);
+    let app = App {
+        manager: Arc::clone(&manager),
+        site_dir: args.site_dir.clone(),
+    };
+
+    let router = Router::new()
+        .route("/", get(serve_index))
+        .route("/api/sessions", get(list_sessions).post(create_session))
+        .route(
+            "/api/sessions/{id}",
+            axum::routing::patch(rename_session).delete(close_session),
+        )
+        .route("/api/sessions/{id}/ws", get(terminal_ws))
+        .route("/api/sessions/{id}/doc", get(session_doc))
+        .route("/api/ws", get(events_ws));
+    let router = match args.site_dir {
+        Some(ref dir) => router.fallback_service(ServeDir::new(dir.clone())),
+        None => router,
+    };
+    let router = router.with_state(app);
+
+    let listener = tokio::net::TcpListener::bind(args.listen)
+        .await
+        .with_context(|| format!("cannot bind {}", args.listen))?;
+    tracing::info!(listen = %args.listen, "ix-term server up");
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async {
+            let _ = tokio::signal::ctrl_c().await;
+        })
+        .await
+        .context("server error")
+}
+
+/// Serve the SPA entry point with `no-store` so UI deploys take effect on
+/// reload (the hashed assets under it stay cacheable via `ServeDir`).
+async fn serve_index(State(app): State<App>) -> Response {
+    let Some(dir) = app.site_dir else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "ix-term: no site directory configured (IX_TERM_SITE_DIR)",
+        )
+            .into_response();
+    };
+    match tokio::fs::read(dir.join("index.html")).await {
+        Ok(body) => (
+            [
+                (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+                (header::CACHE_CONTROL, "no-store"),
+            ],
+            body,
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("ix-term: cannot read index.html: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn list_sessions(State(app): State<App>) -> Response {
+    axum::Json(app.manager.list().await).into_response()
+}
+
+/// Body for session create/rename.
+#[derive(serde::Deserialize, Default)]
+struct NameBody {
+    name: Option<String>,
+}
+
+async fn create_session(State(app): State<App>, body: Option<axum::Json<NameBody>>) -> Response {
+    let name = body.and_then(|b| b.0.name);
+    match app.manager.create(name).await {
+        Ok(session) => axum::Json(session.meta()).into_response(),
+        Err(error) => {
+            tracing::error!(%error, "session create failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}")).into_response()
+        }
+    }
+}
+
+/// Parse a session id path segment.
+fn parse_id(id: &str) -> Result<Uuid, StatusCode> {
+    Uuid::parse_str(id).map_err(|_| StatusCode::BAD_REQUEST)
+}
+
+async fn rename_session(
+    State(app): State<App>,
+    Path(id): Path<String>,
+    axum::Json(body): axum::Json<NameBody>,
+) -> Response {
+    let id = match parse_id(&id) {
+        Ok(id) => id,
+        Err(status) => return status.into_response(),
+    };
+    let Some(name) = body.name else {
+        return (StatusCode::BAD_REQUEST, "missing name").into_response();
+    };
+    if app.manager.rename(id, name).await {
+        StatusCode::NO_CONTENT.into_response()
+    } else {
+        StatusCode::NOT_FOUND.into_response()
+    }
+}
+
+async fn close_session(State(app): State<App>, Path(id): Path<String>) -> Response {
+    let id = match parse_id(&id) {
+        Ok(id) => id,
+        Err(status) => return status.into_response(),
+    };
+    if app.manager.close(id).await {
+        StatusCode::NO_CONTENT.into_response()
+    } else {
+        StatusCode::NOT_FOUND.into_response()
+    }
+}
+
+async fn terminal_ws(
+    State(app): State<App>,
+    Path(id): Path<String>,
+    upgrade: WebSocketUpgrade,
+) -> Response {
+    let id = match parse_id(&id) {
+        Ok(id) => id,
+        Err(status) => return status.into_response(),
+    };
+    let Some(session) = app.manager.get(id).await else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    upgrade.on_upgrade(move |socket| ws::terminal_client(session, socket))
+}
+
+async fn events_ws(State(app): State<App>, upgrade: WebSocketUpgrade) -> Response {
+    upgrade.on_upgrade(move |socket| ws::events_client(app.manager, socket))
+}
+
+/// Serve the session's opened HTML document into its sandboxed iframe.
+///
+/// "Sandboxed, no network in v1": the iframe carries `sandbox="allow-scripts"`
+/// (no same-origin), and this response's Content-Security-Policy forbids
+/// every fetch the document could make — inline style/script may run, but
+/// nothing loads over the network.
+async fn session_doc(State(app): State<App>, Path(id): Path<String>) -> Response {
+    let id = match parse_id(&id) {
+        Ok(id) => id,
+        Err(status) => return status.into_response(),
+    };
+    let Some(session) = app.manager.get(id).await else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let Some(path) = session.doc_path() else {
+        return (StatusCode::NOT_FOUND, "no document opened").into_response();
+    };
+    match tokio::fs::read(&path).await {
+        Ok(body) => (
+            [
+                (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+                (header::CACHE_CONTROL, "no-store"),
+                (
+                    header::CONTENT_SECURITY_POLICY,
+                    "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; \
+                     img-src data:; font-src data:; form-action 'none'; base-uri 'none'",
+                ),
+            ],
+            body,
+        )
+            .into_response(),
+        Err(error) => {
+            (StatusCode::NOT_FOUND, format!("cannot read {path}: {error}")).into_response()
+        }
+    }
+}
+
+/// One full-screen synthetic redraw: home the cursor, rewrite every row with
+/// per-frame content and a color change, like a busy TUI (btop-ish).
+fn flood_frame(frame: u64, rows: u16, cols: u16) -> Vec<u8> {
+    use std::fmt::Write as _;
+    const LETTERS: &[u8; 26] = b"abcdefghijklmnopqrstuvwxyz";
+    let mut out = String::with_capacity(usize::from(rows) * (usize::from(cols) + 16));
+    out.push_str("\x1b[H");
+    for y in 0..rows {
+        let color = 31 + ((frame + u64::from(y)) % 7);
+        let _ = write!(out, "\x1b[{color}m");
+        for x in 0..cols {
+            let index = usize::try_from((frame + u64::from(y) + u64::from(x)) % 26)
+                .expect("value below 26 fits usize");
+            out.push(char::from(LETTERS[index]));
+        }
+        if y + 1 < rows {
+            out.push_str("\r\n");
+        }
+    }
+    out.into_bytes()
+}
+
+/// The pre-freeze benchmark (index#3797): drive a synthetic escape flood
+/// through the VT engine and the dirty-row pipeline and report rows/sec.
+async fn bench_flood(rows: u16, cols: u16, duration: Duration) -> anyhow::Result<()> {
+    bench_ingest(rows, cols, duration)?;
+
+    // Phase 2: the full pipeline — engine thread, frame coalescing, dirty-row
+    // diff, wire serialization — with a flood producer.
+    let (events, mut rx) = tokio::sync::broadcast::channel::<Arc<proto::ServerMsg>>(1024);
+    let engine = vt::spawn_engine(rows, cols, 0, events)?;
+    let deadline = Instant::now() + duration;
+    let producer = tokio::spawn(async move {
+        let mut frame: u64 = 0;
+        let mut sent_rows: u64 = 0;
+        while Instant::now() < deadline {
+            engine.send(vt::EngineMsg::Feed(flood_frame(frame, rows, cols)));
+            frame += 1;
+            sent_rows += u64::from(rows);
+            // Pace the producer so the unbounded engine queue stays shallow;
+            // 2000 frames/sec of full redraws is far beyond any real TUI.
+            if frame.is_multiple_of(16) {
+                tokio::time::sleep(Duration::from_millis(8)).await;
+            }
+        }
+        sent_rows
+    });
+
+    let mut wire_rows: u64 = 0;
+    let mut wire_frames: u64 = 0;
+    let mut wire_bytes: u64 = 0;
+    let started = Instant::now();
+    loop {
+        let timeout = tokio::time::timeout(Duration::from_millis(200), rx.recv()).await;
+        match timeout {
+            Ok(Ok(msg)) => {
+                if let proto::ServerMsg::Grid { changed, .. } = msg.as_ref() {
+                    wire_rows += u64::try_from(changed.len()).expect("row count fits u64");
+                    wire_frames += 1;
+                    let frame_len = serde_json::to_string(msg.as_ref()).map_or(0, |s| s.len());
+                    wire_bytes += u64::try_from(frame_len).expect("frame length fits u64");
+                }
+            }
+            Ok(Err(_)) | Err(_) => {
+                if producer.is_finished() && Instant::now() > deadline {
+                    break;
+                }
+            }
+        }
+    }
+    let elapsed = started.elapsed().as_secs_f64();
+    let sent_rows = producer.await.unwrap_or(0);
+    println!(
+        "pipeline: absorbed {sent_rows} input rows ({:.0} rows/sec); \
+         shipped {wire_rows} dirty rows in {wire_frames} frames ({:.0} rows/sec, {:.1} fps, {:.0} KiB/s wire)",
+        f64_from(sent_rows) / elapsed,
+        f64_from(wire_rows) / elapsed,
+        f64_from(wire_frames) / elapsed,
+        f64_from(wire_bytes) / elapsed / 1024.0
+    );
+    Ok(())
+}
+
+/// Phase 1 of the benchmark: raw VT ingestion (parse + state), no pipeline.
+///
+/// Separate from [`bench_flood`] because the `!Send` [`ix_vt::Terminal`] must
+/// not live across an await point in an async fn.
+fn bench_ingest(rows: u16, cols: u16, duration: Duration) -> anyhow::Result<()> {
+    let mut terminal = ix_vt::Terminal::new(rows, cols, 0)?;
+    let start = Instant::now();
+    let mut frames_in: u64 = 0;
+    while start.elapsed() < duration {
+        terminal.vt_write(&flood_frame(frames_in, rows, cols));
+        frames_in += 1;
+    }
+    let ingest_secs = start.elapsed().as_secs_f64();
+    let ingest_rows = frames_in * u64::from(rows);
+    println!(
+        "ingest: {ingest_rows} rows in {ingest_secs:.2}s = {:.0} rows/sec ({frames_in} frames)",
+        f64_from(ingest_rows) / ingest_secs
+    );
+    Ok(())
+}
+
+/// `u64 -> f64` for benchmark reporting (precision loss is irrelevant here,
+/// and the fork's `fallible_int_fallback` lint forbids `as`).
+const fn f64_from(value: u64) -> f64 {
+    #[allow(clippy::cast_precision_loss, reason = "benchmark reporting only")]
+    let out = value as f64;
+    out
+}

--- a/packages/ix-term/server/src/osc.rs
+++ b/packages/ix-term/server/src/osc.rs
@@ -1,0 +1,344 @@
+//! Extraction of the private ix-term OSC (number 5522, from index#3797) out
+//! of a raw PTY byte stream.
+//!
+//! The `ixterm` CLI (`packages/ixterm`) writes `ESC ] 5522 ; open ; <abs
+//! path> BEL` to the session pts in a single `write(2)`. The server scans the
+//! PTY output for exactly that sequence, strips it from the bytes fed to the
+//! VT engine, and surfaces each occurrence as an [`OscEvent`]. Interception
+//! happens here, in front of libghostty-vt, because ghostty's OSC command
+//! enum is closed: an unknown code like 5522 parses to `INVALID` with no
+//! accessible payload, so the engine would swallow the sequence silently.
+//! This scanner is also the seam that keeps the VT engine swappable — any
+//! replacement engine sees the same cleaned stream.
+//!
+//! Everything that is not an `OSC 5522` sequence passes through byte for
+//! byte, including every other OSC, so the engine sees exactly what the
+//! application wrote. The scanner is streaming: a sequence split across
+//! arbitrary read boundaries is still recognized, and bytes are only held
+//! back while they are a live prefix of the opener.
+//!
+//! The CLI terminates with `BEL`; this scanner additionally accepts the 7-bit
+//! string terminator `ESC \` so hand-written emitters that follow ECMA-48
+//! framing work too. The 8-bit C1 forms (`0x9d` opener, `0x9c` ST) are not
+//! recognized, matching the CLI and `ix_vt::OscTitleTracker`.
+
+/// `ESC` (0x1b), the introducer of every escape sequence.
+const ESC: u8 = 0x1b;
+/// `BEL` (0x07), the OSC terminator the `ixterm` CLI emits.
+const BEL: u8 = 0x07;
+/// `CAN` (0x18): per ECMA-48 aborts an in-progress control string.
+const CAN: u8 = 0x18;
+/// `SUB` (0x1a): like `CAN`, aborts an in-progress control string.
+const SUB: u8 = 0x1a;
+
+/// The exact opener of the private sequence: `ESC ] 5522 ;`.
+const PREFIX: &[u8] = b"\x1b]5522;";
+
+/// Cap on the bytes buffered for one payload. Real payloads are `open;<abs
+/// path>`, far below this; the cap bounds memory if a writer opens the
+/// sequence and never terminates it.
+const MAX_PAYLOAD: usize = 4096;
+
+/// A parsed occurrence of the private OSC.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OscEvent {
+    /// `OSC 5522 ; open ; <path>`: the session asked the server to open
+    /// `path` (an absolute path to an HTML file) in the session's split view.
+    Open(String),
+    /// A 5522 sequence arrived but its payload was not a well-formed `open`
+    /// request. The sequence is still stripped from the stream; the server
+    /// renders the reason in the session UI (the issue's "no backchannel"
+    /// error path).
+    Malformed(String),
+}
+
+/// Where the scanner is within an `ESC ] 5522 ; … (BEL | ESC \)` sequence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum State {
+    /// Outside the private sequence; bytes pass through.
+    Ground,
+    /// The last `n` bytes matched `PREFIX[..n]`; they are held back until the
+    /// prefix completes or diverges.
+    Prefix(usize),
+    /// Inside the payload of a recognized `ESC ] 5522 ;`.
+    Payload,
+    /// Saw `ESC` inside the payload: either the start of `ESC \` (ST) or an
+    /// abort that opens a new escape sequence.
+    PayloadEsc,
+}
+
+/// A streaming scanner that strips `OSC 5522` sequences from a byte stream.
+pub struct Scanner {
+    state: State,
+    payload: Vec<u8>,
+    /// The payload exceeded [`MAX_PAYLOAD`]; excess bytes are dropped and the
+    /// sequence reports as [`OscEvent::Malformed`] at its terminator.
+    overflowed: bool,
+}
+
+impl Scanner {
+    /// Create a scanner in the ground state.
+    pub const fn new() -> Self {
+        Self {
+            state: State::Ground,
+            payload: Vec::new(),
+            overflowed: false,
+        }
+    }
+
+    /// Scan `input`, appending non-5522 bytes to `passthrough` and parsed
+    /// 5522 sequences to `events`.
+    pub fn feed(&mut self, input: &[u8], passthrough: &mut Vec<u8>, events: &mut Vec<OscEvent>) {
+        for &byte in input {
+            self.step(byte, passthrough, events);
+        }
+    }
+
+    /// Flush bytes held as a live opener prefix at end of stream.
+    ///
+    /// A partial prefix was ordinary output that happened to end the stream;
+    /// an unterminated payload has no such interpretation (its bytes were
+    /// only ever addressed to the server) and is dropped.
+    pub fn flush_pending(&mut self, passthrough: &mut Vec<u8>) {
+        if let State::Prefix(matched) = self.state {
+            passthrough.extend_from_slice(&PREFIX[..matched]);
+        }
+        self.payload.clear();
+        self.overflowed = false;
+        self.state = State::Ground;
+    }
+
+    /// Advance the state machine by one byte.
+    ///
+    /// The loop re-dispatches a byte after a state change that consumed no
+    /// input (prefix divergence, payload abort), so held bytes are replayed
+    /// without recursion.
+    fn step(&mut self, byte: u8, passthrough: &mut Vec<u8>, events: &mut Vec<OscEvent>) {
+        loop {
+            match self.state {
+                State::Ground => {
+                    if byte == ESC {
+                        self.state = State::Prefix(1);
+                    } else {
+                        passthrough.push(byte);
+                    }
+                    return;
+                }
+                State::Prefix(matched) => {
+                    if byte == PREFIX[matched] {
+                        self.state = if matched + 1 == PREFIX.len() {
+                            self.payload.clear();
+                            self.overflowed = false;
+                            State::Payload
+                        } else {
+                            State::Prefix(matched + 1)
+                        };
+                        return;
+                    }
+                    // Divergence: the held bytes were ordinary output (for
+                    // example another OSC's opener). Release them and rescan
+                    // the current byte from the ground state.
+                    passthrough.extend_from_slice(&PREFIX[..matched]);
+                    self.state = State::Ground;
+                }
+                State::Payload => {
+                    match byte {
+                        BEL => {
+                            self.finish(events);
+                            self.state = State::Ground;
+                        }
+                        ESC => self.state = State::PayloadEsc,
+                        // An aborted control string produces nothing; its
+                        // bytes were never output.
+                        CAN | SUB => {
+                            self.payload.clear();
+                            self.state = State::Ground;
+                        }
+                        _ => self.push_payload(byte),
+                    }
+                    return;
+                }
+                State::PayloadEsc => {
+                    if byte == b'\\' {
+                        self.finish(events);
+                        self.state = State::Ground;
+                        return;
+                    }
+                    // Per ECMA-48 an ESC that is not part of ST aborts the
+                    // control string and opens a new escape sequence; rescan
+                    // the current byte as the byte after that ESC.
+                    self.payload.clear();
+                    self.state = State::Prefix(1);
+                }
+            }
+        }
+    }
+
+    fn push_payload(&mut self, byte: u8) {
+        if self.payload.len() >= MAX_PAYLOAD {
+            self.overflowed = true;
+        } else {
+            self.payload.push(byte);
+        }
+    }
+
+    /// Terminate the current payload and emit its event.
+    fn finish(&mut self, events: &mut Vec<OscEvent>) {
+        let payload = std::mem::take(&mut self.payload);
+        if std::mem::take(&mut self.overflowed) {
+            events.push(OscEvent::Malformed(format!(
+                "OSC 5522 payload exceeded {MAX_PAYLOAD} bytes"
+            )));
+            return;
+        }
+        events.push(parse_payload(&payload));
+    }
+}
+
+/// Parse a complete 5522 payload (`open;<abs path>`).
+fn parse_payload(payload: &[u8]) -> OscEvent {
+    let Some(path) = payload.strip_prefix(b"open;") else {
+        return OscEvent::Malformed(format!(
+            "unknown OSC 5522 request {:?} (expected \"open;<abs path>\")",
+            String::from_utf8_lossy(payload)
+        ));
+    };
+    let Ok(path) = std::str::from_utf8(path) else {
+        return OscEvent::Malformed("OSC 5522 open path is not UTF-8".to_owned());
+    };
+    if !path.starts_with('/') {
+        return OscEvent::Malformed(format!("OSC 5522 open path is not absolute: {path:?}"));
+    }
+    OscEvent::Open(path.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OscEvent, Scanner};
+
+    /// Run `input` through a fresh scanner in one feed.
+    fn scan(input: &[u8]) -> (Vec<u8>, Vec<OscEvent>) {
+        let mut scanner = Scanner::new();
+        let mut passthrough = Vec::new();
+        let mut events = Vec::new();
+        scanner.feed(input, &mut passthrough, &mut events);
+        (passthrough, events)
+    }
+
+    #[test]
+    fn plain_bytes_pass_through_byte_exact() {
+        let input = b"hello \x1b[31mred\x1b[0m world\r\n";
+        let (out, events) = scan(input);
+        assert_eq!(out, input);
+        assert_eq!(events, vec![]);
+    }
+
+    #[test]
+    fn bel_terminated_open_is_extracted() {
+        // The exact bytes `ixterm open` writes (packages/ixterm/src/osc.rs).
+        let (out, events) = scan(b"before\x1b]5522;open;/tmp/report.html\x07after");
+        assert_eq!(out, b"beforeafter");
+        assert_eq!(events, vec![OscEvent::Open("/tmp/report.html".to_owned())]);
+    }
+
+    #[test]
+    fn st_terminated_open_is_extracted() {
+        let (out, events) = scan(b"a\x1b]5522;open;/x/y.html\x1b\\b");
+        assert_eq!(out, b"ab");
+        assert_eq!(events, vec![OscEvent::Open("/x/y.html".to_owned())]);
+    }
+
+    #[test]
+    fn every_split_boundary_scans_identically() {
+        let input: &[u8] =
+            b"pre\x1b]5522;open;/tmp/x.html\x07mid\x1b]5522;open;/tmp/y.html\x1b\\post";
+        for split in 0..=input.len() {
+            let mut scanner = Scanner::new();
+            let mut out = Vec::new();
+            let mut events = Vec::new();
+            scanner.feed(&input[..split], &mut out, &mut events);
+            scanner.feed(&input[split..], &mut out, &mut events);
+            assert_eq!(out, b"premidpost", "split at {split}");
+            assert_eq!(
+                events,
+                vec![
+                    OscEvent::Open("/tmp/x.html".to_owned()),
+                    OscEvent::Open("/tmp/y.html".to_owned()),
+                ],
+                "split at {split}"
+            );
+        }
+    }
+
+    #[test]
+    fn other_osc_sequences_pass_through_untouched() {
+        for input in [
+            b"\x1b]0;window title\x07".as_slice(),
+            b"\x1b]52;c;aGVsbG8=\x1b\\".as_slice(),
+            // A code that shares the 5522 digit prefix but diverges.
+            b"\x1b]55221;x\x07".as_slice(),
+            b"\x1b]55;x\x07".as_slice(),
+        ] {
+            let (out, events) = scan(input);
+            assert_eq!(out, input);
+            assert_eq!(events, vec![]);
+        }
+    }
+
+    #[test]
+    fn double_escape_releases_the_first() {
+        let (out, events) = scan(b"\x1b\x1b]5522;open;/a.html\x07");
+        assert_eq!(out, b"\x1b");
+        assert_eq!(events, vec![OscEvent::Open("/a.html".to_owned())]);
+    }
+
+    #[test]
+    fn unknown_verb_is_malformed() {
+        let (out, events) = scan(b"\x1b]5522;close;/a.html\x07");
+        assert_eq!(out, b"");
+        assert!(matches!(&events[..], [OscEvent::Malformed(_)]));
+    }
+
+    #[test]
+    fn relative_path_is_malformed() {
+        let (_, events) = scan(b"\x1b]5522;open;tmp/x.html\x07");
+        assert!(matches!(&events[..], [OscEvent::Malformed(_)]));
+    }
+
+    #[test]
+    fn can_aborts_the_sequence_silently() {
+        let (out, events) = scan(b"a\x1b]5522;open;/x\x18b");
+        assert_eq!(out, b"ab");
+        assert_eq!(events, vec![]);
+    }
+
+    #[test]
+    fn esc_abort_opens_a_new_sequence() {
+        // The aborting ESC starts a fresh, complete 5522 sequence.
+        let (out, events) = scan(b"\x1b]5522;open;/dropped\x1b]5522;open;/kept.html\x07");
+        assert_eq!(out, b"");
+        assert_eq!(events, vec![OscEvent::Open("/kept.html".to_owned())]);
+    }
+
+    #[test]
+    fn oversized_payload_is_malformed_not_unbounded() {
+        let mut input = b"\x1b]5522;open;/".to_vec();
+        input.extend(std::iter::repeat_n(b'a', super::MAX_PAYLOAD * 2));
+        input.push(0x07);
+        let (out, events) = scan(&input);
+        assert_eq!(out, b"");
+        assert!(matches!(&events[..], [OscEvent::Malformed(_)]));
+    }
+
+    #[test]
+    fn flush_pending_releases_a_partial_prefix() {
+        let mut scanner = Scanner::new();
+        let mut out = Vec::new();
+        let mut events = Vec::new();
+        scanner.feed(b"tail\x1b]55", &mut out, &mut events);
+        assert_eq!(out, b"tail");
+        scanner.flush_pending(&mut out);
+        assert_eq!(out, b"tail\x1b]55");
+        assert_eq!(events, vec![]);
+    }
+}

--- a/packages/ix-term/server/src/proto.rs
+++ b/packages/ix-term/server/src/proto.rs
@@ -1,0 +1,460 @@
+//! The browser wire protocol: JSON text frames over a per-session websocket.
+//!
+//! The format is deliberately engine- and transport-agnostic (index#3797
+//! keeps it swappable for a ghostty-web WASM client speaking raw bytes): the
+//! server ships *dirty rows* — for every changed row, the full new row
+//! content as styled spans — plus cursor state, and the client patches its
+//! DOM grid. Nothing in the frame references libghostty-vt.
+//!
+//! Serialization is externally observable behavior (the Svelte client and
+//! any future client depend on it), so the tests here pin exact JSON bytes.
+
+use serde::{Deserialize, Serialize};
+
+/// One session in the tab bar.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SessionMetaWire {
+    /// The session id (a UUID; also the directory name under
+    /// `/run/ix-term/sessions`).
+    pub id: String,
+    /// The user-visible tab name.
+    pub name: String,
+    /// Creation time in milliseconds since the Unix epoch.
+    pub created_at_ms: u64,
+}
+
+/// One styled run of text within a row. Attribute keys are omitted when
+/// false and colors when the terminal default applies, so a plain-text row
+/// serializes as just `{"text":"…"}`.
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "one bool per independent SGR attribute on the wire; they are not a state enum"
+)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct Span {
+    /// The run's text, one cell per column (spaces for empty cells).
+    pub text: String,
+    /// Resolved foreground as `#rrggbb`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fg: Option<String>,
+    /// Resolved background as `#rrggbb`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bg: Option<String>,
+    /// Bold (SGR 1).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub bold: bool,
+    /// Italic (SGR 3).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub italic: bool,
+    /// Any underline (SGR 4 family).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub underline: bool,
+    /// Inverse video (SGR 7); the client swaps its effective fg/bg.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub inverse: bool,
+    /// Faint (SGR 2).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub dim: bool,
+    /// Strikethrough (SGR 9).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub strikethrough: bool,
+}
+
+/// The full new content of one changed row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RowUpdate {
+    /// Zero-based viewport row.
+    pub y: u16,
+    /// The row's cells as consecutive styled runs covering every column.
+    pub spans: Vec<Span>,
+}
+
+/// Cursor state shipped with every grid frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct CursorWire {
+    /// Zero-based column.
+    pub x: u16,
+    /// Zero-based viewport row.
+    pub y: u16,
+    /// Whether the cursor is shown.
+    pub visible: bool,
+    /// Requested shape.
+    pub shape: CursorShapeWire,
+}
+
+/// The cursor shape names the client renders.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CursorShapeWire {
+    /// Filled block.
+    Block,
+    /// Vertical bar.
+    Bar,
+    /// Underline.
+    Underline,
+    /// Hollow block (unfocused terminals).
+    Hollow,
+}
+
+impl From<ix_vt::CursorVisualStyle> for CursorShapeWire {
+    fn from(style: ix_vt::CursorVisualStyle) -> Self {
+        match style {
+            ix_vt::CursorVisualStyle::Bar => Self::Bar,
+            ix_vt::CursorVisualStyle::Block => Self::Block,
+            ix_vt::CursorVisualStyle::Underline => Self::Underline,
+            ix_vt::CursorVisualStyle::BlockHollow => Self::Hollow,
+        }
+    }
+}
+
+/// Server-to-client messages.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ServerMsg {
+    /// First message on a terminal socket: the client's connection id and
+    /// the session it joined.
+    Hello {
+        /// This connection's id, compared against [`ServerMsg::Driver`] to
+        /// know whether the client holds the driver seat.
+        conn: String,
+        /// The joined session.
+        session: SessionMetaWire,
+    },
+    /// A grid frame: `full` frames carry every row (and may change the grid
+    /// size); patch frames carry only rows that changed.
+    Grid {
+        /// Monotonic frame number within the session.
+        seq: u64,
+        /// Grid width in columns.
+        cols: u16,
+        /// Grid height in rows.
+        rows: u16,
+        /// Whether `changed` covers the entire grid.
+        full: bool,
+        /// The dirty rows, each with its full new content.
+        changed: Vec<RowUpdate>,
+        /// Cursor state, if the cursor is inside the viewport.
+        cursor: Option<CursorWire>,
+        /// Whether DECCKM (application cursor keys) is set; selects the
+        /// arrow-key encoding the client must send.
+        app_cursor: bool,
+    },
+    /// The driver seat changed hands or the authoritative size changed.
+    Driver {
+        /// The connection holding the seat, or `None` when it is free.
+        conn: Option<String>,
+        /// Authoritative grid width.
+        cols: u16,
+        /// Authoritative grid height.
+        rows: u16,
+    },
+    /// The session's opened document changed. `path` of `None` closes the
+    /// split view.
+    Open {
+        /// Absolute path of the opened HTML file.
+        path: Option<String>,
+        /// Cache-buster for the iframe URL; bumps on every open.
+        nonce: u64,
+    },
+    /// An error to render inside the session view (the issue's "server
+    /// renders errors in the session UI" path — there is no backchannel to
+    /// the writer).
+    OpenError {
+        /// Human-readable reason.
+        message: String,
+    },
+    /// The session's child process exited.
+    Exit {
+        /// The exit code, if the process exited normally.
+        code: Option<i32>,
+    },
+    /// The current session list (sent on the `/api/ws` events socket).
+    Sessions {
+        /// All live sessions, oldest first.
+        sessions: Vec<SessionMetaWire>,
+    },
+}
+
+/// Client-to-server messages on a terminal socket.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClientMsg {
+    /// Raw input bytes (as a UTF-8 string, escape sequences included).
+    /// Sending input claims the driver seat.
+    Input {
+        /// The bytes to write to the PTY.
+        data: String,
+    },
+    /// Resize the PTY; honored only from the driver (or when the seat is
+    /// free).
+    Resize {
+        /// Requested width in columns.
+        cols: u16,
+        /// Requested height in rows.
+        rows: u16,
+    },
+    /// Ask for a full grid frame (sent after connect/reconnect).
+    Refresh,
+    /// Close the opened document split for every viewer.
+    CloseDoc,
+}
+
+/// Format a resolved RGB color as `#rrggbb`.
+fn color_hex(color: ix_vt::Rgb) -> String {
+    format!("#{:02x}{:02x}{:02x}", color.r, color.g, color.b)
+}
+
+/// The style key of a cell: two cells with equal keys join one span.
+fn span_of(cell: &ix_vt::Cell) -> Span {
+    Span {
+        text: String::new(),
+        fg: cell.fg.map(color_hex),
+        bg: cell.bg.map(color_hex),
+        bold: cell.style.bold,
+        italic: cell.style.italic,
+        underline: cell.style.underline.is_some(),
+        inverse: cell.style.inverse,
+        dim: cell.style.faint,
+        strikethrough: cell.style.strikethrough,
+    }
+}
+
+/// Whether two spans carry the same style (everything but the text).
+fn same_style(a: &Span, b: &Span) -> bool {
+    a.fg == b.fg
+        && a.bg == b.bg
+        && a.bold == b.bold
+        && a.italic == b.italic
+        && a.underline == b.underline
+        && a.inverse == b.inverse
+        && a.dim == b.dim
+        && a.strikethrough == b.strikethrough
+}
+
+/// Encode one snapshot row as consecutive styled runs.
+///
+/// Empty cells render as spaces so concatenated span text always covers every
+/// column; wide-glyph spacer cells therefore also render as spaces, which
+/// keeps column arithmetic exact in fonts that draw CJK at single width and
+/// is the v1 tradeoff for fonts that draw them double width.
+pub fn encode_row(cells: &[ix_vt::Cell]) -> Vec<Span> {
+    let mut spans: Vec<Span> = Vec::new();
+    for cell in cells {
+        let style = span_of(cell);
+        if !spans.last().is_some_and(|last| same_style(last, &style)) {
+            spans.push(style);
+        }
+        let span = spans
+            .last_mut()
+            .expect("span pushed above when the list was empty");
+        span.text.push(cell.ch.unwrap_or(' '));
+        span.text.extend(cell.combining.iter());
+    }
+    spans
+}
+
+/// A dirty-row delta between two snapshots.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GridDiff {
+    /// Whether every row is included (first frame or size change).
+    pub full: bool,
+    /// The changed rows.
+    pub changed: Vec<RowUpdate>,
+}
+
+/// Diff `next` against `prev`, emitting full content for each changed row.
+pub fn diff_snapshots(prev: Option<&ix_vt::Snapshot>, next: &ix_vt::Snapshot) -> GridDiff {
+    let full = !prev.is_some_and(|p| p.cols == next.cols && p.rows == next.rows);
+    // Rows are indexed in u16 from the start: a viewport is at most
+    // `next.rows` (u16) rows tall, so the zip never truncates.
+    let changed = (0u16..)
+        .zip(next.viewport.iter())
+        .filter(|&(y, row)| {
+            full || prev.is_none_or(|p| p.viewport.get(usize::from(y)).is_none_or(|old| old != row))
+        })
+        .map(|(y, row)| RowUpdate {
+            y,
+            spans: encode_row(row),
+        })
+        .collect();
+    GridDiff { full, changed }
+}
+
+/// Map a snapshot cursor to its wire form.
+pub fn cursor_wire(cursor: &ix_vt::Cursor) -> Option<CursorWire> {
+    cursor.viewport.map(|(x, y)| CursorWire {
+        x,
+        y,
+        visible: cursor.visible,
+        shape: cursor.visual_style.into(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClientMsg, RowUpdate, ServerMsg, Span, diff_snapshots, encode_row};
+
+    fn cell(ch: char) -> ix_vt::Cell {
+        ix_vt::Cell {
+            ch: Some(ch),
+            combining: Vec::new(),
+            style: ix_vt::Style::default(),
+            fg: None,
+            bg: None,
+        }
+    }
+
+    fn red_cell(ch: char) -> ix_vt::Cell {
+        ix_vt::Cell {
+            fg: Some(ix_vt::Rgb { r: 255, g: 0, b: 0 }),
+            ..cell(ch)
+        }
+    }
+
+    #[test]
+    fn equal_styles_merge_into_one_span() {
+        let row = vec![cell('h'), cell('i'), red_cell('!'), red_cell('?')];
+        let spans = encode_row(&row);
+        assert_eq!(spans.len(), 2);
+        assert_eq!(spans[0].text, "hi");
+        assert_eq!(spans[1].text, "!?");
+        assert_eq!(spans[1].fg.as_deref(), Some("#ff0000"));
+    }
+
+    #[test]
+    fn empty_cells_render_as_spaces_covering_all_columns() {
+        let row = vec![
+            cell('x'),
+            ix_vt::Cell {
+                ch: None,
+                combining: Vec::new(),
+                style: ix_vt::Style::default(),
+                fg: None,
+                bg: None,
+            },
+        ];
+        let spans = encode_row(&row);
+        let text: String = spans.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(text, "x ");
+    }
+
+    fn snapshot(rows: &[&str]) -> ix_vt::Snapshot {
+        ix_vt::Snapshot {
+            cols: u16::try_from(rows.first().map_or(0, |r| r.len())).expect("test rows fit u16"),
+            rows: u16::try_from(rows.len()).expect("test rows fit u16"),
+            viewport: rows.iter().map(|r| r.chars().map(cell).collect()).collect(),
+            scrollback: 0,
+            cursor: ix_vt::Cursor {
+                visible: true,
+                blinking: true,
+                visual_style: ix_vt::CursorVisualStyle::Block,
+                viewport: Some((0, 0)),
+            },
+        }
+    }
+
+    #[test]
+    fn first_frame_is_full() {
+        let next = snapshot(&["ab", "cd"]);
+        let diff = diff_snapshots(None, &next);
+        assert!(diff.full);
+        assert_eq!(diff.changed.len(), 2);
+    }
+
+    #[test]
+    fn only_changed_rows_ship_in_a_patch_frame() {
+        let prev = snapshot(&["ab", "cd", "ef"]);
+        let next = snapshot(&["ab", "cX", "ef"]);
+        let diff = diff_snapshots(Some(&prev), &next);
+        assert!(!diff.full);
+        assert_eq!(diff.changed.len(), 1);
+        assert_eq!(diff.changed[0].y, 1);
+        assert_eq!(diff.changed[0].spans[0].text, "cX");
+    }
+
+    #[test]
+    fn size_change_forces_a_full_frame() {
+        let prev = snapshot(&["ab", "cd"]);
+        let next = snapshot(&["abc", "def"]);
+        let diff = diff_snapshots(Some(&prev), &next);
+        assert!(diff.full);
+        assert_eq!(diff.changed.len(), 2);
+    }
+
+    // The wire format is a contract with the Svelte client (and any future
+    // one); these pin the exact bytes.
+
+    #[test]
+    fn grid_frame_serializes_byte_exact() {
+        let msg = ServerMsg::Grid {
+            seq: 7,
+            cols: 2,
+            rows: 1,
+            full: false,
+            changed: vec![RowUpdate {
+                y: 0,
+                spans: vec![Span {
+                    text: "hi".to_owned(),
+                    fg: Some("#ff0000".to_owned()),
+                    bold: true,
+                    ..Span::default()
+                }],
+            }],
+            cursor: Some(super::CursorWire {
+                x: 1,
+                y: 0,
+                visible: true,
+                shape: super::CursorShapeWire::Block,
+            }),
+            app_cursor: false,
+        };
+        assert_eq!(
+            serde_json::to_string(&msg).expect("serializes"),
+            r##"{"type":"grid","seq":7,"cols":2,"rows":1,"full":false,"changed":[{"y":0,"spans":[{"text":"hi","fg":"#ff0000","bold":true}]}],"cursor":{"x":1,"y":0,"visible":true,"shape":"block"},"app_cursor":false}"##
+        );
+    }
+
+    #[test]
+    fn driver_and_open_serialize_byte_exact() {
+        let driver = ServerMsg::Driver {
+            conn: Some("3".to_owned()),
+            cols: 120,
+            rows: 32,
+        };
+        assert_eq!(
+            serde_json::to_string(&driver).expect("serializes"),
+            r#"{"type":"driver","conn":"3","cols":120,"rows":32}"#
+        );
+        let open = ServerMsg::Open {
+            path: Some("/tmp/x.html".to_owned()),
+            nonce: 4,
+        };
+        assert_eq!(
+            serde_json::to_string(&open).expect("serializes"),
+            r#"{"type":"open","path":"/tmp/x.html","nonce":4}"#
+        );
+    }
+
+    #[test]
+    fn client_messages_parse() {
+        assert_eq!(
+            serde_json::from_str::<ClientMsg>(r#"{"type":"input","data":"ls\r"}"#).expect("parses"),
+            ClientMsg::Input {
+                data: "ls\r".to_owned()
+            }
+        );
+        assert_eq!(
+            serde_json::from_str::<ClientMsg>(r#"{"type":"resize","cols":80,"rows":24}"#)
+                .expect("parses"),
+            ClientMsg::Resize { cols: 80, rows: 24 }
+        );
+        assert_eq!(
+            serde_json::from_str::<ClientMsg>(r#"{"type":"refresh"}"#).expect("parses"),
+            ClientMsg::Refresh
+        );
+        assert_eq!(
+            serde_json::from_str::<ClientMsg>(r#"{"type":"close_doc"}"#).expect("parses"),
+            ClientMsg::CloseDoc
+        );
+    }
+}

--- a/packages/ix-term/server/src/session.rs
+++ b/packages/ix-term/server/src/session.rs
@@ -1,0 +1,649 @@
+//! Session lifecycle: server-spawned PTYs, one VT engine per session, and
+//! the `/run/ix-term` contract the `ixterm` CLI resolves against.
+//!
+//! A session is a login shell on a PTY spawned on the serving host. The
+//! server is the single source of truth for terminal state: PTY output runs
+//! through the OSC 5522 scanner, the cleaned bytes feed the libghostty-vt
+//! engine, and every websocket client renders the engine's dirty-row frames.
+//!
+//! The CLI contract (`packages/ixterm/src/pts.rs`): the child environment
+//! carries `IX_TERM_SESSION_ID=<id>`, and `<runtime dir>/sessions/<id>/pts`
+//! contains the session's pts path, so `ixterm open` can write the private
+//! OSC straight to the slave side.
+
+use std::collections::HashMap;
+use std::os::fd::AsRawFd;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Context as _;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::sync::{broadcast, watch};
+use uuid::Uuid;
+
+use crate::osc::{OscEvent, Scanner};
+use crate::proto::{ServerMsg, SessionMetaWire};
+use crate::vt::{EngineHandle, EngineMsg, spawn_engine};
+
+/// Initial PTY size before any driver resizes it.
+const DEFAULT_ROWS: u16 = 24;
+/// Initial PTY width before any driver resizes it.
+const DEFAULT_COLS: u16 = 80;
+
+/// Broadcast ring per session. A client that falls this far behind is
+/// resynced with a full frame instead of the dropped ones.
+const EVENTS_CHANNEL_CAPACITY: usize = 256;
+
+/// Server-wide session configuration.
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    /// Base runtime directory (`/run/ix-term` in production); pts mappings
+    /// live under `<runtime_dir>/sessions/<id>/pts`.
+    pub runtime_dir: PathBuf,
+    /// Shell to spawn; defaults to `$SHELL` then `/bin/sh`.
+    pub shell: Option<String>,
+    /// Scrollback lines kept by the VT engine.
+    pub scrollback: usize,
+}
+
+/// The driver seat: who owns the PTY size.
+///
+/// The seat follows the last keystroke (index#3797's "active driver owns the
+/// PTY size"); a resize is honored only from the holder, or claims the seat
+/// when it is free, so viewers never fight over dimensions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DriverSeat {
+    conn: Option<u64>,
+    /// Authoritative grid height.
+    pub rows: u16,
+    /// Authoritative grid width.
+    pub cols: u16,
+}
+
+impl DriverSeat {
+    const fn new(rows: u16, cols: u16) -> Self {
+        Self {
+            conn: None,
+            rows,
+            cols,
+        }
+    }
+
+    /// Take the seat; returns whether the holder changed.
+    fn claim(&mut self, conn: u64) -> bool {
+        let changed = self.conn != Some(conn);
+        self.conn = Some(conn);
+        changed
+    }
+
+    /// Free the seat if `conn` holds it; returns whether it was freed.
+    fn release(&mut self, conn: u64) -> bool {
+        if self.conn == Some(conn) {
+            self.conn = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Whether `conn` may resize: it holds the seat or the seat is free.
+    const fn may_resize(&self, conn: u64) -> bool {
+        match self.conn {
+            Some(holder) => holder == conn,
+            None => true,
+        }
+    }
+}
+
+/// State of the session's opened document (the OSC 5522 split view).
+#[derive(Debug, Default)]
+struct DocState {
+    path: Option<String>,
+    nonce: u64,
+}
+
+/// A live terminal session.
+pub struct Session {
+    /// The session id (also the runtime directory name).
+    pub id: Uuid,
+    name: std::sync::Mutex<String>,
+    created_at_ms: u64,
+    engine: EngineHandle,
+    events: broadcast::Sender<Arc<ServerMsg>>,
+    writer: tokio::sync::Mutex<pty_process::OwnedWritePty>,
+    seat: std::sync::Mutex<DriverSeat>,
+    doc: std::sync::Mutex<DocState>,
+    next_conn: AtomicU64,
+    /// Flipping to `true` asks the PTY task to kill the child.
+    kill: watch::Sender<bool>,
+}
+
+impl Session {
+    /// The session's wire metadata.
+    pub fn meta(&self) -> SessionMetaWire {
+        SessionMetaWire {
+            id: self.id.to_string(),
+            name: self.name.lock().expect("name lock").clone(),
+            created_at_ms: self.created_at_ms,
+        }
+    }
+
+    /// Allocate a connection id for a new websocket client.
+    pub fn next_conn(&self) -> u64 {
+        self.next_conn.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Subscribe to the session's event stream (grid frames, driver changes,
+    /// opens, exit).
+    pub fn subscribe(&self) -> broadcast::Receiver<Arc<ServerMsg>> {
+        self.events.subscribe()
+    }
+
+    /// Broadcast `msg` to every connected client.
+    pub fn broadcast(&self, msg: ServerMsg) {
+        // No receivers just means no viewers right now.
+        let _ = self.events.send(Arc::new(msg));
+    }
+
+    /// Ask the engine for a full frame (new client or lag resync).
+    pub fn request_full_frame(&self) {
+        self.engine.send(EngineMsg::FullFrame);
+    }
+
+    /// The current driver-seat state as a wire message.
+    pub fn driver_msg(&self) -> ServerMsg {
+        let seat = *self.seat.lock().expect("seat lock");
+        ServerMsg::Driver {
+            conn: seat.conn.map(|c| c.to_string()),
+            cols: seat.cols,
+            rows: seat.rows,
+        }
+    }
+
+    /// The current opened-document state as a wire message.
+    pub fn open_msg(&self) -> ServerMsg {
+        let doc = self.doc.lock().expect("doc lock");
+        ServerMsg::Open {
+            path: doc.path.clone(),
+            nonce: doc.nonce,
+        }
+    }
+
+    /// The absolute path of the currently opened document, if any.
+    pub fn doc_path(&self) -> Option<String> {
+        self.doc.lock().expect("doc lock").path.clone()
+    }
+
+    /// Write client input to the PTY; the sender takes the driver seat.
+    pub async fn write_input(&self, conn: u64, data: &str) {
+        let claimed = self.seat.lock().expect("seat lock").claim(conn);
+        if claimed {
+            self.broadcast(self.driver_msg());
+        }
+        let mut writer = self.writer.lock().await;
+        if let Err(error) = writer.write_all(data.as_bytes()).await {
+            tracing::warn!(%error, session = %self.id, "PTY write failed");
+        }
+    }
+
+    /// Resize the PTY if `conn` may (driver, or free seat which it claims).
+    pub async fn resize(&self, conn: u64, rows: u16, cols: u16) {
+        {
+            let mut seat = self.seat.lock().expect("seat lock");
+            if !seat.may_resize(conn) {
+                return;
+            }
+            seat.claim(conn);
+            seat.rows = rows;
+            seat.cols = cols;
+        }
+        {
+            let writer = self.writer.lock().await;
+            if let Err(error) = writer.resize(pty_process::Size::new(rows, cols)) {
+                tracing::warn!(%error, session = %self.id, "PTY resize failed");
+            }
+        }
+        self.engine.send(EngineMsg::Resize { rows, cols });
+        self.broadcast(self.driver_msg());
+    }
+
+    /// Release the driver seat when a client disconnects.
+    pub fn release_driver(&self, conn: u64) {
+        let released = self.seat.lock().expect("seat lock").release(conn);
+        if released {
+            self.broadcast(self.driver_msg());
+        }
+    }
+
+    /// Close the opened document for every viewer.
+    pub fn close_doc(&self) {
+        {
+            let mut doc = self.doc.lock().expect("doc lock");
+            doc.path = None;
+        }
+        self.broadcast(self.open_msg());
+    }
+
+    /// Apply one parsed OSC 5522 event from the PTY stream.
+    async fn handle_osc(&self, event: OscEvent) {
+        match event {
+            OscEvent::Open(path) => match tokio::fs::metadata(&path).await {
+                Ok(meta) if meta.is_file() => {
+                    {
+                        let mut doc = self.doc.lock().expect("doc lock");
+                        doc.path = Some(path);
+                        doc.nonce += 1;
+                    }
+                    self.broadcast(self.open_msg());
+                }
+                Ok(_) => self.broadcast(ServerMsg::OpenError {
+                    message: format!("open: {path} is not a regular file"),
+                }),
+                Err(error) => self.broadcast(ServerMsg::OpenError {
+                    message: format!("open: cannot read {path}: {error}"),
+                }),
+            },
+            OscEvent::Malformed(message) => self.broadcast(ServerMsg::OpenError { message }),
+        }
+    }
+
+    fn request_kill(&self) {
+        // Send fails only when the PTY task already exited, which is the goal.
+        let _ = self.kill.send(true);
+    }
+}
+
+/// All live sessions plus the watch feed for the tab bar.
+pub struct SessionManager {
+    config: ServerConfig,
+    sessions: tokio::sync::RwLock<HashMap<Uuid, Arc<Session>>>,
+    list_tx: watch::Sender<Vec<SessionMetaWire>>,
+}
+
+impl SessionManager {
+    /// Create a manager and its runtime directory.
+    ///
+    /// # Errors
+    /// Fails if the runtime sessions directory cannot be created (fail fast:
+    /// without it the `ixterm` CLI contract cannot be honored).
+    pub fn new(config: ServerConfig) -> anyhow::Result<Self> {
+        let sessions_dir = config.runtime_dir.join("sessions");
+        std::fs::create_dir_all(&sessions_dir)
+            .with_context(|| format!("cannot create {}", sessions_dir.display()))?;
+        let (list_tx, _) = watch::channel(Vec::new());
+        Ok(Self {
+            config,
+            sessions: tokio::sync::RwLock::new(HashMap::new()),
+            list_tx,
+        })
+    }
+
+    /// Watch the live session list (for the `/api/ws` events socket).
+    pub fn watch_list(&self) -> watch::Receiver<Vec<SessionMetaWire>> {
+        self.list_tx.subscribe()
+    }
+
+    /// The current session list, oldest first.
+    pub async fn list(&self) -> Vec<SessionMetaWire> {
+        let mut list: Vec<_> = self
+            .sessions
+            .read()
+            .await
+            .values()
+            .map(|s| (s.created_at_ms, s.meta()))
+            .collect();
+        list.sort_by_key(|(created, meta)| (*created, meta.id.clone()));
+        list.into_iter().map(|(_, meta)| meta).collect()
+    }
+
+    /// Look up a session.
+    pub async fn get(&self, id: Uuid) -> Option<Arc<Session>> {
+        self.sessions.read().await.get(&id).cloned()
+    }
+
+    /// Spawn a new session: PTY + login shell + VT engine + runtime files.
+    ///
+    /// # Errors
+    /// Fails if the PTY cannot be opened, the shell cannot be spawned, the
+    /// engine thread cannot start, or the runtime files cannot be written.
+    pub async fn create(&self, name: Option<String>) -> anyhow::Result<Arc<Session>> {
+        let id = Uuid::new_v4();
+        let name = name.unwrap_or_else(|| "shell".to_owned());
+
+        let (pty, pts) = pty_process::open().context("cannot open PTY")?;
+        pty.resize(pty_process::Size::new(DEFAULT_ROWS, DEFAULT_COLS))
+            .context("cannot size PTY")?;
+        let pts_path = pts_path_of(&pty)?;
+
+        let shell = self
+            .config
+            .shell
+            .clone()
+            .or_else(|| std::env::var("SHELL").ok())
+            .unwrap_or_else(|| "/bin/sh".to_owned());
+        // `-l` makes it a login shell: sessions are the user's real
+        // environment, matching what they would get on the host.
+        let child = pty_process::Command::new(&shell)
+            .arg("-l")
+            .env("IX_TERM_SESSION_ID", id.to_string())
+            .env("TERM", "xterm-256color")
+            .env("COLORTERM", "truecolor")
+            .spawn(pts)
+            .with_context(|| format!("cannot spawn {shell}"))?;
+
+        // Publish the pts mapping the `ixterm` CLI resolves
+        // (packages/ixterm/src/pts.rs trims and requires an absolute path).
+        let dir = self.session_dir(id);
+        tokio::fs::create_dir_all(&dir)
+            .await
+            .with_context(|| format!("cannot create {}", dir.display()))?;
+        tokio::fs::write(dir.join("pts"), format!("{pts_path}\n"))
+            .await
+            .with_context(|| format!("cannot write {}", dir.join("pts").display()))?;
+
+        let (events, _) = broadcast::channel(EVENTS_CHANNEL_CAPACITY);
+        let engine = spawn_engine(
+            DEFAULT_ROWS,
+            DEFAULT_COLS,
+            self.config.scrollback,
+            events.clone(),
+        )?;
+
+        let (read_half, write_half) = pty.into_split();
+        let (kill_tx, kill_rx) = watch::channel(false);
+        let session = Arc::new(Session {
+            id,
+            name: std::sync::Mutex::new(name),
+            created_at_ms: unix_millis(),
+            engine,
+            events,
+            writer: tokio::sync::Mutex::new(write_half),
+            seat: std::sync::Mutex::new(DriverSeat::new(DEFAULT_ROWS, DEFAULT_COLS)),
+            doc: std::sync::Mutex::new(DocState::default()),
+            next_conn: AtomicU64::new(1),
+            kill: kill_tx,
+        });
+
+        tokio::spawn(pty_task(Arc::clone(&session), read_half, child, kill_rx));
+
+        self.sessions.write().await.insert(id, Arc::clone(&session));
+        self.publish_list().await;
+        Ok(session)
+    }
+
+    /// Rename a session; returns whether it existed.
+    pub async fn rename(&self, id: Uuid, name: String) -> bool {
+        let renamed = self.sessions.read().await.get(&id).is_some_and(|session| {
+            *session.name.lock().expect("name lock") = name;
+            true
+        });
+        if renamed {
+            self.publish_list().await;
+        }
+        renamed
+    }
+
+    /// Kill and remove a session; returns whether it existed.
+    pub async fn close(&self, id: Uuid) -> bool {
+        let Some(session) = self.sessions.write().await.remove(&id) else {
+            return false;
+        };
+        session.request_kill();
+        let dir = self.session_dir(id);
+        if let Err(error) = tokio::fs::remove_dir_all(&dir).await {
+            tracing::warn!(%error, dir = %dir.display(), "cannot remove session runtime dir");
+        }
+        self.publish_list().await;
+        true
+    }
+
+    fn session_dir(&self, id: Uuid) -> PathBuf {
+        self.config
+            .runtime_dir
+            .join("sessions")
+            .join(id.to_string())
+    }
+
+    async fn publish_list(&self) {
+        self.list_tx.send_replace(self.list().await);
+    }
+}
+
+/// Milliseconds since the Unix epoch.
+fn unix_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs() * 1000 + u64::from(d.subsec_millis()))
+}
+
+/// The slave pts path of a PTY master, via `ptsname(3)`.
+fn pts_path_of(pty: &pty_process::Pty) -> anyhow::Result<String> {
+    let fd = pty.as_raw_fd();
+    #[cfg(target_os = "linux")]
+    {
+        let mut buf = [0u8; 128];
+        // SAFETY: `fd` is a live PTY master owned by `pty`; `buf` outlives
+        // the call and its length is passed, so `ptsname_r` cannot overrun.
+        let rc = unsafe { libc::ptsname_r(fd, buf.as_mut_ptr().cast(), buf.len()) };
+        if rc != 0 {
+            return Err(std::io::Error::from_raw_os_error(rc)).context("ptsname_r failed");
+        }
+        let cstr = std::ffi::CStr::from_bytes_until_nul(&buf).context("ptsname_r output")?;
+        Ok(cstr.to_str().context("pts path is not UTF-8")?.to_owned())
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        // Darwin has no ptsname_r; ptsname returns thread-local storage that
+        // is copied out immediately. This path exists for local development
+        // only — the packaged server is linux-only.
+        // SAFETY: `fd` is a live PTY master; the returned pointer is only
+        // read before any other pty call on this thread.
+        let ptr = unsafe { libc::ptsname(fd) };
+        if ptr.is_null() {
+            anyhow::bail!("ptsname failed for fd {fd}");
+        }
+        // SAFETY: a non-null ptsname result is a valid NUL-terminated string.
+        let cstr = unsafe { std::ffi::CStr::from_ptr(ptr) };
+        Ok(cstr.to_str().context("pts path is not UTF-8")?.to_owned())
+    }
+}
+
+/// The PTY task: owns the read half and the child, feeds the scanner and the
+/// engine, reaps the child, and announces its exit.
+async fn pty_task(
+    session: Arc<Session>,
+    mut read_half: pty_process::OwnedReadPty,
+    mut child: tokio::process::Child,
+    mut kill: watch::Receiver<bool>,
+) {
+    let mut scanner = Scanner::new();
+    let mut buf = vec![0u8; 8192];
+    loop {
+        tokio::select! {
+            read = read_half.read(&mut buf) => match read {
+                // EOF or read error both mean the slave side is gone.
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    let mut clean = Vec::with_capacity(n);
+                    let mut events = Vec::new();
+                    scanner.feed(&buf[..n], &mut clean, &mut events);
+                    if !clean.is_empty() {
+                        session.engine.send(EngineMsg::Feed(clean));
+                    }
+                    for event in events {
+                        session.handle_osc(event).await;
+                    }
+                }
+            },
+            changed = kill.changed() => {
+                if changed.is_err() || *kill.borrow() {
+                    if let Err(error) = child.start_kill() {
+                        tracing::debug!(%error, session = %session.id, "child kill failed");
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    let code = child.wait().await.ok().and_then(|status| status.code());
+    let mut tail = Vec::new();
+    scanner.flush_pending(&mut tail);
+    if !tail.is_empty() {
+        session.engine.send(EngineMsg::Feed(tail));
+    }
+    session.broadcast(ServerMsg::Exit { code });
+    session.engine.send(EngineMsg::Shutdown);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DriverSeat, ServerConfig, SessionManager};
+    use crate::proto::ServerMsg;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[test]
+    fn seat_follows_last_claim_and_gates_resize() {
+        let mut seat = DriverSeat::new(24, 80);
+        assert!(seat.may_resize(1), "free seat is resizable by anyone");
+        assert!(seat.claim(1));
+        assert!(!seat.claim(1), "re-claim by the holder is not a change");
+        assert!(seat.may_resize(1));
+        assert!(!seat.may_resize(2), "non-driver may not resize");
+        assert!(seat.claim(2), "last keystroke wins the seat");
+        assert!(!seat.release(1), "stale holder cannot release");
+        assert!(seat.release(2));
+        assert!(seat.may_resize(1));
+    }
+
+    fn test_manager(dir: &std::path::Path) -> SessionManager {
+        SessionManager::new(ServerConfig {
+            runtime_dir: dir.to_path_buf(),
+            shell: Some("/bin/sh".to_owned()),
+            scrollback: 100,
+        })
+        .expect("manager")
+    }
+
+    /// Wait until a grid frame's changed rows contain `needle`.
+    async fn wait_for_text(
+        rx: &mut tokio::sync::broadcast::Receiver<Arc<ServerMsg>>,
+        needle: &str,
+    ) {
+        loop {
+            let msg = rx.recv().await.expect("event stream open");
+            if let ServerMsg::Grid { changed, .. } = msg.as_ref() {
+                let text: String = changed
+                    .iter()
+                    .flat_map(|row| row.spans.iter().map(|s| s.text.as_str()))
+                    .collect();
+                if text.contains(needle) {
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Wait for an event matching a predicate.
+    async fn wait_for_msg(
+        rx: &mut tokio::sync::broadcast::Receiver<Arc<ServerMsg>>,
+        mut pred: impl FnMut(&ServerMsg) -> bool,
+    ) {
+        loop {
+            let msg = rx.recv().await.expect("event stream open");
+            if pred(msg.as_ref()) {
+                return;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn session_lifecycle_pts_env_osc_and_close() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manager = test_manager(dir.path());
+
+        let session = manager
+            .create(Some("test".to_owned()))
+            .await
+            .expect("create");
+        let id = session.id;
+        let mut rx = session.subscribe();
+
+        // The CLI contract: sessions/<id>/pts holds the absolute pts path.
+        let pts_file = dir.path().join("sessions").join(id.to_string()).join("pts");
+        let pts_path = std::fs::read_to_string(&pts_file).expect("pts file");
+        let pts_path = pts_path.trim().to_owned();
+        assert!(
+            pts_path.starts_with('/'),
+            "pts path {pts_path:?} not absolute"
+        );
+
+        // The child sees IX_TERM_SESSION_ID: print it and watch the grid.
+        tokio::time::timeout(Duration::from_secs(20), async {
+            session
+                .write_input(1, "printf 'sid=%s\\n' \"$IX_TERM_SESSION_ID\"\r")
+                .await;
+            wait_for_text(&mut rx, &format!("sid={id}")).await;
+        })
+        .await
+        .expect("session id echoed to the grid");
+
+        // OSC 5522 from the slave side, exactly as `ixterm open` writes it.
+        let html = dir.path().join("view.html");
+        std::fs::write(&html, "<h1>hi</h1>").expect("write html");
+        let osc = format!("\u{1b}]5522;open;{}\u{7}", html.display());
+        tokio::time::timeout(Duration::from_secs(20), async {
+            std::fs::write(&pts_path, osc.as_bytes()).expect("write OSC to pts");
+            wait_for_msg(&mut rx, |msg| {
+                matches!(msg, ServerMsg::Open { path: Some(p), .. } if p.ends_with("view.html"))
+            })
+            .await;
+        })
+        .await
+        .expect("open event broadcast");
+        assert_eq!(
+            session.doc_path().as_deref(),
+            Some(html.to_str().expect("utf8 path"))
+        );
+
+        // A missing file renders an error in the session instead of opening.
+        tokio::time::timeout(Duration::from_secs(20), async {
+            std::fs::write(&pts_path, b"\x1b]5522;open;/nonexistent-ix-term.html\x07")
+                .expect("write OSC to pts");
+            wait_for_msg(&mut rx, |msg| matches!(msg, ServerMsg::OpenError { .. })).await;
+        })
+        .await
+        .expect("open error broadcast");
+
+        // Close: the child is killed, Exit lands, and the runtime dir is gone.
+        tokio::time::timeout(Duration::from_secs(20), async {
+            assert!(manager.close(id).await);
+            wait_for_msg(&mut rx, |msg| matches!(msg, ServerMsg::Exit { .. })).await;
+        })
+        .await
+        .expect("exit broadcast");
+        assert!(!pts_file.exists(), "runtime dir removed on close");
+        assert!(manager.get(id).await.is_none());
+        assert_eq!(manager.list().await.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn rename_updates_the_watched_list() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manager = test_manager(dir.path());
+        let mut list_rx = manager.watch_list();
+
+        let session = manager.create(None).await.expect("create");
+        assert_eq!(session.meta().name, "shell");
+        list_rx.changed().await.expect("list update");
+        assert_eq!(list_rx.borrow_and_update().len(), 1);
+
+        assert!(manager.rename(session.id, "build".to_owned()).await);
+        list_rx.changed().await.expect("list update");
+        assert_eq!(list_rx.borrow_and_update()[0].name, "build");
+
+        assert!(manager.close(session.id).await);
+    }
+}

--- a/packages/ix-term/server/src/vt.rs
+++ b/packages/ix-term/server/src/vt.rs
@@ -1,0 +1,212 @@
+//! The per-session VT engine: a dedicated OS thread that owns the `!Send`
+//! [`ix_vt::Terminal`] (libghostty-vt) and turns byte feeds into dirty-row
+//! grid frames on the session's broadcast channel.
+//!
+//! libghostty-vt's terminal has thread affinity, so one pinned thread owns it
+//! (the same shape as `packages/tui/tui`'s engine actor). Frames are
+//! coalesced: under a redraw storm the engine renders at most one frame per
+//! [`FRAME_INTERVAL`], diffing whole snapshots rather than tracking ghostty's
+//! internal dirty flags, which keeps the wire format independent of the
+//! engine (index#3797 wants it swappable).
+
+use std::sync::Arc;
+use std::sync::mpsc::{RecvTimeoutError, Sender};
+use std::time::{Duration, Instant};
+
+use tokio::sync::broadcast;
+
+use crate::proto::{ServerMsg, cursor_wire, diff_snapshots};
+
+/// Ceiling on the frame rate under continuous output (~30 fps). A quiet
+/// stream renders as soon as it goes idle, so interactive latency is the
+/// engine's poll granularity, not this interval.
+const FRAME_INTERVAL: Duration = Duration::from_millis(33);
+
+/// How long the engine sleeps when there is nothing dirty to ship.
+const IDLE_WAIT: Duration = Duration::from_secs(1);
+
+/// A request to the engine thread.
+pub enum EngineMsg {
+    /// Feed raw VT bytes (already stripped of OSC 5522 by the scanner).
+    Feed(Vec<u8>),
+    /// Resize the terminal; the next frame is full.
+    Resize {
+        /// New height in rows.
+        rows: u16,
+        /// New width in columns.
+        cols: u16,
+    },
+    /// Ship a full frame (a client connected or resynced after lag).
+    FullFrame,
+    /// Stop the engine thread.
+    Shutdown,
+}
+
+/// A handle to a session's engine thread.
+#[derive(Clone)]
+pub struct EngineHandle {
+    tx: Sender<EngineMsg>,
+}
+
+impl EngineHandle {
+    /// Send a request; a dead engine (session tear-down) drops it.
+    pub fn send(&self, msg: EngineMsg) {
+        if self.tx.send(msg).is_err() {
+            tracing::debug!("engine request after engine shutdown");
+        }
+    }
+}
+
+/// Spawn the engine thread for a `rows`x`cols` terminal.
+///
+/// Grid frames (and nothing else) are published to `events`. The terminal is
+/// created on the new thread; creation failure surfaces here through an init
+/// handshake instead of leaving a dead channel.
+///
+/// # Errors
+/// Returns an error if the OS thread cannot be spawned or libghostty-vt
+/// cannot allocate the terminal.
+pub fn spawn_engine(
+    rows: u16,
+    cols: u16,
+    scrollback: usize,
+    events: broadcast::Sender<Arc<ServerMsg>>,
+) -> anyhow::Result<EngineHandle> {
+    let (tx, rx) = std::sync::mpsc::channel::<EngineMsg>();
+    let (init_tx, init_rx) = std::sync::mpsc::sync_channel::<Result<(), ix_vt::Error>>(1);
+
+    std::thread::Builder::new()
+        .name("ix-term-vt".to_owned())
+        .spawn(move || {
+            let mut terminal = match ix_vt::Terminal::new(rows, cols, scrollback) {
+                Ok(terminal) => {
+                    if init_tx.send(Ok(())).is_err() {
+                        return;
+                    }
+                    terminal
+                }
+                Err(error) => {
+                    let _ = init_tx.send(Err(error));
+                    return;
+                }
+            };
+            engine_loop(&mut terminal, &rx, &events);
+        })?;
+
+    init_rx.recv()??;
+    Ok(EngineHandle { tx })
+}
+
+/// The engine thread body: drain requests, pace frames.
+fn engine_loop(
+    terminal: &mut ix_vt::Terminal,
+    rx: &std::sync::mpsc::Receiver<EngineMsg>,
+    events: &broadcast::Sender<Arc<ServerMsg>>,
+) {
+    let mut prev: Option<ix_vt::Snapshot> = None;
+    let mut seq: u64 = 0;
+    let mut dirty = false;
+    let mut last_frame = Instant::now()
+        .checked_sub(FRAME_INTERVAL)
+        .unwrap_or_else(Instant::now);
+
+    loop {
+        // Sleep until the next frame is due (or idle-poll when clean);
+        // requests wake the loop early.
+        let wait = if dirty {
+            FRAME_INTERVAL.saturating_sub(last_frame.elapsed())
+        } else {
+            IDLE_WAIT
+        };
+        match rx.recv_timeout(wait) {
+            Ok(msg) => {
+                if handle(terminal, msg, &mut prev, &mut dirty).is_break() {
+                    return;
+                }
+                // Drain whatever queued behind it so a burst becomes one frame.
+                loop {
+                    match rx.try_recv() {
+                        Ok(msg) => {
+                            if handle(terminal, msg, &mut prev, &mut dirty).is_break() {
+                                return;
+                            }
+                        }
+                        Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                        Err(std::sync::mpsc::TryRecvError::Disconnected) => return,
+                    }
+                }
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => return,
+        }
+
+        if dirty && last_frame.elapsed() >= FRAME_INTERVAL {
+            render_frame(terminal, &mut prev, &mut seq, events);
+            dirty = false;
+            last_frame = Instant::now();
+        }
+    }
+}
+
+/// Apply one request to the terminal. `Break` means shut down.
+fn handle(
+    terminal: &mut ix_vt::Terminal,
+    msg: EngineMsg,
+    prev: &mut Option<ix_vt::Snapshot>,
+    dirty: &mut bool,
+) -> std::ops::ControlFlow<()> {
+    match msg {
+        EngineMsg::Feed(bytes) => {
+            terminal.vt_write(&bytes);
+            *dirty = true;
+        }
+        EngineMsg::Resize { rows, cols } => {
+            if let Err(error) = terminal.resize(rows, cols) {
+                tracing::warn!(%error, rows, cols, "terminal resize rejected");
+            }
+            *prev = None;
+            *dirty = true;
+        }
+        EngineMsg::FullFrame => {
+            *prev = None;
+            *dirty = true;
+        }
+        EngineMsg::Shutdown => return std::ops::ControlFlow::Break(()),
+    }
+    std::ops::ControlFlow::Continue(())
+}
+
+/// Render, diff against the previous snapshot, and broadcast a grid frame.
+fn render_frame(
+    terminal: &ix_vt::Terminal,
+    prev: &mut Option<ix_vt::Snapshot>,
+    seq: &mut u64,
+    events: &broadcast::Sender<Arc<ServerMsg>>,
+) {
+    let snapshot = match terminal.render() {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            tracing::warn!(%error, "terminal render failed; skipping frame");
+            return;
+        }
+    };
+    if prev.as_ref() == Some(&snapshot) {
+        return;
+    }
+    let diff = diff_snapshots(prev.as_ref(), &snapshot);
+    let app_cursor = terminal.application_cursor_keys().unwrap_or(false);
+    let msg = ServerMsg::Grid {
+        seq: *seq,
+        cols: snapshot.cols,
+        rows: snapshot.rows,
+        full: diff.full,
+        changed: diff.changed,
+        cursor: cursor_wire(&snapshot.cursor),
+        app_cursor,
+    };
+    *seq += 1;
+    *prev = Some(snapshot);
+    // No receivers is fine: frames before the first client attach are simply
+    // state the next full frame covers.
+    let _ = events.send(Arc::new(msg));
+}

--- a/packages/ix-term/server/src/ws.rs
+++ b/packages/ix-term/server/src/ws.rs
@@ -1,0 +1,108 @@
+//! Websocket endpoints: the per-session terminal channel and the session-list
+//! events channel.
+
+use std::sync::Arc;
+
+use axum::extract::ws::{Message, WebSocket};
+use futures::{SinkExt as _, StreamExt as _};
+use tokio::sync::broadcast;
+
+use crate::proto::{ClientMsg, ServerMsg};
+use crate::session::{Session, SessionManager};
+
+/// Serialize a message for the wire.
+fn frame(msg: &ServerMsg) -> Message {
+    Message::Text(
+        serde_json::to_string(msg)
+            .expect("wire types serialize (pinned by proto tests)")
+            .into(),
+    )
+}
+
+/// Drive one terminal client: forward the session's event stream out and
+/// apply the client's input/resize/refresh messages.
+pub async fn terminal_client(session: Arc<Session>, socket: WebSocket) {
+    let conn = session.next_conn();
+    // Subscribe before requesting the full frame so it cannot be missed.
+    let mut events = session.subscribe();
+    let (mut sink, mut stream) = socket.split();
+
+    // Joining state: identity, seat, opened doc, then a full grid.
+    let hello = ServerMsg::Hello {
+        conn: conn.to_string(),
+        session: session.meta(),
+    };
+    for msg in [&hello, &session.driver_msg(), &session.open_msg()] {
+        if sink.send(frame(msg)).await.is_err() {
+            return;
+        }
+    }
+    session.request_full_frame();
+
+    // Outbound pump. A slow client that lags off the broadcast ring is
+    // resynced with a fresh full frame instead of the dropped ones.
+    let pump_session = Arc::clone(&session);
+    let mut pump = tokio::spawn(async move {
+        loop {
+            match events.recv().await {
+                Ok(msg) => {
+                    if sink.send(frame(msg.as_ref())).await.is_err() {
+                        return;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    pump_session.request_full_frame();
+                }
+                Err(broadcast::error::RecvError::Closed) => return,
+            }
+        }
+    });
+
+    // Inbound loop on this task; ends on disconnect or pump failure.
+    loop {
+        tokio::select! {
+            _ = &mut pump => break,
+            incoming = stream.next() => {
+                let Some(Ok(message)) = incoming else { break };
+                let Message::Text(text) = message else { continue };
+                match serde_json::from_str::<ClientMsg>(&text) {
+                    Ok(ClientMsg::Input { data }) => session.write_input(conn, &data).await,
+                    Ok(ClientMsg::Resize { cols, rows }) => session.resize(conn, rows, cols).await,
+                    Ok(ClientMsg::Refresh) => session.request_full_frame(),
+                    Ok(ClientMsg::CloseDoc) => session.close_doc(),
+                    Err(error) => {
+                        tracing::debug!(%error, "ignoring malformed client message");
+                    }
+                }
+            }
+        }
+    }
+
+    pump.abort();
+    session.release_driver(conn);
+}
+
+/// Drive one events client: push the session list on connect and on change.
+pub async fn events_client(manager: Arc<SessionManager>, mut socket: WebSocket) {
+    let mut list = manager.watch_list();
+    loop {
+        let sessions = list.borrow_and_update().clone();
+        let msg = ServerMsg::Sessions { sessions };
+        if socket.send(frame(&msg)).await.is_err() {
+            return;
+        }
+        tokio::select! {
+            changed = list.changed() => {
+                if changed.is_err() {
+                    return;
+                }
+            }
+            // Drain (and thereby notice the close of) the client side.
+            incoming = socket.recv() => {
+                if incoming.is_none() {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/packages/site/src/lib/updates/ix-term-web-terminal.svx
+++ b/packages/site/src/lib/updates/ix-term-web-terminal.svx
@@ -1,0 +1,57 @@
+---
+id: ix-term-web-terminal
+postedAt: 2026-07-20T16:30:00-07:00
+title: "ix-term: a tailnet web terminal on server-side libghostty-vt"
+tags: [terminal, rust, svelte, interesting]
+links:
+  - label: issue 3797
+    href: https://github.com/indexable-inc/index/issues/3797
+  - label: server crate
+    href: https://github.com/indexable-inc/index/tree/main/packages/ix-term/server
+  - label: ixterm CLI
+    href: https://github.com/indexable-inc/index/tree/main/packages/ixterm
+---
+
+`ix-term-server` is a web terminal meant to live inside the tailnet
+(term.ix.dev): a Rust server owns one libghostty-vt terminal state per
+session as the single source of truth, spawns PTY login shells on the
+serving host, and streams *dirty rows* to a Svelte frontend over a
+websocket. Browsers are thin views — reconnecting, or opening the same
+session on a second machine, always shows exactly what the server knows.
+
+The UI is an Arc-style left tab bar of sessions (create, inline rename,
+close), a DOM-rendered grid, and one seat rule: the last keystroke wins the
+driver seat, the driver's viewport owns the PTY size, and everyone else sees
+the driver-sized grid CSS-scaled down. No resize fights.
+
+Sessions carry `IX_TERM_SESSION_ID`, and the server publishes each
+session's pts path at `/run/ix-term/sessions/<id>/pts`. That is the whole
+contract behind `ixterm open`:
+
+```sh
+ixterm open /tmp/report.html
+```
+
+writes a private OSC (`ESC ] 5522 ; open ; <abs path> BEL`) straight to the
+session pts in one `write(2)`. The server strips it from the byte stream
+before the VT engine sees it (ghostty's OSC enum is closed, so a scanner in
+front of `vt_write` is also the seam that keeps the engine swappable) and
+opens the HTML file as a split next to the terminal — a sandboxed iframe
+whose CSP forbids all network fetches. Bad paths render as an error inside
+the session; there is no backchannel to the writer.
+
+Operators get a NixOS module with typed options:
+
+```nix
+services.ix-term = {
+  enable = true;
+  port = 7533;            # loopback by default
+  user = "andrewgazelka"; # sessions are this account's login shells
+};
+```
+
+Auth is the reverse proxy / tailnet boundary; per-request Tailscale WhoIs is
+the tracked TODO before the term.ix.dev host wiring lands in the ix repo.
+The wire format was benchmarked under a synthetic full-screen redraw storm
+(numbers in the PR) and stays abstract enough to swap the client for
+ghostty-web WASM later.


### PR DESCRIPTION
Part of #3797; together with the already-merged `ixterm` CLI (#3799) this closes the issue. Closes #3797.

## What this is

A tailnet-internal web terminal (term.ix.dev). The server owns one **libghostty-vt** terminal state per session (via the repo's existing `ix-vt` safe wrapper over `ix-vt-sys`), spawns PTY **login shells on the serving host**, and streams **dirty rows** to a Svelte 5 frontend over a websocket. Companion NixOS module `services.ix-term` with typed options.

## How it fits together

- **VT engine** (`src/vt.rs`): a pinned OS thread owns the `!Send` `ix_vt::Terminal` (same actor shape as `packages/tui`). Frames coalesce to at most ~30 fps under redraw storms; each frame is a whole-snapshot diff, so the wire format never references ghostty internals and stays swappable (ghostty-web WASM + raw bytes remains an open door, per the issue).
- **OSC 5522** (`src/osc.rs`): ghostty's OSC command enum is closed (no unknown-OSC payload access), so a byte-exact streaming scanner sits in front of `vt_write`: it strips `ESC ] 5522 ; open ; <abs path> BEL` (and the `ESC \` ST form) from the PTY stream and passes everything else through byte-for-byte. Tested at every split boundary, plus abort (`CAN`/`SUB`/`ESC`), overflow, and non-5522 passthrough cases.
- **CLI contract** (`src/session.rs`): children get `IX_TERM_SESSION_ID`; the server writes `<runtime dir>/sessions/<id>/pts` exactly as `packages/ixterm/src/pts.rs` reads it (trimmed absolute path). The lifecycle test drives a real `/bin/sh` on a PTY, echoes the session id through the grid, and writes the OSC to the pts **exactly as `ixterm open` does**.
- **Wire protocol** (`src/proto.rs`): JSON text frames (`hello`/`grid`/`driver`/`open`/`open_error`/`exit` down; `input`/`resize`/`refresh`/`close_doc` up). Golden tests pin exact bytes.
- **Frontend** (`site/`): Svelte 5 + Vite (nix-web-monitor pattern: `ix.buildSvelteSite` + `ix.wrapPackage`, served by `ServeDir`). Arc-style left tab bar (create / inline rename / close, live via `/api/ws`), DOM grid with cursor overlay, keyboard encoder (DECCKM-aware arrows, ctrl/alt combos, paste), reconnect with full-frame gating.
- **Driver-owns-size**: last keystroke claims the seat server-side; only the seat holder (or a free seat) may resize. Non-drivers render the driver-sized grid CSS-scaled (`scale(min(1, availW/gridW, availH/gridH))`) with a driving/viewing chip.
- **Opened HTML**: a split next to the terminal in that session; `<iframe sandbox="allow-scripts">` and the doc response carries CSP `default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; font-src data:; form-action 'none'; base-uri 'none'` — inline content runs, nothing loads over the network. Bad paths render an `open_error` banner in the session (no backchannel to the writer).
- **Auth**: binds `127.0.0.1:7533` by default and trusts the reverse proxy / tailnet. Tailscale WhoIs per request is a documented TODO (module header + crate docs). No login UI by design.

## Benchmark (pre-freeze, per the issue)

`ix-term-server bench-flood --rows 40 --cols 120 --seconds 5`, release build, Apple M-series (hydra), synthetic full-screen redraw flood (cursor home + full rewrite + rotating SGR color per row):

- raw VT ingestion (parse + state, no pipeline): **5,141,600 rows in 5.00s = ~1,028,000 rows/sec** (128,540 full frames)
- full pipeline (engine thread -> coalescing -> row diff -> JSON): absorbed ~64,000 input rows/sec (producer paced at 2k frames/sec) while shipping **29.0 fps, ~1,160 dirty rows/sec, ~192 KiB/s wire** — the coalescer collapses the storm to one full-grid diff per frame interval, which is the design working as intended (a btop-style TUI redraws far below the ingest ceiling).

## v1 decisions (overridable, recorded per the issue's open list)

- tab bar population: **server-spawned PTY sessions created from the UI** (`POST /api/sessions`); nothing else in v1
- driver handoff: **last keystroke wins**, shown as a driving/viewing chip; seat releases on disconnect
- opened HTML: **split in the session tab** (not a separate tab), sandboxed iframe, **no network** via CSP
- **no persistence across server restart** (sessions die with the daemon)
- **no unix socket and no HTTP open endpoint** (pts write is the only open path); `--listen` covers the port config
- which fleet host serves term.ix.dev: **out of scope here** — DNS + systemd host wiring is the follow-up in the ix repo

## Deviations from the issue, named

- Dirty rows are computed by whole-snapshot row diffing at the coalescing boundary rather than ghostty's internal dirty flags: simpler, engine-agnostic, and the benchmark shows the diff cost is negligible next to the 30 fps wire cap. Swapping to `GHOSTTY_RENDER_STATE_ROW_DATA_DIRTY` later is an internal change only.
- The scanner accepts both `BEL` and `ESC \` terminators (CLI emits `BEL` only).
- tmux allow-passthrough documentation is deferred to the term.ix.dev host-wiring follow-up.
- Wide (double-width) glyphs render as base char + space cell; fonts that draw CJK at double width will misalign those cells (noted in `proto.rs`; a cell-width field can ride the existing span format compatibly).

## Validation

- `cargo test -p ix-term-server`: 23/23 (OSC split-boundary/byte-exact suite, protocol golden bytes, diff semantics, driver seat, real-PTY session lifecycle incl. OSC-via-pts and close/cleanup)
- local clippy (pedantic+nursery, fork lints eyeballed per repo recipe): clean; `nix run .#lint`: 12/12
- `nix eval .#packages.aarch64-linux.ix-term-server.name` resolves; full linux package build running (cargo-unit + `buildSvelteSite` + wrapper) alongside CI
- frontend `npm run build` (svelte-check + eslint strictTypeChecked + vite): green

(sent by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ix-term web terminal server backed by libghostty-vt
> - Introduces a new `ix-term-server` Rust binary ([main.rs](https://github.com/indexable-inc/index/pull/3800/files#diff-a5710daeea99f234f2ec2200c6dc8bb22b0d63abfedd1a40c4d98940d143ca00)) serving an Axum HTTP API for PTY-backed terminal sessions, including REST endpoints for session CRUD and WebSocket endpoints for live terminal I/O and session-list updates.
> - Each session spawns a login shell attached to a PTY, feeds output through a `libghostty-vt` VT engine ([vt.rs](https://github.com/indexable-inc/index/pull/3800/files#diff-acda0d89125c3ebbba5c5b7c88b606b95bf1952ba4b58c0b4aa0f94c6ada138f)) that emits paced grid frames (~30fps) with sparse diff updates, cursor state, and app-cursor mode.
> - A streaming OSC 5522 scanner ([osc.rs](https://github.com/indexable-inc/index/pull/3800/files#diff-abf3876cd82aa15cd547a3abfee8d9e99fa823db230abfc8bd30f265717d5bcd)) strips document-open escape sequences from PTY output and triggers `Open`/`OpenError` broadcasts; opened files are served via `/api/sessions/{id}/doc` with a restrictive CSP.
> - Driver-seat arbitration ([session.rs](https://github.com/indexable-inc/index/pull/3800/files#diff-530b143a1ce52d7fcf0f5b7bb768f61bece42c01597c960974364db150e3a379)) ensures only the last active typist can resize the terminal; other clients see a scaled read-only view.
> - A Svelte/Vite frontend ([site/](https://github.com/indexable-inc/index/pull/3800/files#diff-5756eac405dc62cf37b1f341fe56f46edb83e9d4ac36c8e4e0e65e8a6fbc4bfa)) provides a tab bar for session management, a DOM-rendered terminal grid, keyboard/paste input encoding, and WebSocket reconnection with exponential backoff.
> - A NixOS module ([modules/services/ix-term/default.nix](https://github.com/indexable-inc/index/pull/3800/files#diff-14183cca60966bf05a40f66db07904859db205c7102f20863ca91d7d445b1484)) adds `services.ix-term` with configurable listen address, port, user, and scrollback, running the server as a systemd service with a `/run/ix-term` runtime directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9329be8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->