### PR TITLE
usage: local usage telemetry walking skeleton (spool+SQLite, ix-wrap, withUsage)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5722,6 +5722,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ix-usage"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ix-usage-core",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "ureq",
+]
+
+[[package]]
+name = "ix-usage-core"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "libc",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "toml 1.1.2+spec-1.1.0",
+ "uuid",
+]
+
+[[package]]
 name = "ix-vt"
 version = "0.1.0"
 dependencies = [
@@ -5748,6 +5777,19 @@ dependencies = [
  "tokio",
  "uuid",
  "wry",
+]
+
+[[package]]
+name = "ix-wrap"
+version = "0.1.0"
+dependencies = [
+ "ix-usage-core",
+ "libc",
+ "nix 0.31.3",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,9 @@ members = [
   "packages/unibind/runtime",
   "packages/unibind/test-support",
   "packages/upstream-sync",
+  "packages/usage/cli",
+  "packages/usage/core",
+  "packages/usage/wrap",
   "packages/vm/panes/audio",
   "packages/vm/panes/compositor",
   "packages/vm/panes/guest-transport",
@@ -233,6 +236,7 @@ google-gmail = { path = "packages/google/gmail" }
 indexbench = { path = "packages/indexbench" }
 ix-vt = { path = "packages/tui/vt/ix-vt" }
 ix-vt-sys = { path = "packages/tui/vt/ix-vt-sys", version = "0.1.0" }
+ix-usage-core = { path = "packages/usage/core" }
 kitty = { path = "packages/terminal/kitty" }
 lake-iceberg = { path = "packages/search/lake/iceberg" }
 color-eyre = "0.6"

--- a/lib/packages.nix
+++ b/lib/packages.nix
@@ -49,6 +49,12 @@
     # packages need not re-thread `ix` through callPackage. The overlay path
     # leaves it unset, which is the signal to omit the updater.
     updateScriptWriter = ixForPackages.writeNushellApplication pkgs;
+    # Usage-telemetry wrapper (index#3802): rewrap a package's bin/* with
+    # ix-wrap so invocations and failures land in the local usage store.
+    withUsage = import ./with-usage.nix {
+      inherit lib pkgs;
+      ix = ixForPackages;
+    };
   };
   mkPackageSet = import ./mk-package-set.nix {inherit lib;};
 in

--- a/lib/with-usage.nix
+++ b/lib/with-usage.nix
@@ -1,0 +1,62 @@
+# Usage-telemetry wrapper seam (index#3802).
+#
+# `withUsage pkg { ... }` rewraps every executable in `pkg`'s bin/ with
+# `ix-wrap` so invocations and failures land in the local usage store
+# (spool + SQLite; see packages/usage). Policy is rendered per binary into a
+# JSON spec consumed via IX_USAGE_SPEC, the same wiring shape as
+# config-launch's IX_LAUNCH_SPEC. The wrapper records after the child exits,
+# so the tool's own latency is untouched; `mode = "count-only"` records then
+# exec()s for hot-path tools called in tight loops.
+{
+  lib,
+  pkgs,
+  ix,
+}: pkg: {
+  # Package id recorded in counts; defaults to the wrapped package's name.
+  id ? lib.getName pkg,
+  version ? pkg.version or "unknown",
+  # "observe" (default) or "count-only".
+  mode ? "observe",
+  # Whether failing invocations keep argv/cwd in the LOCAL database (never
+  # uploaded either way).
+  errors ? true,
+  # Whether invocations may kick the detached `ix-usage upload --if-due`.
+  uploader ? true,
+}: let
+  ixWrap = ix.rustWorkspace.units.binaries.ix-wrap;
+  ixUsage = ix.rustWorkspace.units.binaries.ix-usage;
+  specBase =
+    {
+      pkg = id;
+      inherit version mode errors;
+    }
+    // lib.optionalAttrs uploader {
+      uploader = "${ixUsage}/bin/ix-usage";
+    };
+  specBaseFile = pkgs.writeText "ix-usage-spec-${id}.json" (builtins.toJSON specBase);
+in
+  pkgs.runCommand "${id}-with-usage"
+  {
+    nativeBuildInputs = [pkgs.makeBinaryWrapper pkgs.jq];
+    meta = pkg.meta or {};
+    passthru = {unwrapped = pkg;};
+  }
+  ''
+    mkdir -p "$out/bin" "$out/share/ix-usage"
+    found=0
+    for bin in ${pkg}/bin/*; do
+      if [ -f "$bin" ] && [ -x "$bin" ]; then
+        found=1
+        name=$(basename "$bin")
+        spec="$out/share/ix-usage/$name.json"
+        jq --arg target "$bin" '. + {target: $target}' ${specBaseFile} > "$spec"
+        makeBinaryWrapper ${ixWrap}/bin/ix-wrap "$out/bin/$name" \
+          --inherit-argv0 \
+          --set IX_USAGE_SPEC "$spec"
+      fi
+    done
+    if [ "$found" != 1 ]; then
+      echo "withUsage: ${id} has no executables in bin/" >&2
+      exit 1
+    fi
+  ''

--- a/packages/usage/cli/Cargo.toml
+++ b/packages/usage/cli/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "ix-usage"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Agent-first CLI over the local ix usage store: consent, captured failures as JSON, spool compaction, and count-only uploads"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+ix-usage-core.workspace = true
+rusqlite.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+ureq = { workspace = true, features = ["json"] }
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[[bin]]
+name = "ix-usage"
+path = "src/main.rs"

--- a/packages/usage/cli/default.nix
+++ b/packages/usage/cli/default.nix
@@ -1,0 +1,13 @@
+{
+  ix,
+  lib,
+  ...
+}:
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "ix-usage";
+  meta = {
+    description = "Agent-first CLI over the local ix usage store: consent, captured failures as JSON, spool compaction, and count-only uploads";
+    license = lib.licenses.mit;
+    mainProgram = "ix-usage";
+  };
+}

--- a/packages/usage/cli/package.nix
+++ b/packages/usage/cli/package.nix
@@ -1,0 +1,8 @@
+{
+  id = "ix-usage";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/usage/cli/src/main.rs
+++ b/packages/usage/cli/src/main.rs
@@ -1,0 +1,316 @@
+//! `ix-usage`: agent-first CLI over the local usage telemetry store
+//! (index#3802).
+//!
+//! Every read subcommand compacts the spool first, so callers always see
+//! current data, and every listing supports `--json`. The upload path sends
+//! aggregated counts only; see `ix_usage_core::payload` for the invariant.
+
+use anyhow::Context as _;
+use clap::{Parser, Subcommand};
+use ix_usage_core::{consent, paths, payload, spool, store};
+use rusqlite::Connection;
+use serde::Serialize;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(
+    name = "ix-usage",
+    version,
+    about = "Local ix usage telemetry: consent, captured failures, uploads"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Show consent state and store locations.
+    Status {
+        /// Machine-readable output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Enable uploads (writes the config file).
+    On,
+    /// Disable uploads (writes the config file). Local recording continues.
+    Off,
+    /// Print the exact JSON payload the next upload would send.
+    Show,
+    /// List captured failures, newest first.
+    Errors {
+        /// Machine-readable output.
+        #[arg(long)]
+        json: bool,
+        /// Maximum rows.
+        #[arg(long, default_value_t = 20)]
+        limit: u32,
+    },
+    /// Show one captured failure by id.
+    Error {
+        /// Row id from `ix-usage errors`.
+        id: i64,
+        /// Machine-readable output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Fold pending spool records into the database.
+    Compact,
+    /// Upload aggregated counts to the collector.
+    Upload {
+        /// Only upload when consent allows and the last upload is stale;
+        /// exit quietly otherwise (used by the wrapper's detached kick).
+        #[arg(long)]
+        if_due: bool,
+        /// Build and print the payload without sending.
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
+/// Minimum spacing between uploads.
+const UPLOAD_INTERVAL_MS: i64 = 24 * 3600 * 1000;
+
+fn main() -> anyhow::Result<()> {
+    match Cli::parse().command {
+        Command::Status { json } => status(json),
+        Command::On => set_enabled(true),
+        Command::Off => set_enabled(false),
+        Command::Show => show(),
+        Command::Errors { json, limit } => errors(json, limit),
+        Command::Error { id, json } => error_by_id(id, json),
+        Command::Compact => compact_cmd(),
+        Command::Upload { if_due, dry_run } => upload(if_due, dry_run),
+    }
+}
+
+fn state_dir() -> anyhow::Result<PathBuf> {
+    paths::state_dir().context("no home directory: usage telemetry has no state here")
+}
+
+/// Compact, then open the database (the read-side convention: readers always
+/// see current data).
+fn compacted_db() -> anyhow::Result<Connection> {
+    let state = state_dir()?;
+    store::compact(&state)?;
+    store::open(&state.join("usage.db"))
+}
+
+#[derive(Serialize)]
+struct Status {
+    upload_enabled: bool,
+    source: &'static str,
+    ci: bool,
+    config_path: Option<PathBuf>,
+    state_dir: Option<PathBuf>,
+    last_upload_ms: Option<i64>,
+    install_id: Option<String>,
+}
+
+fn read_status() -> anyhow::Result<Status> {
+    let consent = consent::resolve()?;
+    let mut last_upload_ms = None;
+    let mut install_id = None;
+    if let Some(db) = paths::db_path().filter(|db| db.exists()) {
+        let conn = store::open(&db)?;
+        last_upload_ms = store::meta_get(&conn, "last_upload_ms")?
+            .map(|value| value.parse::<i64>())
+            .transpose()?;
+        install_id = store::meta_get(&conn, "install_id")?;
+    }
+    Ok(Status {
+        upload_enabled: consent.upload,
+        source: consent.source.as_str(),
+        ci: consent::is_ci(),
+        config_path: paths::config_path(),
+        state_dir: paths::state_dir(),
+        last_upload_ms,
+        install_id,
+    })
+}
+
+fn status(json: bool) -> anyhow::Result<()> {
+    let status = read_status()?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&status)?);
+        return Ok(());
+    }
+    println!(
+        "uploads:   {} (decided by {})",
+        on_off(status.upload_enabled),
+        status.source
+    );
+    println!("ci:        {}", status.ci);
+    match &status.config_path {
+        Some(path) => println!("config:    {}", path.display()),
+        None => println!("config:    (no home directory)"),
+    }
+    match &status.state_dir {
+        Some(dir) => println!("state:     {}", dir.display()),
+        None => println!("state:     (no home directory)"),
+    }
+    match status.last_upload_ms {
+        Some(ts) => println!("last sent: {ts} (unix ms)"),
+        None => println!("last sent: never"),
+    }
+    Ok(())
+}
+
+const fn on_off(enabled: bool) -> &'static str {
+    if enabled { "on" } else { "off" }
+}
+
+fn set_enabled(enabled: bool) -> anyhow::Result<()> {
+    let mut config = consent::read_config()?.unwrap_or_default();
+    config.enabled = Some(enabled);
+    let path = consent::write_config(&config)?;
+    println!("uploads {} ({})", on_off(enabled), path.display());
+    Ok(())
+}
+
+fn show() -> anyhow::Result<()> {
+    let conn = compacted_db()?;
+    let since = payload::since_day(payload::REPORT_WINDOW_DAYS)?;
+    let report = payload::build_report(&conn, &since, consent::is_ci())?;
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    Ok(())
+}
+
+/// A captured failure as stored locally. Never uploaded.
+#[derive(Serialize)]
+struct ErrorRow {
+    id: i64,
+    ts_ms: i64,
+    pkg: String,
+    version: String,
+    exit_code: Option<i32>,
+    argv: Option<Vec<String>>,
+    cwd: Option<String>,
+    duration_ms: Option<i64>,
+    reported_ref: Option<String>,
+}
+
+fn map_error_row(row: &rusqlite::Row) -> rusqlite::Result<ErrorRow> {
+    let argv_json: Option<String> = row.get(5)?;
+    Ok(ErrorRow {
+        id: row.get(0)?,
+        ts_ms: row.get(1)?,
+        pkg: row.get(2)?,
+        version: row.get(3)?,
+        exit_code: row.get(4)?,
+        argv: argv_json.and_then(|text| serde_json::from_str(&text).ok()),
+        cwd: row.get(6)?,
+        duration_ms: row.get(7)?,
+        reported_ref: row.get(8)?,
+    })
+}
+
+const ERROR_COLUMNS: &str =
+    "id, ts_ms, pkg, version, exit_code, argv, cwd, duration_ms, reported_ref";
+
+fn errors(json: bool, limit: u32) -> anyhow::Result<()> {
+    let conn = compacted_db()?;
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {ERROR_COLUMNS} FROM errors ORDER BY id DESC LIMIT ?1"
+    ))?;
+    let rows = stmt
+        .query_map([limit], |row| map_error_row(row))?
+        .collect::<Result<Vec<_>, _>>()?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+        return Ok(());
+    }
+    if rows.is_empty() {
+        println!("no captured failures");
+        return Ok(());
+    }
+    for row in &rows {
+        let exit = row
+            .exit_code
+            .map_or_else(|| "?".to_owned(), |code| code.to_string());
+        println!(
+            "{}  {}  {}@{}  exit {exit}",
+            row.id, row.ts_ms, row.pkg, row.version
+        );
+    }
+    Ok(())
+}
+
+fn error_by_id(id: i64, json: bool) -> anyhow::Result<()> {
+    let conn = compacted_db()?;
+    let row = conn
+        .query_row(
+            &format!("SELECT {ERROR_COLUMNS} FROM errors WHERE id = ?1"),
+            [id],
+            |row| map_error_row(row),
+        )
+        .with_context(|| format!("no captured failure with id {id}"))?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&row)?);
+        return Ok(());
+    }
+    println!("{}", serde_json::to_string_pretty(&row)?);
+    Ok(())
+}
+
+fn compact_cmd() -> anyhow::Result<()> {
+    let stats = store::compact(&state_dir()?)?;
+    println!(
+        "folded {} record(s), skipped {}",
+        stats.folded, stats.skipped
+    );
+    Ok(())
+}
+
+fn endpoint(config: Option<&consent::Config>) -> String {
+    if let Ok(endpoint) = std::env::var("IX_USAGE_ENDPOINT") {
+        return endpoint;
+    }
+    config
+        .and_then(|config| config.endpoint.clone())
+        .unwrap_or_else(|| payload::DEFAULT_ENDPOINT.to_owned())
+}
+
+fn upload(if_due: bool, dry_run: bool) -> anyhow::Result<()> {
+    let config = consent::read_config()?;
+    let resolved = consent::resolve()?;
+    if !resolved.upload {
+        if if_due {
+            return Ok(());
+        }
+        anyhow::bail!("uploads are off (decided by {})", resolved.source.as_str());
+    }
+
+    let conn = compacted_db()?;
+    let now = spool::now_ms()?;
+    if if_due {
+        let last = store::meta_get(&conn, "last_upload_ms")?
+            .map(|value| value.parse::<i64>())
+            .transpose()?;
+        if last.is_some_and(|last| now - last < UPLOAD_INTERVAL_MS) {
+            return Ok(());
+        }
+    }
+
+    let since = payload::since_day(payload::REPORT_WINDOW_DAYS)?;
+    let report = payload::build_report(&conn, &since, consent::is_ci())?;
+    if dry_run {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+    if report.counts.is_empty() {
+        println!("nothing to upload");
+        return Ok(());
+    }
+
+    let endpoint = endpoint(config.as_ref());
+    ureq::post(&endpoint)
+        .send_json(&report)
+        .with_context(|| format!("posting usage report to {endpoint}"))?;
+    store::meta_set(&conn, "last_upload_ms", &now.to_string())?;
+    println!(
+        "uploaded {} count row(s) to {endpoint}",
+        report.counts.len()
+    );
+    Ok(())
+}

--- a/packages/usage/cli/tests/cli.rs
+++ b/packages/usage/cli/tests/cli.rs
@@ -1,0 +1,88 @@
+//! Agent-facing JSON contract tests for the `ix-usage` CLI.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn run(dir: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_ix-usage"))
+        .args(args)
+        .env("IX_USAGE_STATE_DIR", dir.join("state"))
+        .env("IX_USAGE_CONFIG", dir.join("usage.toml"))
+        .env_remove("IX_USAGE")
+        .env_remove("DO_NOT_TRACK")
+        .output()
+        .expect("run ix-usage")
+}
+
+fn json(output: &Output) -> serde_json::Value {
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("stdout is JSON")
+}
+
+fn seed_failure(dir: &Path) {
+    // Recent timestamp so the record falls inside the report window.
+    let ts_ms = ix_usage_core::spool::now_ms().expect("clock");
+    let record = ix_usage_core::spool::Record {
+        ts_ms,
+        pkg: "demo".to_owned(),
+        version: "1.0".to_owned(),
+        exit: Some(2),
+        duration_ms: Some(4),
+        argv: Some(vec!["demo".to_owned(), "--boom".to_owned()]),
+        cwd: None,
+    };
+    ix_usage_core::spool::append_at(&dir.join("state/usage.spool"), &record).expect("seed");
+}
+
+#[test]
+fn status_defaults_to_upload_on() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let status = json(&run(dir.path(), &["status", "--json"]));
+    assert_eq!(status["upload_enabled"], true);
+    assert_eq!(status["source"], "default");
+}
+
+#[test]
+fn off_flips_consent_via_config() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    assert!(run(dir.path(), &["off"]).status.success());
+    let status = json(&run(dir.path(), &["status", "--json"]));
+    assert_eq!(status["upload_enabled"], false);
+    assert_eq!(status["source"], "config");
+}
+
+#[test]
+fn errors_json_carries_the_whole_record() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    seed_failure(dir.path());
+    let errors = json(&run(dir.path(), &["errors", "--json"]));
+    let rows = errors.as_array().expect("array");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["pkg"], "demo");
+    assert_eq!(rows[0]["exit_code"], 2);
+    assert_eq!(rows[0]["argv"][1], "--boom");
+}
+
+#[test]
+fn show_prints_counts_only_payload() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    seed_failure(dir.path());
+    let output = run(dir.path(), &["show"]);
+    let report = json(&output);
+    assert_eq!(report["v"], 1);
+    assert_eq!(report["counts"].as_array().map(Vec::len), Some(1));
+    let wire = String::from_utf8_lossy(&output.stdout);
+    assert!(!wire.contains("--boom"), "payload must never carry argv");
+}
+
+#[test]
+fn upload_dry_run_needs_no_network() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    seed_failure(dir.path());
+    let report = json(&run(dir.path(), &["upload", "--dry-run"]));
+    assert_eq!(report["counts"][0]["failures"], 1);
+}

--- a/packages/usage/core/Cargo.toml
+++ b/packages/usage/core/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ix-usage-core"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Local usage telemetry: O_APPEND spool hot path, flock-singleton compaction into SQLite (WAL), consent resolution, and count-only upload payloads"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+chrono = { workspace = true, features = ["std"] }
+libc.workspace = true
+rusqlite.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+toml = { workspace = true, features = ["display", "parse", "serde"] }
+uuid = { workspace = true, features = ["v4"] }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/packages/usage/core/package.nix
+++ b/packages/usage/core/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "usage-core";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/usage/core/src/consent.rs
+++ b/packages/usage/core/src/consent.rs
@@ -1,0 +1,352 @@
+//! Consent resolution and the first-run notice or prompt.
+//!
+//! Precedence, first match wins: `IX_USAGE` env, `DO_NOT_TRACK` env, the
+//! config file, then default-on (announced by a one-time notice). CI and
+//! non-interactive processes never prompt. Only uploads are gated; local
+//! recording always stays on so a later opt-in has history.
+
+use std::io::{BufRead as _, ErrorKind, IsTerminal as _, Read, Write};
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// `~/.config/ix/usage.toml`.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
+pub struct Config {
+    /// Whether aggregate counts may be uploaded. Local recording is not
+    /// gated by this; it only controls the network.
+    pub enabled: Option<bool>,
+    /// Collector endpoint override.
+    pub endpoint: Option<String>,
+}
+
+/// Which layer decided the consent outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    /// `IX_USAGE` environment variable.
+    EnvIxUsage,
+    /// `DO_NOT_TRACK` environment variable (always a refusal).
+    DoNotTrack,
+    /// The config file.
+    ConfigFile,
+    /// No layer decided; the documented default (on).
+    DefaultOn,
+}
+
+impl Source {
+    /// Stable identifier used in `--json` output.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::EnvIxUsage => "env:IX_USAGE",
+            Self::DoNotTrack => "env:DO_NOT_TRACK",
+            Self::ConfigFile => "config",
+            Self::DefaultOn => "default",
+        }
+    }
+}
+
+/// A resolved consent decision plus the layer that decided it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Consent {
+    /// Whether uploads are allowed.
+    pub upload: bool,
+    /// The deciding layer.
+    pub source: Source,
+}
+
+fn truthy(value: &str) -> bool {
+    !matches!(value.trim(), "" | "0" | "false" | "no" | "off")
+}
+
+/// Pure consent resolution over already-read inputs (testable without
+/// touching the process environment).
+#[must_use]
+pub fn resolve_with(
+    ix_usage: Option<&str>,
+    do_not_track: Option<&str>,
+    config: Option<&Config>,
+) -> Consent {
+    if let Some(value) = ix_usage {
+        return Consent {
+            upload: truthy(value),
+            source: Source::EnvIxUsage,
+        };
+    }
+    if do_not_track.is_some_and(truthy) {
+        return Consent {
+            upload: false,
+            source: Source::DoNotTrack,
+        };
+    }
+    if let Some(enabled) = config.and_then(|config| config.enabled) {
+        return Consent {
+            upload: enabled,
+            source: Source::ConfigFile,
+        };
+    }
+    Consent {
+        upload: true,
+        source: Source::DefaultOn,
+    }
+}
+
+/// Resolve consent from the live environment and config file.
+///
+/// # Errors
+/// Fails when a config file exists but cannot be read or parsed; callers
+/// that cannot surface the error should treat that as upload-off, never as
+/// consent.
+pub fn resolve() -> anyhow::Result<Consent> {
+    let ix_usage = std::env::var("IX_USAGE").ok();
+    let do_not_track = std::env::var("DO_NOT_TRACK").ok();
+    let config = read_config()?;
+    Ok(resolve_with(
+        ix_usage.as_deref(),
+        do_not_track.as_deref(),
+        config.as_ref(),
+    ))
+}
+
+/// `CI` set truthy: never prompt, and uploads are tagged `ci: true`.
+#[must_use]
+pub fn is_ci() -> bool {
+    std::env::var("CI").is_ok_and(|value| truthy(&value))
+}
+
+/// Read the config file; `Ok(None)` when it does not exist (or no home).
+///
+/// # Errors
+/// A config file that exists but cannot be read or parsed.
+pub fn read_config() -> anyhow::Result<Option<Config>> {
+    let Some(path) = crate::paths::config_path() else {
+        return Ok(None);
+    };
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    Ok(Some(toml::from_str(&text)?))
+}
+
+/// Write the config file, creating parent directories.
+///
+/// # Errors
+/// No home directory, or filesystem/serialization failures.
+pub fn write_config(config: &Config) -> anyhow::Result<PathBuf> {
+    let Some(path) = crate::paths::config_path() else {
+        anyhow::bail!("no home directory; cannot write consent config");
+    };
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, toml::to_string_pretty(config)?)?;
+    Ok(path)
+}
+
+/// What [`first_run`] did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FirstRun {
+    /// A config file already exists (or another process just won the race).
+    AlreadyConfigured,
+    /// Consent is managed by environment (`IX_USAGE`, `DO_NOT_TRACK`, CI);
+    /// no file written, nothing printed.
+    EnvManaged,
+    /// No home directory; nothing to do (nix sandbox).
+    SandboxNoop,
+    /// Interactive prompt answered yes (or enter).
+    PromptedYes,
+    /// Interactive prompt answered no.
+    PromptedNo,
+    /// Non-interactive: notice printed to stderr, default-on recorded.
+    NoticePrinted,
+}
+
+/// The interactive first-run prompt, shown once per install.
+///
+/// The payload sample is literal on purpose: nobody trusts prose about
+/// telemetry, so we show the bytes instead.
+const PROMPT: &str = "\nWelcome to ix.\n\n\
+To make ix better we count how often each tool runs and how often it\n\
+fails. Counts only: the contents of errors, your commands, and your\n\
+code never leave this machine. Sent at most once a day. Here is\n\
+exactly what a report looks like:\n\n\
+  { \"install\": \"b3f1...\", \"os\": \"macos\", \"arch\": \"aarch64\",\n\
+    \"counts\": [ { \"pkg\": \"clippy\", \"runs\": 41, \"failures\": 3 } ] }\n\n\
+Turn off anytime: `ix-usage off`.\n\n\
+Share anonymous usage counts? [Yes] / no: ";
+
+const NOTICE: &str = "ix: anonymous usage counts are on (counts only; error contents never leave this machine).\n\
+ix: opt out: `ix-usage off` or enabled=false in ~/.config/ix/usage.toml or DO_NOT_TRACK=1.\n";
+
+/// Handle first run: create the config exactly once.
+///
+/// Prompts when a human terminal is attached and prints a stderr notice
+/// otherwise. Call this after the wrapped tool has finished so its output is
+/// never interleaved.
+///
+/// Prompts write to `/dev/tty` and read from `/dev/tty`; notices go to
+/// stderr; stdout is never touched, so piped output cannot be corrupted.
+/// Parallel first runs race on an `O_EXCL` create and exactly one process
+/// prompts.
+///
+/// # Errors
+/// Filesystem failures creating or writing the config file.
+pub fn first_run() -> anyhow::Result<FirstRun> {
+    if std::env::var_os("IX_USAGE").is_some()
+        || std::env::var_os("DO_NOT_TRACK").is_some()
+        || is_ci()
+    {
+        return Ok(FirstRun::EnvManaged);
+    }
+    let Some(path) = crate::paths::config_path() else {
+        return Ok(FirstRun::SandboxNoop);
+    };
+    if path.exists() {
+        return Ok(FirstRun::AlreadyConfigured);
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // Win the race before prompting: losers see the file and stay silent.
+    let mut file = match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+    {
+        Ok(file) => file,
+        Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+            return Ok(FirstRun::AlreadyConfigured);
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    let answer = if std::io::stderr().is_terminal() {
+        prompt_yes_no()
+    } else {
+        None
+    };
+    let outcome = match answer {
+        Some(true) => FirstRun::PromptedYes,
+        Some(false) => FirstRun::PromptedNo,
+        None => {
+            let mut stderr = std::io::stderr().lock();
+            let _ = stderr.write_all(NOTICE.as_bytes());
+            FirstRun::NoticePrinted
+        }
+    };
+    let enabled = outcome != FirstRun::PromptedNo;
+    let config = Config {
+        enabled: Some(enabled),
+        endpoint: None,
+    };
+    file.write_all(toml::to_string_pretty(&config)?.as_bytes())?;
+    Ok(outcome)
+}
+
+/// Prompt on `/dev/tty`; `None` when no controlling terminal is available
+/// (callers fall back to the notice).
+fn prompt_yes_no() -> Option<bool> {
+    let mut tty = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+        .ok()?;
+    tty.write_all(PROMPT.as_bytes()).ok()?;
+    tty.flush().ok()?;
+    let mut line = String::new();
+    let mut reader = std::io::BufReader::new(ByteTty { inner: &mut tty });
+    reader.read_line(&mut line).ok()?;
+    Some(!matches!(
+        line.trim().to_ascii_lowercase().as_str(),
+        "no" | "n"
+    ))
+}
+
+/// Adapter so the reader half borrows the same `/dev/tty` handle.
+struct ByteTty<'a> {
+    inner: &'a mut std::fs::File,
+}
+
+impl Read for ByteTty<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, Consent, Source, resolve_with};
+
+    const fn config(enabled: Option<bool>) -> Config {
+        Config {
+            enabled,
+            endpoint: None,
+        }
+    }
+
+    #[test]
+    fn env_wins_over_everything() {
+        let consent = resolve_with(Some("0"), None, Some(&config(Some(true))));
+        assert_eq!(
+            consent,
+            Consent {
+                upload: false,
+                source: Source::EnvIxUsage
+            }
+        );
+        let consent = resolve_with(Some("1"), Some("1"), Some(&config(Some(false))));
+        assert_eq!(
+            consent,
+            Consent {
+                upload: true,
+                source: Source::EnvIxUsage
+            }
+        );
+    }
+
+    #[test]
+    fn do_not_track_wins_over_config() {
+        let consent = resolve_with(None, Some("1"), Some(&config(Some(true))));
+        assert_eq!(
+            consent,
+            Consent {
+                upload: false,
+                source: Source::DoNotTrack
+            }
+        );
+    }
+
+    #[test]
+    fn config_decides_when_env_is_silent() {
+        let consent = resolve_with(None, Some("0"), Some(&config(Some(false))));
+        assert_eq!(
+            consent,
+            Consent {
+                upload: false,
+                source: Source::ConfigFile
+            }
+        );
+    }
+
+    #[test]
+    fn default_is_on() {
+        let consent = resolve_with(None, None, Some(&config(None)));
+        assert_eq!(
+            consent,
+            Consent {
+                upload: true,
+                source: Source::DefaultOn
+            }
+        );
+        let consent = resolve_with(None, None, None);
+        assert_eq!(
+            consent,
+            Consent {
+                upload: true,
+                source: Source::DefaultOn
+            }
+        );
+    }
+}

--- a/packages/usage/core/src/lib.rs
+++ b/packages/usage/core/src/lib.rs
@@ -1,0 +1,16 @@
+//! Local usage telemetry for ix-distributed tools (index#3802).
+//!
+//! The hot path is [`spool::append`]: one `O_APPEND` write, no locks, no
+//! `SQLite`, so wrapped tools stay fast under arbitrary parallelism. A
+//! flock-singleton compactor ([`store::compact`]) folds spool records into
+//! `SQLite` (WAL), the queryable source of truth for humans and agents alike.
+//!
+//! Privacy invariant: upload payloads are built only by
+//! [`payload::build_report`], which reads only the `counts` and `meta`
+//! tables. Raw error records (argv, cwd) have no code path off the machine.
+
+pub mod consent;
+pub mod paths;
+pub mod payload;
+pub mod spool;
+pub mod store;

--- a/packages/usage/core/src/paths.rs
+++ b/packages/usage/core/src/paths.rs
@@ -1,0 +1,53 @@
+//! Filesystem locations. Every accessor returns `None` when no home
+//! directory exists (for example inside a nix build sandbox); callers treat
+//! that as "telemetry is a no-op here".
+
+use std::path::PathBuf;
+
+/// State dir holding the spool and the `SQLite` database.
+///
+/// `IX_USAGE_STATE_DIR` overrides (tests, sandboxes), else
+/// `$XDG_STATE_HOME/ix`, else `~/.local/state/ix`.
+#[must_use]
+pub fn state_dir() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("IX_USAGE_STATE_DIR") {
+        return Some(PathBuf::from(dir));
+    }
+    if let Some(dir) = std::env::var_os("XDG_STATE_HOME") {
+        let dir = PathBuf::from(dir);
+        if dir.is_absolute() {
+            return Some(dir.join("ix"));
+        }
+    }
+    std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".local/state/ix"))
+}
+
+/// The append-only ingress spool, folded into `SQLite` by [`crate::store::compact`].
+#[must_use]
+pub fn spool_path() -> Option<PathBuf> {
+    state_dir().map(|dir| dir.join("usage.spool"))
+}
+
+/// The `SQLite` database (source of truth, agent-queryable).
+#[must_use]
+pub fn db_path() -> Option<PathBuf> {
+    state_dir().map(|dir| dir.join("usage.db"))
+}
+
+/// The consent config file.
+///
+/// `IX_USAGE_CONFIG` overrides, else `$XDG_CONFIG_HOME/ix/usage.toml`, else
+/// `~/.config/ix/usage.toml`.
+#[must_use]
+pub fn config_path() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("IX_USAGE_CONFIG") {
+        return Some(PathBuf::from(path));
+    }
+    if let Some(dir) = std::env::var_os("XDG_CONFIG_HOME") {
+        let dir = PathBuf::from(dir);
+        if dir.is_absolute() {
+            return Some(dir.join("ix/usage.toml"));
+        }
+    }
+    std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".config/ix/usage.toml"))
+}

--- a/packages/usage/core/src/payload.rs
+++ b/packages/usage/core/src/payload.rs
@@ -1,0 +1,149 @@
+//! Upload payload: aggregated counts only.
+//!
+//! This module is the only code the uploader calls, and it reads only the
+//! `counts` and `meta` tables. Error records (argv, cwd, exit details) have
+//! no code path into a [`Report`]; keep it that way, it is the privacy
+//! guarantee users were shown at first run.
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+/// The default collector endpoint (`ix` fleet leader; see indexable-inc/ix).
+pub const DEFAULT_ENDPOINT: &str = "https://usage.ix.dev/v1/report";
+
+/// How many trailing days of day-buckets each report carries.
+///
+/// Uploads are idempotent server-side (keyed install/pkg/version/day), so
+/// overlap between consecutive reports is harmless and covers offline gaps.
+pub const REPORT_WINDOW_DAYS: i64 = 7;
+
+/// One day-bucketed count row.
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct CountRow {
+    /// Package id.
+    pub pkg: String,
+    /// Package version.
+    pub version: String,
+    /// `YYYY-MM-DD` (UTC).
+    pub day: String,
+    /// Invocations that day (non-negative; `i64` is `SQLite`'s integer type).
+    pub runs: i64,
+    /// Invocations that exited nonzero.
+    pub failures: i64,
+}
+
+/// The wire payload `POST`ed to the collector.
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct Report {
+    /// Payload schema version.
+    pub v: u32,
+    /// Random per-install UUID (minted locally, meaningless elsewhere).
+    pub install: String,
+    /// `std::env::consts::OS`.
+    pub os: &'static str,
+    /// `std::env::consts::ARCH`.
+    pub arch: &'static str,
+    /// Whether this environment looks like CI (`CI` env truthy).
+    pub ci: bool,
+    /// Day-bucketed counts.
+    pub counts: Vec<CountRow>,
+}
+
+/// Build the next report from counts on or after `since_day` (inclusive,
+/// `YYYY-MM-DD`).
+///
+/// # Errors
+/// `SQLite` failures.
+pub fn build_report(conn: &Connection, since_day: &str, ci: bool) -> anyhow::Result<Report> {
+    let install = crate::store::install_id(conn)?;
+    let mut stmt = conn.prepare(
+        "SELECT pkg, version, day, invocations, nonzero_exits
+         FROM counts WHERE day >= ?1 ORDER BY day, pkg, version",
+    )?;
+    let counts = stmt
+        .query_map([since_day], |row| {
+            Ok(CountRow {
+                pkg: row.get(0)?,
+                version: row.get(1)?,
+                day: row.get(2)?,
+                runs: row.get(3)?,
+                failures: row.get(4)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Report {
+        v: 1,
+        install,
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
+        ci,
+        counts,
+    })
+}
+
+/// `YYYY-MM-DD` (UTC) for `days_back` days before now; the default report
+/// window lower bound.
+///
+/// # Errors
+/// Clock failures (before epoch) or unrepresentable timestamps.
+pub fn since_day(days_back: i64) -> anyhow::Result<String> {
+    let now = crate::spool::now_ms()?;
+    let ts = now - days_back * 86_400_000;
+    crate::store::day_from_ts_ms(ts)
+        .ok_or_else(|| anyhow::anyhow!("timestamp {ts} maps to no calendar day"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_report;
+    use crate::spool::{Record, append_at};
+    use crate::store::{compact, open};
+
+    #[test]
+    fn report_carries_counts_and_never_argv() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let record = Record {
+            ts_ms: 1_700_000_000_000,
+            pkg: "demo".to_owned(),
+            version: "1.0".to_owned(),
+            exit: Some(9),
+            duration_ms: Some(2),
+            argv: Some(vec!["demo".to_owned(), "--secret-token=hunter2".to_owned()]),
+            cwd: Some("/home/user/secret-project".to_owned()),
+        };
+        append_at(&dir.path().join("usage.spool"), &record).expect("append");
+        compact(dir.path()).expect("compact");
+
+        let conn = open(&dir.path().join("usage.db")).expect("open");
+        let report = build_report(&conn, "1970-01-01", false).expect("build");
+        assert_eq!(report.counts.len(), 1);
+        assert_eq!(report.counts[0].runs, 1);
+        assert_eq!(report.counts[0].failures, 1);
+
+        let wire = serde_json::to_string(&report).expect("serialize");
+        assert!(!wire.contains("argv"), "payload must never mention argv");
+        assert!(
+            !wire.contains("hunter2"),
+            "payload must never carry argv contents"
+        );
+        assert!(
+            !wire.contains("secret-project"),
+            "payload must never carry cwd"
+        );
+    }
+
+    #[test]
+    fn since_day_filters_old_buckets() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let conn = open(&dir.path().join("usage.db")).expect("open");
+        conn.execute_batch(
+            "INSERT INTO counts VALUES ('old', '1', '2000-01-01', 5, 0);
+             INSERT INTO counts VALUES ('new', '1', '2999-01-01', 2, 1);",
+        )
+        .expect("seed");
+        let report = build_report(&conn, "2500-01-01", true).expect("build");
+        assert_eq!(report.counts.len(), 1);
+        assert_eq!(report.counts[0].pkg, "new");
+        assert!(report.ci);
+    }
+}

--- a/packages/usage/core/src/spool.rs
+++ b/packages/usage/core/src/spool.rs
@@ -1,0 +1,107 @@
+//! Hot-path recording: one `O_APPEND` write per invocation.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// One tool invocation, JSON-encoded as a single spool line.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct Record {
+    /// Unix milliseconds when the record was written.
+    pub ts_ms: i64,
+    /// Package id (the nix package name, not the binary basename).
+    pub pkg: String,
+    /// Package version.
+    pub version: String,
+    /// Child exit code (`128 + signal` for signal deaths); `None` when the
+    /// wrapper exec'd the target without observing it (count-only mode).
+    pub exit: Option<i32>,
+    /// Wall time from spawn to exit; `None` in count-only mode.
+    pub duration_ms: Option<u64>,
+    /// Full argv of a failing invocation. Stays in the local database; the
+    /// upload path cannot read it (see [`crate::payload`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub argv: Option<Vec<String>>,
+    /// Working directory of a failing invocation, local-only like `argv`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+}
+
+/// Append one record to the spool at the default location.
+///
+/// Succeeds without writing when no state dir exists (nix sandbox, no HOME).
+///
+/// # Errors
+/// Any filesystem error. Wrapper callers swallow it: telemetry must never
+/// break the wrapped tool.
+pub fn append(record: &Record) -> std::io::Result<()> {
+    crate::paths::spool_path().map_or(Ok(()), |path| append_at(&path, record))
+}
+
+/// Append one record to the spool at `path` (one `O_APPEND` write; atomic
+/// for lines under `PIPE_BUF`).
+///
+/// # Errors
+/// Any filesystem error.
+pub fn append_at(path: &Path, record: &Record) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut line = serde_json::to_vec(record).map_err(std::io::Error::other)?;
+    line.push(b'\n');
+    let mut file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .mode(0o600)
+        .open(path)?;
+    file.write_all(&line)
+}
+
+/// Unix milliseconds now.
+///
+/// # Errors
+/// Fails when the system clock reads before the Unix epoch or beyond `i64`
+/// milliseconds.
+pub fn now_ms() -> std::io::Result<i64> {
+    let elapsed = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(std::io::Error::other)?;
+    i64::try_from(elapsed.as_millis()).map_err(std::io::Error::other)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Record, append_at};
+
+    fn record() -> Record {
+        Record {
+            ts_ms: 1_700_000_000_000,
+            pkg: "demo".to_owned(),
+            version: "1.0".to_owned(),
+            exit: Some(3),
+            duration_ms: Some(12),
+            argv: Some(vec!["demo".to_owned(), "--flag".to_owned()]),
+            cwd: Some("/tmp".to_owned()),
+        }
+    }
+
+    #[test]
+    fn round_trips_as_json_line() {
+        let line = serde_json::to_string(&record()).expect("serialize");
+        let back: Record = serde_json::from_str(&line).expect("parse");
+        assert_eq!(back, record());
+    }
+
+    #[test]
+    fn appends_one_line_per_record() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("usage.spool");
+        append_at(&path, &record()).expect("first append");
+        append_at(&path, &record()).expect("second append");
+        let text = std::fs::read_to_string(&path).expect("read spool");
+        assert_eq!(text.lines().count(), 2);
+    }
+}

--- a/packages/usage/core/src/store.rs
+++ b/packages/usage/core/src/store.rs
@@ -1,0 +1,323 @@
+//! `SQLite` source of truth and the spool compactor.
+//!
+//! Exactly one process writes to `SQLite` at a time: [`compact`] holds an
+//! exclusive flock for its whole run, so wrapped tools never contend on the
+//! database (they only append to the spool). WAL keeps readers non-blocking.
+
+use std::fs::File;
+use std::io;
+use std::os::fd::AsRawFd;
+use std::path::Path;
+
+use anyhow::Context as _;
+use rusqlite::{Connection, OptionalExtension as _};
+
+/// Current `PRAGMA user_version`.
+const SCHEMA_VERSION: i64 = 1;
+/// Errors-table cap; the oldest rows beyond it are pruned at compaction.
+const MAX_ERROR_ROWS: i64 = 500;
+/// Live spool file name inside the state dir.
+const SPOOL_NAME: &str = "usage.spool";
+/// Prefix of spool files renamed aside for folding (crash leftovers included).
+const COMPACTING_PREFIX: &str = "usage.spool.compacting-";
+
+/// Open (creating and migrating as needed) the usage database at `path`.
+///
+/// # Errors
+/// Directory creation or `SQLite` failures.
+pub fn open(path: &Path) -> anyhow::Result<Connection> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating state dir {}", parent.display()))?;
+    }
+    let conn = Connection::open(path)?;
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    conn.pragma_update(None, "synchronous", "NORMAL")?;
+    conn.busy_timeout(std::time::Duration::from_millis(250))?;
+    migrate(&conn)?;
+    Ok(conn)
+}
+
+fn migrate(conn: &Connection) -> rusqlite::Result<()> {
+    let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    if version >= SCHEMA_VERSION {
+        return Ok(());
+    }
+    conn.execute_batch(
+        "BEGIN;
+         CREATE TABLE IF NOT EXISTS counts(
+           pkg TEXT NOT NULL,
+           version TEXT NOT NULL,
+           day TEXT NOT NULL,
+           invocations INTEGER NOT NULL DEFAULT 0,
+           nonzero_exits INTEGER NOT NULL DEFAULT 0,
+           PRIMARY KEY (pkg, version, day));
+         CREATE TABLE IF NOT EXISTS errors(
+           id INTEGER PRIMARY KEY,
+           ts_ms INTEGER NOT NULL,
+           pkg TEXT NOT NULL,
+           version TEXT NOT NULL,
+           exit_code INTEGER,
+           argv TEXT,
+           cwd TEXT,
+           duration_ms INTEGER,
+           reported_ref TEXT);
+         CREATE TABLE IF NOT EXISTS meta(
+           key TEXT PRIMARY KEY,
+           value TEXT NOT NULL);
+         PRAGMA user_version = 1;
+         COMMIT;",
+    )
+}
+
+/// Read one meta value.
+///
+/// # Errors
+/// `SQLite` failures.
+pub fn meta_get(conn: &Connection, key: &str) -> rusqlite::Result<Option<String>> {
+    conn.query_row("SELECT value FROM meta WHERE key = ?1", [key], |row| {
+        row.get(0)
+    })
+    .optional()
+}
+
+/// Upsert one meta value.
+///
+/// # Errors
+/// `SQLite` failures.
+pub fn meta_set(conn: &Connection, key: &str, value: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT INTO meta(key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        [key, value],
+    )
+    .map(|_| ())
+}
+
+/// Get, or mint and persist, the random per-install id.
+///
+/// # Errors
+/// `SQLite` failures.
+pub fn install_id(conn: &Connection) -> rusqlite::Result<String> {
+    if let Some(id) = meta_get(conn, "install_id")? {
+        return Ok(id);
+    }
+    let id = uuid::Uuid::new_v4().to_string();
+    meta_set(conn, "install_id", &id)?;
+    Ok(id)
+}
+
+/// `YYYY-MM-DD` (UTC) for a Unix-milliseconds timestamp; `None` when the
+/// timestamp is unrepresentable.
+#[must_use]
+pub fn day_from_ts_ms(ts_ms: i64) -> Option<String> {
+    chrono::DateTime::from_timestamp_millis(ts_ms).map(|ts| ts.format("%Y-%m-%d").to_string())
+}
+
+/// Outcome of a [`compact`] run.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct CompactStats {
+    /// Spool records folded into the database.
+    pub folded: u64,
+    /// Lines skipped as torn or unparseable (a crash mid-append leaves at
+    /// most one).
+    pub skipped: u64,
+}
+
+/// Fold every pending spool file under `state_dir` into the database.
+///
+/// Holds an exclusive advisory lock (`compact.lock`) so this is the single
+/// database writer, renames the live spool aside so hot-path writers start a
+/// fresh one, then folds every `usage.spool.compacting-*` file (including
+/// leftovers from crashed compactors) in one transaction each, deleting each
+/// file after its transaction commits.
+///
+/// # Errors
+/// Filesystem or `SQLite` failures. Safe to rerun: records fold at most once
+/// because a file is deleted only after its transaction commits, and a
+/// crash between commit and delete refolds counts for at most one file.
+pub fn compact(state_dir: &Path) -> anyhow::Result<CompactStats> {
+    std::fs::create_dir_all(state_dir)?;
+    let lock = File::create(state_dir.join("compact.lock"))?;
+    flock_exclusive(&lock)?;
+
+    let live = state_dir.join(SPOOL_NAME);
+    if live.exists() {
+        let aside = state_dir.join(format!(
+            "{COMPACTING_PREFIX}{}-{}",
+            std::process::id(),
+            crate::spool::now_ms()?
+        ));
+        std::fs::rename(&live, &aside)?;
+    }
+
+    let mut pending = Vec::new();
+    for entry in std::fs::read_dir(state_dir)? {
+        let entry = entry?;
+        if entry
+            .file_name()
+            .to_string_lossy()
+            .starts_with(COMPACTING_PREFIX)
+        {
+            pending.push(entry.path());
+        }
+    }
+    if pending.is_empty() {
+        return Ok(CompactStats::default());
+    }
+    pending.sort();
+
+    let mut conn = open(&state_dir.join("usage.db"))?;
+    let mut stats = CompactStats::default();
+    for file in pending {
+        fold_file(&mut conn, &file, &mut stats)?;
+        std::fs::remove_file(&file)?;
+    }
+    Ok(stats)
+}
+
+fn fold_file(conn: &mut Connection, file: &Path, stats: &mut CompactStats) -> anyhow::Result<()> {
+    let text = std::fs::read_to_string(file)?;
+    let tx = conn.transaction()?;
+    for line in text.lines() {
+        match serde_json::from_str::<crate::spool::Record>(line) {
+            Ok(record) => {
+                if fold_record(&tx, &record)? {
+                    stats.folded += 1;
+                } else {
+                    stats.skipped += 1;
+                }
+            }
+            Err(_) => stats.skipped += 1,
+        }
+    }
+    tx.execute(
+        "DELETE FROM errors WHERE id NOT IN
+           (SELECT id FROM errors ORDER BY id DESC LIMIT ?1)",
+        [MAX_ERROR_ROWS],
+    )?;
+    tx.commit()?;
+    Ok(())
+}
+
+/// Returns `false` (skip) only for records whose timestamp maps to no day.
+fn fold_record(tx: &rusqlite::Transaction, record: &crate::spool::Record) -> anyhow::Result<bool> {
+    let Some(day) = day_from_ts_ms(record.ts_ms) else {
+        return Ok(false);
+    };
+    let failed = record.exit.is_some_and(|code| code != 0);
+    tx.execute(
+        "INSERT INTO counts(pkg, version, day, invocations, nonzero_exits)
+         VALUES (?1, ?2, ?3, 1, ?4)
+         ON CONFLICT(pkg, version, day) DO UPDATE SET
+           invocations = invocations + 1,
+           nonzero_exits = nonzero_exits + excluded.nonzero_exits",
+        rusqlite::params![record.pkg, record.version, day, i64::from(failed)],
+    )?;
+    if failed {
+        let argv_json = match &record.argv {
+            Some(argv) => Some(serde_json::to_string(argv)?),
+            None => None,
+        };
+        tx.execute(
+            "INSERT INTO errors(ts_ms, pkg, version, exit_code, argv, cwd, duration_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            rusqlite::params![
+                record.ts_ms,
+                record.pkg,
+                record.version,
+                record.exit,
+                argv_json,
+                record.cwd,
+                record.duration_ms.map(i64::try_from).transpose()?,
+            ],
+        )?;
+    }
+    Ok(true)
+}
+
+fn flock_exclusive(file: &File) -> io::Result<()> {
+    // SAFETY: flock(2) on a file descriptor `file` keeps open for the whole
+    // compaction; the lock dies with the fd.
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CompactStats, compact, day_from_ts_ms, install_id, open};
+    use crate::spool::{Record, append_at};
+
+    fn record(exit: Option<i32>) -> Record {
+        Record {
+            ts_ms: 1_700_000_000_000,
+            pkg: "demo".to_owned(),
+            version: "1.0".to_owned(),
+            exit,
+            duration_ms: Some(5),
+            argv: exit.map(|_| vec!["demo".to_owned(), "--x".to_owned()]),
+            cwd: None,
+        }
+    }
+
+    #[test]
+    fn epoch_is_day_zero() {
+        assert_eq!(day_from_ts_ms(0).as_deref(), Some("1970-01-01"));
+    }
+
+    #[test]
+    fn compacts_counts_errors_and_torn_lines() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let spool = dir.path().join("usage.spool");
+        append_at(&spool, &record(Some(0))).expect("append ok record");
+        append_at(&spool, &record(Some(3))).expect("append failing record");
+        append_at(&spool, &record(None)).expect("append count-only record");
+        // Simulate a crash mid-append: a torn, unterminated final line.
+        let mut text = std::fs::read_to_string(&spool).expect("read spool");
+        text.push_str("{\"ts_ms\":17");
+        std::fs::write(&spool, text).expect("tear spool");
+
+        let stats = compact(dir.path()).expect("compact");
+        assert_eq!(
+            stats,
+            CompactStats {
+                folded: 3,
+                skipped: 1
+            }
+        );
+        assert!(!spool.exists(), "live spool was renamed aside and removed");
+
+        let conn = open(&dir.path().join("usage.db")).expect("open db");
+        let row: (i64, i64) = conn
+            .query_row(
+                "SELECT invocations, nonzero_exits FROM counts
+                 WHERE pkg = 'demo' AND version = '1.0' AND day = '2023-11-14'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("counts row");
+        assert_eq!(row, (3, 1));
+        let argv: String = conn
+            .query_row("SELECT argv FROM errors", [], |row| row.get(0))
+            .expect("error row");
+        assert_eq!(argv, "[\"demo\",\"--x\"]");
+
+        // Idempotent when nothing is pending.
+        let stats = compact(dir.path()).expect("second compact");
+        assert_eq!(stats, CompactStats::default());
+    }
+
+    #[test]
+    fn install_id_is_stable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let conn = open(&dir.path().join("usage.db")).expect("open db");
+        let first = install_id(&conn).expect("mint id");
+        let second = install_id(&conn).expect("reread id");
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 36, "uuid shape");
+    }
+}

--- a/packages/usage/demo/default.nix
+++ b/packages/usage/demo/default.nix
@@ -1,0 +1,11 @@
+# Walking-skeleton consumer of the withUsage seam (index#3802): git-log-pretty
+# rewrapped so every invocation lands in the local usage store. Tree-wide
+# default-on wrapping is a follow-up; this package proves the seam end to end.
+{
+  withUsage,
+  repoPackages,
+  ...
+}:
+withUsage repoPackages.git-log-pretty {
+  id = "git-log-pretty";
+}

--- a/packages/usage/demo/package.nix
+++ b/packages/usage/demo/package.nix
@@ -1,0 +1,6 @@
+{
+  id = "usage-demo";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+}

--- a/packages/usage/wrap/Cargo.toml
+++ b/packages/usage/wrap/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "ix-wrap"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Transparent usage-counting exec wrapper: spawn the IX_USAGE_SPEC target with inherited stdio/argv0, forward signals, record one spool line after exit, exit with the child's status"
+
+[lints]
+workspace = true
+
+[dependencies]
+ix-usage-core.workspace = true
+libc.workspace = true
+nix = { workspace = true, features = ["signal"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+[dev-dependencies]
+ix-usage-core.workspace = true
+rusqlite.workspace = true
+tempfile.workspace = true
+
+[[bin]]
+name = "ix-wrap"
+path = "src/main.rs"

--- a/packages/usage/wrap/default.nix
+++ b/packages/usage/wrap/default.nix
@@ -1,0 +1,13 @@
+{
+  ix,
+  lib,
+  ...
+}:
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "ix-wrap";
+  meta = {
+    description = "Transparent usage-counting exec wrapper driven by an IX_USAGE_SPEC JSON file";
+    license = lib.licenses.mit;
+    mainProgram = "ix-wrap";
+  };
+}

--- a/packages/usage/wrap/package.nix
+++ b/packages/usage/wrap/package.nix
@@ -1,0 +1,8 @@
+{
+  id = "ix-wrap";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/usage/wrap/src/main.rs
+++ b/packages/usage/wrap/src/main.rs
@@ -1,0 +1,281 @@
+//! `ix-wrap`: transparent usage-counting exec wrapper (index#3802).
+//!
+//! nix `withUsage` points each wrapped binary here via `IX_USAGE_SPEC`. The
+//! wrapper spawns the real target with inherited stdio and argv0, stays out
+//! of the way (ctrl-C reaches the child, SIGTERM is forwarded), and after
+//! the child exits appends one line to the local spool: a single `O_APPEND`
+//! write, no locks, no SQLite on the hot path. It then exits with the
+//! child's status (`128 + signal` for signal deaths).
+//!
+//! Failure policy: anything telemetry-internal is dropped silently
+//! (telemetry must never break the wrapped tool), but a broken spec is a
+//! build bug and fails loudly with exit 127 so it cannot masquerade as the
+//! tool's own failure.
+
+use std::os::unix::process::{CommandExt as _, ExitStatusExt as _};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::time::{Duration, Instant};
+
+use nix::sys::signal::{SigHandler, Signal};
+use serde::Deserialize;
+
+/// Wrapper policy baked by nix `withUsage` into the `IX_USAGE_SPEC` file.
+#[derive(Deserialize)]
+struct Spec {
+    /// Absolute path of the real binary.
+    target: String,
+    /// Package id recorded in counts.
+    pkg: String,
+    /// Package version recorded in counts.
+    version: String,
+    /// `observe` (default) waits and records the exit code; `count-only`
+    /// records the invocation and `exec()`s the target so no wrapper
+    /// process lingers (for hot-path tools called in tight loops).
+    #[serde(default)]
+    mode: Mode,
+    /// Whether failing invocations keep argv and cwd in the local database
+    /// (never uploaded either way).
+    #[serde(default = "default_true")]
+    errors: bool,
+    /// Path to the `ix-usage` CLI for the detached upload kick; absent
+    /// disables kicks.
+    #[serde(default)]
+    uploader: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+enum Mode {
+    #[default]
+    Observe,
+    CountOnly,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+/// Spool size above which the wrapper triggers a compaction.
+const COMPACT_THRESHOLD_BYTES: u64 = 256 * 1024;
+/// Minimum spacing between detached upload kicks. The uploader enforces the
+/// real 24h cadence; this only avoids spawning a kick process per
+/// invocation.
+const KICK_INTERVAL: Duration = Duration::from_secs(6 * 3600);
+
+fn main() {
+    let spec = load_spec().unwrap_or_else(|err| {
+        eprintln!("ix-wrap: {err}");
+        std::process::exit(127)
+    });
+    match spec.mode {
+        Mode::CountOnly => run_count_only(&spec),
+        Mode::Observe => run_observe(&spec),
+    }
+}
+
+fn load_spec() -> Result<Spec, String> {
+    let path = std::env::var_os("IX_USAGE_SPEC").ok_or_else(|| {
+        "IX_USAGE_SPEC is not set; ix-wrap is only invoked through nix withUsage wrappers"
+            .to_owned()
+    })?;
+    let path = Path::new(&path);
+    let text = std::fs::read_to_string(path)
+        .map_err(|err| format!("reading spec {}: {err}", path.display()))?;
+    serde_json::from_str(&text).map_err(|err| format!("parsing spec {}: {err}", path.display()))
+}
+
+/// The target command with our argv, argv0, environment, and stdio.
+fn build_command(spec: &Spec) -> Command {
+    let mut args = std::env::args_os();
+    let arg0 = args.next();
+    let mut command = Command::new(&spec.target);
+    command.args(args);
+    // The spec must not leak: a target that spawns other wrapped tools would
+    // otherwise record them under this spec's package.
+    command.env_remove("IX_USAGE_SPEC");
+    if let Some(arg0) = arg0 {
+        command.arg0(arg0);
+    }
+    command
+}
+
+/// Record the invocation, then replace this process with the target.
+fn run_count_only(spec: &Spec) -> ! {
+    // Consent bookkeeping and upload kicks are skipped on purpose: this mode
+    // exists for tools in tight loops, and observe-mode invocations of other
+    // packages carry that bookkeeping for the install.
+    record(spec, None, None);
+    let err = build_command(spec).exec();
+    eprintln!("ix-wrap: exec {}: {err}", spec.target);
+    std::process::exit(127)
+}
+
+static CHILD_PID: AtomicI32 = AtomicI32::new(0);
+
+extern "C" fn forward_signal(signal: libc::c_int) {
+    let pid = CHILD_PID.load(Ordering::Relaxed);
+    if pid > 0 {
+        // SAFETY: kill(2) is async-signal-safe.
+        unsafe {
+            libc::kill(pid, signal);
+        }
+    }
+}
+
+/// Spawn, observe, record, and mirror the child's exit status.
+fn run_observe(spec: &Spec) -> ! {
+    // SIGTERM/SIGHUP forwarding installs before spawn: handler dispositions
+    // reset to default across exec, so the child is unaffected. Failure to
+    // install a forwarder degrades signal fidelity but must not block the
+    // tool, hence the discarded results.
+    // SAFETY: the handler only performs an atomic load and kill(2), both
+    // async-signal-safe.
+    unsafe {
+        let _ = nix::sys::signal::signal(Signal::SIGTERM, SigHandler::Handler(forward_signal));
+        let _ = nix::sys::signal::signal(Signal::SIGHUP, SigHandler::Handler(forward_signal));
+    }
+
+    let started = Instant::now();
+    let mut child = match build_command(spec).spawn() {
+        Ok(child) => child,
+        Err(err) => {
+            eprintln!("ix-wrap: spawn {}: {err}", spec.target);
+            std::process::exit(127)
+        }
+    };
+    if let Ok(pid) = i32::try_from(child.id()) {
+        CHILD_PID.store(pid, Ordering::Relaxed);
+    }
+    // Ignore INT/QUIT only after the spawn so the child does not inherit the
+    // ignore disposition (SIG_IGN survives exec, handlers do not). Ctrl-C
+    // then kills the child via the shared foreground process group while we
+    // stay alive to record its exit, the same shape `time(1)` uses.
+    // SAFETY: SigIgn installs no handler code.
+    unsafe {
+        let _ = nix::sys::signal::signal(Signal::SIGINT, SigHandler::SigIgn);
+        let _ = nix::sys::signal::signal(Signal::SIGQUIT, SigHandler::SigIgn);
+    }
+
+    let status = match child.wait() {
+        Ok(status) => status,
+        Err(err) => {
+            eprintln!("ix-wrap: waiting for {}: {err}", spec.target);
+            std::process::exit(127)
+        }
+    };
+    let Some(exit_code) = status
+        .code()
+        .or_else(|| status.signal().map(|sig| 128 + sig))
+    else {
+        eprintln!("ix-wrap: child reported neither exit code nor signal");
+        std::process::exit(127)
+    };
+
+    record(spec, Some(exit_code), duration_ms(started));
+    after_record(spec);
+    std::process::exit(exit_code)
+}
+
+fn duration_ms(started: Instant) -> Option<u64> {
+    u64::try_from(started.elapsed().as_millis()).ok()
+}
+
+/// Append one spool line; telemetry failures are dropped by policy.
+fn record(spec: &Spec, exit: Option<i32>, duration_ms: Option<u64>) {
+    let Ok(ts_ms) = ix_usage_core::spool::now_ms() else {
+        return;
+    };
+    let failed = exit.is_some_and(|code| code != 0);
+    let (argv, cwd) = if failed && spec.errors {
+        (
+            Some(std::env::args().collect()),
+            std::env::current_dir()
+                .ok()
+                .map(|dir| dir.display().to_string()),
+        )
+    } else {
+        (None, None)
+    };
+    let record = ix_usage_core::spool::Record {
+        ts_ms,
+        pkg: spec.pkg.clone(),
+        version: spec.version.clone(),
+        exit,
+        duration_ms,
+        argv,
+        cwd,
+    };
+    let _ = ix_usage_core::spool::append(&record);
+}
+
+/// Post-exit housekeeping, all best-effort: one-time consent bookkeeping,
+/// compaction when the spool grows past the threshold, and at most one
+/// detached upload kick per [`KICK_INTERVAL`].
+fn after_record(spec: &Spec) {
+    let _ = ix_usage_core::consent::first_run();
+    let Some(state) = ix_usage_core::paths::state_dir() else {
+        return;
+    };
+    if spool_large(&state) {
+        let _ = ix_usage_core::store::compact(&state);
+    }
+    maybe_kick_uploader(spec, &state);
+}
+
+fn spool_large(state: &Path) -> bool {
+    state
+        .join("usage.spool")
+        .metadata()
+        .is_ok_and(|meta| meta.len() > COMPACT_THRESHOLD_BYTES)
+}
+
+fn maybe_kick_uploader(spec: &Spec, state: &Path) {
+    let Some(uploader) = &spec.uploader else {
+        return;
+    };
+    // An unreadable consent state counts as no consent, never as yes.
+    if !matches!(
+        ix_usage_core::consent::resolve().map(|consent| consent.upload),
+        Ok(true)
+    ) {
+        return;
+    }
+    if !marker_stale(&state.join("upload-kick")) {
+        return;
+    }
+    let mut command = Command::new(uploader);
+    command
+        .arg("upload")
+        .arg("--if-due")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    // SAFETY: setsid(2) in the pre-exec child is async-signal-safe; failure
+    // (already a session leader) is harmless, stdio is already detached.
+    unsafe {
+        command.pre_exec(|| {
+            let _ = libc::setsid();
+            Ok(())
+        });
+    }
+    let _ = command.spawn();
+}
+
+/// True when the marker is missing or older than [`KICK_INTERVAL`]. Touches
+/// the marker on staleness so concurrent invocations kick once per interval.
+fn marker_stale(marker: &Path) -> bool {
+    let fresh = std::fs::metadata(marker)
+        .and_then(|meta| meta.modified())
+        .map(|modified| matches!(modified.elapsed(), Ok(age) if age < KICK_INTERVAL));
+    match fresh {
+        Ok(true) => false,
+        // Missing marker, unreadable mtime, or an mtime in the future: treat
+        // as stale and reset it.
+        Ok(false) | Err(_) => {
+            let _ = std::fs::write(marker, b"");
+            true
+        }
+    }
+}

--- a/packages/usage/wrap/tests/wrap.rs
+++ b/packages/usage/wrap/tests/wrap.rs
@@ -1,0 +1,150 @@
+//! Transparency tests: the wrapper must be byte- and status-identical to the
+//! bare tool, and every invocation must land in the local store.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+struct Harness {
+    dir: tempfile::TempDir,
+}
+
+impl Harness {
+    fn new(mode: &str) -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let spec = serde_json::json!({
+            "target": "sh",
+            "pkg": "demo-pkg",
+            "version": "1.2.3",
+            "mode": mode,
+            "errors": true,
+        });
+        std::fs::write(dir.path().join("spec.json"), spec.to_string()).expect("write spec");
+        // Pre-decide consent so no first-run notice lands on stderr and no
+        // upload kick can spawn.
+        std::fs::write(dir.path().join("usage.toml"), "enabled = false\n").expect("write config");
+        Self { dir }
+    }
+
+    fn state_dir(&self) -> PathBuf {
+        self.dir.path().join("state")
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        self.command().args(args).output().expect("run ix-wrap")
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_ix-wrap"));
+        command
+            .env("IX_USAGE_SPEC", self.dir.path().join("spec.json"))
+            .env("IX_USAGE_STATE_DIR", self.state_dir())
+            .env("IX_USAGE_CONFIG", self.dir.path().join("usage.toml"));
+        command
+    }
+
+    fn counts(&self) -> (i64, i64) {
+        ix_usage_core::store::compact(&self.state_dir()).expect("compact");
+        let conn = ix_usage_core::store::open(&self.state_dir().join("usage.db")).expect("open db");
+        conn.query_row(
+            "SELECT invocations, nonzero_exits FROM counts
+             WHERE pkg = 'demo-pkg' AND version = '1.2.3'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("counts row")
+    }
+
+    fn error_rows(&self) -> i64 {
+        let conn = ix_usage_core::store::open(&self.state_dir().join("usage.db")).expect("open db");
+        conn.query_row("SELECT COUNT(*) FROM errors", [], |row| row.get(0))
+            .expect("count errors")
+    }
+}
+
+#[test]
+fn passes_through_exit_code_stdout_and_records_failure() {
+    let harness = Harness::new("observe");
+    let output = harness.run(&["-c", "printf hello; exit 7"]);
+    assert_eq!(output.status.code(), Some(7));
+    assert_eq!(output.stdout, b"hello");
+    assert_eq!(output.stderr, b"", "wrapper must not write to stderr");
+
+    assert_eq!(harness.counts(), (1, 1));
+    assert_eq!(harness.error_rows(), 1);
+}
+
+#[test]
+fn success_records_count_without_error_row() {
+    let harness = Harness::new("observe");
+    let output = harness.run(&["-c", "printf ok"]);
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(output.stdout, b"ok");
+
+    assert_eq!(harness.counts(), (1, 0));
+    assert_eq!(harness.error_rows(), 0);
+}
+
+#[test]
+fn signal_death_maps_to_128_plus_signal() {
+    let harness = Harness::new("observe");
+    let output = harness.run(&["-c", "kill -TERM $$"]);
+    assert_eq!(output.status.code(), Some(143), "SIGTERM death is 128+15");
+
+    assert_eq!(harness.counts(), (1, 1));
+}
+
+#[test]
+fn count_only_execs_and_records_invocation_only() {
+    let harness = Harness::new("count-only");
+    let output = harness.run(&["-c", "printf fast; exit 5"]);
+    assert_eq!(output.status.code(), Some(5));
+    assert_eq!(output.stdout, b"fast");
+
+    // Exit is unknown by design in count-only mode.
+    assert_eq!(harness.counts(), (1, 0));
+    assert_eq!(harness.error_rows(), 0);
+}
+
+#[test]
+fn repeated_runs_accumulate() {
+    let harness = Harness::new("observe");
+    for _ in 0..5 {
+        assert_eq!(harness.run(&["-c", "exit 0"]).status.code(), Some(0));
+    }
+    assert_eq!(harness.run(&["-c", "exit 1"]).status.code(), Some(1));
+    assert_eq!(harness.counts(), (6, 1));
+}
+
+#[test]
+fn missing_spec_fails_loud_with_127() {
+    let harness = Harness::new("observe");
+    let mut command = harness.command();
+    command.env_remove("IX_USAGE_SPEC");
+    let output = command.args(["-c", "exit 0"]).output().expect("run");
+    assert_eq!(output.status.code(), Some(127));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("IX_USAGE_SPEC"),
+        "actionable error, got: {stderr}"
+    );
+}
+
+#[test]
+fn argv_of_failures_stays_local() {
+    let harness = Harness::new("observe");
+    let output = harness.run(&["-c", "exit 9"]);
+    assert_eq!(output.status.code(), Some(9));
+    let _ = harness.counts();
+    let conn = ix_usage_core::store::open(&harness.state_dir().join("usage.db")).expect("open");
+    let argv: String = conn
+        .query_row("SELECT argv FROM errors", [], |row| row.get(0))
+        .expect("argv column");
+    assert!(argv.contains("exit 9"), "argv captured locally: {argv}");
+
+    let report = ix_usage_core::payload::build_report(&conn, "1970-01-01", false).expect("report");
+    let wire = serde_json::to_string(&report).expect("serialize");
+    assert!(
+        !wire.contains("exit 9"),
+        "argv must never enter the upload payload"
+    );
+}


### PR DESCRIPTION
Closes #3802.

Walking skeleton of the usage-telemetry design (reviewed with Andrew today): local recording + consent + counts-only upload client, plus the nix seam, proven end to end on hydra.

## What landed
- **`ix-usage-core`**: hot path = one O_APPEND spool write (lock-free); flock-singleton compactor folds the spool into SQLite (WAL) at `~/.local/state/ix/usage.db`; consent precedence `IX_USAGE` > `DO_NOT_TRACK` > CI > `~/.config/ix/usage.toml` > default-on-with-notice; counts-only payload builder (the module reads only `counts`+`meta`; argv/cwd of failures stay local by construction, with tests asserting the wire payload never carries them).
- **`ix-usage`** CLI: `status|on|off|show|errors|error|compact|upload`, `--json` everywhere, reads compact first (agents always see fresh data).
- **`ix-wrap`**: transparent exec wrapper via `IX_USAGE_SPEC` JSON (same shape as config-launch's `IX_LAUNCH_SPEC`). Inherited stdio/argv0, ctrl-C reaches the child, SIGTERM/SIGHUP forwarded, exit mirrored (`128+signal`), `count-only` mode `exec()`s for tight loops.
- **`withUsage` seam** (`lib/with-usage.nix`, threaded via the package-set context) + `usage-demo` = `git-log-pretty` wrapped as the skeleton consumer. Tree-wide default-on wrapping is a deliberate follow-up.

## Validation (local; CI down per standing decree, force-merging)
- 23/23 tests pass (`cargo test -p ix-usage-core -p ix-usage -p ix-wrap`): 11 core unit (compaction incl. torn-line crash recovery, consent precedence, payload privacy), 5 CLI JSON contracts, 7 wrapper transparency (exit codes, signal death 143, stdout byte-identical, argv-stays-local).
- Stock clippy clean on the new crates (`-Aunknown_lints` for fork-only lints; remaining findings are pre-existing `cve-scan` workspace-context artifacts).
- `nix build .#usage-demo` builds all three crates + wrapper derivation.
- Live E2E on hydra: wrapped `git-log-pretty --help` -> first-run notice + config created -> spool record with duration -> `ix-usage show` emits the counts-only payload (runs=1, day 2026-07-20).
- Overhead: 50-run loop, bare 230ms vs wrapped 523ms = **~5.9ms/invocation added**; `count-only` mode exists for hot paths.

Collector (`usage.ix.dev` -> ClickHouse ledger + aggregate) lands next in indexable-inc/ix.

Written by Claude Code (Claude Opus 4.5).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add local usage telemetry with spool+SQLite store, `ix-wrap` exec wrapper, and `withUsage` Nix utility
> - Introduces three new Rust crates: `ix-usage-core` (shared library), `ix-wrap` (transparent exec wrapper), and `ix-usage` (CLI for managing consent, inspecting errors, and uploading aggregated counts).
> - `ix-wrap` intercepts each wrapped binary invocation, records exit status and duration to a JSON-line spool file, then compacts the spool into SQLite in the background; in count-only mode it execs the target directly after recording.
> - `ix-usage-core` provides the spool append, SQLite compaction with exclusive flock, consent resolution (env → config → default-on with first-run prompt/notice), counts-only payload builder, and filesystem path helpers.
> - Adds a [`withUsage`](https://github.com/indexable-inc/index/pull/3804/files#diff-cbba32c81becf6cebdf4f8781e7ddcd4d9f645f1fcf072755e99b6dee754a07e) Nix function that rewraps each `bin/*` executable with `ix-wrap` via a per-binary JSON spec file; exposed on `ixForPackages` via [`lib/packages.nix`](https://github.com/indexable-inc/index/pull/3804/files#diff-f353132c25d1c6d3f15551dba2d12c8c65c630f707c44f44e14229726bad009c).
> - A [`packages/usage/demo`](https://github.com/indexable-inc/index/pull/3804/files#diff-5a46da248f55cbf2b10e97cfc7deea24d0bf7a4dc2053eaeeefbb4b235421c5f) package wraps `git-log-pretty` as an end-to-end usage example.
> - Behavioral Change: wrapped binaries now run through `ix-wrap` and spawn a detached `ix-usage upload --if-due` subprocess at most once per 6 hours; argv and cwd for failures are stored locally only and never included in upload payloads.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f8960b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->