### PR TITLE
ix-vt: mouse/alt-screen/scrollbar state accessors for input routing

### DIFF
--- a/packages/tui/vt/ix-vt/src/lib.rs
+++ b/packages/tui/vt/ix-vt/src/lib.rs
@@ -269,6 +269,38 @@ pub enum ScrollViewport {
     Delta(isize),
 }
 
+/// The mouse-reporting flavor an application has requested via DEC private
+/// modes 9/1000/1002/1003 (see [`Terminal::mouse_reporting`]). The variants
+/// are ordered by how much the application asked to see; when several modes
+/// are set at once the strongest wins, matching how terminals dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MouseReporting {
+    /// No mouse mode set: the terminal owns the mouse (scrollback, selection).
+    None,
+    /// X10 compatibility mode (DECSET 9): presses only, no release events.
+    X10,
+    /// Normal tracking (DECSET 1000): presses and releases.
+    Normal,
+    /// Button-event tracking (DECSET 1002): 1000 plus drag motion while a
+    /// button is held.
+    Button,
+    /// Any-event tracking (DECSET 1003): 1002 plus all motion.
+    Any,
+}
+
+/// Scrollbar geometry for the terminal viewport, in rows: `total` scrollable
+/// rows, the viewport's `offset` from the top, and its `len`. The viewport is
+/// at the live bottom iff `offset + len == total`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Scrollbar {
+    /// Total rows in the scrollable area (scrollback plus active screen).
+    pub total: u64,
+    /// Rows above the top of the viewport.
+    pub offset: u64,
+    /// Viewport height in rows.
+    pub len: u64,
+}
+
 /// Options for creating a [`Terminal`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TerminalOptions {
@@ -298,6 +330,17 @@ pub struct Terminal {
 /// `(value & 0x7FFF) | ((ansi as u16) << 15)`, which for value 1 / DEC-private
 /// is simply `1`. See `ghostty/vt/modes.h` (`GHOSTTY_MODE_DECCKM`).
 const DECCKM: sys::GhosttyMode = 1;
+
+/// The DEC private mouse modes, in libghostty's packed mode encoding (the
+/// DEC-private packing is the value itself; see [`DECCKM`]). Names follow
+/// ghostty's `modes.zig` table.
+const MOUSE_EVENT_X10: sys::GhosttyMode = 9;
+const MOUSE_EVENT_NORMAL: sys::GhosttyMode = 1000;
+const MOUSE_EVENT_BUTTON: sys::GhosttyMode = 1002;
+const MOUSE_EVENT_ANY: sys::GhosttyMode = 1003;
+/// DECSET 1006: report mouse events in the SGR encoding (`CSI < b;x;y M/m`),
+/// which is unambiguous and unbounded, unlike the legacy X10 byte encoding.
+const MOUSE_FORMAT_SGR: sys::GhosttyMode = 1006;
 
 impl Terminal {
     /// Create a terminal sized `rows` by `cols` with `scrollback` lines of
@@ -434,6 +477,68 @@ impl Terminal {
     /// Returns [`Error::InvalidValue`] if ghostty rejects the mode query.
     pub fn application_cursor_keys(&self) -> Result<bool> {
         self.mode_enabled(DECCKM)
+    }
+
+    /// The mouse-reporting flavor the application has requested (DEC private
+    /// modes 9/1000/1002/1003). [`MouseReporting::None`] means the terminal
+    /// keeps the mouse: wheel input should scroll scrollback rather than be
+    /// forwarded. When set, an input driver forwards encoded mouse events —
+    /// in the SGR encoding iff [`sgr_mouse`](Self::sgr_mouse) is also set.
+    ///
+    /// # Errors
+    /// Returns [`Error::InvalidValue`] if ghostty rejects a mode query.
+    pub fn mouse_reporting(&self) -> Result<MouseReporting> {
+        // Strongest first: TUIs commonly set several (vim sets 1000+1002),
+        // and the strongest one determines which events they expect.
+        for (mode, reporting) in [
+            (MOUSE_EVENT_ANY, MouseReporting::Any),
+            (MOUSE_EVENT_BUTTON, MouseReporting::Button),
+            (MOUSE_EVENT_NORMAL, MouseReporting::Normal),
+            (MOUSE_EVENT_X10, MouseReporting::X10),
+        ] {
+            if self.mode_enabled(mode)? {
+                return Ok(reporting);
+            }
+        }
+        Ok(MouseReporting::None)
+    }
+
+    /// Whether DECSET 1006 (SGR mouse encoding) is set. Meaningful only when
+    /// [`mouse_reporting`](Self::mouse_reporting) is not `None`.
+    ///
+    /// # Errors
+    /// Returns [`Error::InvalidValue`] if ghostty rejects the mode query.
+    pub fn sgr_mouse(&self) -> Result<bool> {
+        self.mode_enabled(MOUSE_FORMAT_SGR)
+    }
+
+    /// Whether the alternate screen is active (DECSET 47/1047/1049), read
+    /// from the terminal's active-screen state rather than any single mode
+    /// bit, so every enter/leave path is covered.
+    ///
+    /// # Errors
+    /// Returns an [`Error`] if ghostty rejects the state query.
+    pub fn alternate_screen(&self) -> Result<bool> {
+        let screen: sys::GhosttyTerminalScreen =
+            unsafe { self.get(sys::GhosttyTerminalData::GHOSTTY_TERMINAL_DATA_ACTIVE_SCREEN) }?;
+        Ok(screen == sys::GhosttyTerminalScreen::GHOSTTY_TERMINAL_SCREEN_ALTERNATE)
+    }
+
+    /// Scrollbar geometry of the current viewport (ghostty's terminal
+    /// scrollbar data). Ghostty documents this query as potentially
+    /// expensive when the viewport is pinned into scrollback; call it per
+    /// rendered frame, not per byte fed.
+    ///
+    /// # Errors
+    /// Returns an [`Error`] if ghostty rejects the state query.
+    pub fn scrollbar(&self) -> Result<Scrollbar> {
+        let bar: sys::GhosttyTerminalScrollbar =
+            unsafe { self.get(sys::GhosttyTerminalData::GHOSTTY_TERMINAL_DATA_SCROLLBAR) }?;
+        Ok(Scrollbar {
+            total: bar.total,
+            offset: bar.offset,
+            len: bar.len,
+        })
     }
 
     /// Read a DEC/ANSI mode's current state via `ghostty_terminal_mode_get`.

--- a/packages/tui/vt/ix-vt/tests/modes.rs
+++ b/packages/tui/vt/ix-vt/tests/modes.rs
@@ -1,0 +1,84 @@
+//! Mode-state accessors for input routing (`mouse_reporting`, `sgr_mouse`,
+//! `alternate_screen`, `scrollbar`): the queries a server-side input driver
+//! needs to decide whether wheel input scrolls scrollback, becomes arrow
+//! keys, or is forwarded to the application as encoded mouse events.
+
+use ix_vt::{MouseReporting, Terminal};
+
+#[test]
+fn mouse_reporting_follows_decset_and_strongest_wins() {
+    let mut term = Terminal::new(24, 80, 1000).expect("create terminal");
+    assert_eq!(term.mouse_reporting().expect("query"), MouseReporting::None);
+    assert!(!term.sgr_mouse().expect("query"));
+
+    // vim's usual request: normal tracking + button drag + SGR encoding.
+    term.vt_write(b"\x1b[?1000h\x1b[?1002h\x1b[?1006h");
+    assert_eq!(
+        term.mouse_reporting().expect("query"),
+        MouseReporting::Button,
+        "1002 outranks 1000"
+    );
+    assert!(term.sgr_mouse().expect("query"));
+
+    term.vt_write(b"\x1b[?1003h");
+    assert_eq!(term.mouse_reporting().expect("query"), MouseReporting::Any);
+
+    // Reset everything: back to terminal-owned mouse.
+    term.vt_write(b"\x1b[?1003l\x1b[?1002l\x1b[?1000l\x1b[?1006l");
+    assert_eq!(term.mouse_reporting().expect("query"), MouseReporting::None);
+    assert!(!term.sgr_mouse().expect("query"));
+}
+
+#[test]
+fn alternate_screen_tracks_1049_and_1047() {
+    let mut term = Terminal::new(24, 80, 1000).expect("create terminal");
+    assert!(!term.alternate_screen().expect("query"));
+
+    term.vt_write(b"\x1b[?1049h");
+    assert!(term.alternate_screen().expect("query"), "1049 enters alt");
+    term.vt_write(b"\x1b[?1049l");
+    assert!(!term.alternate_screen().expect("query"), "1049 leaves alt");
+
+    term.vt_write(b"\x1b[?1047h");
+    assert!(term.alternate_screen().expect("query"), "1047 enters alt");
+    term.vt_write(b"\x1b[?1047l");
+    assert!(!term.alternate_screen().expect("query"), "1047 leaves alt");
+}
+
+#[test]
+fn scrollbar_reports_history_and_bottom() {
+    let mut term = Terminal::new(4, 20, 100).expect("create terminal");
+
+    let bar = term.scrollbar().expect("query");
+    assert_eq!(bar.len, 4, "viewport height");
+    assert_eq!(
+        bar.offset + bar.len,
+        bar.total,
+        "fresh terminal viewport is at the bottom"
+    );
+    let empty_total = bar.total;
+
+    // Push 8 lines through a 4-row grid: history grows past the viewport.
+    for i in 0..8 {
+        term.vt_write(format!("line {i}\r\n").as_bytes());
+    }
+    let bar = term.scrollbar().expect("query");
+    assert!(bar.total > empty_total, "output grew the scrollable area");
+    assert_eq!(
+        bar.offset + bar.len,
+        bar.total,
+        "viewport follows the live bottom"
+    );
+
+    term.scroll_viewport(ix_vt::ScrollViewport::Top);
+    let bar = term.scrollbar().expect("query");
+    assert_eq!(bar.offset, 0, "scrolled to the oldest row");
+    assert!(
+        bar.offset + bar.len < bar.total,
+        "viewport is no longer at the bottom"
+    );
+
+    term.scroll_viewport(ix_vt::ScrollViewport::Bottom);
+    let bar = term.scrollbar().expect("query");
+    assert_eq!(bar.offset + bar.len, bar.total, "back at the bottom");
+}


### PR DESCRIPTION
Additive `ix_vt::Terminal` accessors needed by the ix-term v2 input driver (indexable-inc/ix#7989): `mouse_reporting()` (DECSET 9/1000/1002/1003, strongest wins), `sgr_mouse()` (1006), `alternate_screen()` (active-screen data), and `scrollbar()` (viewport geometry). Covered by new `tests/modes.rs` against the real libghostty-vt; all ix-vt tests pass locally on darwin.

Authored by Claude Code (Claude Sonnet).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add mouse reporting, alternate screen, and scrollbar state accessors to `ix-vt` Terminal
> - Adds `Terminal::mouse_reporting()` returning a new `MouseReporting` enum reflecting the strongest active DECSET mode (9/1000/1002/1003), and `Terminal::sgr_mouse()` for DECSET 1006 state.
> - Adds `Terminal::alternate_screen()` to query whether the alternate screen is active, and `Terminal::scrollbar()` returning a new `Scrollbar` struct with `total`, `offset`, and `len` fields.
> - Adds tests in [modes.rs](https://github.com/indexable-inc/index/pull/3815/files#diff-c0fcf70802e1e425b94500b2a154317049613cb063aa0fea7797c6c370ec00e4) covering all four accessors, including history growth, viewport scrolling, and mode priority.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c02b21f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->