### PR TITLE
mcp-ex: Edit.replace/Edit.write with Claude Code file-tool semantics

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/api.ex
+++ b/packages/mcp-ex/lib/ix_mcp/api.ex
@@ -20,6 +20,7 @@ defmodule IxMcp.Api do
     IxMcp.Workspace,
     IxMcp.Checkpoint,
     IxMcp.Read,
+    IxMcp.Edit,
     IxMcp.PrWatch,
     IxMcp.Tui,
     IxMcp.TuiLocal,

--- a/packages/mcp-ex/lib/ix_mcp/edit.ex
+++ b/packages/mcp-ex/lib/ix_mcp/edit.ex
@@ -1,0 +1,110 @@
+defmodule IxMcp.Edit do
+  @moduledoc """
+  File writing and exact-string find/replace for cells, aliased in the
+  workspace prelude as `Edit`. The semantics mirror Claude Code's native
+  Write and Edit tools (messages lifted from the 2.1.215 binary) because
+  they are shaped for LLM callers: a replacement that matches nowhere or
+  more than once fails loudly instead of guessing, `replace_all:` is an
+  explicit opt-in, and success returns a line-numbered snippet of the
+  edited region so the caller sees the change without re-reading. The
+  native stale-read guard is subsumed by exactness: content that drifted
+  since `old_string` was copied no longer matches, so the call raises
+  instead of clobbering.
+  """
+
+  # Lines of context around the edited region in the success snippet.
+  @snippet_context 4
+
+  @doc """
+  Replace one exact occurrence of `old_string` in `path` with `new_string`
+  (every occurrence with `replace_all: true`).
+
+  Raises `ArgumentError` when the strings are equal, `old_string` is empty,
+  no occurrence exists, or several do without `replace_all: true`.
+  """
+  @spec replace(Path.t(), String.t(), String.t(), keyword()) :: String.t()
+  def replace(path, old_string, new_string, opts \\ []) do
+    replace_all = Keyword.get(opts, :replace_all, false)
+    validate_strings!(old_string, new_string)
+
+    content = File.read!(path)
+    matches = length(String.split(content, old_string)) - 1
+
+    cond do
+      matches == 0 ->
+        raise ArgumentError,
+              "String to replace not found in file. " <>
+                "Re-read the file and copy the exact surrounding text."
+
+      matches > 1 and not replace_all ->
+        raise ArgumentError,
+              "Found #{matches} matches of the string to replace, but replace_all is " <>
+                "false. To replace all occurrences, set replace_all to true. To " <>
+                "replace only one occurrence, please provide more context to " <>
+                "uniquely identify the instance."
+
+      true ->
+        updated = String.replace(content, old_string, new_string, global: replace_all)
+        File.write!(path, updated)
+        note = snippet(content, updated, old_string, new_string)
+        confirmation(path, matches, replace_all) <> "\n" <> note
+    end
+  end
+
+  @doc """
+  Write `content` to `path`, overwriting any existing file; parent
+  directories are created. The return names whether the file was created
+  or updated.
+  """
+  @spec write(Path.t(), String.t()) :: String.t()
+  def write(path, content) do
+    existed = File.exists?(path)
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, content)
+
+    if existed do
+      "The file #{path} has been updated successfully."
+    else
+      "File created successfully at: #{path}"
+    end
+  end
+
+  defp validate_strings!(old_string, new_string) do
+    if old_string == new_string do
+      raise ArgumentError,
+            "No changes to make: old_string and new_string are exactly the same."
+    end
+
+    if old_string == "" do
+      raise ArgumentError,
+            "old_string must not be empty; use Edit.write/2 to create content."
+    end
+  end
+
+  defp confirmation(path, matches, replace_all) do
+    if replace_all and matches > 1 do
+      "The file #{path} has been updated. All occurrences were successfully replaced."
+    else
+      "The file #{path} has been updated successfully."
+    end
+  end
+
+  # The edited region of `updated`, cat -n numbered with context lines,
+  # anchored at the first occurrence of `old_string` in the original.
+  defp snippet(original, updated, old_string, new_string) do
+    {pos, _len} = :binary.match(original, old_string)
+    first = newlines(binary_part(original, 0, pos))
+    lines = String.split(updated, "\n")
+    lo = max(first - @snippet_context, 0)
+    hi = min(first + newlines(new_string) + @snippet_context, length(lines) - 1)
+
+    lines
+    |> Enum.slice(lo..hi//1)
+    |> Enum.with_index(lo + 1)
+    |> Enum.map_join("\n", fn {text, n} ->
+      String.pad_leading(Integer.to_string(n), 6) <> "\t" <> text
+    end)
+  end
+
+  defp newlines(s), do: length(String.split(s, "\n")) - 1
+end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -28,6 +28,13 @@ defmodule IxMcp.MCP.Tools do
       Jobs.tail("ab12", 20)   Jobs.await("ab12")   Jobs.cancel("ab12")   Jobs.history()
       Read.file(path)                       a file; Read.file(path, first, last) slices
                                             a 1-based inclusive line range
+      Edit.replace(path, old, new)          exact-string find/replace with native
+                                            Claude Code Edit semantics: raises on
+                                            zero or ambiguous matches (replace_all:
+                                            true replaces every one), returns a
+                                            numbered snippet of the edited region
+      Edit.write(path, content)             write a file, creating parent dirs;
+                                            the return names created vs updated
       Ix.trace()                            stack dump of every running job's processes,
                                             taken from outside with Process.info/2
       Ix.restart()                          cancel running jobs (sparing the calling
@@ -99,7 +106,10 @@ defmodule IxMcp.MCP.Tools do
         #{@surface_guide}
         Write plain Elixir, not shell. For files and data use the standard
         library directly -- File.read!/1, File.write!/2, Path.wildcard/1,
-        File.ls!/1, File.stat!/1 -- instead of shelling out. Reserve
+        File.ls!/1, File.stat!/1 -- instead of shelling out. To change
+        an existing file, reach for Edit.replace/4 before hand-rolled
+        String.replace rewrites: it fails loudly on zero or ambiguous
+        matches and confirms what changed. Reserve
         System.cmd/3 for real external programs (git, nix, gh), and always
         pass its arguments as a list: System.cmd("git", ["-C", dir, "status"]).
         A subprocess's stdin is a pipe that never closes, so tools that read

--- a/packages/mcp-ex/lib/ix_mcp/workspace.ex
+++ b/packages/mcp-ex/lib/ix_mcp/workspace.ex
@@ -15,7 +15,7 @@ defmodule IxMcp.Workspace do
 
   # `Kernel` would shadow Elixir's; cells reach trace/restart as `Ix`.
   @prelude "alias IxMcp.Jobs; alias IxMcp.Api; alias IxMcp.Fleet; " <>
-             "alias IxMcp.Read; alias IxMcp.PrWatch; alias IxMcp.Tui; " <>
+             "alias IxMcp.Read; alias IxMcp.Edit; alias IxMcp.PrWatch; alias IxMcp.Tui; " <>
              "alias IxMcp.TuiLocal; alias IxMcp.Gmail; " <>
              "alias IxMcp.Kernel, as: Ix; alias IxMcp.Agents"
 

--- a/packages/mcp-ex/test/ix_mcp/edit_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/edit_test.exs
@@ -1,0 +1,73 @@
+defmodule IxMcp.EditTest do
+  use ExUnit.Case, async: true
+
+  alias IxMcp.Edit
+
+  @moduletag :tmp_dir
+
+  describe "replace/4" do
+    test "replaces a unique match and returns a numbered snippet", %{tmp_dir: dir} do
+      path = Path.join(dir, "unique.txt")
+      File.write!(path, "alpha\nfoo bar\nomega\n")
+
+      message = Edit.replace(path, "bar", "BAZ")
+
+      assert File.read!(path) == "alpha\nfoo BAZ\nomega\n"
+      assert message =~ "The file #{path} has been updated successfully."
+      assert message =~ "     2\tfoo BAZ"
+    end
+
+    test "zero matches raise the not-found error", %{tmp_dir: dir} do
+      path = Path.join(dir, "none.txt")
+      File.write!(path, "alpha\n")
+
+      assert_raise ArgumentError, ~r/String to replace not found in file/, fn ->
+        Edit.replace(path, "zzz", "yyy")
+      end
+    end
+
+    test "ambiguous matches raise unless replace_all", %{tmp_dir: dir} do
+      path = Path.join(dir, "multi.txt")
+      File.write!(path, "foo bar foo\n")
+
+      assert_raise ArgumentError, ~r/Found 2 matches of the string to replace/, fn ->
+        Edit.replace(path, "foo", "qux")
+      end
+
+      message = Edit.replace(path, "foo", "qux", replace_all: true)
+
+      assert File.read!(path) == "qux bar qux\n"
+      assert message =~ "All occurrences were successfully replaced."
+    end
+
+    test "identical old and new strings raise", %{tmp_dir: dir} do
+      path = Path.join(dir, "same.txt")
+      File.write!(path, "alpha\n")
+
+      assert_raise ArgumentError, ~r/exactly the same/, fn ->
+        Edit.replace(path, "alpha", "alpha")
+      end
+    end
+
+    test "an empty old_string raises", %{tmp_dir: dir} do
+      path = Path.join(dir, "empty-needle.txt")
+      File.write!(path, "alpha\n")
+
+      assert_raise ArgumentError, ~r/old_string must not be empty/, fn ->
+        Edit.replace(path, "", "x")
+      end
+    end
+  end
+
+  describe "write/2" do
+    test "creates with parents, then reports update on overwrite", %{tmp_dir: dir} do
+      path = Path.join([dir, "nested", "deep", "new.txt"])
+
+      assert Edit.write(path, "one") == "File created successfully at: #{path}"
+      assert File.read!(path) == "one"
+
+      assert Edit.write(path, "two") == "The file #{path} has been updated successfully."
+      assert File.read!(path) == "two"
+    end
+  end
+end

--- a/packages/site/src/lib/updates/kernel-file-edit-helpers.svx
+++ b/packages/site/src/lib/updates/kernel-file-edit-helpers.svx
@@ -1,0 +1,13 @@
+---
+id: kernel-file-edit-helpers
+postedAt: 2026-07-21T02:55:00-07:00
+title: Kernel cells get Claude Code's Edit/Write file semantics
+tags: [kernel, mcp]
+links:
+  - label: index#3819
+    href: https://github.com/indexable-inc/index/issues/3819
+---
+
+Editing a file from a kernel cell used to mean hand-rolled `String.replace` plus `File.write!`, which silently rewrites whatever matched, zero times included. Claude Code's native Edit tool solved this for LLM callers long ago: exact-string replacement that errors on zero matches and on ambiguity, an explicit `replace_all`, and a numbered snippet of the changed region.
+
+The kernel now ships those semantics in-language. `Edit.replace(path, old, new)` raises on a missing or ambiguous match (`replace_all: true` to change every occurrence) and returns a `cat -n` style snippet of the edited region; `Edit.write(path, content)` creates parent directories and says whether it created or updated. Error and success texts were lifted byte-for-byte from the Claude Code 2.1.215 binary rather than reconstructed from memory, so agents trained against the native tools see familiar failure shapes. The native stale-read guard is subsumed by exactness: content that drifted since you copied the old string no longer matches, and the call raises instead of clobbering.


### PR DESCRIPTION
In-cell `Edit.replace/4` and `Edit.write/2` mirroring Claude Code's native Edit/Write tool semantics: raise on zero or ambiguous matches, explicit `replace_all: true`, cat -n numbered snippet of the edited region, created-vs-updated write confirmation. Error and success strings extracted byte-for-byte from the Claude Code 2.1.215 binary (the deny-list on this machine blocks live tool probing, so the binary was the strongest source). Aliased in the workspace prelude, listed in Api discovery, taught in the exec surface guide.

Validated locally: `nix build .#mcp-ex.tests.elixir` (compile -W as errors, format, credo strict, 88 tests 0 failures) and `nix run .#lint` (12/12).

Closes #3819

(sent by an AI agent via Claude Code, model claude-fable-5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Edit.replace/4` and `Edit.write/2` with Claude Code file-tool semantics to mcp-ex
> - Adds `Edit.replace/4` in [`edit.ex`](https://github.com/indexable-inc/index/pull/3820/files#diff-04c72da0bcf3908e00b4d88115a0dabc1e07d4ca3afeb7c9bf61b1d9e5289914) for exact-string file replacement: raises on zero matches or ambiguous matches (unless `replace_all: true`), writes the result, and returns a `cat -n` style snippet of the edited region.
> - Adds `Edit.write/2` which creates parent directories as needed and returns whether the file was created or updated.
> - Aliases `IxMcp.Edit` in the workspace prelude and registers it in the API module so kernel cells can reference `Edit` directly.
> - Updates the tools usage guide to document `Edit` semantics and prefer `Edit.replace/4` over ad-hoc `String.replace` for file edits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73024ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->