### PR TITLE
lib: TigerBeetle deployment contract as data

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -332,6 +332,14 @@
   systemdHardening = import ./services/systemd-hardening.nix;
 
   /**
+  TigerBeetle's documented deployment contract (memory floor, reference
+  `--cache-grid`, `CAP_IPC_LOCK`) as data, so consumers running a replica
+  (ix billing-ledger) size units from the vendor doc instead of re-deriving
+  it. See [`lib/services/tigerbeetle.nix`](lib/services/tigerbeetle.nix).
+  */
+  tigerbeetle = import ./services/tigerbeetle.nix;
+
+  /**
   The pinned fabric/Ray execution environment as data: env tag, node
   resources, cluster env vars, wrapped `ray` CLI. One owner shared by the
   ray modules and the mcp wrappers. See [`lib/fabric.nix`](lib/fabric.nix).
@@ -753,6 +761,7 @@
       selfVersionFor
       skills
       systemdHardening
+      tigerbeetle
       toml
       unibind
       unibindFor

--- a/lib/services/tigerbeetle.nix
+++ b/lib/services/tigerbeetle.nix
@@ -1,0 +1,33 @@
+/**
+TigerBeetle's documented deployment contract as data, one owner for every
+repo that runs a replica (today: ix's billing-ledger). Values come from the
+vendor docs, not from any deployment's measurements; a consumer that wants
+different numbers is diverging from the vendor and should say so at its own
+call site.
+
+- `minRamGiBPerReplica` / `recommendedCacheRamGiB`: hardware floor and the
+  recommended cache allocation range
+  (https://docs.tigerbeetle.com/operating/hardware/). TigerBeetle allocates
+  its whole footprint statically at startup and never shrinks, so a memory
+  limit below the live footprint is permanent reclaim thrash by
+  construction (ix#8020), never pressure relief.
+- `referenceCacheGrid`: the `--cache-grid` value the vendor's reference
+  systemd unit pins explicitly
+  (https://docs.tigerbeetle.com/operating/deploying/systemd/). Pass it (or
+  a deliberate override) so the static footprint is chosen, not floating on
+  a binary default.
+- `capabilities`: the reference unit ships
+  `AmbientCapabilities=CAP_IPC_LOCK` so TigerBeetle can mlock everything it
+  allocates (io_uring setup, and keeping swap from silently bypassing its
+  storage fault model). CAP_IPC_LOCK also exempts mlock from
+  RLIMIT_MEMLOCK, so no LimitMEMLOCK override is needed alongside it.
+*/
+{
+  minRamGiBPerReplica = 6;
+  recommendedCacheRamGiB = {
+    low = 16;
+    high = 32;
+  };
+  referenceCacheGrid = "1GiB";
+  capabilities = ["CAP_IPC_LOCK"];
+}


### PR DESCRIPTION
Closes #3824.

`lib.tigerbeetle` = the vendor deployment contract as a plain attrset (memory floor, recommended cache range, reference `--cache-grid`, `CAP_IPC_LOCK`), doc-commented with the why behind each value and the thrash failure mode it prevents (ix#8020). Style matches `systemdHardening` (argless data file under `lib/services/`).

Validated: `nix eval .#lib.tigerbeetle --json` returns the attrset; `nix fmt` clean.

Follow-up: ix bumps its index pin and replaces the hardcoded values from ix#8022.

(authored by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add TigerBeetle deployment contract constants to lib
> Adds [lib/services/tigerbeetle.nix](https://github.com/indexable-inc/index/pull/3825/files#diff-19bfc5af81a2f333e03001f6ea7d2b7452eece62484388d1ffdb36e76d68f530) exposing a set of TigerBeetle deployment contract constants: `minRamGiBPerReplica=6`, recommended cache RAM ranges (16/32 GiB), a reference cache grid of `1GiB`, and required Linux capability `CAP_IPC_LOCK`. The module is exported via `lib.tigerbeetle` in [lib/default.nix](https://github.com/indexable-inc/index/pull/3825/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f205e4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->