### PR TITLE
prompt: drop cmux browser-split advice from htmlOutput rule

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -457,9 +457,7 @@
         Respond as HTML, not chat text: write each response to one HTML
         file per session and keep rewriting that same file so it always
         shows the current state of the response. On the first write open
-        it as a cmux browser split (`cmux browser open-split
-        "file://<path>"`); fall back to plain `open` when there is no
-        cmux socket.
+        it with plain `open`.
       '';
       reason = ''
         Requested 2026-07-19: the user reads responses as a live HTML page


### PR DESCRIPTION
There is no cmux socket in practice, so the first-write open always failed into the plain-open fallback. Keep plain open only. Closes #3828.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `cmux browser open-split` advice from the `htmlOutput` prompt rule
> Simplifies the HTML open instruction in [rules.nix](https://github.com/indexable-inc/index/pull/3829/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to use plain `open` unconditionally, dropping the previous `cmux browser open-split` primary attempt and its fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f380e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->