### PR TITLE
nix: emit terminal progress (OSC 9;4) and repaint on resize

### DIFF
--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -791,6 +791,22 @@
           upstream = "hold";
           reason = "Port of the MonitorFdHup half of NixOS/nix#15691 (open since 2026-04, indexable-inc/index#3769); retire if that PR merges. Hold: humans submit Nix patches upstream per NixOS/nix#15984.";
         };
+        # 0036: the progress bar emits the ConEmu-style progress OSC (9;4) so
+        # terminals that understand it (Ghostty, WezTerm, Windows Terminal,
+        # ConEmu) show a native build-progress indicator; percent mirrors the
+        # build + copy counters of the textual status line.
+        "0036-libmain-emit-terminal-progress-OSC-9-4-from-the-prog.patch" = {
+          upstream = "hold";
+          reason = "UX feature (indexable-inc/index#3830) upstream may want behind a setting or with broader terminal detection. Hold: humans submit Nix patches upstream per NixOS/nix#15984.";
+        };
+        # 0037: the status line never repaints on SIGWINCH (redraw() dedupes
+        # and nothing invalidates on resize), so resizing the terminal leaves
+        # a stale truncated or wrapped line; adds a window-size callback in
+        # libutil and registers the progress bar to repaint through it.
+        "0037-libmain-repaint-the-progress-bar-on-terminal-resize.patch" = {
+          upstream = "hold";
+          reason = "Real upstream bug worth a PR (stale progress line after resize, indexable-inc/index#3830). Hold: humans submit Nix patches upstream per NixOS/nix#15984.";
+        };
       };
     }
     {

--- a/packages/nix/nix/patches/0036-libmain-emit-terminal-progress-OSC-9-4-from-the-prog.patch
+++ b/packages/nix/nix/patches/0036-libmain-emit-terminal-progress-OSC-9-4-from-the-prog.patch
@@ -1,0 +1,139 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew@ix.dev>
+Date: Tue, 21 Jul 2026 05:13:39 -0700
+Subject: [PATCH] libmain: emit terminal progress (OSC 9;4) from the progress
+ bar
+
+Terminals that understand the ConEmu-style progress OSC (Ghostty,
+WezTerm, Windows Terminal, ConEmu) can render a native progress
+indicator for the foreground command, but nix never tells them how far
+a build has got. Emit the overall build + copy percentage (the same
+counters the textual status line shows) on every redraw, switch to the
+error state once something has failed, report indeterminate while
+nothing is expected yet, and remove the indicator on stop and pause.
+Detection is by terminal identity because there is no capability
+query; non-TTY output is unaffected.
+
+Refs indexable-inc/index#3830
+
+diff --git a/src/libmain/progress-bar.cc b/src/libmain/progress-bar.cc
+index a973102..a0a0cbe 100644
+--- a/src/libmain/progress-bar.cc
++++ b/src/libmain/progress-bar.cc
+@@ -1,4 +1,5 @@
+ #include "nix/main/progress-bar.hh"
++#include "nix/util/environment-variables.hh"
+ #include "nix/util/terminal.hh"
+ #include "nix/util/sync.hh"
+ #include "nix/store/store-api.hh"
+@@ -27,6 +28,18 @@ static uint64_t getI(const std::vector<Logger::Field> & fields, size_t n)
+     return fields[n].i;
+ }
+ 
++/* Whether the terminal understands the ConEmu-style progress OSC
++   (`ESC ] 9 ; 4 ; st ; pct BEL`), used by Ghostty, WezTerm, Windows
++   Terminal and ConEmu to show a native progress indicator for the
++   foreground command. There is no capability query, so recognise the
++   terminals known to support it. */
++static bool terminalSupportsProgress()
++{
++    auto termProgram = getEnv("TERM_PROGRAM").value_or("");
++    return termProgram == "ghostty" || termProgram == "WezTerm" || getEnv("WT_SESSION").has_value()
++        || getEnv("ConEmuANSI").value_or("") == "ON";
++}
++
+ static std::string_view storePathToName(std::string_view path)
+ {
+     auto base = baseNameOf(path);
+@@ -93,11 +106,13 @@ private:
+ 
+     bool printBuildLogs = false;
+     bool isTTY;
++    bool emitTerminalProgress;
+ 
+ public:
+ 
+     ProgressBar(bool isTTY)
+         : isTTY(isTTY)
++        , emitTerminalProgress(isTTY && terminalSupportsProgress())
+     {
+         state_.lock()->active = isTTY;
+         updateThread = std::thread([&]() {
+@@ -125,6 +140,7 @@ public:
+             if (state->active) {
+                 state->active = false;
+                 writeToStderr("\r\e[K");
++                clearTerminalProgress();
+                 updateCV.notify_one();
+                 quitCV.notify_one();
+             }
+@@ -142,8 +158,10 @@ public:
+             return;
+         }
+ 
+-        if (state->active)
++        if (state->active) {
+             writeToStderr("\r\e[K");
++            clearTerminalProgress();
++        }
+     }
+ 
+     void resume() override
+@@ -460,11 +478,56 @@ public:
+         if (width <= 0)
+             width = std::numeric_limits<decltype(width)>::max();
+ 
+-        redraw("\r" + filterANSIEscapes(line, false, width) + ANSI_NORMAL + "\e[K");
++        redraw("\r" + filterANSIEscapes(line, false, width) + ANSI_NORMAL + "\e[K" + terminalProgress(state));
+ 
+         return nextWakeup;
+     }
+ 
++    /* Render the terminal progress OSC for the overall build + copy
++       progress, mirroring the counters shown in the textual status.
++       Failures switch the indicator to the error state; while nothing
++       is expected yet but work is running, report indeterminate. */
++    std::string terminalProgress(State & state)
++    {
++        if (!emitTerminalProgress)
++            return "";
++
++        uint64_t done = 0, expected = 0, running = 0, failed = 0;
++        for (auto type : {actBuilds, actCopyPaths}) {
++            auto & act = state.activitiesByType[type];
++            uint64_t typeExpected = act.done;
++            done += act.done;
++            failed += act.failed;
++            for (auto & j : act.its) {
++                done += j.second->done;
++                typeExpected += j.second->expected;
++                running += j.second->running;
++                failed += j.second->failed;
++            }
++            expected += std::max(typeExpected, act.expected);
++        }
++
++        auto percent = expected ? std::min<uint64_t>(done * 100 / expected, 100) : 100;
++
++        if (failed)
++            return fmt("\e]9;4;2;%d\a", percent);
++        if (expected)
++            return fmt("\e]9;4;1;%d\a", percent);
++        if (running)
++            return "\e]9;4;3;0\a";
++        return "\e]9;4;0;0\a";
++    }
++
++    /* Remove the terminal progress indicator, and forget the last drawn
++       output so the next draw() repaints both the line and the OSC. */
++    void clearTerminalProgress()
++    {
++        if (!emitTerminalProgress)
++            return;
++        writeToStderr("\e]9;4;0;0\a");
++        lastOutput_.lock()->clear();
++    }
++
+     std::string getStatus(State & state)
+     {
+         std::string res;

--- a/packages/nix/nix/patches/0037-libmain-repaint-the-progress-bar-on-terminal-resize.patch
+++ b/packages/nix/nix/patches/0037-libmain-repaint-the-progress-bar-on-terminal-resize.patch
@@ -1,0 +1,142 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew@ix.dev>
+Date: Tue, 21 Jul 2026 05:23:55 -0700
+Subject: [PATCH] libmain: repaint the progress bar on terminal resize
+
+The status line is truncated to the window width at draw time and
+redraw() dedupes identical output, so after a resize nothing repaints:
+widening the terminal (smaller font) leaves the old truncated line,
+and narrowing it leaves a soft-wrapped leftover row. updateWindowSize()
+already refreshes the cached size from the SIGWINCH handler thread;
+give it a callback hook and have the progress bar use it to invalidate
+the last drawn output and wake the update thread, so the line is
+redrawn at the new width immediately. The callback runs on the signal
+handler thread (a real thread, not an async signal handler), and
+unregistration blocks until an in-flight callback returns, so it
+cannot outlive the progress bar.
+
+Refs indexable-inc/index#3830
+
+diff --git a/src/libmain/progress-bar.cc b/src/libmain/progress-bar.cc
+index a0a0cbe..cef8344 100644
+--- a/src/libmain/progress-bar.cc
++++ b/src/libmain/progress-bar.cc
+@@ -115,6 +115,19 @@ public:
+         , emitTerminalProgress(isTTY && terminalSupportsProgress())
+     {
+         state_.lock()->active = isTTY;
++        if (isTTY)
++            /* Repaint on terminal resize: the drawn line is truncated to
++               the window width and redraw() dedupes identical output, so
++               without this a widened window keeps the old truncation and
++               a narrowed one keeps a wrapped leftover. */
++            setWindowSizeCallback([this]() {
++                auto state(state_.lock());
++                if (!state->active)
++                    return;
++                lastOutput_.lock()->clear();
++                state->haveUpdate = true;
++                updateCV.notify_one();
++            });
+         updateThread = std::thread([&]() {
+             auto state(state_.lock());
+             auto nextWakeup = std::chrono::milliseconds::max();
+@@ -147,6 +160,10 @@ public:
+         }
+         if (updateThread.joinable())
+             updateThread.join();
++        if (isTTY)
++            /* Blocks until any in-flight callback returns, so it can't
++               outlive this object. */
++            setWindowSizeCallback({});
+     }
+ 
+     void pause() override
+diff --git a/src/libutil/include/nix/util/terminal.hh b/src/libutil/include/nix/util/terminal.hh
+index 5e35cbb..2bf142e 100644
+--- a/src/libutil/include/nix/util/terminal.hh
++++ b/src/libutil/include/nix/util/terminal.hh
+@@ -1,6 +1,7 @@
+ #pragma once
+ ///@file
+ 
++#include <functional>
+ #include <limits>
+ #include <string>
+ 
+@@ -44,6 +45,15 @@ void updateWindowSize();
+  */
+ std::pair<unsigned short, unsigned short> getWindowSize();
+ 
++/**
++ * Register a callback invoked after `updateWindowSize()` refreshes the
++ * cached size, i.e. on `SIGWINCH`. The callback runs on the signal
++ * handler thread (a real thread, not an async signal handler), so it
++ * may take locks. Pass an empty function to unregister; the previous
++ * callback has finished running by the time this returns.
++ */
++void setWindowSizeCallback(std::function<void()> cb);
++
+ /**
+  * Get the slave name of a pseudoterminal in a thread-safe manner.
+  *
+diff --git a/src/libutil/terminal.cc b/src/libutil/terminal.cc
+index 48d6928..60e99eb 100644
+--- a/src/libutil/terminal.cc
++++ b/src/libutil/terminal.cc
+@@ -165,23 +165,48 @@ std::string filterANSIEscapes(std::string_view s, bool filterAll, unsigned int w
+ // getWindowSize() after windowSize has been destroyed).
+ static auto * const windowSize = new Sync<std::pair<unsigned short, unsigned short>>{{0, 0}};
+ 
++// Leaked for the same destructor ordering reason as windowSize: the
++// signal handler thread may outlive static destruction.
++static auto * const windowSizeCallback = new Sync<std::function<void()>>;
++
++void setWindowSizeCallback(std::function<void()> cb)
++{
++    *windowSizeCallback->lock() = std::move(cb);
++}
++
++static void notifyWindowSizeChanged()
++{
++    // Invoked under the lock so unregistration (setWindowSizeCallback
++    // with an empty function) can't race a callback into a destroyed
++    // listener.
++    auto cb(windowSizeCallback->lock());
++    if (*cb)
++        (*cb)();
++}
++
+ void updateWindowSize()
+ {
+ #ifndef _WIN32
+     struct winsize ws;
+     if (ioctl(2, TIOCGWINSZ, &ws) == 0) {
+-        auto windowSize_(windowSize->lock());
+-        windowSize_->first = ws.ws_row;
+-        windowSize_->second = ws.ws_col;
++        {
++            auto windowSize_(windowSize->lock());
++            windowSize_->first = ws.ws_row;
++            windowSize_->second = ws.ws_col;
++        }
++        notifyWindowSizeChanged();
+     }
+ #else
+     CONSOLE_SCREEN_BUFFER_INFO info;
+     // From https://stackoverflow.com/a/12642749
+     if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info) != 0) {
+-        auto windowSize_(windowSize->lock());
+-        // From https://github.com/libuv/libuv/blob/v1.48.0/src/win/tty.c#L1130
+-        windowSize_->first = info.srWindow.Bottom - info.srWindow.Top + 1;
+-        windowSize_->second = info.dwSize.X;
++        {
++            auto windowSize_(windowSize->lock());
++            // From https://github.com/libuv/libuv/blob/v1.48.0/src/win/tty.c#L1130
++            windowSize_->first = info.srWindow.Bottom - info.srWindow.Top + 1;
++            windowSize_->second = info.dwSize.X;
++        }
++        notifyWindowSizeChanged();
+     }
+ #endif
+ }

--- a/packages/nix/nix/patches/dag.json
+++ b/packages/nix/nix/patches/dag.json
@@ -168,6 +168,16 @@
     {
       "patch": "0035-libutil-treat-POLLERR-POLLNVAL-as-fd-death-in-Monito.patch",
       "deps": []
+    },
+    {
+      "patch": "0036-libmain-emit-terminal-progress-OSC-9-4-from-the-prog.patch",
+      "deps": []
+    },
+    {
+      "patch": "0037-libmain-repaint-the-progress-bar-on-terminal-resize.patch",
+      "deps": [
+        "0036-libmain-emit-terminal-progress-OSC-9-4-from-the-prog.patch"
+      ]
     }
   ]
 }

--- a/packages/site/src/lib/updates/nix-terminal-progress-osc.svx
+++ b/packages/site/src/lib/updates/nix-terminal-progress-osc.svx
@@ -1,0 +1,19 @@
+---
+id: nix-terminal-progress-osc
+postedAt: 2026-07-21T06:20:00-07:00
+title: "nix builds now drive the terminal's native progress indicator"
+tags: [nix, fork, terminal, ux]
+links:
+  - label: patch 0036 (OSC 9;4)
+    href: https://github.com/indexable-inc/index/blob/main/packages/nix/nix/patches/0036-libmain-emit-terminal-progress-OSC-9-4-from-the-prog.patch
+  - label: patch 0037 (resize repaint)
+    href: https://github.com/indexable-inc/index/blob/main/packages/nix/nix/patches/0037-libmain-repaint-the-progress-bar-on-terminal-resize.patch
+  - label: issue 3830
+    href: https://github.com/indexable-inc/index/issues/3830
+---
+
+Two new patches in the nix fork series improve the progress bar's terminal integration.
+
+Patch 0036 emits the ConEmu-style progress OSC (`ESC ] 9 ; 4 ; state ; percent BEL`) on every redraw. Terminals that understand it, including Ghostty, WezTerm, Windows Terminal, and ConEmu, show a native progress indicator for the foreground command: percent is the overall build plus copy completion, the same counters the textual `[3/47 built, 12 copied]` status renders. Failures flip the indicator to the error state, unknown totals report indeterminate, and the indicator is removed when the bar stops or pauses. Terminals are recognized by identity (`TERM_PROGRAM`, `WT_SESSION`, `ConEmuANSI`) since there is no capability query; everything else sees the same bytes as before.
+
+Patch 0037 fixes a longstanding upstream wart the first patch made more visible: the status line never repainted on `SIGWINCH`. The line is truncated to the window width at draw time and the redraw path dedupes identical output, so growing the window kept the old truncation and shrinking it left a soft-wrapped leftover row. `updateWindowSize()` already runs on the signal handler thread; it now takes a callback, and the progress bar registers one that invalidates the last drawn output and wakes the update thread, so the line redraws at the new width immediately.


### PR DESCRIPTION
Closes #3830.

Two new patches in the nix fork series (`packages/nix/nix/patches/`):

**0036 — emit terminal progress (OSC 9;4).** The progress bar emits the ConEmu-style progress OSC (`ESC ] 9 ; 4 ; state ; percent BEL`) on every redraw. Ghostty, WezTerm, Windows Terminal, and ConEmu render it as a native progress indicator. Percent mirrors the build + copy counters of the textual status; failures switch to the error state, unknown totals report indeterminate, and the indicator clears on stop/pause. Gated on TTY + terminal identity (`TERM_PROGRAM`, `WT_SESSION`, `ConEmuANSI`); other terminals see unchanged output.

**0037 — repaint on terminal resize.** The status line is truncated to the window width at draw time and `redraw()` dedupes identical output, so nothing repainted on SIGWINCH: widening the window kept the old truncation, narrowing left a wrapped leftover. `updateWindowSize()` (already running on the signal handler thread) gains a callback; the progress bar registers one that invalidates the last drawn output and wakes the update thread.

Also: dag.json regenerated (0037 depends on 0036), per-patch `hold` intent declared in `lib/fork-packages.nix` (humans submit Nix patches upstream per NixOS/nix#15984), and a site update entry.

Validation: `checks.aarch64-darwin.patched-src-nix`, `checks.aarch64-darwin.patch-dag-nix`, and a full `nix build .#nix-ix` compile (in flight at PR-open time; merge follows local pass).

Authored by Claude Code (Fable) with Andrew.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OSC 9;4 terminal progress and repaint on resize to forked Nix
> - Adds a patch to `progress-bar.cc` that emits OSC 9;4 progress sequences on terminals that support them (Ghostty, WezTerm, Windows Terminal, ConEmu), reflecting combined build+copy percent, error, or indeterminate state, and clears the indicator on pause/stop.
> - Adds a second patch that repaints the progress bar immediately on terminal resize (SIGWINCH) by registering a window-size callback that invalidates last output and wakes the update thread.
> - Both patches are registered in the patch DAG via [dag.json](https://github.com/indexable-inc/index/pull/3832/files#diff-bb8cabe3c8aca5a21a04124e99377308810f2ffd5701104ed528dd747207dc2d) with the resize patch depending on the OSC patch.
> - Non-TTYs and unsupported terminals are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 294a6f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->