### PR TITLE
ghostty: expose per-cell OSC 8 hyperlink URIs to ix-vt

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,23 +152,6 @@
         "type": "github"
       }
     },
-    "ghostty": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1774297202,
-        "narHash": "sha256-zJwCCkqH/4TNwzxidiCLmj9hhkTiUMvQoIKFgGNPuHM=",
-        "owner": "ghostty-org",
-        "repo": "ghostty",
-        "rev": "fd49716ea2084108aa098db390931c007495a1ab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ghostty-org",
-        "repo": "ghostty",
-        "rev": "fd49716ea2084108aa098db390931c007495a1ab",
-        "type": "github"
-      }
-    },
     "ghostty-src": {
       "flake": false,
       "locked": {
@@ -634,7 +617,6 @@
         "drgn-src": "drgn-src",
         "examples": "examples",
         "fff-src": "fff-src",
-        "ghostty": "ghostty",
         "ghostty-src": "ghostty-src",
         "git-src": "git-src",
         "hermes-agent": "hermes-agent",

--- a/flake.nix
+++ b/flake.nix
@@ -313,28 +313,19 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # Ghostty's terminal VT engine, consumed as a source tree (not a flake) so
-    # `packages/tui/vt/libghostty-vt` owns the build. Pinned to the commit the
-    # local clone validated against; `requireZig` in `build.zig.zon` is exact
-    # minor (0.15.x), so the build uses `pkgs.zig_0_15`. The pinned tree ships
-    # `build.zig.zon.nix` (zon2nix output), which vendors every lazy Zig
-    # dependency with SRI hashes for a network-free build. Bump by repointing
-    # this rev and running `nix flake update ghostty`.
-    ghostty = {
-      url = "github:ghostty-org/ghostty/fd49716ea2084108aa098db390931c007495a1ab";
-      flake = false;
-    };
-
-    # Ghostty's terminal application, patched in-repo (packages/ghostty/patches,
-    # empty for now: index#3768 vendors the fork source and build; the
-    # surface-teardown fix -- killing the child process group on close_surface
-    # -- lands as a follow-up patch in this series). Distinct from the
-    # `ghostty` input above: that one pins a single rev unpatched, consumed
-    # only by `packages/tui/vt/libghostty-vt` for the VT-engine-only
-    # `-Demit-lib-vt` build. This input is the full application source that
-    # `packages/ghostty` builds against -- currently the same recipe, since
-    # the rest of ghostty's darwin core is not buildable in the sandbox (see
-    # `lib/build/libghostty-vt.nix`'s doc comment).
+    # Ghostty's full application source, patched in-repo
+    # (packages/ghostty/patches, the vendored fork of index#3768). The one
+    # ghostty input: `packages/ghostty` and `packages/tui/vt/libghostty-vt`
+    # (plus the Rust workspace's ix-vt link) all build the VT-engine-only
+    # `-Demit-lib-vt` subtree from this tree WITH the patch series applied --
+    # the series includes C-API additions (per-cell hyperlink URIs,
+    # index#3835) that ix-vt binds, so an unpatched build no longer links.
+    # The rest of ghostty's darwin core is not buildable in the sandbox (see
+    # `lib/build/libghostty-vt.nix`'s doc comment). `requireZig` in
+    # `build.zig.zon` is exact minor (0.15.x), so builds use `pkgs.zig_0_15`;
+    # the pinned tree ships `build.zig.zon.nix` (zon2nix output), which
+    # vendors every lazy Zig dependency with SRI hashes for a network-free
+    # build.
     #
     # Pinned BY REV (autoUpdate = false in lib/fork-packages.nix), same as
     # `nix-src`/`clippy-src`: ghostty's own `build.zig` changed, somewhere
@@ -404,7 +395,6 @@
     nix-derivation-src,
     rnix-0-12-src,
     rnix-0-14-src,
-    ghostty,
     ghostty-src,
     mesa-src,
     skills,
@@ -484,7 +474,6 @@
         nix-derivation-src
         rnix-0-12-src
         rnix-0-14-src
-        ghostty
         ghostty-src
         mesa-src
         ;

--- a/lib/build/libghostty-vt.nix
+++ b/lib/build/libghostty-vt.nix
@@ -55,8 +55,8 @@ in
 
   Arguments:
   - `pkgs`: package set to build against; the artifact is host-system specific.
-  - `ghosttySource`: ghostty source tree (the `ghostty` flake input, or a
-    patched fork source). Must ship `build.zig`, `build.zig.zon`, and
+  - `ghosttySource`: ghostty source tree (in this repo always the patched
+    fork source: `ix.patchedSrc` over the `ghostty-src` input). Must ship `build.zig`, `build.zig.zon`, and
     `build.zig.zon.nix` (the zon2nix output that vendors every lazy Zig
     dependency with SRI hashes for a network-free build).
   - `baseSource`: optional. When set, zig's own `--cache-dir` (a
@@ -68,9 +68,8 @@ in
     builds per-crate, without needing a per-translation-unit Nix decomposition
     zig's build graph has no boundary for. `warmCache` is keyed on `baseSource`
     alone, so it survives every patch-series change and rebuilds only when the
-    upstream pin moves. Omit (the default) when `ghosttySource` never diverges
-    from `baseSource` -- the existing unpatched `packages/tui/vt/libghostty-vt`
-    consumer -- where warming a separate cache buys nothing.
+    upstream pin moves. Omit (the default) only when `ghosttySource` never
+    diverges from `baseSource`, where warming a separate cache buys nothing.
   - `version`: derivation version. Defaults to the value in `build.zig.zon`.
 
   The static archive does not bundle its C++ dependencies (`libhighway`,
@@ -177,7 +176,58 @@ in
 
       doCheck = false;
 
-      passthru = lib.optionalAttrs (warmCache != null) {inherit warmCache;};
+      passthru =
+        lib.optionalAttrs (warmCache != null) {inherit warmCache;}
+        // {
+          # Ghostty's own vt/vt_c module unit tests (`zig build test-lib-vt`).
+          # Unlike the full `zig build test` exe this step never goes through
+          # `deps.add()`, so it has no `/usr/bin/xcrun metal` dependency and
+          # runs inside the sandbox on every platform -- the one lane that
+          # executes fork-patch test additions to the VT engine (e.g. the
+          # per-cell hyperlink URI patch, index#3835).
+          unitTests = stdenv.mkDerivation {
+            pname = "libghostty-vt-unit-tests";
+            inherit version;
+
+            src = builtins.path {
+              name = "ghostty-source";
+              path = ghosttySource;
+            };
+
+            strictDeps = true;
+            nativeBuildInputs = commonNativeBuildInputs;
+            buildInputs = commonBuildInputs;
+
+            dontConfigure = true;
+            dontBuild = true;
+
+            installPhase = ''
+              # shell
+              runHook preInstall
+
+              ${seedGlobalCache}
+              mkdir -p "$TMPDIR/zig-local-cache"
+              ${zigWarmCache.seedFrom warmCache}
+
+              buildCores=1
+              if [ "''${enableParallelBuilding-1}" ]; then
+                buildCores="$NIX_BUILD_CORES"
+              fi
+
+              zig build test-lib-vt \
+                "-j$buildCores" \
+                --global-cache-dir "$ZIG_GLOBAL_CACHE_DIR" \
+                --cache-dir "$TMPDIR/zig-local-cache" \
+                -Dcpu=baseline \
+                -fsys=zlib --search-prefix ${pkgs.zlib} \
+                --summary all
+
+              mkdir -p "$out"
+
+              runHook postInstall
+            '';
+          };
+        };
 
       meta = {
         description = "Ghostty's terminal VT engine as a standalone C library (parser, screen, render state)";

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -28,7 +28,6 @@
   nix-derivation-src,
   rnix-0-12-src,
   rnix-0-14-src,
-  ghostty,
   ghostty-src,
   mesa-src,
   # The flake's own source (`self`), carrying `.outPath` (a `-source` store
@@ -548,7 +547,6 @@
       goUnitFor
       rustWorkspaceFor
       clippy-src
-      ghostty
       zed-src
       ;
   };
@@ -572,12 +570,13 @@
       cargoUnitFor
       buildSvelteSite
       buildLibghosttyVt
-      ghostty
+      patchedSrcFor
       writeBashApplication
       macosSdk
       appleSdkToolchain
       pins
       ;
+    ghosttySrc = ghostty-src;
     rustToolchainFor = languages.rust.toolchain;
   };
   rustWorkspace = rustWorkspaceFor pkgs;

--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -291,12 +291,11 @@
       };
     }
     {
-      # Full ghostty application source (index#3768), distinct from the bare
-      # `ghostty` input `packages/tui/vt/libghostty-vt` consumes unpatched: this
-      # is the fork's actual patch point. No patches yet -- `packages/ghostty`
-      # builds the pinned base as-is; the surface-teardown fix (kill the child
-      # process group and waitpid-reap on close_surface) lands here as a
-      # follow-up patch.
+      # Full ghostty application source (index#3768), the fork's single patch
+      # point: `packages/ghostty`, `packages/tui/vt/libghostty-vt`, and the
+      # Rust workspace's ix-vt link all build the VT-only subtree from this
+      # series. 0003 adds C API that ix-vt's checked-in bindings reference,
+      # so the patched source is load-bearing, not just validated.
       name = "ghostty";
       input = "ghostty-src";
       url = "https://github.com/ghostty-org/ghostty.git";
@@ -325,6 +324,11 @@
           upstream = "attempt";
           reason = "Darwin killpg EPERM at surface close can mean the hangup reached nobody (root-owned login(1) alone in the spawn-time group; the shell moved to its own job-control group), leaving shells alive against a revoked tty.";
           prExtra = "Related earlier lifecycle issues: ghostty-org/ghostty#2273, ghostty-org/ghostty#4554.";
+        };
+        "0003-terminal-expose-per-cell-OSC-8-hyperlink-URIs-throug.patch" = {
+          upstream = "attempt";
+          reason = "The render-state C API exposes only a per-cell has-hyperlink bool (the row flag may false-positive), so a libghostty-vt embedder cannot learn a cell's OSC 8 link target; the URI must be duplicated out of page memory during update() like graphemes and styles already are.";
+          prExtra = "Motivating embedder: ix-term (indexable-inc/ix#8008), which renders the terminal grid in a browser and needs real anchors for OSC 8 hyperlinks.";
         };
       };
     }

--- a/lib/packages.nix
+++ b/lib/packages.nix
@@ -6,7 +6,6 @@
   goUnitFor,
   rustWorkspaceFor,
   clippy-src,
-  ghostty,
   zed-src,
 }: pkgs: let
   packageSystem = pkgs.stdenv.hostPlatform.system;
@@ -34,7 +33,6 @@
       pkgs
       packageSystem
       clippy-src
-      ghostty
       ixForPackages
       ;
     ix = ixForPackages;

--- a/lib/rust/workspace.nix
+++ b/lib/rust/workspace.nix
@@ -5,7 +5,8 @@
   cargoUnitFor,
   buildSvelteSite,
   buildLibghosttyVt,
-  ghostty,
+  ghosttySrc,
+  patchedSrcFor,
   writeBashApplication,
   # Cross-compilation leaves, threaded in so `unitsFor { target }` can build a
   # second unit graph for a non-host triple without `workspace.nix` having
@@ -20,14 +21,22 @@
 }: workspacePkgs: let
   inherit (paths) root;
 
-  # libghostty-vt built for the workspace's package set. ix-vt-sys links this
-  # dylib, so the unit graph needs both the build-script env (so the build
-  # script emits the link directives) and a workspace-wide `-L` search path (a
-  # build script's own link-search does not propagate to the final per-unit
-  # link in this graph; see the alsa note below for the same shape). The dylib
-  # dir is also a runtime input for the ix-vt tests, which dlopen it.
+  # libghostty-vt built for the workspace's package set, from the PATCHED
+  # fork source (packages/ghostty/patches; the fork's C-API additions such as
+  # the per-cell hyperlink URI are part of the surface ix-vt binds, so the
+  # unpatched base would fail the link). ix-vt-sys links this dylib, so the
+  # unit graph needs both the build-script env (so the build script emits the
+  # link directives) and a workspace-wide `-L` search path (a build script's
+  # own link-search does not propagate to the final per-unit link in this
+  # graph; see the alsa note below for the same shape). The dylib dir is also
+  # a runtime input for the ix-vt tests, which dlopen it.
   libghosttyVt = buildLibghosttyVt workspacePkgs {
-    ghosttySource = ghostty;
+    ghosttySource = (patchedSrcFor workspacePkgs) {
+      name = "ghostty";
+      src = ghosttySrc;
+      patchDir = root + "/packages/ghostty/patches";
+    };
+    baseSource = ghosttySrc;
   };
   ghosttyLibDir = "${libghosttyVt}/lib";
 

--- a/packages/ghostty/default.nix
+++ b/packages/ghostty/default.nix
@@ -43,6 +43,10 @@ in
           (old.passthru.tests or {})
           // {
             inherit layout;
+            # Runs ghostty's vt/vt_c Zig unit tests from the PATCHED tree, so
+            # fork-patch test additions execute in CI instead of only
+            # upstream.
+            unit = package.unitTests;
           };
       };
   })

--- a/packages/ghostty/patches/0003-terminal-expose-per-cell-OSC-8-hyperlink-URIs-throug.patch
+++ b/packages/ghostty/patches/0003-terminal-expose-per-cell-OSC-8-hyperlink-URIs-throug.patch
@@ -1,0 +1,350 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Gazelka <andrew@ix.dev>
+Date: Tue, 21 Jul 2026 08:21:29 -0700
+Subject: [PATCH] terminal: expose per-cell OSC 8 hyperlink URIs through the
+ render state
+
+The C API exposes only GHOSTTY_CELL_DATA_HAS_HYPERLINK (a bool) and the
+row-level GHOSTTY_ROW_DATA_HYPERLINK flag (which may have false
+positives), so an embedder rendering from the render state cannot learn
+a cell's actual link target: the URI lives in page memory
+(hyperlink_map -> hyperlink_set), unreachable through the value-typed
+GhosttyCell/GhosttyRow handles.
+
+Duplicate the resolved URI into RenderState.Cell during update() -- the
+same arena-copy treatment graphemes and styles already get, and the
+arena's own comment already names hyperlinks as an intended use -- and
+surface it through the row-cells C API as
+GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_HYPERLINK_URI_LEN/_BUF, following
+the GRAPHEMES_LEN/_BUF two-call convention. The per-cell result is
+exact (only the row flag has false positives), so callers get an
+honest URI or nothing.
+
+Needed by ix-term (a libghostty-vt embedder) to render OSC 8 anchors
+as clickable links; any render-state consumer that wants clickable
+hyperlinks needs this surface.
+
+Refs indexable-inc/index#3835
+(patch authored by an AI agent via Claude Code, model Claude Sonnet)
+
+diff --git a/include/ghostty/vt/render.h b/include/ghostty/vt/render.h
+index 0a300dde0..b85674de2 100644
+--- a/include/ghostty/vt/render.h
++++ b/include/ghostty/vt/render.h
+@@ -530,6 +530,17 @@ typedef enum {
+    *  color, in which case the caller should use whatever default foreground
+    *  color it wants (e.g. the terminal foreground). */
+   GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_FG_COLOR = 6,
++
++  /** The byte length of the cell's OSC 8 hyperlink URI (uint32_t).
++   *  Returns 0 if the cell has no hyperlink. Unlike the row-level
++   *  GHOSTTY_ROW_DATA_HYPERLINK flag this is exact: a nonzero length
++   *  means the URI resolved, never a false positive. */
++  GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_HYPERLINK_URI_LEN = 7,
++
++  /** Write the cell's OSC 8 hyperlink URI into a caller-provided buffer
++   *  (uint8_t*). The buffer must be at least hyperlink_uri_len bytes; the
++   *  bytes are UTF-8 and not NUL-terminated. */
++  GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_HYPERLINK_URI_BUF = 8,
+ } GhosttyRenderStateRowCellsData;
+ 
+ /**
+diff --git a/src/terminal/c/render.zig b/src/terminal/c/render.zig
+index 020dbc202..188851fb9 100644
+--- a/src/terminal/c/render.zig
++++ b/src/terminal/c/render.zig
+@@ -45,6 +45,7 @@ const RowCellsWrapper = struct {
+     raws: []const page.Cell,
+     graphemes: []const []const u21,
+     styles: []const Style,
++    hyperlink_uris: []const []const u8,
+ 
+     /// The color palette, needed to resolve palette-indexed background colors.
+     palette: *const colorpkg.Palette,
+@@ -401,6 +402,7 @@ pub fn row_cells_new(
+         .raws = undefined,
+         .graphemes = undefined,
+         .styles = undefined,
++        .hyperlink_uris = undefined,
+         .palette = undefined,
+     };
+     result.* = ptr;
+@@ -438,6 +440,15 @@ pub const RowCellsData = enum(c_int) {
+     bg_color = 5,
+     fg_color = 6,
+ 
++    /// The byte length of the cell's OSC 8 hyperlink URI.
++    /// Output type: uint32_t. 0 if the cell has no hyperlink.
++    hyperlink_uri_len = 7,
++
++    /// Write the cell's OSC 8 hyperlink URI bytes (UTF-8, not
++    /// NUL-terminated) into a caller-provided buffer of at least
++    /// hyperlink_uri_len bytes.
++    hyperlink_uri_buf = 8,
++
+     /// Output type expected for querying the data of the given kind.
+     pub fn OutType(comptime self: RowCellsData) type {
+         return switch (self) {
+@@ -447,6 +458,8 @@ pub const RowCellsData = enum(c_int) {
+             .graphemes_len => u32,
+             .graphemes_buf => u32,
+             .bg_color, .fg_color => colorpkg.RGB.C,
++            .hyperlink_uri_len => u32,
++            .hyperlink_uri_buf => u8,
+         };
+     }
+ };
+@@ -505,6 +518,19 @@ fn rowCellsGetTyped(
+                 buf[i] = cp;
+             }
+         },
++        .hyperlink_uri_len => {
++            if (!cell.hyperlink) {
++                out.* = 0;
++                return .success;
++            }
++            out.* = @intCast(cells.hyperlink_uris[x].len);
++        },
++        .hyperlink_uri_buf => {
++            if (!cell.hyperlink) return .success;
++            const uri = cells.hyperlink_uris[x];
++            const buf: [*]u8 = @ptrCast(out);
++            @memcpy(buf[0..uri.len], uri);
++        },
+         .bg_color => {
+             const s: Style = if (cell.hasStyling()) cells.styles[x] else .{};
+             const bg = s.bg(&cell, cells.palette) orelse return .invalid_value;
+@@ -593,6 +619,7 @@ fn rowGetTyped(
+                 .raws = cell_data.items(.raw),
+                 .graphemes = cell_data.items(.grapheme),
+                 .styles = cell_data.items(.style),
++                .hyperlink_uris = cell_data.items(.hyperlink_uri),
+                 .palette = it.palette,
+             };
+         },
+@@ -1385,3 +1412,136 @@ test "render: colors get supports truncated sized struct" {
+     try testing.expectEqual(state_colors.palette[1].cval(), colors.palette[1]);
+     try testing.expectEqual(sentinel, colors.palette[2]);
+ }
++
++test "render: row cells hyperlink uri" {
++    var terminal: terminal_c.Terminal = null;
++    try testing.expectEqual(Result.success, terminal_c.new(
++        &lib_alloc.test_allocator,
++        &terminal,
++        .{
++            .cols = 80,
++            .rows = 24,
++            .max_scrollback = 10_000,
++        },
++    ));
++    defer terminal_c.free(terminal);
++
++    // Write an OSC 8 hyperlink whose anchor text differs from the URI.
++    const seq = "\x1b]8;;http://example.com\x1b\\LINK\x1b]8;;\x1b\\";
++    terminal_c.vt_write(terminal, seq, seq.len);
++
++    var state: RenderState = null;
++    try testing.expectEqual(Result.success, new(
++        &lib_alloc.test_allocator,
++        &state,
++    ));
++    defer free(state);
++
++    try testing.expectEqual(Result.success, update(state, terminal));
++
++    var it: RowIterator = null;
++    try testing.expectEqual(Result.success, row_iterator_new(
++        &lib_alloc.test_allocator,
++        &it,
++    ));
++    defer row_iterator_free(it);
++
++    try testing.expectEqual(Result.success, get(state, .row_iterator, @ptrCast(&it)));
++    try testing.expect(row_iterator_next(it));
++
++    var cells: RowCells = null;
++    try testing.expectEqual(Result.success, row_cells_new(
++        &lib_alloc.test_allocator,
++        &cells,
++    ));
++    defer row_cells_free(cells);
++
++    try testing.expectEqual(Result.success, row_get(it, .cells, @ptrCast(&cells)));
++
++    // Every cell of the anchor text carries the URI.
++    for (0..4) |x| {
++        try testing.expectEqual(Result.success, row_cells_select(
++            cells,
++            @intCast(x),
++        ));
++
++        var len: u32 = 0;
++        try testing.expectEqual(Result.success, row_cells_get(
++            cells,
++            .hyperlink_uri_len,
++            @ptrCast(&len),
++        ));
++        try testing.expectEqual(@as(u32, "http://example.com".len), len);
++
++        var buf: [64]u8 = undefined;
++        try testing.expectEqual(Result.success, row_cells_get(
++            cells,
++            .hyperlink_uri_buf,
++            @ptrCast(&buf),
++        ));
++        try testing.expectEqualStrings("http://example.com", buf[0..len]);
++    }
++
++    // The cell after the anchor has no hyperlink: len reads 0.
++    try testing.expectEqual(Result.success, row_cells_select(cells, 4));
++    var len: u32 = 99;
++    try testing.expectEqual(Result.success, row_cells_get(
++        cells,
++        .hyperlink_uri_len,
++        @ptrCast(&len),
++    ));
++    try testing.expectEqual(@as(u32, 0), len);
++}
++
++test "render: row cells hyperlink uri without any links" {
++    var terminal: terminal_c.Terminal = null;
++    try testing.expectEqual(Result.success, terminal_c.new(
++        &lib_alloc.test_allocator,
++        &terminal,
++        .{
++            .cols = 80,
++            .rows = 24,
++            .max_scrollback = 10_000,
++        },
++    ));
++    defer terminal_c.free(terminal);
++
++    terminal_c.vt_write(terminal, "plain", 5);
++
++    var state: RenderState = null;
++    try testing.expectEqual(Result.success, new(
++        &lib_alloc.test_allocator,
++        &state,
++    ));
++    defer free(state);
++
++    try testing.expectEqual(Result.success, update(state, terminal));
++
++    var it: RowIterator = null;
++    try testing.expectEqual(Result.success, row_iterator_new(
++        &lib_alloc.test_allocator,
++        &it,
++    ));
++    defer row_iterator_free(it);
++
++    try testing.expectEqual(Result.success, get(state, .row_iterator, @ptrCast(&it)));
++    try testing.expect(row_iterator_next(it));
++
++    var cells: RowCells = null;
++    try testing.expectEqual(Result.success, row_cells_new(
++        &lib_alloc.test_allocator,
++        &cells,
++    ));
++    defer row_cells_free(cells);
++
++    try testing.expectEqual(Result.success, row_get(it, .cells, @ptrCast(&cells)));
++    try testing.expect(row_cells_next(cells));
++
++    var len: u32 = 99;
++    try testing.expectEqual(Result.success, row_cells_get(
++        cells,
++        .hyperlink_uri_len,
++        @ptrCast(&len),
++    ));
++    try testing.expectEqual(@as(u32, 0), len);
++}
+diff --git a/src/terminal/render.zig b/src/terminal/render.zig
+index 09e0c6b93..7e1da05e1 100644
+--- a/src/terminal/render.zig
++++ b/src/terminal/render.zig
+@@ -223,6 +223,13 @@ pub const RenderState = struct {
+         /// The style data for the cell. This is undefined unless
+         /// the style_id is non-default on raw.
+         style: Style,
++
++        /// The OSC 8 hyperlink URI for the cell, duplicated out of page
++        /// memory (like grapheme/style above) so it stays valid after the
++        /// terminal updates. This is undefined unless `raw.hyperlink` is
++        /// set. An empty slice means the flag was set but the id resolved
++        /// to no entry, which callers should treat as "no hyperlink".
++        hyperlink_uri: []const u8,
+     };
+ 
+     // Dirty state.
+@@ -510,6 +517,7 @@ pub const RenderState = struct {
+             const arena_alloc = arena.allocator();
+             const cells_grapheme = cells_slice.items(.grapheme);
+             const cells_style = cells_slice.items(.style);
++            const cells_hyperlink = cells_slice.items(.hyperlink_uri);
+             for (page_cells, 0..) |*page_cell, x| {
+                 // Append assuming its a single-codepoint, styled cell
+                 // (most common by far).
+@@ -518,6 +526,20 @@ pub const RenderState = struct {
+                     page_cell.style_id,
+                 ).*;
+ 
++                // Duplicate the hyperlink URI out of page memory so render
++                // consumers can read the link target without dereferencing
++                // page pins (which are invalid once the terminal updates).
++                if (page_cell.hyperlink) {
++                    @branchHint(.unlikely);
++                    cells_hyperlink[x] = if (p.lookupHyperlink(page_cell)) |link_id|
++                        try arena_alloc.dupe(u8, p.hyperlink_set.get(
++                            p.memory,
++                            link_id,
++                        ).uri.slice(p.memory))
++                    else
++                        &.{};
++                }
++
+                 // Switch on our content tag to handle less likely cases.
+                 switch (page_cell.content_tag) {
+                     .codepoint => {
+@@ -1297,6 +1319,41 @@ test "linkCells" {
+     try testing.expectEqual(0, cells2.count());
+ }
+ 
++test "hyperlink uri duplicated per cell" {
++    const testing = std.testing;
++    const alloc = testing.allocator;
++
++    var t = try Terminal.init(alloc, .{
++        .cols = 10,
++        .rows = 5,
++    });
++    defer t.deinit(alloc);
++
++    var s = t.vtStream();
++    defer s.deinit();
++
++    var state: RenderState = .empty;
++    defer state.deinit(alloc);
++
++    // Create a hyperlink
++    s.nextSlice("\x1b]8;;http://example.com\x1b\\LINK\x1b]8;;\x1b\\");
++    try state.update(alloc, &t);
++
++    const cells = state.row_data.items(.cells)[0];
++    for (0..4) |x| {
++        const cell = cells.get(x);
++        try testing.expect(cell.raw.hyperlink);
++        try testing.expectEqualStrings("http://example.com", cell.hyperlink_uri);
++    }
++    try testing.expect(!cells.get(4).raw.hyperlink);
++
++    // The URI must survive the source terminal changing: overwrite the
++    // link on screen, then read the copy captured by the earlier update.
++    const first = cells.get(0).hyperlink_uri;
++    s.nextSlice("\x1b[H\x1b[2Jplain");
++    try testing.expectEqualStrings("http://example.com", first);
++}
++
+ test "string" {
+     const testing = std.testing;
+     const alloc = testing.allocator;

--- a/packages/ghostty/patches/README.md
+++ b/packages/ghostty/patches/README.md
@@ -9,6 +9,12 @@ The surface-teardown series (index#3768), regenerated with
 - `0002` termio: when the spawn-time `killpg` EPERMs on Darwin (root-owned
   `login(1)` alone in that group), hang up each direct child's current
   process group instead of ignoring the error.
+- `0003` terminal: duplicate each cell's resolved OSC 8 hyperlink URI into
+  the render state and expose it through the row-cells C API
+  (`…_HYPERLINK_URI_LEN`/`_BUF`), so embedders (ix-term via ix-vt,
+  indexable-inc/ix#8008) can render real anchors. Unlike 0001/0002 this
+  patch is compiled by the vt build lane and exercised end-to-end by
+  ix-vt's tests against the patched library.
 
 Verification level: the vt build lane compiles neither `macos/Sources`
 (Swift) nor `src/termio` (app-only zig), so these are verified by

--- a/packages/ghostty/patches/dag.json
+++ b/packages/ghostty/patches/dag.json
@@ -9,6 +9,10 @@
     {
       "patch": "0002-termio-hang-up-child-process-groups-when-spawn-time-.patch",
       "deps": []
+    },
+    {
+      "patch": "0003-terminal-expose-per-cell-OSC-8-hyperlink-URIs-throug.patch",
+      "deps": []
     }
   ]
 }

--- a/packages/tui/vt/ix-vt-sys/regen-bindings.sh
+++ b/packages/tui/vt/ix-vt-sys/regen-bindings.sh
@@ -9,8 +9,10 @@
 #   nix shell nixpkgs#rust-bindgen nixpkgs#clang nixpkgs#rustfmt \
 #     -c packages/tui/vt/ix-vt-sys/regen-bindings.sh
 #
-# It builds libghostty-vt through the flake to locate the headers, so it needs a
-# working Nix and the `ghostty` flake input.
+# It builds libghostty-vt through the flake to locate the headers (the
+# PATCHED fork source, packages/ghostty/patches -- the fork's C-API additions
+# are part of the generated surface), so it needs a working Nix and the
+# `ghostty-src` flake input.
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/packages/tui/vt/ix-vt-sys/src/bindings.rs
+++ b/packages/tui/vt/ix-vt-sys/src/bindings.rs
@@ -692,6 +692,8 @@ pub enum GhosttyRenderStateRowCellsData {
     GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_GRAPHEMES_BUF = 4,
     GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_BG_COLOR = 5,
     GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_FG_COLOR = 6,
+    GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_HYPERLINK_URI_LEN = 7,
+    GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_HYPERLINK_URI_BUF = 8,
 }
 unsafe extern "C" {
     pub fn ghostty_render_state_row_cells_next(cells: GhosttyRenderStateRowCells_ptr) -> bool;

--- a/packages/tui/vt/ix-vt/src/lib.rs
+++ b/packages/tui/vt/ix-vt/src/lib.rs
@@ -197,6 +197,11 @@ pub struct Cell {
     /// The resolved background RGB, with palette indices already looked up.
     /// `None` means the cell uses the terminal default background.
     pub bg: Option<Rgb>,
+    /// The cell's OSC 8 hyperlink URI, or `None` when the cell is not part
+    /// of a hyperlink. Per-cell and exact: unlike the row-level
+    /// `GHOSTTY_ROW_DATA_HYPERLINK` flag (which may false-positive), this is
+    /// only `Some` when the library resolved a real URI for the cell.
+    pub hyperlink: Option<String>,
 }
 
 /// The terminal cursor's visual style (the shape requested via DECSCUSR).
@@ -1003,15 +1008,48 @@ fn read_row(cells: &RowCells, cols: u16) -> Result<Vec<Cell>> {
             CellData::GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_BG_COLOR,
         )?;
 
+        let hyperlink = read_hyperlink(cells)?;
+
         row.push(Cell {
             ch,
             combining,
             style,
             fg,
             bg,
+            hyperlink,
         });
     }
     Ok(row)
+}
+
+/// Read the selected cell's OSC 8 hyperlink URI, `None` when it has none.
+///
+/// Two-call convention like [`read_graphemes`]: a length query sizes the
+/// caller-provided buffer the URI bytes are copied into. A zero length is
+/// the library's "no hyperlink" signal (it also covers a set hyperlink flag
+/// whose id resolved to no entry, which the C API reports as an empty URI).
+fn read_hyperlink(cells: &RowCells) -> Result<Option<String>> {
+    use sys::GhosttyRenderStateRowCellsData as CellData;
+
+    let len: u32 =
+        unsafe { cells.get(CellData::GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_HYPERLINK_URI_LEN) }?;
+    if len == 0 {
+        return Ok(None);
+    }
+
+    let mut buf = vec![0u8; len as usize];
+    check(unsafe {
+        sys::ghostty_render_state_row_cells_get(
+            cells.raw,
+            CellData::GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_HYPERLINK_URI_BUF,
+            buf.as_mut_ptr().cast::<c_void>(),
+        )
+    })?;
+
+    // Ghostty stores the URI bytes as the application sent them; OSC 8
+    // payloads are ASCII-restricted in practice but not enforced, so decode
+    // lossily rather than erroring the whole row on a weird sequence.
+    Ok(Some(String::from_utf8_lossy(&buf).into_owned()))
 }
 
 /// A cell's grapheme: its base codepoint plus any trailing combining marks.

--- a/packages/tui/vt/ix-vt/tests/hyperlink.rs
+++ b/packages/tui/vt/ix-vt/tests/hyperlink.rs
@@ -1,0 +1,91 @@
+//! OSC 8 hyperlink URI exposure through the render state (index#3835).
+//!
+//! The anchor text deliberately differs from the URI ("click me" vs
+//! https://example.com), the exact case plain-URL detection cannot cover
+//! (indexable-inc/ix#8008). Exercises the fork's C API end-to-end against
+//! the real patched library: per-cell URIs on anchor cells, `None`
+//! elsewhere, distinct adjacent links kept apart, and the copied URI
+//! surviving later terminal writes.
+
+use ix_vt::Terminal;
+
+/// OSC 8 anchor: `ESC ] 8 ; params ; URI ST text ESC ] 8 ; ; ST`.
+fn osc8(uri: &str, text: &str) -> Vec<u8> {
+    format!("\x1b]8;;{uri}\x1b\\{text}\x1b]8;;\x1b\\").into_bytes()
+}
+
+#[test]
+fn anchor_cells_carry_the_uri() {
+    let mut term = Terminal::new(24, 80, 1000).expect("create terminal");
+    term.vt_write(&osc8("https://example.com", "click me"));
+
+    let snap = term.render().expect("render snapshot");
+    let row = &snap.viewport[0];
+
+    // Every cell of the 8-column anchor text carries the URI...
+    for (x, cell) in row.iter().enumerate().take("click me".len()) {
+        assert_eq!(
+            cell.hyperlink.as_deref(),
+            Some("https://example.com"),
+            "cell {x} carries the link URI"
+        );
+    }
+    // ...and the text is the anchor text, not the URI.
+    let text: String = row
+        .iter()
+        .take("click me".len())
+        .map(|c| c.ch.unwrap_or(' '))
+        .collect();
+    assert_eq!(text, "click me");
+
+    // The cell after the anchor has no hyperlink.
+    assert_eq!(row["click me".len()].hyperlink, None);
+}
+
+#[test]
+fn adjacent_distinct_links_stay_distinct() {
+    let mut term = Terminal::new(24, 80, 1000).expect("create terminal");
+    let mut bytes = osc8("https://a.example", "AA");
+    bytes.extend_from_slice(&osc8("https://b.example", "BB"));
+    term.vt_write(&bytes);
+
+    let snap = term.render().expect("render snapshot");
+    let row = &snap.viewport[0];
+    assert_eq!(row[0].hyperlink.as_deref(), Some("https://a.example"));
+    assert_eq!(row[1].hyperlink.as_deref(), Some("https://a.example"));
+    assert_eq!(row[2].hyperlink.as_deref(), Some("https://b.example"));
+    assert_eq!(row[3].hyperlink.as_deref(), Some("https://b.example"));
+    assert_eq!(row[4].hyperlink, None);
+}
+
+#[test]
+fn plain_rows_have_no_links() {
+    let mut term = Terminal::new(24, 80, 1000).expect("create terminal");
+    term.vt_write(b"no links here, not even https://example.com as text");
+
+    let snap = term.render().expect("render snapshot");
+    assert!(
+        snap.viewport
+            .iter()
+            .flatten()
+            .all(|cell| cell.hyperlink.is_none()),
+        "plain text (even URL-shaped) yields no hyperlink metadata"
+    );
+}
+
+#[test]
+fn snapshot_uri_is_owned_not_borrowed_from_the_terminal() {
+    let mut term = Terminal::new(24, 80, 1000).expect("create terminal");
+    term.vt_write(&osc8("https://example.com", "link"));
+    let snap = term.render().expect("render snapshot");
+
+    // Scroll the link away and overwrite the screen; the earlier snapshot
+    // must still hold the URI (the wrapper copies out of the C state).
+    for _ in 0..200 {
+        term.vt_write(b"filler\r\n");
+    }
+    assert_eq!(
+        snap.viewport[0][0].hyperlink.as_deref(),
+        Some("https://example.com")
+    );
+}

--- a/packages/tui/vt/libghostty-vt/default.nix
+++ b/packages/tui/vt/libghostty-vt/default.nix
@@ -1,17 +1,31 @@
-# libghostty-vt: ghostty's VT engine built as a standalone C library.
+# libghostty-vt: ghostty's VT engine built as a standalone C library, from the
+# PATCHED fork source (packages/ghostty/patches). The patch series includes
+# C-API additions -- per-cell OSC 8 hyperlink URIs (index#3835) -- that
+# `ix-vt-sys` binds, so the artifact every consumer links (this flake output,
+# the Rust workspace's unit graph, and indexable-inc/ix via
+# `index.packages.<system>.libghostty-vt`) must carry them.
 #
 # The build recipe (zon2nix-vendored deps, the `-Demit-lib-vt=true` zig build,
-# and the darwin SDK shim) lives in `lib/libghostty-vt.nix` so the Rust
+# and the darwin SDK shim) lives in `lib/build/libghostty-vt.nix` so the Rust
 # workspace can reuse the exact same artifact when linking `ix-vt-sys`. This
-# package is the thin flake-output wrapper plus a smoke test.
+# package is the thin flake-output wrapper plus a smoke test. `baseSource`
+# warms zig's content-addressed cache from the unpatched pin, so a
+# patch-series edit recompiles only what it touches.
 {
   ix,
   pkgs,
-  ghostty,
   ...
 }: let
   inherit (pkgs) lib;
-  package = ix.buildLibghosttyVt pkgs {ghosttySource = ghostty;};
+  source = ix.patchedSrc {
+    name = "ghostty";
+    src = ix.ghosttySrc;
+    patchDir = ix.paths.packagesRoot + "/ghostty/patches";
+  };
+  package = ix.buildLibghosttyVt pkgs {
+    ghosttySource = source;
+    baseSource = ix.ghosttySrc;
+  };
 
   # Confirm the build emitted the artifacts `ix-vt-sys` links against and the
   # headers `bindgen` parses, rather than re-asserting the build recipe.
@@ -31,6 +45,13 @@
       test -f ${package}/lib/libghostty-vt.a
       test -f ${package}/include/ghostty/vt.h
       test -d ${package}/include/ghostty/vt
+
+      # The patched header surface is what ix-vt-sys' checked-in bindings
+      # were generated from; assert the fork's C-API addition is present so
+      # a silent repoint to an unpatched source fails here, not at ix link
+      # time.
+      grep -q GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_HYPERLINK_URI_LEN \
+        ${package}/include/ghostty/vt/render.h
 
       # A versioned self-contained shared library (libghostty-vt.<ver>.<ext>)
       # is what ix-vt-sys links; assert one exists rather than the bare


### PR DESCRIPTION
Closes #3835. Unblocks the ix-term side of indexable-inc/ix#8008.

**Fork patch 0003** (`packages/ghostty/patches`): duplicate each cell's resolved OSC 8 hyperlink URI into `RenderState.Cell` during `update()` — the same arena-copy treatment graphemes and styles already get — and surface it through the row-cells C API as `GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_HYPERLINK_URI_LEN`/`_BUF`, following the `GRAPHEMES_LEN`/`_BUF` two-call convention. Per-cell resolution is exact (only the row-level `GHOSTTY_ROW_DATA_HYPERLINK` flag may false-positive), so callers get an honest URI or nothing. Patch-reason intent declared in `lib/fork-packages.nix` (`upstream = "attempt"`).

**The patched source is now load-bearing, not just validated:** the bare `ghostty` flake input is gone; `packages/tui/vt/libghostty-vt`, the Rust workspace's ix-vt link, and `packages/ghostty` all build the VT subtree from the patched fork source (`ix.patchedSrc` over `ghostty-src`), with `baseSource` warming zig's content-addressed cache from the unpatched pin so a patch edit recompiles only what it touches. The libghostty-vt smoke test greps the new C enum out of the installed header so a silent repoint to an unpatched source fails at build, not at ix link time.

**ix-vt:** `Cell.hyperlink: Option<String>` via the two-call convention; bindings regenerated. New `ghostty.tests.unit` passthru runs ghostty's own `zig build test-lib-vt` from the PATCHED tree — the one sandbox-safe lane that executes fork-patch Zig test additions.

Validation (aarch64-darwin):
- `nix run .#lint` green
- `nix build .#ghostty.tests.unit --rebuild`: `test-lib-vt success`, 3733/3765 passed, 32 skipped (includes the new hyperlink tests in `src/terminal/render.zig` and `src/terminal/c/render.zig`)
- `nix build .#checks.aarch64-darwin.patched-src-ghostty .#checks.aarch64-darwin.patch-dag-ghostty .#libghostty-vt .#ix-vt`
- `cargo test -p ix-vt` against the patched dylib: 24 passed, 0 failed (4 new in `tests/hyperlink.rs`: per-cell URIs on anchor cells, `None` elsewhere, adjacent distinct links kept apart, snapshot URI owned not borrowed)

Pre-existing and unrelated: the darwin cargo-unit test manifest aborts listing `unibind` on main and this branch alike — filed as #3836.

Follow-up (ix repo): bump ix's cargo git pin for ix-vt + the index flake input, wire `Span.href` over the WS wire, render anchors in the SPA (indexable-inc/ix#8008).

Authored by Claude Code (Claude Sonnet).
