### PR TITLE
ci: extend substitute fallback to the check lane

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -32,7 +32,8 @@ concurrency:
 
 env:
   # Shared with check.yml; restricted settings are daemon-owned and ignored here.
-  # `fallback` is push-only (not in check.yml): a poisoned substitute -- a
+  # `fallback` is shared with check.yml (since the 2026-07-21 cache-plane
+  # cutover incident, indexable-inc/ix#8026): a poisoned substitute -- a
   # truncated HTTP 200 NAR from a cache incident (ix#6139) -- otherwise aborts
   # realising a push root, and that root silently never publishes. Run
   # 28657772825 lost the cross-IFD `cargo-vendor-dir` root exactly this way,

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -60,11 +60,20 @@ env:
   # Without the feature the evaluator aborts with "experimental Nix feature
   # 'ca-derivations' is disabled". Keep the client feature here because CI
   # intentionally does not consume repository flake configuration.
+  #
+  # `fallback = true`: shared with cache-push.yml (see its comment for the
+  # poisoned-substitute history). During the 2026-07-21 cache-plane cutover
+  # (indexable-inc/ix#8026) the plane bootstrapped empty and served narinfos
+  # whose NARs were missing or mis-compressed; the evaluator died with "some
+  # substitutes for the outputs of derivation ... failed" (run 29847101121)
+  # instead of building from source. A cache incident should cost wall-clock,
+  # not turn the required gate red.
   NIX_CONFIG: |-
     experimental-features = nix-command flakes ca-derivations
     accept-flake-config = false
     max-jobs = auto
     cores = 1
+    fallback = true
 
 jobs:
   ci-budget:


### PR DESCRIPTION
## Why

Check has been red on every main commit today (10+ runs). The newest layer was the clone gate (fixed in 14bfca488), but the layer under it is the cache plane: since the 2026-07-21 cutover (indexable-inc/ix#8026) bootstrapped the plane empty, the caches serve narinfos whose NARs are missing or mis-compressed while drains republish the world.

flake-check run [29847101121](https://github.com/indexable-inc/index/actions/runs/29847101121) shows the failure shape: 113x `file 'nar/....nar' does not exist in binary cache 'http://cache.ix.dev:8501'`, repeated `error: input compression not recognized` from the local ncps proxy, then a fatal `some substitutes for the outputs of derivation '...blake3-1.8.3.drv' failed` that kills nix-eval-jobs.

## What

Add `fallback = true` to check.yml's `NIX_CONFIG`, so a failed substitution degrades to a source build instead of failing eval. cache-push.yml has run this setting for the same failure class since ix#6139 (poisoned substitutes) — its comment explicitly scoped it push-only because only push roots were being lost back then; today the required gate is being lost the same way. Also updates that now-stale push-only claim.

A cache incident should cost wall-clock, not turn the required gate red.

Not addressed here (infra-side, ix repo): the cache plane serving inconsistent narinfo/NAR pairs, and the nix-daemon crash on the CI worker in run [29860280249](https://github.com/indexable-inc/index/actions/runs/29860280249) (`Nix daemon disconnected unexpectedly` x16 while 16 eval workers force-built the IFD input nushell-patched after its NAR 404'd).

Refs indexable-inc/ix#8026

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `fallback = true` to the check lane CI Nix config
> The check lane now sets `fallback = true` in `NIX_CONFIG`, matching the behavior already present in [cache-push.yml](.github/workflows/cache-push.yml). This causes Nix to build from source when substitutes are unavailable or fail, rather than aborting. The comment in `cache-push.yml` is updated to note the setting is shared with `check.yml` and references the 2026-07-21 cache-plane cutover incident.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6f892f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->