### PR TITLE
agent: re-enable AskUserQuestion; rule: surface fundamental redesigns unprompted

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -317,7 +317,11 @@
     # skills listing (verified 2026-07, index#3607); the sibling `dataviz`
     # skill is removed via `skillOverrides` in houseSettingsDefaults below.
     Artifact = false;
-    AskUserQuestion = false;
+    # On: the redesign-at-the-root rule (prompt/rules.nix) routes fundamental
+    # design forks through this dialog instead of silently patching the old
+    # shape (index#3841); the AFK auto-continue env keeps an unanswered
+    # dialog from blocking unattended runs.
+    AskUserQuestion = true;
     DesignSync = false;
     EnterPlanMode = false;
     EnterWorktree = false;

--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -502,6 +502,23 @@
     };
   }
   {
+    redesignAtTheRoot = {
+      topics = ["architecture" "agency"];
+      text = ''
+        Designing or fixing a system, first judge whether its current shape
+        is fundamentally right. On finding a fundamentally better design,
+        even a major one, surface it unprompted and put the choice to the
+        user with AskUserQuestion, costs named; this early, the rework is
+        usually wanted.
+      '';
+      reason = ''
+        A jobs-registry death (index#3839) drew a three-patch fix on a shape
+        the author thought wrong; the ledger redesign surfaced only when the
+        user asked "would you design it differently".
+      '';
+    };
+  }
+  {
     respectGuards = {
       topics = ["agency"];
       text = ''


### PR DESCRIPTION
Closes #3841.

AskUserQuestion went off with the costly-system-tools sweep (#2330), but design forks need a structured way to reach the user: the #3839 jobs incident got a tactical fix drafted on a shape the author considered fundamentally wrong, and the ledger redesign only surfaced on an explicit "would you design it differently".

Two changes: AskUserQuestion=true in defaultSystemTools (comment cites the rule + AFK auto-continue), and a redesignAtTheRoot rule in prompt/rules.nix (architecture+agency): judge whether the current shape is fundamentally right, surface a fundamentally better design unprompted, and put the choice to the user via AskUserQuestion with costs named. Verified rendered via nix eval .#claude-code.systemPrompt.

🤖 Generated with Claude Code (Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-enable `AskUserQuestion` and add rule to surface fundamental redesigns unprompted
> - Re-enables `AskUserQuestion` in [default.nix](https://github.com/indexable-inc/index/pull/3842/files#diff-1486691320e78b9fda64e84db6ffae1e08a87f662a3c5bbb183df571504d9cd8) by flipping the flag from `false` to `true`, allowing the agent to present user dialogs when invoked by prompts or rules.
> - Adds a new `redesignAtTheRoot` rule in [rules.nix](https://github.com/indexable-inc/index/pull/3842/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) instructing the agent to detect fundamentally better system designs and surface them via `AskUserQuestion` rather than silently proceeding with incremental fixes.
> - Behavioral Change: the agent will now pause and prompt the user when it identifies a fundamental design fork, instead of continuing autonomously.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63fe7d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->