### PR TITLE
prompt: file-and-dispatch rule for separately found issues

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -171,12 +171,16 @@
       text = ''
         Real work starts from an issue, referenced in branch and PR. File
         friction as it happens, in the owning repo, with the exact error.
-        Spawn a background agent named for an issue you could fix yourself.
+        On finding an issue separate from the task at hand, file it and in
+        the same breath spawn a background subagent to fix it, the issue
+        number in its brief and branch; filing without dispatching is a
+        dropped ball unless the fix needs the user.
       '';
       reason = ''
         Root-cause notes died with sessions (#1941 through #1946); filed
-        problems were forgotten. Sub-issue mechanics moved to memories
-        (index#3594).
+        problems were forgotten even when filed (a deploy-verify defect sat
+        as ix#8055 while its noise reddened every deploy). Sub-issue
+        mechanics moved to memories (index#3594).
       '';
     };
   }


### PR DESCRIPTION
Sharpens tieToIssue: an issue found mid-task gets filed and a fixing subagent spawned immediately with the issue number, instead of filed-and-forgotten. User directive 2026-07-21; ix#8055 sat unfixed while its noise reddened every deploy today. Verified in rendered systemPrompt.

🤖 Generated with Claude Code (Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add file-and-dispatch rule for separately found issues in agent prompt
> Updates the agent prompt rule in [rules.nix](https://github.com/indexable-inc/index/pull/3844/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to instruct that when an unrelated issue is found, it must be filed and a background subagent spawned immediately with the issue number in its brief and branch. Filing without dispatching is now explicitly called a dropped ball unless user input is required. The reason text is updated to note that filed problems were previously forgotten and that sub-issue mechanics have moved to memories.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8577275.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->