### PR TITLE
mcp-ex: iMessage + Contacts cell helpers

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/contacts.ex
+++ b/packages/mcp-ex/lib/ix_mcp/contacts.ex
@@ -1,0 +1,81 @@
+defmodule IxMcp.Contacts do
+  @moduledoc """
+  The user's macOS address book from a cell, `Contacts` in the workspace
+  prelude: name -> phone numbers and emails, the handles `Imsg` takes.
+
+      {:ok, [%{name: "Hari", phones: ["+14343101227"], ...}]} =
+        Contacts.search("hari")
+
+  Reads every `AddressBook-v22.abcddb` under
+  `~/Library/Application Support/AddressBook` read-only -- the populated
+  database usually lives under `Sources/<uuid>/`, not at the top level,
+  so all of them are unioned.
+  """
+
+  alias IxMcp.Sqlite
+
+  @doc """
+  Contacts whose first name, last name, full name, or organization
+  contains `name` (case-insensitive): `name`, `org`, `phones`, `emails`.
+  Options: `limit:` (default 20), `dbs:` (paths, for tests).
+  """
+  @spec search(String.t(), keyword()) :: {:ok, [map()]} | {:error, String.t()}
+  def search(name, opts \\ []) do
+    sql = """
+    SELECT r.Z_PK AS pk, r.ZFIRSTNAME AS first, r.ZLASTNAME AS last,
+      r.ZORGANIZATION AS org, p.ZFULLNUMBER AS phone, e.ZADDRESS AS email
+    FROM ZABCDRECORD r
+    LEFT JOIN ZABCDPHONENUMBER p ON p.ZOWNER = r.Z_PK
+    LEFT JOIN ZABCDEMAILADDRESS e ON e.ZOWNER = r.Z_PK
+    WHERE r.ZFIRSTNAME LIKE ?1 OR r.ZLASTNAME LIKE ?1
+      OR (r.ZFIRSTNAME || ' ' || r.ZLASTNAME) LIKE ?1
+      OR r.ZORGANIZATION LIKE ?1
+    """
+
+    case dbs(opts) do
+      [] ->
+        {:error, "no AddressBook database found (macOS Contacts; needs Full Disk Access)"}
+
+      dbs ->
+        dbs
+        |> Enum.reduce_while({:ok, []}, fn db, {:ok, acc} ->
+          case Sqlite.query(db, sql, ["%" <> name <> "%"]) do
+            {:ok, rows} -> {:cont, {:ok, acc ++ group(rows)}}
+            {:error, _} = err -> {:halt, err}
+          end
+        end)
+        |> case do
+          {:ok, people} ->
+            {:ok, people |> Enum.uniq() |> Enum.take(Keyword.get(opts, :limit, 20))}
+
+          err ->
+            err
+        end
+    end
+  end
+
+  # The joins fan out to one row per (record, phone, email) combination;
+  # fold them back into one map per person.
+  defp group(rows) do
+    rows
+    |> Enum.group_by(& &1["pk"])
+    |> Enum.map(fn {_pk, rows} ->
+      first = hd(rows)
+
+      %{
+        name: Enum.join(Enum.reject([first["first"], first["last"]], &(&1 in [nil, ""])), " "),
+        org: first["org"],
+        phones: rows |> Enum.map(& &1["phone"]) |> Enum.reject(&is_nil/1) |> Enum.uniq(),
+        emails: rows |> Enum.map(& &1["email"]) |> Enum.reject(&is_nil/1) |> Enum.uniq()
+      }
+    end)
+    |> Enum.sort_by(& &1.name)
+  end
+
+  defp dbs(opts) do
+    opts[:dbs] ||
+      Path.wildcard(
+        Path.expand("~/Library/Application Support/AddressBook/**/AddressBook-v22.abcddb")
+      )
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/imsg.ex
+++ b/packages/mcp-ex/lib/ix_mcp/imsg.ex
@@ -1,0 +1,194 @@
+defmodule IxMcp.Imsg do
+  @moduledoc """
+  iMessage from a cell -- send, browse, and search the signed-in user's
+  Messages. `Imsg` in the workspace prelude.
+
+      Imsg.send("+14155551212", "on my way")
+      Imsg.chats(limit: 10)
+      Imsg.recent(with: "+14155551212")
+      Imsg.search("lunch")
+
+  Reads `~/Library/Messages/chat.db` read-only (needs Full Disk Access,
+  which the kernel has) and sends through Messages.app via osascript, so
+  everything here works only on the mac the kernel runs on; elsewhere the
+  calls return `{:error, _}`.
+
+  A message's `text` column is often NULL -- the user's own sends in
+  particular -- with the real body inside the `attributedBody`
+  typedstream. `decode_body/1` extracts it, and every helper here returns
+  the decoded text already; a send therefore cannot be found again by
+  `WHERE text LIKE`, only through `search/2`.
+
+  Handles are phone numbers in +E.164 form or iMessage email addresses;
+  `Contacts.search/2` maps names to handles.
+  """
+
+  alias IxMcp.Sqlite
+
+  @osascript "/usr/bin/osascript"
+
+  @doc """
+  Send `text` over iMessage to the handle `to`. Returns as soon as
+  Messages.app accepts the message; delivery is asynchronous, so when it
+  matters check the message's `error` flag via `recent/1` a moment later.
+  """
+  @spec send(String.t(), String.t()) :: :ok | {:error, String.t()}
+  def send(to, text) do
+    script = """
+    tell application "Messages"
+      set svc to 1st account whose service type = iMessage
+      send #{applescript_str(text)} to participant #{applescript_str(to)} of svc
+    end tell
+    """
+
+    if File.exists?(@osascript) do
+      case System.cmd(@osascript, ["-e", script], stderr_to_stdout: true) do
+        {_, 0} -> :ok
+        {out, code} -> {:error, "osascript exit #{code}: #{String.trim(out)}"}
+      end
+    else
+      {:error, "#{@osascript} not found: sending needs the macOS host"}
+    end
+  end
+
+  @doc """
+  Recent chats, most recently active first: `guid` (the stable id other
+  helpers take via `chat:`), `identifier` (the handle, or an opaque hex
+  id for group chats), `name` (group display name, often empty),
+  `last_at`, and message count `n`. Options: `limit:` (default 20),
+  `db:`.
+  """
+  @spec chats(keyword()) :: {:ok, [map()]} | {:error, String.t()}
+  def chats(opts \\ []) do
+    Sqlite.query(
+      db(opts),
+      """
+      SELECT c.guid, c.chat_identifier AS identifier, c.display_name AS name,
+        datetime(MAX(m.date)/1000000000 + 978307200, 'unixepoch', 'localtime') AS last_at,
+        COUNT(m.ROWID) AS n
+      FROM chat c
+      JOIN chat_message_join cmj ON cmj.chat_id = c.ROWID
+      JOIN message m ON m.ROWID = cmj.message_id
+      GROUP BY c.ROWID
+      ORDER BY MAX(m.date) DESC
+      LIMIT ?
+      """,
+      [limit(opts)]
+    )
+  end
+
+  @doc """
+  Recent messages, newest first: sender handle (`"me"` for own sends),
+  decoded text, chat guid, timestamp, and the async-delivery `error`
+  flag. Options: `with:` (a handle; selects every chat it participates
+  in, groups included -- group chats have opaque identifiers, so go
+  through handles, never chat names), `chat:` (a guid from `chats/1`),
+  `limit:` (default 20), `db:`.
+  """
+  @spec recent(keyword()) :: {:ok, [map()]} | {:error, String.t()}
+  def recent(opts \\ []) do
+    filters =
+      Enum.reject(
+        [
+          opts[:chat] && {"c.guid = ?", opts[:chat]},
+          opts[:with] &&
+            {"""
+             c.ROWID IN (SELECT chj.chat_id FROM chat_handle_join chj
+               JOIN handle h2 ON h2.ROWID = chj.handle_id
+               WHERE h2.id = ?)
+             """, opts[:with]}
+        ],
+        &is_nil/1
+      )
+
+    messages(opts, Enum.map(filters, &elem(&1, 0)), Enum.map(filters, &elem(&1, 1)))
+  end
+
+  @doc """
+  Search message text, newest first, same row shape as `recent/1`.
+  Plain-text rows match case-insensitively; rich-text rows (NULL `text`,
+  body in the typedstream) are prefiltered byte-wise, so they match the
+  query as typed plus its lower, UPPER, and Capitalized variants.
+  Options: `limit:` (default 20), `db:`.
+  """
+  @spec search(String.t(), keyword()) :: {:ok, [map()]} | {:error, String.t()}
+  def search(query, opts \\ []) do
+    variants =
+      [query, String.downcase(query), String.upcase(query), String.capitalize(query)]
+      |> Enum.uniq()
+
+    clauses =
+      ["m.text LIKE ?" | List.duplicate("instr(hex(m.attributedBody), ?) > 0", length(variants))]
+
+    params = ["%" <> query <> "%" | Enum.map(variants, &Base.encode16/1)]
+    messages(opts, ["(" <> Enum.join(clauses, " OR ") <> ")"], params)
+  end
+
+  @doc """
+  The text inside a message's raw `attributedBody` typedstream blob; nil
+  when there is none to find.
+  """
+  @spec decode_body(binary() | nil) :: String.t() | nil
+  def decode_body(nil), do: nil
+
+  def decode_body(bin) do
+    with {i, _} <- :binary.match(bin, "NSString"),
+         rest = binary_part(bin, i, byte_size(bin) - i),
+         {j, _} <- :binary.match(rest, "+"),
+         text when is_binary(text) <- payload(binary_part(rest, j + 1, byte_size(rest) - j - 1)),
+         true <- String.valid?(text) do
+      text
+    else
+      _ -> nil
+    end
+  end
+
+  # Typedstream length prefix: one byte below 0x80, or 0x81 then u16le.
+  defp payload(<<0x81, len::little-16, text::binary-size(len), _::binary>>), do: text
+  defp payload(<<len::8, text::binary-size(len), _::binary>>) when len < 0x80, do: text
+  defp payload(_), do: nil
+
+  defp messages(opts, filters, params) do
+    where = if filters == [], do: "", else: "WHERE " <> Enum.join(filters, " AND ")
+
+    rows =
+      Sqlite.query(
+        db(opts),
+        """
+        SELECT m.ROWID AS id, c.guid AS chat, h.id AS sender, m.is_from_me,
+          m.error, m.text, m.attributedBody AS body,
+          datetime(m.date/1000000000 + 978307200, 'unixepoch', 'localtime') AS at
+        FROM message m
+        JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
+        JOIN chat c ON c.ROWID = cmj.chat_id
+        LEFT JOIN handle h ON h.ROWID = m.handle_id
+        #{where}
+        ORDER BY m.date DESC
+        LIMIT ?
+        """,
+        params ++ [limit(opts)]
+      )
+
+    with {:ok, rows} <- rows do
+      {:ok,
+       Enum.map(rows, fn row ->
+         %{
+           id: row["id"],
+           chat: row["chat"],
+           sender: if(row["is_from_me"] == 1, do: "me", else: row["sender"]),
+           text: row["text"] || decode_body(row["body"]),
+           at: row["at"],
+           error: row["error"]
+         }
+       end)}
+    end
+  end
+
+  defp db(opts), do: opts[:db] || Path.expand("~/Library/Messages/chat.db")
+
+  defp limit(opts), do: Keyword.get(opts, :limit, 20)
+
+  defp applescript_str(s) do
+    ~s{"} <> (s |> String.replace("\\", "\\\\") |> String.replace(~s{"}, ~s{\\"})) <> ~s{"}
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -59,6 +59,13 @@ defmodule IxMcp.MCP.Tools do
                                             Gmail.search("from:x newer_than:7d",
                                             limit: 5), Gmail.show(id),
                                             Gmail.status() for the auth state
+      Imsg.send(handle, text)               send an iMessage via Messages.app;
+                                            Imsg.chats(), .recent(with: handle),
+                                            .search(q) read the local chat.db
+                                            (own sends have NULL text; helpers
+                                            decode the typedstream body)
+      Contacts.search(name)                 macOS address book: name -> the
+                                            phone/email handles Imsg takes
       Agents.spawn(brief, backend: :claude | :codex | :kimi)
                                             spawn a real agent CLI as an async depth-1
                                             subagent (Fable 5 card sec 8.15.3, #3700);

--- a/packages/mcp-ex/lib/ix_mcp/sqlite.ex
+++ b/packages/mcp-ex/lib/ix_mcp/sqlite.ex
@@ -1,0 +1,34 @@
+defmodule IxMcp.Sqlite do
+  @moduledoc """
+  One-shot read-only queries against local SQLite files (Messages,
+  AddressBook) over the exqlite NIF the action log already ships: rows
+  come back as maps keyed by column name, parameters bind properly, and
+  nothing shells out.
+  """
+
+  alias Exqlite.Sqlite3
+
+  @doc "Run `sql` against `db` read-only with `params` bound."
+  @spec query(Path.t(), String.t(), list()) :: {:ok, [map()]} | {:error, String.t()}
+  def query(db, sql, params \\ []) do
+    # :readonly still creates an empty file for a missing path on some
+    # platforms; an explicit check keeps the message honest either way.
+    with true <- File.exists?(db) || {:error, "#{db}: no such database"},
+         {:ok, conn} <- wrap(db, Sqlite3.open(db, mode: :readonly)) do
+      try do
+        with {:ok, stmt} <- wrap(db, Sqlite3.prepare(conn, sql)),
+             :ok <- wrap(db, Sqlite3.bind(stmt, params)),
+             {:ok, cols} <- wrap(db, Sqlite3.columns(conn, stmt)),
+             {:ok, rows} <- wrap(db, Sqlite3.fetch_all(conn, stmt)) do
+          {:ok, Enum.map(rows, &Map.new(Enum.zip(cols, &1)))}
+        end
+      after
+        Sqlite3.close(conn)
+      end
+    end
+  end
+
+  defp wrap(_db, :ok), do: :ok
+  defp wrap(_db, {:ok, value}), do: {:ok, value}
+  defp wrap(db, {:error, reason}), do: {:error, "#{db}: #{inspect(reason)}"}
+end

--- a/packages/mcp-ex/lib/ix_mcp/workspace.ex
+++ b/packages/mcp-ex/lib/ix_mcp/workspace.ex
@@ -16,7 +16,7 @@ defmodule IxMcp.Workspace do
   # `Kernel` would shadow Elixir's; cells reach trace/restart as `Ix`.
   @prelude "alias IxMcp.Jobs; alias IxMcp.Api; alias IxMcp.Fleet; " <>
              "alias IxMcp.Read; alias IxMcp.Edit; alias IxMcp.PrWatch; alias IxMcp.Tui; " <>
-             "alias IxMcp.TuiLocal; alias IxMcp.Gmail; " <>
+             "alias IxMcp.TuiLocal; alias IxMcp.Gmail; alias IxMcp.Imsg; alias IxMcp.Contacts; " <>
              "alias IxMcp.Kernel, as: Ix; alias IxMcp.Agents"
 
   @spec start_link(term()) :: GenServer.on_start()

--- a/packages/mcp-ex/test/ix_mcp/contacts_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/contacts_test.exs
@@ -1,0 +1,41 @@
+defmodule IxMcp.ContactsTest do
+  use ExUnit.Case, async: true
+
+  alias IxMcp.Contacts
+
+  @tag :tmp_dir
+  test "search folds phone/email join fan-out into one map per person", %{tmp_dir: dir} do
+    db =
+      seed(Path.join(dir, "AddressBook-v22.abcddb"), [
+        "CREATE TABLE ZABCDRECORD (Z_PK INTEGER PRIMARY KEY, ZFIRSTNAME TEXT, ZLASTNAME TEXT, ZORGANIZATION TEXT)",
+        "CREATE TABLE ZABCDPHONENUMBER (Z_PK INTEGER PRIMARY KEY, ZOWNER INTEGER, ZFULLNUMBER TEXT)",
+        "CREATE TABLE ZABCDEMAILADDRESS (Z_PK INTEGER PRIMARY KEY, ZOWNER INTEGER, ZADDRESS TEXT)",
+        "INSERT INTO ZABCDRECORD VALUES (1, 'Ada', 'Lovelace', 'Analytical Engines')",
+        "INSERT INTO ZABCDRECORD VALUES (2, 'Adam', NULL, NULL)",
+        "INSERT INTO ZABCDPHONENUMBER VALUES (1, 1, '+15550002222'), (2, 1, '+15550003333')",
+        "INSERT INTO ZABCDEMAILADDRESS VALUES (1, 1, 'ada@example.com')"
+      ])
+
+    {:ok, [ada]} = Contacts.search("lovelace", dbs: [db])
+    assert ada.name == "Ada Lovelace"
+    assert Enum.sort(ada.phones) == ["+15550002222", "+15550003333"]
+    assert ada.emails == ["ada@example.com"]
+
+    {:ok, both} = Contacts.search("ada", dbs: [db])
+    assert Enum.map(both, & &1.name) == ["Ada Lovelace", "Adam"]
+
+    assert {:ok, []} = Contacts.search("nobody", dbs: [db])
+  end
+
+  test "no databases at all is an error" do
+    assert {:error, msg} = Contacts.search("x", dbs: [])
+    assert msg =~ "no AddressBook database"
+  end
+
+  defp seed(db, statements) do
+    {:ok, conn} = Exqlite.Sqlite3.open(db)
+    Enum.each(statements, fn sql -> :ok = Exqlite.Sqlite3.execute(conn, sql) end)
+    :ok = Exqlite.Sqlite3.close(conn)
+    db
+  end
+end

--- a/packages/mcp-ex/test/ix_mcp/imsg_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/imsg_test.exs
@@ -1,0 +1,75 @@
+defmodule IxMcp.ImsgTest do
+  use ExUnit.Case, async: true
+
+  alias IxMcp.Imsg
+
+  # A minimal typedstream: the decoder anchors on "NSString", skips to
+  # the "+" marker, and reads a length-prefixed payload.
+  defp body(text) do
+    "stream" <> "NSString" <> <<1, 0x94, 0x84>> <> "+" <> len(text) <> text <> <<0x86>>
+  end
+
+  defp len(text) when byte_size(text) < 0x80, do: <<byte_size(text)>>
+  defp len(text), do: <<0x81, byte_size(text)::little-16>>
+
+  test "decodes a short-form body" do
+    assert Imsg.decode_body(body("hello there")) == "hello there"
+  end
+
+  test "decodes a long-form (0x81 u16le) body" do
+    text = String.duplicate("na", 200)
+    assert Imsg.decode_body(body(text)) == text
+  end
+
+  test "nil blob and non-text blobs decode to nil" do
+    assert Imsg.decode_body(nil) == nil
+    assert Imsg.decode_body("no marker here") == nil
+    assert Imsg.decode_body("NSString without plus") == nil
+  end
+
+  @tag :tmp_dir
+  test "recent and search read a chat.db, decoding NULL-text rows", %{tmp_dir: dir} do
+    db = seed_chat_db(dir)
+
+    {:ok, [reply, hello]} = Imsg.recent(db: db, with: "+15550001111")
+    assert %{sender: "+15550001111", text: "hello from alice", error: 0} = hello
+    # Own send: NULL text, body only in the typedstream.
+    assert %{sender: "me", text: "typedstream reply"} = reply
+
+    {:ok, hits} = Imsg.search("Typedstream", db: db)
+    assert [%{text: "typedstream reply"}] = hits
+
+    {:ok, [chat]} = Imsg.chats(db: db)
+    assert %{"guid" => "any;-;+15550001111", "n" => 2} = chat
+  end
+
+  test "missing database is an error, not a crash" do
+    assert {:error, msg} = Imsg.recent(db: "/nonexistent/chat.db")
+    assert msg =~ "no such database"
+  end
+
+  defp seed_chat_db(dir) do
+    db = Path.join(dir, "chat.db")
+
+    seed(db, [
+      "CREATE TABLE chat (ROWID INTEGER PRIMARY KEY, guid TEXT, chat_identifier TEXT, display_name TEXT)",
+      "CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT)",
+      "CREATE TABLE message (ROWID INTEGER PRIMARY KEY, handle_id INTEGER, text TEXT, attributedBody BLOB, date INTEGER, is_from_me INTEGER, error INTEGER DEFAULT 0)",
+      "CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER)",
+      "CREATE TABLE chat_handle_join (chat_id INTEGER, handle_id INTEGER)",
+      "INSERT INTO chat VALUES (1, 'any;-;+15550001111', '+15550001111', '')",
+      "INSERT INTO handle VALUES (1, '+15550001111')",
+      "INSERT INTO chat_handle_join VALUES (1, 1)",
+      "INSERT INTO message VALUES (1, 1, 'hello from alice', NULL, 1000000000, 0, 0)",
+      "INSERT INTO message VALUES (2, 1, NULL, X'#{Base.encode16(body("typedstream reply"))}', 2000000000, 1, 0)",
+      "INSERT INTO chat_message_join VALUES (1, 1), (1, 2)"
+    ])
+  end
+
+  defp seed(db, statements) do
+    {:ok, conn} = Exqlite.Sqlite3.open(db)
+    Enum.each(statements, fn sql -> :ok = Exqlite.Sqlite3.execute(conn, sql) end)
+    :ok = Exqlite.Sqlite3.close(conn)
+    db
+  end
+end


### PR DESCRIPTION
Closes #3843.

`Imsg` and `Contacts` join the workspace prelude:

- `Imsg.send(handle, text)` through Messages.app osascript (validated live: accepted send lands with `is_sent=1`, `error=0`)
- `Imsg.chats/1`, `Imsg.recent/1` (`with:` goes through `chat_handle_join`, so group chats with opaque identifiers work), `Imsg.search/2`
- own sends carry NULL `text`; the typedstream `attributedBody` decoder recovers the body (short and 0x81 u16le length forms)
- `Contacts.search/2` unions every `AddressBook-v22.abcddb` (the populated one lives under `Sources/<uuid>/`) and folds the phone/email join fan-out into one map per person
- shared `IxMcp.Sqlite` one-shot read-only runner on the exqlite NIF the action log already ships: bound parameters, no CLI subprocess

Darwin-only data by nature; on other hosts the helpers return `{:error, _}`. Validated against the live chat.db and AddressBook on hydra; `mix test` 95/95.

(sent by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add iMessage and Contacts cell helpers to `IxMcp`
> - Adds [`IxMcp.Imsg`](https://github.com/indexable-inc/index/pull/3845/files#diff-7157a5350860662125c118a311035a6ff49f32f14bdeb6c5ddf1bd95646eaa6b) with functions to send iMessages via AppleScript, query recent chats and messages, search message text (including typedstream-encoded `attributedBody`), and decode raw typedstream blobs.
> - Adds [`IxMcp.Contacts`](https://github.com/indexable-inc/index/pull/3845/files#diff-a6bf4b1616e2198e1bf2bf374a4cd60220d91f78f5d0557f2e82fe895469d528) to search macOS AddressBook SQLite databases by name, returning per-person maps of name, org, phones, and emails.
> - Adds [`IxMcp.Sqlite`](https://github.com/indexable-inc/index/pull/3845/files#diff-e9a8419a44c42092cf9b255475b7cdfb313d7781d9c0c5506e3e41e9e4173a18) as a shared read-only SQLite query helper returning rows as column-keyed maps.
> - Registers `Imsg` and `Contacts` as default aliases in the workspace cell prelude so they are available without qualification.
> - Risk: iMessage sending shells out to `/usr/bin/osascript` and Contacts search reads directly from AddressBook SQLite files — both require macOS and appropriate permissions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 94b1996.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->