### PR TITLE
site: mcp-ex iMessage + Contacts update

### DIFF
--- a/packages/site/src/lib/updates/mcp-ex-imessage-contacts.svx
+++ b/packages/site/src/lib/updates/mcp-ex-imessage-contacts.svx
@@ -1,0 +1,19 @@
+---
+id: mcp-ex-imessage-contacts
+postedAt: 2026-07-21T13:05:00-07:00
+title: "The kernel speaks iMessage: `Imsg` and `Contacts` cell helpers"
+tags: [mcp-ex, imessage, macos]
+links:
+  - label: Imsg
+    href: https://github.com/indexable-inc/index/blob/main/packages/mcp-ex/lib/ix_mcp/imsg.ex
+  - label: Contacts
+    href: https://github.com/indexable-inc/index/blob/main/packages/mcp-ex/lib/ix_mcp/contacts.ex
+  - label: PR 3845
+    href: https://github.com/indexable-inc/index/pull/3845
+---
+
+Workspace cells on a mac can now send and read iMessages and look people up in the address book. `Imsg.send("+14155551212", "on my way")` goes through Messages.app via osascript; `Imsg.chats()`, `Imsg.recent(with: handle)`, and `Imsg.search(q)` read `~/Library/Messages/chat.db` read-only over the exqlite NIF the action log already ships.
+
+The awkward parts are handled where they belong: your own sends land with a NULL `text` column, so the helpers decode the `attributedBody` typedstream and always return real text, and group chats have opaque hex identifiers, so `with:` resolves membership through `chat_handle_join` instead of chat names. `Contacts.search("hari")` unions every `AddressBook-v22.abcddb` (the populated one hides under `Sources/<uuid>/`) and returns the phone and email handles `Imsg` takes.
+
+Darwin-only by nature; on other hosts the helpers return errors instead of pretending.


### PR DESCRIPTION
Update entry for #3845. (sent by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add site update page for mcp-ex iMessage and Contacts helpers
> Adds a new update document at [mcp-ex-imessage-contacts.svx](https://github.com/indexable-inc/index/pull/3846/files#diff-832f098919a228552f6503e557b11f0db94a722fb860795c5cdcaec687ae661b) describing iMessage and Contacts MCP helpers, including usage examples and platform notes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d81cfb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->