### PR TITLE
prompt: comment-density rewrite rule

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -523,6 +523,23 @@
     };
   }
   {
+    commentDensityRewrite = {
+      topics = ["architecture" "agency"];
+      text = ''
+        When explaining a piece of code takes more than a couple of
+        sentences of comments, suspect the code, not the docs: it is
+        likely wrong-shaped. Sketch the rewrite that would make the
+        comment unnecessary and put it to the user unprompted, before
+        settling for the explanation.
+      '';
+      reason = ''
+        Requested 2026-07-21: long explanatory comments were papering
+        over spaghetti; the user wants the rewrite proposed proactively,
+        with the choice left to them.
+      '';
+    };
+  }
+  {
     respectGuards = {
       topics = ["agency"];
       text = ''


### PR DESCRIPTION
Adds `commentDensityRewrite` to `packages/agent/prompt/rules.nix`: needing more than a couple sentences of comments to explain code marks the code as wrong-shaped; the agent sketches the rewrite and puts it to the user proactively.

Validated: `nix eval --raw .#claude-code.systemPrompt` renders the rule (sits after redesignAtTheRoot).

Closes #3847

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `commentDensityRewrite` rule to the agent prompt ruleset
> Adds a new rule entry named `commentDensityRewrite` to [rules.nix](https://github.com/indexable-inc/index/pull/3848/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5), tagged with the `architecture` and `agency` topics. The rule provides guidance on rewriting comment density and includes a `reason` note describing its intent and request date.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a63850c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->