### PR TITLE
Agent memory v2: weave store, extraSessionStart seam, kernel Memory helper

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -136,6 +136,12 @@
   # Disabled for the shared wrapper because those hooks print workstation-local
   # context that is not meaningful for other users.
   personalStartupContext ? false,
+  # Consumer-supplied SessionStart context commands
+  # ({ package, exeName ? null, args ? [], timeout ? 10 }): each runs at
+  # session start and its stdout is injected as session context. The generic
+  # seam per-user startup context (e.g. a memory digest) hangs off
+  # (index#3849).
+  extraSessionStart ? [],
   # Sibling repo packages from the flake package set. lib/packages.nix threads
   # the lazily-recursive set in under this one name so a repo package can
   # depend on another by id without a flat merge into callPackage's top-level
@@ -427,6 +433,7 @@
       hookRunner
       primaryCheckouts
       personalStartupContext
+      extraSessionStart
       ;
   };
 

--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -22,6 +22,10 @@
   # Disabled for the shared wrapper because those hooks print workstation-local
   # context that is not meaningful for other users.
   personalStartupContext ? false,
+  # Consumer-supplied SessionStart context commands
+  # ({ package, exeName ? null, args ? [], timeout ? 10 }); same seam as the
+  # claude-code wrapper (index#3849).
+  extraSessionStart ? [],
   # Sibling repo packages from the flake package set (threaded by
   # lib/packages.nix), used to locate the `ix-mcp` entrypoint for the baked
   # `index` MCP server. `{ }` in the overlay package set, where the `mcp`
@@ -197,6 +201,7 @@
           hookRunner
           primaryCheckouts
           personalStartupContext
+          extraSessionStart
           ;
       }).codex;
   };

--- a/packages/agent/home-manager/claude-code.nix
+++ b/packages/agent/home-manager/claude-code.nix
@@ -423,6 +423,7 @@
         (cfg)
         addDirs
         dangerouslySkipPermissions
+        extraSessionStart
         features
         personalStartupContext
         primaryCheckouts
@@ -543,6 +544,34 @@ in {
       type = lib.types.bool;
       default = false;
       description = "Enable Andrew-only startup context hooks in the rendered Claude Code policy.";
+    };
+
+    extraSessionStart = lib.mkOption {
+      type = lib.types.listOf (lib.types.submodule {
+        options = {
+          package = lib.mkOption {
+            type = lib.types.package;
+            description = "Program run at SessionStart; its stdout is injected as session context.";
+          };
+          exeName = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = "Executable name inside the package; null uses the package main program.";
+          };
+          args = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [];
+            description = "Arguments passed to the command.";
+          };
+          timeout = lib.mkOption {
+            type = lib.types.ints.positive;
+            default = 10;
+            description = "Hook timeout in seconds.";
+          };
+        };
+      });
+      default = [];
+      description = "Extra SessionStart context commands folded into the rendered hook policy (index#3849).";
     };
 
     defaultMcpServers = lib.mkOption {

--- a/packages/agent/home-manager/codex.nix
+++ b/packages/agent/home-manager/codex.nix
@@ -51,6 +51,7 @@
     {
       inherit
         (cfg)
+        extraSessionStart
         forcedSettings
         personalStartupContext
         primaryCheckouts
@@ -141,6 +142,34 @@ in {
       type = lib.types.bool;
       default = false;
       description = "Enable Andrew-only startup context hooks in the rendered Codex policy.";
+    };
+
+    extraSessionStart = lib.mkOption {
+      type = lib.types.listOf (lib.types.submodule {
+        options = {
+          package = lib.mkOption {
+            type = lib.types.package;
+            description = "Program run at SessionStart; its stdout is injected as session context.";
+          };
+          exeName = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = "Executable name inside the package; null uses the package main program.";
+          };
+          args = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [];
+            description = "Arguments passed to the command.";
+          };
+          timeout = lib.mkOption {
+            type = lib.types.ints.positive;
+            default = 10;
+            description = "Hook timeout in seconds.";
+          };
+        };
+      });
+      default = [];
+      description = "Extra SessionStart context commands folded into the rendered hook policy (index#3849).";
     };
 
     mcpServers = lib.mkOption {

--- a/packages/agent/policy/hooks.nix
+++ b/packages/agent/policy/hooks.nix
@@ -4,6 +4,11 @@
   hookRunner,
   primaryCheckouts ? [],
   personalStartupContext ? false,
+  # Consumer-supplied SessionStart context commands: each entry
+  # ({ package, exeName ? null, args ? [], timeout ? 10 }) runs at session
+  # start and its stdout is injected as session context. The generic seam
+  # personal memory/notes wiring hangs off (index#3849).
+  extraSessionStart ? [],
 }: let
   hookRunnerSubcommand = sub: {
     package = hookRunner;
@@ -33,30 +38,44 @@
   renderCommand = command:
     lib.escapeShellArgs (
       [
-        (lib.getExe' command.package command.exeName)
+        (
+          if command.exeName or null != null
+          then lib.getExe' command.package command.exeName
+          else lib.getExe command.package
+        )
       ]
       ++ command.args
     );
 
   declarations = {
-    SessionStart = [
-      # Unconditional: agents key session-scoped artifacts (status boards,
-      # scratch dirs) by session id, and nothing else tells them their own id.
-      {
-        command = hookCommands.sessionIdContext;
-        timeout = 5;
-      }
-      {
-        command = hookCommands.cachedStartupNotes;
-        enable = personalStartupContext;
-        timeout = 5;
-      }
-      {
-        command = hookCommands.hostInventoryBanner;
-        enable = personalStartupContext;
-        timeout = 5;
-      }
-    ];
+    SessionStart =
+      [
+        # Unconditional: agents key session-scoped artifacts (status boards,
+        # scratch dirs) by session id, and nothing else tells them their own id.
+        {
+          command = hookCommands.sessionIdContext;
+          timeout = 5;
+        }
+        {
+          command = hookCommands.cachedStartupNotes;
+          enable = personalStartupContext;
+          timeout = 5;
+        }
+        {
+          command = hookCommands.hostInventoryBanner;
+          enable = personalStartupContext;
+          timeout = 5;
+        }
+      ]
+      ++ map (extra: {
+        command = {
+          inherit (extra) package;
+          exeName = extra.exeName or null;
+          args = extra.args or [];
+        };
+        timeout = extra.timeout or 10;
+      })
+      extraSessionStart;
 
     PreToolUse = [
       # Claude edit tools carry file paths; Codex edits through apply_patch.

--- a/packages/mcp-ex/README.md
+++ b/packages/mcp-ex/README.md
@@ -65,6 +65,7 @@ list):
 | in-cell callable | what it does |
 |---|---|
 | `Read.file(path, first \\ nil, last \\ nil)` | a file, optionally a 1-based line range |
+| `Memory.remember(slug, desc, opts)` | durable memory facts in the weave store at `WEAVE_MEMORY_STORE`; recall via `Memory.recall/1` (regex) or `Memory.query/1` (Datalog) |
 | `Ix.trace()` | stack dump of every job's processes, from outside |
 | `Ix.restart()` | cancel jobs (sparing the calling cell), restart the workspace, restore bindings |
 | `PrWatch.start(pr, cwd, interval \\ 15, timeout \\ 3600)` | watch a PR via `gh`, notify on merge/close/timeout |

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -66,6 +66,15 @@ defmodule IxMcp.MCP.Tools do
                                             decode the typedstream body)
       Contacts.search(name)                 macOS address book: name -> the
                                             phone/email handles Imsg takes
+      Memory.remember("slug", "hook", topic: "nix")
+                                            durable memory: append facts to the
+                                            weave store named by
+                                            WEAVE_MEMORY_STORE (loud error when
+                                            unset). Recall with
+                                            Memory.recall("regex") or raw Datalog
+                                            via Memory.query/1;
+                                            Memory.retract(id) kills a wrong
+                                            fact, newer facts win over stale ones
       Agents.spawn(brief, backend: :claude | :codex | :kimi)
                                             spawn a real agent CLI as an async depth-1
                                             subagent (Fable 5 card sec 8.15.3, #3700);

--- a/packages/mcp-ex/lib/ix_mcp/memory.ex
+++ b/packages/mcp-ex/lib/ix_mcp/memory.ex
@@ -1,0 +1,100 @@
+defmodule IxMcp.Memory do
+  @moduledoc """
+  Durable agent memory over a weave store (append-only fact journal with
+  Datalog-derived views), aliased in the workspace prelude as `Memory`.
+  Every call is a one-shot `weave` CLI invocation against the store named
+  by the WEAVE_MEMORY_STORE environment variable; there is no daemon. A
+  host without the env set gets a loud error naming the knob and pays
+  nothing otherwise.
+
+  Conventions (the SessionStart digest is derived from these): entities
+  are `mem:<slug>`; `mem/desc` is the one-line hook, `mem/type` one of
+  user | feedback | project | reference, `mem/topic` a repeatable tag,
+  `mem/handle` the concrete command/path/flag, `mem/body` a blake3 CAS
+  hash of long-form content. History is never edited: newer facts win,
+  `retract/1` kills a wrong one.
+  """
+
+  @doc """
+  Save a memory: `Memory.remember("slug", "hook", type: "project",
+  topic: ["nix", "fleet"], handle: "nix run .#lint", body: long_markdown)`.
+  """
+  @spec remember(String.t(), String.t(), keyword()) :: :ok
+  def remember(slug, desc, opts \\ []) do
+    entity = "mem:" <> slug
+    fact(entity, "mem/desc", desc)
+
+    for key <- [:type, :topic, :handle],
+        value <- List.wrap(Keyword.get(opts, key)) do
+      fact(entity, "mem/#{key}", to_string(value))
+    end
+
+    case Keyword.get(opts, :body) do
+      nil -> :ok
+      body -> fact(entity, "mem/body", put(body))
+    end
+
+    :ok
+  end
+
+  @doc "Append one fact; returns the fact id (`blake3:<hex>`)."
+  @spec fact(String.t(), String.t(), String.t()) :: String.t()
+  def fact(entity, attr, value) do
+    # `weave fact` prints "seq <n>  <fact-id>".
+    ["fact", entity, attr, value] |> run!() |> String.split() |> List.last()
+  end
+
+  @doc "Run a Datalog query program; returns the decoded result rows."
+  @spec query(String.t()) :: [map()]
+  def query(program) do
+    {:ok, %{"rows" => rows}} = ["--json", "query", program] |> run!() |> JSON.decode()
+    rows
+  end
+
+  @doc "Case-insensitive regex search over slugs, hooks, and topics."
+  @spec recall(String.t()) :: [map()]
+  def recall(pattern) do
+    p = pattern |> String.replace("\\", "\\\\") |> String.replace("\"", "\\\"")
+
+    query("""
+    hit(E, D) :- latest(E, "mem/desc", D), regex(D, "(?i)#{p}").
+    hit(E, D) :- latest(E, "mem/topic", T), regex(T, "(?i)#{p}"), latest(E, "mem/desc", D).
+    hit(E, D) :- regex(E, "(?i)#{p}"), latest(E, "mem/desc", D).
+    ?- hit(E, D).
+    """)
+  end
+
+  @doc "Retract a wrong fact by id (staleness prefers newer facts instead)."
+  @spec retract(String.t()) :: String.t()
+  def retract(fact_id), do: ["retract", fact_id] |> run!() |> String.trim()
+
+  @doc "Store long-form content in the CAS; returns its `blake3:<hex>`."
+  @spec put(String.t()) :: String.t()
+  def put(content) do
+    path = Path.join(System.tmp_dir!(), "weave-put-#{System.unique_integer([:positive])}")
+    File.write!(path, content)
+
+    try do
+      ["put", path] |> run!() |> String.trim()
+    after
+      File.rm(path)
+    end
+  end
+
+  @spec run!([String.t()]) :: String.t()
+  defp run!(args) do
+    store =
+      System.get_env("WEAVE_MEMORY_STORE") ||
+        raise "WEAVE_MEMORY_STORE is unset: point it at a weave store " <>
+                "(create one with `weave --store <dir> init`) to enable Memory"
+
+    bin =
+      System.get_env("WEAVE_BIN") || System.find_executable("weave") ||
+        raise "weave binary not found: install weave on PATH or set WEAVE_BIN"
+
+    case System.cmd(bin, ["--store", store] ++ args, stderr_to_stdout: true) do
+      {out, 0} -> out
+      {out, code} -> raise "weave #{Enum.join(args, " ")} exited #{code}: #{out}"
+    end
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/workspace.ex
+++ b/packages/mcp-ex/lib/ix_mcp/workspace.ex
@@ -17,7 +17,7 @@ defmodule IxMcp.Workspace do
   @prelude "alias IxMcp.Jobs; alias IxMcp.Api; alias IxMcp.Fleet; " <>
              "alias IxMcp.Read; alias IxMcp.Edit; alias IxMcp.PrWatch; alias IxMcp.Tui; " <>
              "alias IxMcp.TuiLocal; alias IxMcp.Gmail; alias IxMcp.Imsg; alias IxMcp.Contacts; " <>
-             "alias IxMcp.Kernel, as: Ix; alias IxMcp.Agents"
+             "alias IxMcp.Kernel, as: Ix; alias IxMcp.Agents; alias IxMcp.Memory"
 
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do

--- a/packages/mcp-ex/test/ix_mcp/memory_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/memory_test.exs
@@ -1,0 +1,17 @@
+defmodule IxMcp.MemoryTest do
+  # Mutates process-global env, so never async.
+  use ExUnit.Case, async: false
+
+  test "unset WEAVE_MEMORY_STORE fails loudly with the setup knob" do
+    previous = System.get_env("WEAVE_MEMORY_STORE")
+    System.delete_env("WEAVE_MEMORY_STORE")
+
+    try do
+      assert_raise RuntimeError, ~r/WEAVE_MEMORY_STORE/, fn ->
+        IxMcp.Memory.query("?- latest(E, A, V).")
+      end
+    after
+      if previous, do: System.put_env("WEAVE_MEMORY_STORE", previous)
+    end
+  end
+end

--- a/users/andrewgazelka/options.nix
+++ b/users/andrewgazelka/options.nix
@@ -61,6 +61,11 @@
         default = null;
         description = "Host-native typenix package supplied by the consuming flake.";
       };
+      weave = lib.mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = null;
+        description = "Host-native weave binary (indexable-inc/weave) supplied by the consuming flake; backs the agent memory store.";
+      };
     };
 
     paths = {

--- a/users/andrewgazelka/profiles/darwin-home.nix
+++ b/users/andrewgazelka/profiles/darwin-home.nix
@@ -143,6 +143,7 @@ in {
   home.packages = [
     # pkgs.notify
     cfg.packages.lifelog # `lifelog top` / `sqlite3 "$(lifelog db-path)"`; the recorder runs as the services.portable.lifelog launchd agent
+    cfg.packages.weave # `weave`: the agent memory store CLI (query/fact/log against $WEAVE_MEMORY_STORE); supplied by the consuming flake (index#3849)
     pkgs.duti
     pkgs.iproute2mac
     pkgs.libimobiledevice # `idevice_id -l` / `ideviceinfo` / `idevicepair`: talk to a USB-attached iPhone over Apple's usbmuxd
@@ -196,6 +197,10 @@ in {
     {
       assertion = cfg.packages.lifelog != null;
       message = "users.andrewgazelka.packages.lifelog must be set for the Darwin home profile.";
+    }
+    {
+      assertion = cfg.packages.weave != null;
+      message = "users.andrewgazelka.packages.weave must be set for the Darwin home profile (agent memory store CLI, index#3849).";
     }
     {
       assertion = cfg.rbw.email != null && cfg.rbw.baseUrl != null;

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -97,6 +97,32 @@
     doCheck = false;
   });
 
+  # SessionStart memory digest: the derived replacement for the retired
+  # MEMORY.md flat index (index#3849). One-shot weave queries against the
+  # private store; stdout becomes session context via the wrappers'
+  # extraSessionStart seam. Exits 0 with a pointer when the store is missing
+  # so a fresh machine still boots.
+  memoryDigest = ix.writeBashApplication pkgs {
+    name = "claude-memory-digest";
+    text = ''
+      store="$HOME/.config/nix/claude/memory/.weave"
+      if [ ! -d "$store" ]; then
+        echo "Memory store missing at $store; create it with: weave --store \"$store\" init"
+        exit 0
+      fi
+      echo "## Memory"
+      echo "Durable memory is a weave store at $store: append-only facts, Datalog-derived views."
+      echo "Save at the moment of learning: Memory.remember(\"slug\", \"one-line hook\", type: \"project\", topic: \"nix\", handle: \"cmd/path\", body: long_md) in the index kernel."
+      echo "Recall: Memory.recall(\"regex\") or Memory.query(datalog). Recalled facts go stale; verify before use. Never edit history: newer facts win, Memory.retract(id) kills a wrong one."
+      echo
+      echo "### Hooks (most recent first)"
+      ${lib.getExe cfg.packages.weave} --store "$store" query 'recent(S, E, D) :- latest(E, "mem/desc", D), fact_id(I, E, "mem/desc", D), fact_seq(I, S). ?- recent(S, E, D) order S desc limit 150.'
+      echo
+      echo "### Counts by type"
+      ${lib.getExe cfg.packages.weave} --store "$store" query 'per_type(T, count(E)) :- latest(E, "mem/type", T). ?- per_type(T, N) order N desc.'
+    '';
+  };
+
   # Personal-only Claude config, folded into the wrapper's settings render
   # via `extraSettings` (see the claudeCode override below): the index
   # claude-code Home Manager module materializes the full render into the
@@ -114,7 +140,13 @@
   # `codex.passthru.hooksJson` (Codex, delivered to ~/.codex/hooks.json below).
 
   claudeSettings = {
-    autoMemoryDirectory = "~/.config/nix/claude/auto-memory";
+    # Native markdown auto-memory is retired (index#3849): durable memory now
+    # lives in the weave store at ~/.config/nix/claude/memory/.weave (private
+    # repo), loaded via the memoryDigest SessionStart hook below and written
+    # through the kernel's Memory helper. The env knob matters: merely
+    # dropping autoMemoryDirectory would silently revert to the per-project
+    # ~/.claude/projects/<slug>/memory default instead of disabling.
+    env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = "1";
     enabledPlugins = {
       "ix-docs@ix" = true;
       "ix@ix" = true;
@@ -145,7 +177,11 @@
   # into their defaulted package, and this profile sets `package =` explicitly,
   # which discarded the fold and shipped prompts WITH the forceMerge rule
   # (index#3537).
-  agentPromptOmitRules = ["forceMerge"];
+  # memory: the shared rule prescribes markdown-file memories plus a
+  # MEMORY.md index; this workstation replaced that flow with the weave
+  # store (index#3849), whose usage instructions ride the SessionStart
+  # digest instead.
+  agentPromptOmitRules = ["forceMerge" "memory"];
 
   # claude-code from the index FLAKE PACKAGE SET (packages/claude-code in the
   # indexable-inc/index monorepo), not the overlay's pkgs.claude-code: only the
@@ -198,6 +234,14 @@
     # depth-1 Agents.* surface (reverses the index#3700 default). The kernel
     # still owns shell/file/search.
     omitRules = agentPromptOmitRules ++ ["backgroundSubagents"];
+    # SessionStart memory digest from the weave store; replaces the retired
+    # MEMORY.md load (index#3849).
+    extraSessionStart = lib.optionals (cfg.packages.weave != null) [
+      {
+        package = memoryDigest;
+        timeout = 15;
+      }
+    ];
     # Matches agentPromptOmitRules `forceMerge` above: without this the baked
     # `Bash(gh pr merge*--admin*)` denies still hard-block what the omitted
     # rule permits.
@@ -310,6 +354,13 @@
       # into its defaulted package, and the explicit `package = codex` below
       # discarded it, shipping prompts WITH the forceMerge rule (index#3537).
       omitRules = agentPromptOmitRules;
+      # Same SessionStart memory digest as claudeCode above (index#3849).
+      extraSessionStart = lib.optionals (cfg.packages.weave != null) [
+        {
+          package = memoryDigest;
+          timeout = 15;
+        }
+      ];
     })
     // {
       # Upstream main keeps Cargo's workspace version at 0.0.0. Home Manager
@@ -420,6 +471,12 @@ in {
       # plus any manual `ix-mcp serve`) keeps the policy in one place and the two
       # agents identical, instead of a per-server env override on each.
       IX_MCP_HOST = "127.0.0.1";
+
+      # Weave-backed agent memory (index#3849): the kernel's Memory helper
+      # and manual `weave` calls address the same private store. Device-level
+      # for the same reason as IX_MCP_HOST: inherited by claude/codex and
+      # every kernel they spawn.
+      WEAVE_MEMORY_STORE = "${config.home.homeDirectory}/.config/nix/claude/memory/.weave";
 
       # Skim configuration
       SKIM_CTRL_T_COMMAND = "fd --type f --hidden --follow";

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -97,6 +97,10 @@
     doCheck = false;
   });
 
+  # One statement of the store location: the digest script and the
+  # WEAVE_MEMORY_STORE session variable both derive from it.
+  memoryStore = "${"$"}{config.home.homeDirectory}/.config/nix/claude/memory/.weave";
+
   # SessionStart memory digest: the derived replacement for the retired
   # MEMORY.md flat index (index#3849). One-shot weave queries against the
   # private store; stdout becomes session context via the wrappers'
@@ -105,7 +109,7 @@
   memoryDigest = ix.writeBashApplication pkgs {
     name = "claude-memory-digest";
     text = ''
-      store="$HOME/.config/nix/claude/memory/.weave"
+      store=${lib.escapeShellArg memoryStore}
       if [ ! -d "$store" ]; then
         echo "Memory store missing at $store; create it with: weave --store \"$store\" init"
         exit 0
@@ -476,7 +480,7 @@ in {
       # and manual `weave` calls address the same private store. Device-level
       # for the same reason as IX_MCP_HOST: inherited by claude/codex and
       # every kernel they spawn.
-      WEAVE_MEMORY_STORE = "${config.home.homeDirectory}/.config/nix/claude/memory/.weave";
+      WEAVE_MEMORY_STORE = memoryStore;
 
       # Skim configuration
       SKIM_CTRL_T_COMMAND = "fd --type f --hidden --follow";


### PR DESCRIPTION
Closes #3849.

- **Generic seam**: `extraSessionStart` in `packages/agent/policy/hooks.nix` ({ package, exeName ?, args ?, timeout ? } list), threaded through the claude-code and codex wrappers plus both HM modules; each command runs at SessionStart and its stdout becomes session context. Verified by stub eval: renders for both agents with correct quoting and defaults.
- **Kernel Memory helper** (`packages/mcp-ex`): `Memory.remember/fact/query/recall/retract/put`, one-shot `weave` CLI against `WEAVE_MEMORY_STORE`, loud error when unset. Prelude alias + guide + README. `nix build .#mcp-ex` and `.#mcp-ex.passthru.tests.{elixir,smoke}` pass locally.
- **Andrew profile**: retire markdown auto-memory (`CLAUDE_CODE_DISABLE_AUTO_MEMORY=1`, `autoMemoryDirectory` dropped, `memory` prompt rule omitted), SessionStart weave digest, `users.andrewgazelka.packages.weave` option (supplied by the private flake, lifelog pattern), `WEAVE_MEMORY_STORE` session var.

The store itself is private (~/.config/nix). CI is down (billing lock), so validation is local per above; force-merging per standing decree.

(authored by Claude Code, Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add weave-backed agent memory store with `extraSessionStart` hook seam and `Memory` helper
> - Introduces `IxMcp.Memory` in [memory.ex](https://github.com/indexable-inc/index/pull/3851/files#diff-63ccf8ddac0a59f7258e2446185a73d0df7e308afe53db21f428df0fcb411c22) with `remember`, `recall`, `query`, `retract`, and `put` functions backed by the `weave` CLI; the store path and binary are resolved from `WEAVE_MEMORY_STORE` and `WEAVE_BIN` environment variables.
> - Adds an `extraSessionStart` option to the claude-code and codex Home Manager modules, allowing arbitrary commands to be injected into the `SessionStart` hook policy.
> - Adds a `memoryDigest` bash script in [workstation.nix](https://github.com/indexable-inc/index/pull/3851/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962) that queries recent weave facts and is wired up as the `extraSessionStart` hook for both Claude Code and Codex sessions.
> - Disables Claude Code's built-in auto-memory (`CLAUDE_CODE_DISABLE_AUTO_MEMORY=1`) in favour of the new weave store, and removes the `memory` rule from `agentPromptOmitRules`.
> - Aliases `IxMcp.Memory` into the workspace `@prelude` so `Memory.*` is available in interactive cells.
> - Risk: `IxMcp.Memory.run!` raises at runtime if `WEAVE_MEMORY_STORE` is unset, which will surface as errors in any agent session where the variable is not configured.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00242df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->