### PR TITLE
mcp-ex: Memory CLI writes need the offline lease + -- separator

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/memory.ex
+++ b/packages/mcp-ex/lib/ix_mcp/memory.ex
@@ -40,8 +40,10 @@ defmodule IxMcp.Memory do
   @doc "Append one fact; returns the fact id (`blake3:<hex>`)."
   @spec fact(String.t(), String.t(), String.t()) :: String.t()
   def fact(entity, attr, value) do
+    # CLI writes need the exclusive offline writer lease (no daemon owns the
+    # store here); `--` keeps values that start with `-` positional.
     # `weave fact` prints "seq <n>  <fact-id>".
-    ["fact", entity, attr, value] |> run!() |> String.split() |> List.last()
+    ["fact", "--offline", "--", entity, attr, value] |> run!() |> String.split() |> List.last()
   end
 
   @doc "Run a Datalog query program; returns the decoded result rows."
@@ -66,7 +68,7 @@ defmodule IxMcp.Memory do
 
   @doc "Retract a wrong fact by id (staleness prefers newer facts instead)."
   @spec retract(String.t()) :: String.t()
-  def retract(fact_id), do: ["retract", fact_id] |> run!() |> String.trim()
+  def retract(fact_id), do: ["retract", "--offline", "--", fact_id] |> run!() |> String.trim()
 
   @doc "Store long-form content in the CAS; returns its `blake3:<hex>`."
   @spec put(String.t()) :: String.t()


### PR DESCRIPTION
Follow-up to #3851 / #3849: weave HEAD refuses online CLI writes without `--offline`, and clap eats values starting with a dash without `--`. Verified against freshly built weave main (fact/retract append, digest queries return rows). `nix build .#mcp-ex` passes locally; CI is down, force-merging per decree.

(authored by Claude Code, Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--offline` lease and `--` separator to `IxMcp.Memory` CLI write commands
> Both `fact/3` and `retract/1` in [memory.ex](https://github.com/indexable-inc/index/pull/3852/files#diff-63ccf8ddac0a59f7258e2446185a73d0df7e308afe53db21f428df0fcb411c22) now pass `--offline` and `--` before positional arguments when invoking the CLI. The `--offline` flag acquires the offline writer lease, and `--` ensures values or IDs starting with `-` are not misinterpreted as flags.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1dc7b97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->