### PR TITLE
workstation: fix memoryStore interpolation (broke home switch)

### DIFF
--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -99,7 +99,7 @@
 
   # One statement of the store location: the digest script and the
   # WEAVE_MEMORY_STORE session variable both derive from it.
-  memoryStore = "${"$"}{config.home.homeDirectory}/.config/nix/claude/memory/.weave";
+  memoryStore = "${config.home.homeDirectory}/.config/nix/claude/memory/.weave";
 
   # SessionStart memory digest: the derived replacement for the retired
   # MEMORY.md flat index (index#3849). One-shot weave queries against the


### PR DESCRIPTION
The memoryStore binding used the `${"$"}` escape idiom instead of interpolation; hm-session-vars.sh exported a literal `${config.home.homeDirectory}/...` and babelfish failed the fish render, breaking `home-manager switch`. Repro: babelfish over the rendered hm-session-vars.sh exits 1; with this fix the string interpolates. Follow-up to #3851; CI down, force-merging.

(authored by Claude Code, Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `memoryStore` path interpolation in workstation profile
> The `memoryStore` path in [workstation.nix](https://github.com/indexable-inc/index/pull/3853/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962) was using an escaped dollar sign (`${"$"}{...}`) instead of proper Nix interpolation, causing the home directory to resolve as a literal string rather than the actual path. Removes the escape so `${config.home.homeDirectory}` is evaluated correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d31d6d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->