### PR TITLE
workstation: codex hooks.json must come from the overridden render

### DIFF
--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -1173,7 +1173,7 @@ in {
     # prompt is the single source of agent instructions.
     houseContext.enable = false;
     # hooks.json stays owned by the manual home.file declaration below (from
-    # `codexBase.passthru.hooksJson`, matching the package on PATH). Without
+    # `codex.passthru.hooksJson`, matching the package on PATH). Without
     # this the imported codex module also claims ~/.codex/hooks.json with
     # `finalPackage.hooksJson`, and the two sources conflict as soon as any
     # hook-affecting option diverges from the wrapper defaults.
@@ -1241,7 +1241,10 @@ in {
   # claude-hooks commands are absolute store paths, so a switch bakes the wiring;
   # codex's hash-pinned trust gate means a one-time `/hooks` trust after a bump.
   home.file.".codex/hooks.json" = {
-    source = codexBase.passthru.hooksJson;
+    # The OVERRIDDEN package's render: codexBase's would drop every
+    # override-level hook input (extraSessionStart lost the memory digest
+    # here, index#3849); `codex` is what programs.codex puts on PATH.
+    source = codex.passthru.hooksJson;
     force = true;
   };
 


### PR DESCRIPTION
Follow-up to #3851: `home.file.".codex/hooks.json"` sourced `codexBase.passthru.hooksJson` (pre-override), so override-level hook inputs never reached codex; the SessionStart memory digest exposed it. Verified post-switch: claude settings had the digest hook, codex hooks.json had only session-id. CI down; force-merging.

(authored by Claude Code, Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `~/.codex/hooks.json` to source from the overridden `codex` render
> In [workstation.nix](https://github.com/indexable-inc/index/pull/3854/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962), the `home.file ".codex/hooks.json"` source was pointing to `codexBase.passthru.hooksJson` instead of `codex.passthru.hooksJson`. This meant any overrides applied to `codex` were not reflected in the deployed hooks file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63e66c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->