### PR TITLE
kernel: elicitation-based Ask replaces built-in AskUserQuestion

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -323,11 +323,11 @@
     # skills listing (verified 2026-07, index#3607); the sibling `dataviz`
     # skill is removed via `skillOverrides` in houseSettingsDefaults below.
     Artifact = false;
-    # On: the redesign-at-the-root rule (prompt/rules.nix) routes fundamental
-    # design forks through this dialog instead of silently patching the old
-    # shape (index#3841); the AFK auto-continue env keeps an unanswered
-    # dialog from blocking unattended runs.
-    AskUserQuestion = true;
+    # Off: superseded by the kernel's Ask (index#3856). Ask.user in an exec
+    # cell raises the same native dialog through MCP elicitation, so the
+    # redesign-at-the-root rule (prompt/rules.nix, index#3841) keeps its
+    # user-facing fork without this tool's schema riding in every context.
+    AskUserQuestion = false;
     DesignSync = false;
     EnterPlanMode = false;
     EnterWorktree = false;

--- a/packages/agent/home-manager/claude-code.nix
+++ b/packages/agent/home-manager/claude-code.nix
@@ -509,8 +509,8 @@ in {
       type = lib.types.attrsOf lib.types.bool;
       default = {};
       example = {
-        AskUserQuestion = true;
         DesignSync = true;
+        EnterPlanMode = true;
       };
       description = ''
         Overrides for Claude Code built-in orchestration and hosted-service

--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -512,8 +512,8 @@
         Designing or fixing a system, first judge whether its current shape
         is fundamentally right. On finding a fundamentally better design,
         even a major one, surface it unprompted and put the choice to the
-        user with AskUserQuestion, costs named; this early, the rework is
-        usually wanted.
+        user with the kernel Ask dialog (Ask.user in an exec cell), costs
+        named; this early, the rework is usually wanted.
       '';
       reason = ''
         A jobs-registry death (index#3839) drew a three-patch fix on a shape

--- a/packages/agent/skills/quiz/SKILL.md
+++ b/packages/agent/skills/quiz/SKILL.md
@@ -9,6 +9,6 @@ After a long working session the diff understates what happened, because behavio
 
 1. **Scope the change.** Default to the current branch against its base (or this session's work); accept a PR number or path range instead.
 2. **Brief first.** Before any question, give a compact explainer: the why, the shape of the solution, what was done, and the non-obvious interactions with existing code paths. Use an HTML artifact for large changes, inline prose otherwise.
-3. **Quiz interactively.** 4-7 multiple-choice questions via AskUserQuestion, one at a time, each with one defensible correct answer. Aim at what the diff hides: behavior on existing paths, failure modes, why an approach beat its alternative, what breaks if a given line is removed. No trivia the diff states verbatim.
+3. **Quiz interactively.** 4-7 multiple-choice questions via the kernel Ask dialog (`Ask.user(question, options: [...])` in an exec cell), one at a time, each with one defensible correct answer. Aim at what the diff hides: behavior on existing paths, failure modes, why an approach beat its alternative, what breaks if a given line is removed. No trivia the diff states verbatim.
 4. **Grade honestly.** After each answer, say correct or incorrect and why. At the end report the score and re-explain anything missed.
 5. **Gate.** The bar is a perfect pass before merge; on misses, run a second targeted round on just those areas rather than repeating the whole quiz.

--- a/packages/mcp-ex/lib/ix_mcp/application.ex
+++ b/packages/mcp-ex/lib/ix_mcp/application.ex
@@ -9,6 +9,7 @@ defmodule IxMcp.Application do
       ├── IxMcp.Workspace       the shared binding + Macro.Env every cell sees
       ├── IxMcp.Jobs.Registry   id -> job process
       ├── IxMcp.MCP.Notifier    server-initiated notification fan-out (+ outbox replay)
+      ├── IxMcp.MCP.ClientRequests  server-initiated requests (elicitation) awaiting client replies
       ├── IxMcp.Jobs.Reaper     monitors job processes; finalizes any that die unreported
       ├── IxMcp.Jobs.Supervisor (DynamicSupervisor)  one child per cell/job
       │   └── IxMcp.Jobs.Job*   runs one evaluation in a monitored process
@@ -42,6 +43,7 @@ defmodule IxMcp.Application do
         # the reaper and publishes through the notifier, so both must be up
         # before any job can start (#3839).
         IxMcp.MCP.Notifier,
+        IxMcp.MCP.ClientRequests,
         IxMcp.Jobs.Reaper,
         {DynamicSupervisor, name: IxMcp.Jobs.Supervisor, strategy: :one_for_one},
         {Task.Supervisor, name: IxMcp.PrWatch.Supervisor},

--- a/packages/mcp-ex/lib/ix_mcp/ask.ex
+++ b/packages/mcp-ex/lib/ix_mcp/ask.ex
@@ -1,0 +1,110 @@
+defmodule IxMcp.Ask do
+  @moduledoc """
+  Put a question to the human through the client's native dialog, via MCP
+  elicitation (`elicitation/create`). The successor to Claude Code's built-in
+  AskUserQuestion tool (index#3856): a cell calls `Ask.user/2`, the client
+  renders the dialog, and the cell gets the answer back as a value.
+
+  The call blocks its cell (never the server: each cell runs in its own
+  process), so under `exec`'s budget-then-background contract a pending
+  question simply becomes a background job whose finish notification carries
+  the answer.
+
+      Ask.user("Ship the redesign or patch the old shape?",
+        options: ["Redesign", {"Patch", "keep the current structure"}])
+      #=> {:ok, "Redesign"} | :declined | :cancelled | :timeout
+
+  With no `options` the dialog takes free text. There is no capability
+  sniffing: a client that cannot elicit answers with a JSON-RPC error, which
+  raises here with that error in hand.
+  """
+
+  alias IxMcp.MCP.ClientRequests
+
+  @default_timeout_ms :timer.minutes(30)
+
+  @typedoc "A choice: the value itself, or {value, description}."
+  @type option :: String.t() | {String.t(), String.t()}
+
+  @doc """
+  Ask the user one question and wait for the answer.
+
+  Options:
+    * `:options` - list of choices rendered as a select; omit for free text.
+    * `:timeout_ms` - how long to wait before giving up (default 30 min);
+      on expiry the dialog is cancelled and `:timeout` is returned, so an
+      unattended run parks instead of hanging forever.
+  """
+  @spec user(String.t(), [{:options, [option()]} | {:timeout_ms, pos_integer()}]) ::
+          {:ok, String.t()} | :declined | :cancelled | :timeout
+  def user(message, opts \\ []) when is_binary(message) and is_list(opts) do
+    params = %{
+      "message" => message,
+      "requestedSchema" => schema(Keyword.get(opts, :options))
+    }
+
+    case ClientRequests.request(
+           "elicitation/create",
+           params,
+           Keyword.get(opts, :timeout_ms, @default_timeout_ms)
+         ) do
+      {:ok, %{"action" => "accept", "content" => %{"answer" => answer}}} when is_binary(answer) ->
+        {:ok, answer}
+
+      {:ok, %{"action" => "decline"}} ->
+        :declined
+
+      {:ok, %{"action" => "cancel"}} ->
+        :cancelled
+
+      {:ok, other} ->
+        raise "elicitation returned an unexpected result: " <> inspect(other)
+
+      {:error, :timeout} ->
+        :timeout
+
+      {:error, :no_transport} ->
+        raise "no MCP client is connected; Ask.user needs a live Claude Code session"
+
+      {:error, :transport_closed} ->
+        raise "the MCP client disconnected while the question was pending"
+
+      {:error, {:client_error, error}} ->
+        raise "the client rejected the elicitation request: " <> inspect(error)
+    end
+  end
+
+  # MCP elicitation schemas are flat objects of primitives; one string field
+  # named `answer` is the whole surface. Options become an enum, which the
+  # client renders as a select; enumNames carry the descriptions.
+  defp schema(nil) do
+    %{
+      "type" => "object",
+      "properties" => %{"answer" => %{"type" => "string", "title" => "Answer"}},
+      "required" => ["answer"]
+    }
+  end
+
+  defp schema([_ | _] = options) do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "answer" => %{
+          "type" => "string",
+          "title" => "Answer",
+          "enum" => Enum.map(options, &value_of/1),
+          "enumNames" => Enum.map(options, &name_of/1)
+        }
+      },
+      "required" => ["answer"]
+    }
+  end
+
+  defp value_of({value, _description}) when is_binary(value), do: value
+  defp value_of(value) when is_binary(value), do: value
+
+  defp name_of({value, description}) when is_binary(value) and is_binary(description),
+    do: value <> ": " <> description
+
+  defp name_of(value) when is_binary(value), do: value
+end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/client_requests.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/client_requests.ex
@@ -1,0 +1,145 @@
+defmodule IxMcp.MCP.ClientRequests do
+  @moduledoc """
+  Server-initiated JSON-RPC requests to the connected MCP client (the other
+  direction from `IxMcp.MCP.Server`): assigns request ids, writes through the
+  transport, and parks each caller until the client's response arrives. A
+  message from the client that carries an id but no method is a response to
+  one of these requests; `IxMcp.MCP.Stdio` routes it here.
+
+  One transport (the Notifier tracks its own list for notifications; requests
+  need a reply address, so this server keeps the single live transport and
+  fails callers loudly when none is connected). A request that outlives its
+  deadline is answered `{:error, :timeout}` and a `notifications/cancelled`
+  is sent so the client can tear down whatever UI the request raised.
+  """
+
+  use GenServer
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @doc "Adopt a transport; requests write to it as `{:mcp_send, message}`."
+  @spec register(pid()) :: :ok
+  def register(transport) when is_pid(transport) do
+    GenServer.cast(__MODULE__, {:register, transport})
+  end
+
+  @doc """
+  Send one request and block until the client answers, the deadline passes,
+  or the transport dies. Callers own their patience; the GenServer call
+  itself never times out.
+  """
+  @spec request(String.t(), map(), pos_integer()) ::
+          {:ok, map()}
+          | {:error, :no_transport | :timeout | :transport_closed | {:client_error, map()}}
+  def request(method, params, timeout_ms)
+      when is_binary(method) and is_map(params) and is_integer(timeout_ms) and timeout_ms > 0 do
+    GenServer.call(__MODULE__, {:request, method, params, timeout_ms}, :infinity)
+  end
+
+  @doc "Route a client response (id, no method) back to its blocked caller."
+  @spec resolve(map()) :: :ok
+  def resolve(message) when is_map(message) do
+    GenServer.cast(__MODULE__, {:resolve, message})
+  end
+
+  @impl true
+  def init(_) do
+    {:ok, %{transport: nil, next: 1, pending: %{}}}
+  end
+
+  @impl true
+  def handle_call({:request, _method, _params, _timeout}, _from, %{transport: nil} = state) do
+    {:reply, {:error, :no_transport}, state}
+  end
+
+  def handle_call({:request, method, params, timeout_ms}, from, state) do
+    # A string id namespaced to this side: the client numbers its own
+    # requests, and JSON-RPC only disambiguates ids by direction, so a
+    # distinct shape makes wire logs unambiguous to human readers too.
+    id = "ix-req-" <> Integer.to_string(state.next)
+
+    send(
+      state.transport,
+      {:mcp_send, %{"jsonrpc" => "2.0", "id" => id, "method" => method, "params" => params}}
+    )
+
+    timer = Process.send_after(self(), {:deadline, id}, timeout_ms)
+    pending = Map.put(state.pending, id, %{from: from, timer: timer})
+    {:noreply, %{state | next: state.next + 1, pending: pending}}
+  end
+
+  @impl true
+  def handle_cast({:register, transport}, state) do
+    Process.monitor(transport)
+    {:noreply, %{state | transport: transport}}
+  end
+
+  def handle_cast({:resolve, %{"id" => id} = message}, state) do
+    case Map.pop(state.pending, id) do
+      # A response after its deadline (or a stray id): nothing waits for it.
+      {nil, _pending} ->
+        {:noreply, state}
+
+      {%{from: from, timer: timer}, pending} ->
+        Process.cancel_timer(timer)
+
+        reply =
+          case message do
+            %{"error" => error} ->
+              {:error, {:client_error, error}}
+
+            %{"result" => result} ->
+              {:ok, result}
+
+            _ ->
+              {:error,
+               {:client_error, %{"message" => "response carried neither result nor error"}}}
+          end
+
+        GenServer.reply(from, reply)
+        {:noreply, %{state | pending: pending}}
+    end
+  end
+
+  def handle_cast({:resolve, _message}, state), do: {:noreply, state}
+
+  @impl true
+  def handle_info({:deadline, id}, state) do
+    case Map.pop(state.pending, id) do
+      {nil, _pending} ->
+        {:noreply, state}
+
+      {%{from: from}, pending} ->
+        # Tell the client the request is dead so it can dismiss the dialog;
+        # a late answer then lands in the {nil, _} clause above.
+        if state.transport do
+          send(
+            state.transport,
+            {:mcp_send,
+             %{
+               "jsonrpc" => "2.0",
+               "method" => "notifications/cancelled",
+               "params" => %{"requestId" => id, "reason" => "timed out waiting for an answer"}
+             }}
+          )
+        end
+
+        GenServer.reply(from, {:error, :timeout})
+        {:noreply, %{state | pending: pending}}
+    end
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, %{transport: pid} = state) do
+    Enum.each(state.pending, fn {_id, %{from: from, timer: timer}} ->
+      Process.cancel_timer(timer)
+      GenServer.reply(from, {:error, :transport_closed})
+    end)
+
+    {:noreply, %{state | transport: nil, pending: %{}}}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/stdio.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/stdio.ex
@@ -17,6 +17,7 @@ defmodule IxMcp.MCP.Stdio do
 
   use GenServer
 
+  alias IxMcp.MCP.ClientRequests
   alias IxMcp.MCP.Notifier
   alias IxMcp.MCP.Server
 
@@ -37,6 +38,7 @@ defmodule IxMcp.MCP.Stdio do
     # binary makes stdio a transparent byte pipe in both directions.
     :ok = :io.setopts(:standard_io, binary: true, encoding: :latin1)
     Notifier.register(self())
+    ClientRequests.register(self())
     reader = self()
     spawn_link(fn -> read_loop(reader) end)
     {:ok, %{pending: %{}, eof: false}}
@@ -52,6 +54,13 @@ defmodule IxMcp.MCP.Stdio do
     # exactly the silent hang #3538 diagnosed. Decoding is cheap; the slow
     # part (Server.handle) stays off this process.
     case JSON.decode(line) do
+      # An id without a method is the client answering one of OUR requests
+      # (elicitation and friends); it gets no reply, so it skips the
+      # reply-always pending bookkeeping entirely.
+      {:ok, %{"id" => _} = message} when not is_map_key(message, "method") ->
+        ClientRequests.resolve(message)
+        {:noreply, state}
+
       {:ok, message} ->
         {:ok, pid} =
           Task.start(fn ->

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -66,6 +66,12 @@ defmodule IxMcp.MCP.Tools do
                                             decode the typedstream body)
       Contacts.search(name)                 macOS address book: name -> the
                                             phone/email handles Imsg takes
+      Ask.user("Redesign or patch?", options: ["Redesign", {"Patch", "keep shape"}])
+                                            put one question to the human as a
+                                            native dialog (MCP elicitation);
+                                            blocks the cell, returns {:ok, answer}
+                                            | :declined | :cancelled | :timeout.
+                                            Omit options: for free text
       Memory.remember("slug", "hook", topic: "nix")
                                             durable memory: append facts to the
                                             weave store named by

--- a/packages/mcp-ex/lib/ix_mcp/workspace.ex
+++ b/packages/mcp-ex/lib/ix_mcp/workspace.ex
@@ -17,7 +17,8 @@ defmodule IxMcp.Workspace do
   @prelude "alias IxMcp.Jobs; alias IxMcp.Api; alias IxMcp.Fleet; " <>
              "alias IxMcp.Read; alias IxMcp.Edit; alias IxMcp.PrWatch; alias IxMcp.Tui; " <>
              "alias IxMcp.TuiLocal; alias IxMcp.Gmail; alias IxMcp.Imsg; alias IxMcp.Contacts; " <>
-             "alias IxMcp.Kernel, as: Ix; alias IxMcp.Agents; alias IxMcp.Memory"
+             "alias IxMcp.Kernel, as: Ix; alias IxMcp.Agents; alias IxMcp.Memory; " <>
+             "alias IxMcp.Ask"
 
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do

--- a/packages/mcp-ex/test/ix_mcp/ask_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/ask_test.exs
@@ -1,0 +1,88 @@
+defmodule IxMcp.AskTest do
+  use ExUnit.Case, async: false
+
+  alias IxMcp.Ask
+  alias IxMcp.MCP.ClientRequests
+
+  # ClientRequests is a named singleton in the supervision tree; these tests
+  # adopt the test process as its transport, so each one drains and answers
+  # the wire messages itself. async: false keeps sibling tests from racing
+  # for the transport slot.
+
+  setup do
+    ClientRequests.register(self())
+    :ok
+  end
+
+  defp receive_request do
+    assert_receive {:mcp_send, %{"id" => id, "method" => method, "params" => params}}, 1_000
+    {id, method, params}
+  end
+
+  test "Ask.user round trip: options become an enum schema, accept returns the answer" do
+    task =
+      Task.async(fn ->
+        Ask.user("Redesign or patch?", options: ["Redesign", {"Patch", "keep the shape"}])
+      end)
+
+    {id, "elicitation/create", params} = receive_request()
+
+    assert params["message"] == "Redesign or patch?"
+    answer = params["requestedSchema"]["properties"]["answer"]
+    assert answer["enum"] == ["Redesign", "Patch"]
+    assert answer["enumNames"] == ["Redesign", "Patch: keep the shape"]
+    assert params["requestedSchema"]["required"] == ["answer"]
+
+    ClientRequests.resolve(%{
+      "jsonrpc" => "2.0",
+      "id" => id,
+      "result" => %{"action" => "accept", "content" => %{"answer" => "Redesign"}}
+    })
+
+    assert Task.await(task) == {:ok, "Redesign"}
+  end
+
+  test "free-text questions carry a plain string schema; decline and cancel map to atoms" do
+    for {action, expected} <- [{"decline", :declined}, {"cancel", :cancelled}] do
+      task = Task.async(fn -> Ask.user("Name the branch") end)
+      {id, "elicitation/create", params} = receive_request()
+
+      answer = params["requestedSchema"]["properties"]["answer"]
+      assert answer == %{"type" => "string", "title" => "Answer"}
+
+      ClientRequests.resolve(%{"jsonrpc" => "2.0", "id" => id, "result" => %{"action" => action}})
+      assert Task.await(task) == expected
+    end
+  end
+
+  test "a client error raises with the error in hand" do
+    # The raise crosses the async link as an exit signal; trap it so this
+    # test observes the exit instead of dying with the task.
+    Process.flag(:trap_exit, true)
+    task = Task.async(fn -> Ask.user("Anyone home?") end)
+    {id, _method, _params} = receive_request()
+
+    ClientRequests.resolve(%{
+      "jsonrpc" => "2.0",
+      "id" => id,
+      "error" => %{"code" => -32_601, "message" => "method not found"}
+    })
+
+    assert {{exception, _stack}, _mfa} = catch_exit(Task.await(task))
+    assert Exception.message(exception) =~ "method not found"
+  end
+
+  test "timeout cancels the dialog and returns :timeout; a late answer is dropped" do
+    task = Task.async(fn -> Ask.user("Still there?", timeout_ms: 30) end)
+    {id, _method, _params} = receive_request()
+
+    assert Task.await(task) == :timeout
+
+    assert_receive {:mcp_send,
+                    %{"method" => "notifications/cancelled", "params" => %{"requestId" => ^id}}},
+                   1_000
+
+    # The late answer must not crash the server or leak a reply anywhere.
+    ClientRequests.resolve(%{"jsonrpc" => "2.0", "id" => id, "result" => %{"action" => "accept"}})
+  end
+end

--- a/packages/mcp-ex/test/ix_mcp/stdio_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/stdio_test.exs
@@ -40,6 +40,27 @@ defmodule IxMcp.MCP.StdioTest do
     assert output == ""
   end
 
+  test "a client response (id, no method) routes to ClientRequests, not the handler" do
+    IxMcp.MCP.ClientRequests.register(self())
+
+    task =
+      Task.async(fn -> IxMcp.MCP.ClientRequests.request("elicitation/create", %{}, 5_000) end)
+
+    assert_receive {:mcp_send, %{"id" => id}}, 1_000
+
+    state = %{pending: %{}, eof: false}
+    line = JSON.encode!(%{"jsonrpc" => "2.0", "id" => id, "result" => %{"action" => "decline"}})
+
+    output =
+      capture_io(fn ->
+        assert {:noreply, ^state} = Stdio.handle_info({:mcp_recv, line}, state)
+        assert Task.await(task) == {:ok, %{"action" => "decline"}}
+      end)
+
+    # No reply goes back out for a response, and no handler task is spawned.
+    assert output == ""
+  end
+
   test "an unencodable response degrades to an error reply instead of killing the transport" do
     state = %{pending: %{}, eof: false}
     message = %{"jsonrpc" => "2.0", "id" => 3, "result" => %{"content" => <<0xFF>>}}


### PR DESCRIPTION
Closes #3856.

`Ask.user("Redesign or patch?", options: ["Redesign", {"Patch", "keep the shape"}])` in an exec cell now raises the client's native dialog through MCP `elicitation/create` and returns `{:ok, answer} | :declined | :cancelled | :timeout` to the cell. Claude Code 2.1.215 handles elicitation as a client (verified against the binary). Under exec's budget-then-background contract a pending question just becomes a background job whose finish notification carries the answer; a 30-minute default deadline cancels the dialog (`notifications/cancelled`) so unattended runs park instead of hanging.

Plumbing: new `IxMcp.MCP.ClientRequests` GenServer owns server-initiated JSON-RPC (id namespace `ix-req-N`, caller parking, deadline, transport-death cleanup); `Stdio` routes inbound messages with an id and no method to it. No capability sniffing: a client that cannot elicit answers with a JSON-RPC error, which raises in the cell with that error in hand.

The built-in AskUserQuestion is denied again (its schema rode in every session's context); the redesign-at-the-root rule and the quiz skill now name `Ask.user`. Not yet verified live: Claude Code's rendering of the enum schema as a select dialog; that needs a deployed kernel and an interactive session, and I'll check it after merge + switch.

104/104 mcp-ex tests pass, including new round-trip, decline/cancel, client-error, and timeout coverage.

(sent by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `AskUserQuestion` tool with elicitation-based `Ask.user` in kernel
> - Adds `IxMcp.Ask.user/2` that sends an MCP `elicitation/create` request and synchronously returns `{:ok, answer} | :declined | :cancelled | :timeout`, raising on transport or client errors.
> - Adds `IxMcp.MCP.ClientRequests` GenServer to manage server-initiated JSON-RPC requests to the client, with timeout handling, cancellation notifications, and transport-closure cleanup.
> - Updates `IxMcp.MCP.Stdio` to register with `ClientRequests` as the outbound transport and route client responses (id, no method) to `ClientRequests.resolve/1` instead of spawning a handler task.
> - Disables `AskUserQuestion` by default in Claude Code config and updates prompt rules and skill docs to use `Ask.user` instead.
> - `Ask` is aliased into the workspace prelude so cells can call `Ask.user` without a full module prefix.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5489f3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->