### PR TITLE
site: update entry for kernel Ask.user elicitation

### DIFF
--- a/packages/site/src/lib/updates/kernel-ask-user-elicitation.svx
+++ b/packages/site/src/lib/updates/kernel-ask-user-elicitation.svx
@@ -1,0 +1,15 @@
+---
+id: kernel-ask-user-elicitation
+postedAt: 2026-07-21T14:00:00-07:00
+title: Kernel Ask.user replaces the built-in AskUserQuestion tool
+tags: [kernel, mcp]
+links:
+  - label: index#3857
+    href: https://github.com/indexable-inc/index/pull/3857
+  - label: index#3856
+    href: https://github.com/indexable-inc/index/issues/3856
+---
+
+Agents can now ask the human a question from an exec cell. `Ask.user("Redesign or patch?", options: ["Redesign", {"Patch", "keep the shape"}])` raises the client's native dialog through MCP `elicitation/create` and returns `{:ok, answer}`, `:declined`, `:cancelled`, or `:timeout`, so the answer lands as an ordinary value the cell can branch on. A question still pending when the cell's budget runs out becomes a background job like any other long call, and the job's finish notification carries the answer, so the agent keeps working instead of blocking on the human.
+
+A 30-minute deadline cancels the dialog, so unattended runs park as `:timeout` rather than holding a stale prompt open. With the kernel path in place, Claude Code's built-in AskUserQuestion tool is denied again, and its schema no longer costs tokens in every session. Under the hood, a new `IxMcp.MCP.ClientRequests` handles server-initiated JSON-RPC over the stdio transport, which is what lets the server originate `elicitation/create` at all.


### PR DESCRIPTION
Adds a site updates entry for the kernel-side `Ask.user` built on MCP elicitation, merged in #3857.

Refs #3856.

Covers: asking from an exec cell, the return shape, background-job handoff for pending questions, the 30-minute deadline, and re-denying the built-in AskUserQuestion tool.

Written by Claude Opus 4.5 via Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add site update entry for Kernel `Ask.user` elicitation feature
> Adds a new changelog/update entry in [kernel-ask-user-elicitation.svx](https://github.com/indexable-inc/index/pull/3859/files#diff-a50daf1d1dd5a4e3072aadd5bc72e98fef3569542bb1de454e52fbdd35ed0c40) documenting the `Ask.user` API that replaces the built-in `AskUserQuestion` tool.
>
> - Describes return values: `:ok` with answer, `:declined`, `:cancelled`, and `:timeout`
> - Documents background job behavior when budget runs out and the 30-minute cancellation deadline
> - Notes that the `AskUserQuestion` tool is blocked when `Ask.user` is active
> - Mentions the new `IxMcp.MCP.ClientRequests` module for handling server-initiated JSON-RPC
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05f6893.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->