### PR TITLE
claude-code: add extraSessionStart to knob reference block (#3858)

### DIFF
--- a/packages/agent/home-manager/claude-code.nix
+++ b/packages/agent/home-manager/claude-code.nix
@@ -88,6 +88,7 @@
   #   pluginDirs = [ ];  option pluginDirs; --plugin-dir=<dir> flags: namespaced plugin bundles (the house plugin rides this layer)
   #   primaryCheckouts = <"/home/*/index", "/home/*/ix">;  option primaryCheckouts; globs the PreToolUse worktree guard denies edits under
   #   personalStartupContext = false;  option personalStartupContext; Andrew-only startup context hooks
+  #   extraSessionStart = [ ];  option extraSessionStart; SessionStart context commands ({ package, exeName ? null, args ? [ ], timeout ? 10 }): each runs at session start with stdout injected as session context (#3849)
   #   repoPackages = { };  plumbing: sibling repo packages threaded by lib/packages.nix, not a config knob
   #   mcpServers = <ix.mcp default pair: index + exa>;  option defaultMcpServers; baked --mcp-config layer (CLI layers merge, additions only)
   #   developmentChannels = <"server:index" when the index server is baked>;  channel specs for --dangerously-load-development-channels


### PR DESCRIPTION
Main's flake-check is red: `checks.claude-code-knob-reference` asserts the commented knob reference block against the wrapper's accepted formals, and #3849 added the `extraSessionStart` knob without its row. This adds the row (stock default `[ ]`), between `personalStartupContext` and `repoPackages` to match the wrapper's formal order.

Validated locally by instantiating the check derivation against the edited tree (`nix eval` of `knob-reference-check.nix` with the flake's claude-code package): all eval-time asserts pass.

Fixes #3858

Generated with Claude Opus 4.5 via Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `extraSessionStart` to claude-code knob reference documentation
> Adds a commented documentation entry for the `extraSessionStart` option in the knob reference block of [claude-code.nix](https://github.com/indexable-inc/index/pull/3861/files#diff-b941f4c92dd8de3d70290f80abe17e83e8710287c6a7430cad3d5f1c81cdbdab), including its schema and session-start behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc1c6f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->