### PR TITLE
kernel: give subprocesses a stdin that EOFs (Cmd.run)

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/ask.ex
+++ b/packages/mcp-ex/lib/ix_mcp/ask.ex
@@ -43,11 +43,15 @@ defmodule IxMcp.Ask do
       "requestedSchema" => schema(Keyword.get(opts, :options))
     }
 
-    case ClientRequests.request(
-           "elicitation/create",
-           params,
-           Keyword.get(opts, :timeout_ms, @default_timeout_ms)
-         ) do
+    "elicitation/create"
+    |> ClientRequests.request(params, Keyword.get(opts, :timeout_ms, @default_timeout_ms))
+    |> interpret()
+  end
+
+  # The wire-result decode lives apart from user/2 so each half stays under
+  # credo's complexity ceiling.
+  defp interpret(result) do
+    case result do
       {:ok, %{"action" => "accept", "content" => %{"answer" => answer}}} when is_binary(answer) ->
         {:ok, answer}
 

--- a/packages/mcp-ex/lib/ix_mcp/cmd.ex
+++ b/packages/mcp-ex/lib/ix_mcp/cmd.ex
@@ -1,0 +1,36 @@
+defmodule IxMcp.Cmd do
+  @moduledoc """
+  `System.cmd/3` with a stdin that delivers EOF.
+
+  A port's stdin is a pipe the BEAM never closes, so a subprocess that falls
+  back to reading stdin when given no input path -- pathless `rg` and `grep`
+  especially -- blocks forever (#3867). Wrapping the spawn in `sh` with stdin
+  redirected from `/dev/null` hands every command an immediate EOF; `exec`
+  replaces the shell, so no extra process outlives the redirect and job
+  cancellation (`IxMcp.OsProc`) still sees one process tree.
+  """
+
+  @doc """
+  Run `cmd` with `args`, stdin redirected from `/dev/null`.
+
+  Options and return match `System.cmd/3` (`cd:`, `env:`,
+  `stderr_to_stdout:`, `into:`, ...), except a missing executable exits 127
+  with a shell diagnostic instead of raising, because `sh` resolves `cmd`.
+  """
+  @spec run(binary(), [binary()], keyword()) :: {Collectable.t(), non_neg_integer()}
+  def run(cmd, args \\ [], opts \\ []) do
+    # `$0` is `cmd` and `$@` the args, so no shell parsing touches them.
+    System.cmd("/bin/sh", ["-c", ~S(exec "$0" "$@" </dev/null), cmd | args], opts)
+  end
+
+  @doc """
+  Run a one-line shell script (pipes, redirects) with stdin from `/dev/null`.
+
+  The leading bare `exec` redirects the whole script, so pipeline heads
+  (`rg pat | head`) see EOF too, not just the final command.
+  """
+  @spec sh(binary(), keyword()) :: {Collectable.t(), non_neg_integer()}
+  def sh(script, opts \\ []) do
+    System.cmd("/bin/sh", ["-c", "exec </dev/null\n" <> script], opts)
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -35,6 +35,12 @@ defmodule IxMcp.MCP.Tools do
                                             numbered snippet of the edited region
       Edit.write(path, content)             write a file, creating parent dirs;
                                             the return names created vs updated
+      Cmd.run("rg", ["-n", "pat"], cd: dir) System.cmd/3 with stdin from /dev/null,
+                                            so pathless rg/grep see EOF instead of
+                                            hanging forever on the port's
+                                            never-closing stdin pipe (#3867);
+                                            Cmd.sh("rg pat | head") runs a one-line
+                                            pipeline with the same EOF stdin
       Ix.trace()                            stack dump of every running job's processes,
                                             taken from outside with Process.info/2
       Ix.restart()                          cancel running jobs (sparing the calling
@@ -136,12 +142,14 @@ defmodule IxMcp.MCP.Tools do
         an existing file, reach for Edit.replace/4 before hand-rolled
         String.replace rewrites: it fails loudly on zero or ambiguous
         matches and confirms what changed. Reserve
-        System.cmd/3 for real external programs (git, nix, gh), and always
-        pass its arguments as a list: System.cmd("git", ["-C", dir, "status"]).
-        A subprocess's stdin is a pipe that never closes, so tools that read
+        subprocesses for real external programs (git, nix, gh), spawn them
+        with Cmd.run/3, and always pass arguments as a list:
+        Cmd.run("git", ["-C", dir, "status"]). Cmd is System.cmd/3 with
+        stdin redirected from /dev/null: a raw System.cmd subprocess gets a
+        stdin pipe that never closes, so tools that fall back to reading
         stdin when given no input path -- rg and grep especially -- hang
-        forever, even with cd: set. Always pass an explicit path argument:
-        System.cmd("rg", ["-n", "pat", "."], cd: dir).
+        forever, even with cd: set (#3867). Cmd.sh("rg pat | head") runs a
+        one-line pipeline with the same EOF stdin.
         Never build shell command strings, and never use bash here-docs or
         nested quoting to pass multi-line text -- they are brittle and can
         wedge this transport. To hand multi-line text to a program, write it

--- a/packages/mcp-ex/lib/ix_mcp/os_proc.ex
+++ b/packages/mcp-ex/lib/ix_mcp/os_proc.ex
@@ -3,9 +3,9 @@ defmodule IxMcp.OsProc do
   Finds and kills the OS processes a job's cells spawned, so cancelling a job
   never leaks orphan subprocesses.
 
-  There is no blessed shell helper in this server -- a cell that needs a
-  subprocess writes `System.cmd/3` or opens a `Port` itself -- but the
-  cancellation contract survives the cut: every port opened by any process in
+  Whether a cell spawns through the blessed `IxMcp.Cmd` helper, raw
+  `System.cmd/3`, or a `Port` it opens itself, the cancellation contract is
+  the same: every port opened by any process in
   the job's process tree (identified by the job's group leader, which spawned
   processes inherit) is resolved to its OS pid, and that pid's whole descendant
   tree is killed.

--- a/packages/mcp-ex/lib/ix_mcp/workspace.ex
+++ b/packages/mcp-ex/lib/ix_mcp/workspace.ex
@@ -18,7 +18,7 @@ defmodule IxMcp.Workspace do
              "alias IxMcp.Read; alias IxMcp.Edit; alias IxMcp.PrWatch; alias IxMcp.Tui; " <>
              "alias IxMcp.TuiLocal; alias IxMcp.Gmail; alias IxMcp.Imsg; alias IxMcp.Contacts; " <>
              "alias IxMcp.Kernel, as: Ix; alias IxMcp.Agents; alias IxMcp.Memory; " <>
-             "alias IxMcp.Ask"
+             "alias IxMcp.Ask; alias IxMcp.Cmd"
 
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do

--- a/packages/mcp-ex/test/ix_mcp/cmd_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/cmd_test.exs
@@ -1,0 +1,49 @@
+defmodule IxMcp.CmdTest do
+  use ExUnit.Case, async: true
+
+  alias IxMcp.Cmd
+
+  # Everything here would hang forever under raw System.cmd/3: a port's
+  # stdin pipe never closes, so a command that falls back to reading stdin
+  # blocks until cancelled (#3867). The Task timeout turns "hangs forever"
+  # into a test failure instead of a stuck suite.
+  defp await_5s(fun) do
+    fun |> Task.async() |> Task.await(5_000)
+  end
+
+  defp tmp_dir! do
+    dir = Path.join(System.tmp_dir!(), "ix-cmd-test-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    dir
+  end
+
+  test "a stdin-reading command sees EOF instead of hanging" do
+    # `cat` with no file argument is the hermetic stand-in for pathless rg:
+    # the identical read-stdin fallback, present in every environment.
+    assert {"", 0} = await_5s(fn -> Cmd.run("cat") end)
+  end
+
+  # The literal #3867 repro; the sandboxed check env carries no ripgrep, so
+  # this compiles away there and the `cat` test above covers the mechanism.
+  if System.find_executable("rg") do
+    test "pathless rg returns matches instead of hanging (#3867)" do
+      dir = tmp_dir!()
+      File.write!(Path.join(dir, "haystack.txt"), "needle\n")
+      assert {out, 0} = await_5s(fn -> Cmd.run("rg", ["-n", "needle"], cd: dir) end)
+      assert out =~ "needle"
+    end
+  end
+
+  test "run passes System.cmd options through" do
+    dir = tmp_dir!()
+    File.write!(Path.join(dir, "marker"), "")
+    assert {out, 0} = Cmd.run("ls", [], cd: dir)
+    assert String.trim(out) == "marker"
+  end
+
+  test "sh redirects the whole script, pipeline heads included" do
+    assert {out, 0} = await_5s(fn -> Cmd.sh("cat | wc -c") end)
+    assert String.trim(out) == "0"
+  end
+end

--- a/packages/mcp-ex/test/ix_mcp/stdio_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/stdio_test.exs
@@ -3,6 +3,7 @@ defmodule IxMcp.MCP.StdioTest do
 
   import ExUnit.CaptureIO
 
+  alias IxMcp.MCP.ClientRequests
   alias IxMcp.MCP.Stdio
 
   # These drive the GenServer callbacks directly in the test process: the
@@ -41,10 +42,10 @@ defmodule IxMcp.MCP.StdioTest do
   end
 
   test "a client response (id, no method) routes to ClientRequests, not the handler" do
-    IxMcp.MCP.ClientRequests.register(self())
+    ClientRequests.register(self())
 
     task =
-      Task.async(fn -> IxMcp.MCP.ClientRequests.request("elicitation/create", %{}, 5_000) end)
+      Task.async(fn -> ClientRequests.request("elicitation/create", %{}, 5_000) end)
 
     assert_receive {:mcp_send, %{"id" => id}}, 1_000
 

--- a/packages/site/src/lib/updates/kernel-cmd-stdin-eof.svx
+++ b/packages/site/src/lib/updates/kernel-cmd-stdin-eof.svx
@@ -1,0 +1,15 @@
+---
+id: kernel-cmd-stdin-eof
+postedAt: 2026-07-21T15:33:21-07:00
+title: "Kernel: Cmd.run gives subprocesses a stdin that EOFs"
+tags: [kernel, mcp]
+links:
+  - label: index#3867
+    href: https://github.com/indexable-inc/index/issues/3867
+---
+
+Three kernel jobs in one evening hung for 69 to 142 seconds and had to be cancelled. All were `rg` invoked through `System.cmd/3` with no path argument: rg with no path and a non-tty stdin falls back to searching stdin, and a BEAM port's stdin pipe never closes, so the read blocks forever. The same queries with an explicit path returned in a tenth of a second.
+
+Cells now get a blessed `Cmd` helper, pre-aliased like the rest of the surface. `Cmd.run("rg", ["-n", "pat"], cd: dir)` is `System.cmd/3` with stdin redirected from `/dev/null`: the command is exec'd through `sh` with `$0`/`$@`, so no shell parsing touches the arguments and no extra process outlives the redirect, which keeps job cancellation seeing one process tree. `Cmd.sh("rg pat | head")` does the same for one-line pipelines, redirecting the whole script so pipeline heads see EOF too. The kernel's exec instructions now steer subprocess spawns to `Cmd.run` instead of asking agents to remember an explicit path.
+
+*Written by Claude Code, an AI coding agent.*


### PR DESCRIPTION
Fixes #3867.

Three kernel jobs in one evening hung 69-142s and had to be cancelled; all were `rg` run through `System.cmd/3` with no path argument. rg with no path and a non-tty stdin falls back to searching stdin, and a BEAM port's stdin pipe never closes, so the read blocks forever. Reproduced in a live kernel cell: pathless `System.cmd("rg", ...)` still blocked past 3s, the same query with `"."` returned in 81ms.

The fix gives kernel-spawned commands a stdin that EOFs, at the seam the workspace already owns: a new `IxMcp.Cmd` module, pre-aliased into every cell by the prelude like `Read`/`Edit`/`Jobs`.

- `Cmd.run(cmd, args, opts)` is `System.cmd/3` execed through `sh` with `</dev/null`; `$0`/`$@` keep shell parsing away from the arguments, and `exec` means no extra process outlives the redirect (job cancellation still sees one tree).
- `Cmd.sh(script)` covers one-line pipelines: a leading bare `exec </dev/null` redirects the whole script, so pipeline heads see EOF too (one of the three hangs was `sh -c "rg ... | head"`).
- The exec tool instructions now steer subprocess spawns to `Cmd.run` instead of asking agents to remember an explicit path, and the stale "no blessed shell helper" note in `OsProc` is gone.
- Regression tests: bare `cat` (the hermetic stand-in for pathless rg, same stdin fallback) must return `{"", 0}` instead of hanging, plus the literal `rg` repro where ripgrep is installed, option passthrough, and the pipeline-head case.

The second commit clears two pre-existing credo-strict findings (`Ask.user` complexity 10 > 9, inline nested module names in the stdio test) that had `nix build .#mcp-ex.tests.elixir` red on clean main; this PR's gate would have inherited them.

Verified: `nix build .#mcp-ex.tests.elixir` green (compile -Werror, format, credo strict, 107 tests / 0 failures); `nix run .#lint` shows only the failures already present on clean main (`shell-fence`, `astlog` on untouched files). Live check against the compiled module: pathless `Cmd.run("rg", ["-n", "needle"], cd: dir)` returned the match in 9ms.

Written by an AI agent (Claude Opus 4.5 via Claude Code).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Cmd.run/3` and `Cmd.sh/2` helpers that give subprocesses a stdin that EOFs
> - Adds [IxMcp.Cmd](https://github.com/indexable-inc/index/pull/3869/files#diff-b19457e1b4efbbfa827f50123aa2b3bcf7faa96953297c02aa1f57c2cef83453) with `run/3` (wraps `System.cmd` via `/bin/sh -c` with `</dev/null`) and `sh/2` (prefixes scripts with `exec </dev/null`) so spawned processes receive EOF on stdin immediately rather than hanging.
> - `run/3` returns exit status 127 with a shell diagnostic when the executable is missing, instead of raising.
> - Adds `Cmd` as an alias in the workspace prelude so tools can call `Cmd.run/3` and `Cmd.sh/2` without the full module name.
> - Updates `IxMcp.MCP.Tools` docs to recommend these helpers over raw `System.cmd/3` for tool implementations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc6b4b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->