### PR TITLE
agent: enrich Memory recall, add typed edges and verification receipts

### DIFF
--- a/packages/mcp-ex/README.md
+++ b/packages/mcp-ex/README.md
@@ -65,7 +65,7 @@ list):
 | in-cell callable | what it does |
 |---|---|
 | `Read.file(path, first \\ nil, last \\ nil)` | a file, optionally a 1-based line range |
-| `Memory.remember(slug, desc, opts)` | durable memory facts in the weave store at `WEAVE_MEMORY_STORE`; recall via `Memory.recall/1` (regex) or `Memory.query/1` (Datalog) |
+| `Memory.remember(slug, desc, opts)` | durable memory facts in the weave store at `WEAVE_MEMORY_STORE`; `supersedes:`/`relates:` write typed edges for `Memory.graph/1`; recall rich rows via `Memory.recall/2` (regex) or `Memory.query/1` (Datalog); `Memory.verify/2` records re-check receipts |
 | `Ix.trace()` | stack dump of every job's processes, from outside |
 | `Ix.restart()` | cancel jobs (sparing the calling cell), restart the workspace, restore bindings |
 | `PrWatch.start(pr, cwd, interval \\ 15, timeout \\ 3600)` | watch a PR via `gh`, notify on merge/close/timeout |

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -76,9 +76,14 @@ defmodule IxMcp.MCP.Tools do
                                             durable memory: append facts to the
                                             weave store named by
                                             WEAVE_MEMORY_STORE (loud error when
-                                            unset). Recall with
-                                            Memory.recall("regex") or raw Datalog
-                                            via Memory.query/1;
+                                            unset); supersedes:/relates: opts
+                                            write typed edges Memory.graph(slug)
+                                            walks. Recall with
+                                            Memory.recall("regex") -- whole-word
+                                            rows with id, time, type, topic,
+                                            handle, body -- or raw Datalog via
+                                            Memory.query/1. Memory.verify(slug)
+                                            records a re-check receipt;
                                             Memory.retract(id) kills a wrong
                                             fact, newer facts win over stale ones
       Agents.spawn(brief, backend: :claude | :codex | :kimi)

--- a/packages/mcp-ex/lib/ix_mcp/memory.ex
+++ b/packages/mcp-ex/lib/ix_mcp/memory.ex
@@ -11,22 +11,39 @@ defmodule IxMcp.Memory do
   are `mem:<slug>`; `mem/desc` is the one-line hook, `mem/type` one of
   user | feedback | project | reference, `mem/topic` a repeatable tag,
   `mem/handle` the concrete command/path/flag, `mem/body` a blake3 CAS
-  hash of long-form content. History is never edited: newer facts win,
-  `retract/1` kills a wrong one.
+  hash of long-form content, `mem/verified-at` a re-check receipt
+  (UTC timestamp plus provenance, see `verify/2`). `mem/supersedes` and
+  `mem/relates` hold other `mem:` entities: weave treats entity-valued
+  facts as typed edges, so corrections and clusters are walkable via
+  `graph/1` instead of discoverable only by regex. History is never
+  edited: newer facts win, `retract/1` kills a wrong one.
   """
+
+  @recall_limit 20
 
   @doc """
   Save a memory: `Memory.remember("slug", "hook", type: "project",
-  topic: ["nix", "fleet"], handle: "nix run .#lint", body: long_markdown)`.
+  topic: ["nix", "fleet"], handle: "nix run .#lint", body: long_markdown,
+  supersedes: "old-slug", relates: ["peer-slug"])`.
+
+  `supersedes:` and `relates:` take slugs or `mem:` names and are written
+  as entity-valued facts, which weave treats as typed edges (`graph/1`
+  walks them). `supersedes:` makes a correction explicit instead of
+  relying on newer-wins; `relates:` links peers.
   """
   @spec remember(String.t(), String.t(), keyword()) :: :ok
   def remember(slug, desc, opts \\ []) do
-    entity = "mem:" <> slug
+    entity = mem_entity(slug)
     fact(entity, "mem/desc", desc)
 
     for key <- [:type, :topic, :handle],
         value <- List.wrap(Keyword.get(opts, key)) do
       fact(entity, "mem/#{key}", to_string(value))
+    end
+
+    for key <- [:supersedes, :relates],
+        value <- List.wrap(Keyword.get(opts, key)) do
+      fact(entity, "mem/#{key}", mem_entity(to_string(value)))
     end
 
     case Keyword.get(opts, :body) do
@@ -53,17 +70,93 @@ defmodule IxMcp.Memory do
     rows
   end
 
-  @doc "Case-insensitive regex search over slugs, hooks, and topics."
-  @spec recall(String.t()) :: [map()]
-  def recall(pattern) do
-    p = pattern |> String.replace("\\", "\\\\") |> String.replace("\"", "\\\"")
+  @doc """
+  Case-insensitive regex search over slugs, hooks, and topics: whole-word
+  by default (`match: :substring` opts out, so `recall("hil")` stops
+  matching every hook containing "while"), newest first, `limit: 20`.
 
-    query("""
-    hit(E, D) :- latest(E, "mem/desc", D), regex(D, "(?i)#{p}").
-    hit(E, D) :- latest(E, "mem/topic", T), regex(T, "(?i)#{p}"), latest(E, "mem/desc", D).
-    hit(E, D) :- regex(E, "(?i)#{p}"), latest(E, "mem/desc", D).
-    ?- hit(E, D).
-    """)
+  Each row carries what trusting, fetching, or killing the memory needs:
+  `%{entity, id, seq, time, desc, type, topic, handle, body, verified_at}`.
+  `id` feeds `retract/1`, `seq`/`time` show staleness, `topic` is the
+  list of live tags, `body` is the CAS content resolved via `weave get`,
+  and `verified_at` is the latest re-check receipt (nil when never
+  verified, see `verify/2`).
+  """
+  @spec recall(String.t(), keyword()) :: [map()]
+  def recall(pattern, opts \\ []) do
+    opts = Keyword.validate!(opts, limit: @recall_limit, match: :word)
+    limit = Keyword.fetch!(opts, :limit)
+
+    rx =
+      case Keyword.fetch!(opts, :match) do
+        :word -> dl_string("(?i)\\b(?:#{pattern})\\b")
+        :substring -> dl_string("(?i)" <> pattern)
+      end
+
+    hits =
+      query("""
+      hit(E) :- latest(E, "mem/desc", D), regex(D, "#{rx}").
+      hit(E) :- fact(E, "mem/topic", T), regex(T, "#{rx}").
+      hit(E) :- latest(E, "mem/desc", _), regex(E, "#{rx}").
+      row(S, T, I, E, D) :- hit(E), latest(E, "mem/desc", D), fact_id(I, E, "mem/desc", D), fact_seq(I, S), fact_time(I, T).
+      ?- row(S, T, I, E, D) order S desc limit #{limit}.
+      """)
+
+    attrs = attrs(Enum.map(hits, & &1["E"]))
+
+    for %{"E" => entity, "D" => desc, "I" => id, "S" => seq, "T" => time} <-
+          Enum.uniq_by(hits, & &1["E"]) do
+      entity_attrs = Map.get(attrs, entity, %{})
+
+      %{
+        entity: entity,
+        id: id,
+        seq: seq,
+        time: DateTime.from_unix!(time, :millisecond),
+        desc: desc,
+        type: newest_value(entity_attrs, "mem/type"),
+        topic: live_values(entity_attrs, "mem/topic"),
+        handle: newest_value(entity_attrs, "mem/handle"),
+        body: body_text(entity_attrs),
+        verified_at: newest_value(entity_attrs, "mem/verified-at")
+      }
+    end
+  end
+
+  @doc """
+  The typed-edge neighborhood of `mem:<slug>`: every live entity-valued
+  fact (mem/supersedes, mem/relates, any future edge attribute) pointing
+  into or out of the entity, as `%{from, edge, to}` rows.
+  """
+  @spec graph(String.t()) :: [map()]
+  def graph(slug) do
+    anchor = dl_string("^" <> Regex.escape(mem_entity(slug)) <> "$")
+
+    rows =
+      query("""
+      edge(S, A, O) :- fact(S, A, O), regex(O, "^mem:").
+      hit(S, A, O) :- edge(S, A, O), regex(S, "#{anchor}").
+      hit(S, A, O) :- edge(S, A, O), regex(O, "#{anchor}").
+      ?- hit(S, A, O).
+      """)
+
+    for %{"S" => from, "A" => edge, "O" => to} <- rows, do: %{from: from, edge: edge, to: to}
+  end
+
+  @doc """
+  Record that a memory was re-checked against reality: appends a
+  `mem/verified-at` fact whose value is the UTC timestamp plus a
+  provenance string (`session:` overrides; the default is the kernel
+  session name, else CLAUDE_SESSION_ID, else user@host). `recall/2` rows
+  surface the receipt as `verified_at` and the SessionStart digest ranks
+  verified memories first, so verifying keeps a memory near the top.
+  Returns the fact id.
+  """
+  @spec verify(String.t(), keyword()) :: String.t()
+  def verify(slug, opts \\ []) do
+    session = Keyword.fetch!(Keyword.validate!(opts, session: nil), :session) || provenance()
+    stamp = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+    fact(mem_entity(slug), "mem/verified-at", "#{stamp} #{session}")
   end
 
   @doc "Retract a wrong fact by id (staleness prefers newer facts instead)."
@@ -81,6 +174,93 @@ defmodule IxMcp.Memory do
     after
       File.rm(path)
     end
+  end
+
+  @doc "Fetch a CAS blob by `blake3:<hex>` hash (verifies integrity)."
+  @spec get(String.t()) :: String.t()
+  def get(hash), do: run!(["get", hash])
+
+  # One query for every live `mem/` fact on the hit entities, keyed
+  # entity -> attribute -> [{seq, value}]. Sourced from fact/3 rather than
+  # latest/3 because latest keeps one value per (entity, attribute), which
+  # would collapse repeatable topics to the newest tag; latest-per-attribute
+  # for the scalar attributes is resolved in `newest_value/2`.
+  @spec attrs([String.t()]) :: %{String.t() => %{String.t() => [{integer(), String.t()}]}}
+  defp attrs([]), do: %{}
+
+  defp attrs(entities) do
+    anchor =
+      entities
+      |> Enum.uniq()
+      |> Enum.map_join("|", &Regex.escape/1)
+      |> then(&dl_string("^(?:#{&1})$"))
+
+    rows =
+      query("""
+      attr(S, E, A, V) :- fact(E, A, V), fact_id(I, E, A, V), fact_seq(I, S), regex(E, "#{anchor}"), regex(A, "^mem/").
+      ?- attr(S, E, A, V).
+      """)
+
+    rows
+    |> Enum.group_by(& &1["E"])
+    |> Map.new(fn {entity, entity_rows} ->
+      {entity, Enum.group_by(entity_rows, & &1["A"], &{&1["S"], &1["V"]})}
+    end)
+  end
+
+  @spec body_text(%{String.t() => [{integer(), String.t()}]}) :: String.t() | nil
+  defp body_text(by_attr) do
+    case newest_value(by_attr, "mem/body") do
+      nil -> nil
+      hash -> get(hash)
+    end
+  end
+
+  @spec newest_value(%{String.t() => [{integer(), String.t()}]}, String.t()) ::
+          String.t() | nil
+  defp newest_value(by_attr, attr) do
+    case Map.get(by_attr, attr) do
+      nil -> nil
+      pairs -> pairs |> Enum.max_by(fn {seq, _value} -> seq end) |> elem(1)
+    end
+  end
+
+  @spec live_values(%{String.t() => [{integer(), String.t()}]}, String.t()) :: [String.t()]
+  defp live_values(by_attr, attr) do
+    by_attr
+    |> Map.get(attr, [])
+    |> Enum.sort()
+    |> Enum.map(fn {_seq, value} -> value end)
+    |> Enum.uniq()
+  end
+
+  @spec mem_entity(String.t()) :: String.t()
+  defp mem_entity("mem:" <> _rest = entity), do: entity
+  defp mem_entity(slug), do: "mem:" <> slug
+
+  # Escape for embedding in a weave Datalog double-quoted string literal.
+  @spec dl_string(String.t()) :: String.t()
+  defp dl_string(s), do: s |> String.replace("\\", "\\\\") |> String.replace("\"", "\\\"")
+
+  @spec provenance() :: String.t()
+  defp provenance do
+    kernel_session() || System.get_env("CLAUDE_SESSION_ID") || user_at_host()
+  end
+
+  # The kernel names sessions via IxMcp.Session; outside a running kernel
+  # (plain IEx) the process is absent or the session unnamed, so fall through.
+  @spec kernel_session() :: String.t() | nil
+  defp kernel_session do
+    case Process.whereis(IxMcp.Session) do
+      nil -> nil
+      _pid -> IxMcp.Session.get().name
+    end
+  end
+
+  @spec user_at_host() :: String.t()
+  defp user_at_host do
+    {:ok, host} = :inet.gethostname()
+    "#{System.get_env("USER") || "unknown"}@#{host}"
   end
 
   @spec run!([String.t()]) :: String.t()

--- a/packages/mcp-ex/test/ix_mcp/memory_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/memory_test.exs
@@ -14,4 +14,87 @@ defmodule IxMcp.MemoryTest do
       if previous, do: System.put_env("WEAVE_MEMORY_STORE", previous)
     end
   end
+
+  # The module is a thin shell over the weave CLI, so the round-trip
+  # coverage needs the real binary: it runs on dev machines and compiles
+  # away in the sandboxed nix check, where weave is not staged.
+  if System.find_executable("weave") do
+    describe "against a throwaway store" do
+      alias IxMcp.Memory
+
+      setup do
+        store =
+          Path.join(System.tmp_dir!(), "ix-memory-test-#{System.unique_integer([:positive])}")
+
+        {_, 0} = System.cmd("weave", ["--store", store, "init"])
+        previous = System.get_env("WEAVE_MEMORY_STORE")
+        System.put_env("WEAVE_MEMORY_STORE", store)
+
+        on_exit(fn ->
+          case previous do
+            nil -> System.delete_env("WEAVE_MEMORY_STORE")
+            _ -> System.put_env("WEAVE_MEMORY_STORE", previous)
+          end
+
+          File.rm_rf!(store)
+        end)
+
+        :ok
+      end
+
+      test "recall matches whole words and returns rich rows" do
+        Memory.remember("loops", "while loops are tricky")
+
+        Memory.remember("hil-rig", "hil bench notes",
+          type: "reference",
+          topic: ["hardware", "lab"],
+          handle: "ssh hil",
+          body: "long-form hil notes"
+        )
+
+        # Word-boundary default: "hil" must not match "while".
+        assert [row] = Memory.recall("hil")
+        assert row.entity == "mem:hil-rig"
+        assert row.desc == "hil bench notes"
+        assert row.type == "reference"
+        assert row.topic == ["hardware", "lab"]
+        assert row.handle == "ssh hil"
+        assert row.body == "long-form hil notes"
+        assert row.verified_at == nil
+        assert String.starts_with?(row.id, "blake3:")
+        assert is_integer(row.seq)
+        assert %DateTime{} = row.time
+
+        substring = Memory.recall("hil", match: :substring)
+        assert substring |> Enum.map(& &1.entity) |> Enum.sort() == ["mem:hil-rig", "mem:loops"]
+
+        assert [_only] = Memory.recall("notes|tricky", limit: 1)
+      end
+
+      test "supersedes/relates become typed edges that graph walks" do
+        Memory.remember("old", "stale advice")
+        Memory.remember("peer", "adjacent note")
+        Memory.remember("new", "fresh advice", supersedes: "old", relates: ["peer"])
+
+        assert Enum.sort(Memory.graph("new")) == [
+                 %{from: "mem:new", edge: "mem/relates", to: "mem:peer"},
+                 %{from: "mem:new", edge: "mem/supersedes", to: "mem:old"}
+               ]
+
+        # The neighborhood is bidirectional: the superseded side sees the edge.
+        assert Memory.graph("old") == [
+                 %{from: "mem:new", edge: "mem/supersedes", to: "mem:old"}
+               ]
+      end
+
+      test "verify appends a receipt that recall surfaces" do
+        Memory.remember("claim", "checkable claim")
+        id = Memory.verify("claim", session: "sess-42")
+        assert String.starts_with?(id, "blake3:")
+
+        assert [row] = Memory.recall("checkable")
+        assert row.verified_at =~ ~r/^\d{4}-\d{2}-\d{2}T[0-9:.]+Z sess-42$/
+      end
+    end
+  end
 end

--- a/packages/site/src/lib/updates/memory-recall-edges-verify.svx
+++ b/packages/site/src/lib/updates/memory-recall-edges-verify.svx
@@ -10,6 +10,8 @@ links:
     href: https://github.com/indexable-inc/index/issues/3864
   - label: index#3865 (verification)
     href: https://github.com/indexable-inc/index/issues/3865
+  - label: PR #3870
+    href: https://github.com/indexable-inc/index/pull/3870
 ---
 
 Three gaps in the weave-backed agent memory (`IxMcp.Memory`, aliased `Memory` in the kernel) are closed.

--- a/packages/site/src/lib/updates/memory-recall-edges-verify.svx
+++ b/packages/site/src/lib/updates/memory-recall-edges-verify.svx
@@ -1,0 +1,23 @@
+---
+id: memory-recall-edges-verify
+postedAt: 2026-07-21T16:30:00-07:00
+title: "Agent memory: rich recall rows, typed edges, verification receipts"
+tags: [agents, weave, memory, claude-code]
+links:
+  - label: index#3863 (recall rows)
+    href: https://github.com/indexable-inc/index/issues/3863
+  - label: index#3864 (typed edges)
+    href: https://github.com/indexable-inc/index/issues/3864
+  - label: index#3865 (verification)
+    href: https://github.com/indexable-inc/index/issues/3865
+---
+
+Three gaps in the weave-backed agent memory (`IxMcp.Memory`, aliased `Memory` in the kernel) are closed.
+
+`Memory.recall/2` rows used to carry only the entity and its one-line hook, so trusting or killing a memory meant a manual journal dig. Rows now carry the fact id (feeds `Memory.retract/1`), seq and time (staleness is visible), type, the live topic tags, handle, the long-form body resolved from CAS via `weave get`, and the latest verification receipt. Matching is whole-word by default: `recall("hil")` no longer matches every hook containing "while" (`match: :substring` restores the old behavior), and `limit:` caps the rows at 20 unless raised.
+
+`Memory.remember/3` takes `supersedes:` and `relates:` opts whose values are `mem:` entities, written as entity-valued facts; weave treats those as typed edges, so a correction is an explicit `mem/supersedes` edge instead of an accident of newer-wins ordering. `Memory.graph(slug)` returns the edge neighborhood in both directions.
+
+`Memory.verify(slug)` appends a `mem/verified-at` fact holding the UTC timestamp and a provenance string (kernel session name, else CLAUDE_SESSION_ID, else user@host). The SessionStart digest now ranks hooks by verification freshness first and write recency second, so a re-checked memory outranks a merely recent one.
+
+*Written by Claude Code (Claude Opus 4.5), an AI coding agent.*

--- a/shell-allowlist.txt
+++ b/shell-allowlist.txt
@@ -182,7 +182,7 @@ users/andrewgazelka/config/scripts/git-wt-submodules.sh
 users/andrewgazelka/config/scripts/main-sync.sh
 users/andrewgazelka/home.nix:writeBashApplication:5
 users/andrewgazelka/profiles/darwin-home.nix:writeBashApplication:4
-users/andrewgazelka/profiles/workstation.nix:writeBashApplication:5
+users/andrewgazelka/profiles/workstation.nix:writeBashApplication:6
 users/andrewgazelka/scripts/ci-triage.sh
 users/andrewgazelka/scripts/ix-downtime.sh
 users/andrewgazelka/scripts/pr-watch.sh

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -117,10 +117,13 @@
       echo "## Memory"
       echo "Durable memory is a weave store at $store: append-only facts, Datalog-derived views."
       echo "Save at the moment of learning: Memory.remember(\"slug\", \"one-line hook\", type: \"project\", topic: \"nix\", handle: \"cmd/path\", body: long_md) in the index kernel."
-      echo "Recall: Memory.recall(\"regex\") or Memory.query(datalog). Recalled facts go stale; verify before use. Never edit history: newer facts win, Memory.retract(id) kills a wrong one."
+      echo "Recall: Memory.recall(\"regex\") (rich rows: id, time, type, topic, handle, body) or Memory.query(datalog). Recalled facts go stale; verify before use and record the re-check with Memory.verify(\"slug\") -- verified memories rank first below. Never edit history: newer facts win, Memory.retract(id) kills a wrong one."
       echo
-      echo "### Hooks (most recent first)"
-      ${lib.getExe cfg.packages.weave} --store "$store" query 'recent(S, E, D) :- latest(E, "mem/desc", D), fact_id(I, E, "mem/desc", D), fact_seq(I, S). ?- recent(S, E, D) order S desc limit 150.'
+      echo "### Hooks (freshest verification first, then recency)"
+      # Rank by the newest mem/verified-at seq per entity (0 when never
+      # verified), then by the desc fact's own seq: a re-checked memory
+      # outranks a merely recent one (index#3865).
+      ${lib.getExe cfg.packages.weave} --store "$store" query 'vseq(E, max(S)) :- fact_id(I, E, "mem/verified-at", V), fact_seq(I, S). rank(V, S, E, D) :- latest(E, "mem/desc", D), fact_id(I, E, "mem/desc", D), fact_seq(I, S), vseq(E, V). rank(0, S, E, D) :- latest(E, "mem/desc", D), fact_id(I, E, "mem/desc", D), fact_seq(I, S), not vseq(E, _). ?- rank(V, S, E, D) order V desc, S desc limit 150.'
       echo
       echo "### Counts by type"
       ${lib.getExe cfg.packages.weave} --store "$store" query 'per_type(T, count(E)) :- latest(E, "mem/type", T). ?- per_type(T, N) order N desc.'
@@ -240,12 +243,10 @@
     omitRules = agentPromptOmitRules ++ ["backgroundSubagents"];
     # SessionStart memory digest from the weave store; replaces the retired
     # MEMORY.md load (index#3849).
-    extraSessionStart = lib.optionals (cfg.packages.weave != null) [
-      {
-        package = memoryDigest;
-        timeout = 15;
-      }
-    ];
+    extraSessionStart = lib.optional (cfg.packages.weave != null) {
+      package = memoryDigest;
+      timeout = 15;
+    };
     # Matches agentPromptOmitRules `forceMerge` above: without this the baked
     # `Bash(gh pr merge*--admin*)` denies still hard-block what the omitted
     # rule permits.
@@ -359,12 +360,10 @@
       # discarded it, shipping prompts WITH the forceMerge rule (index#3537).
       omitRules = agentPromptOmitRules;
       # Same SessionStart memory digest as claudeCode above (index#3849).
-      extraSessionStart = lib.optionals (cfg.packages.weave != null) [
-        {
-          package = memoryDigest;
-          timeout = 15;
-        }
-      ];
+      extraSessionStart = lib.optional (cfg.packages.weave != null) {
+        package = memoryDigest;
+        timeout = 15;
+      };
     })
     // {
       # Upstream main keeps Cargo's workspace version at 0.0.0. Home Manager


### PR DESCRIPTION
Closes #3863, closes #3864, closes #3865. All three touch `packages/mcp-ex/lib/ix_mcp/memory.ex`, so one PR.

## What changed

**Recall rows (#3863).** `Memory.recall/2` rows now carry `entity`, `id` (feeds `retract/1`), `seq`, `time`, `desc`, `type`, `topic` (all live tags via `fact/3`; `latest/3` collapses repeatable tags to the newest write), `handle`, `body` (CAS content resolved with `weave get`), and `verified_at`. Matching is whole-word by default, so `recall("hil")` stops matching every hook containing "while"; `match: :substring` restores the old behavior. `limit:` defaults to 20.

**Typed edges (#3864).** `remember/3` takes `supersedes:` and `relates:` opts; values (slugs or `mem:` names) are written as entity-valued facts, which weave treats as typed edges. `Memory.graph(slug)` returns the bidirectional edge neighborhood via a Datalog query over `fact/3` (not `latest/3`, which would collapse multiple `relates` edges per entity).

**Verification (#3865).** `Memory.verify(slug)` appends `mem/verified-at` with a UTC timestamp plus provenance (kernel session name, else `CLAUDE_SESSION_ID`, else user@host). Recall rows surface it, and the SessionStart digest in `users/andrewgazelka/profiles/workstation.nix` ranks hooks by newest verification seq first (0 when never verified), then desc-fact seq. The rank query (aggregate `max` + `not` negation) was validated verbatim against a throwaway store.

The digest consumer keeps working: it issues its own raw `weave query` and never destructured recall rows; no code call site depends on the old `{E, D}` shape (checked every `Memory.*` reference in the repo). Docstrings, the kernel tool text, and the README row are synced.

Two latent lint findings surfaced by touching `workstation.nix`: `lib.optionals cond [x]` collapsed to `lib.optional cond x` (two sites), and the shell-allowlist entry for the file was stale at 5 while main already has 6 `writeBashApplication` call sites (the 6th landed in 40965a94); the entry now matches reality, no new shell was added.

## Testing

- `packages/mcp-ex/test/ix_mcp/memory_test.exs` gains round-trip coverage against a throwaway store (`weave --store <dir> init`, `--offline` writes): word-boundary vs substring recall, limit, rich row fields, graph edges both directions, verify receipt surfacing. Compile-time guarded on a `weave` binary, so the sandboxed nix check (no weave staged) compiles it away.
- `mix test`: 107 tests, 0 failures locally (weave tests included); `nix build .#packages.aarch64-darwin.mcp-ex.tests.elixir` green (compile with warnings-as-errors, format, credo strict, ExUnit).
- `nix run .#lint`: 13 tasks green.

Update page: `packages/site/src/lib/updates/memory-recall-edges-verify.svx`.

Written by an AI agent (Claude Opus 4.5 via Claude Code).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enrich Memory recall with typed edges, rich rows, and verification receipts
> - `Memory.recall/2` now returns enriched rows (id, seq, time, type, topics, handle, body text, verified_at) with whole-word regex matching by default; accepts `:match` (`:word` or `:substring`) and `:limit` (default 20) options.
> - `Memory.remember/3` accepts `:supersedes` and `:relates` options that write typed entity-valued edges, using either slugs or `mem:`-prefixed values.
> - `Memory.graph/1` returns the bidirectional edge neighborhood for a given slug by querying all `mem/*` entity-valued facts that originate from or target it.
> - `Memory.verify/2` appends a `mem/verified-at` receipt with a UTC timestamp and provenance string derived from the kernel session, `CLAUDE_SESSION_ID`, or `USER@hostname`.
> - The workstation memory report now ranks hooks by most recently verified first, then by recency.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 185fb3d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->