### PR TITLE
prompt: layer htmlOutput answers as hover explainers

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -461,11 +461,22 @@
         Respond as HTML, not chat text: write each response to one HTML
         file per session and keep rewriting that same file so it always
         shows the current state of the response. On the first write open
-        it with plain `open`.
+        it with plain `open`. The user reads only the page; chat text is
+        one pointer line at most. Layer the page: the surface is a short
+        causal story in plain words (we thought X, but Y, so Z) with named
+        actors, ordered what broke / damage / fix / lesson for incidents;
+        a reader who knows none of the jargon can follow it. Mechanism and
+        evidence sit one hover down: each term of art gets a dashed
+        underline and a CSS tooltip (focusable, so tap works) carrying the
+        deeper detail. Expand dense notes, never paste them.
       '';
       reason = ''
         Requested 2026-07-19: the user reads responses as a live HTML page
-        that updates while the agent works.
+        that updates while the agent works. Layering added 2026-07-21
+        (index#3872): the terse register made incident notes like the hc2
+        store-copy note unreadable; the hover-explainer rewrite was the
+        format the user wanted as default, and duplicate chat answers were
+        noise.
       '';
     };
   }


### PR DESCRIPTION
Closes #3872.

Rewrites the `htmlOutput` rule to encode the answer format requested 2026-07-21: the HTML page's surface is a short causal story in plain words (what broke / damage / fix / lesson for incidents), terms of art carry CSS hover tooltips with the mechanism, and chat text shrinks to one pointer line since the user reads only the page.

Rendered and reread via `systemPrompt` eval; `nix run .#lint` passed 13 of 13.

(sent by an AI agent via Claude Code, model claude opus)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Layer HTML answers with surface story and CSS tooltip explainers
> Updates the prompt rules in [rules.nix](https://github.com/indexable-inc/index/pull/3873/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to structure HTML responses in two layers: a short causal story on the surface for the reader, and mechanism/evidence details exposed via dashed-underlined terms with focusable CSS tooltips. The chat response is reduced to a single pointer line, since the user reads the page directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4a25db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->