### PR TITLE
mcp-ex: announce newly filed GitHub issues on the channel

### DIFF
--- a/packages/mcp-ex/README.md
+++ b/packages/mcp-ex/README.md
@@ -140,6 +140,7 @@ IxMcp.Supervisor (one_for_one)
 ├── IxMcp.Jobs.History     ordered record of every run
 ├── IxMcp.MCP.Notifier     server-initiated notification fan-out
 ├── IxMcp.PrWatch.Supervisor (Task.Supervisor) one task per PR watch
+├── IxMcp.IssueWatch       new-issue channel feed (stdio-gated, `gh search issues`)
 └── IxMcp.MCP.Stdio        newline-delimited JSON-RPC on stdin/stdout
 ```
 

--- a/packages/mcp-ex/lib/ix_mcp/application.ex
+++ b/packages/mcp-ex/lib/ix_mcp/application.ex
@@ -14,6 +14,7 @@ defmodule IxMcp.Application do
       ├── IxMcp.Jobs.Supervisor (DynamicSupervisor)  one child per cell/job
       │   └── IxMcp.Jobs.Job*   runs one evaluation in a monitored process
       ├── IxMcp.PrWatch.Supervisor (Task.Supervisor)  one task per PR watch
+      ├── IxMcp.IssueWatch      (only when IX_MCP_STDIO=1) new-issue channel feed
       ├── IxMcp.Agents.Harness     (AgentHarness) depth-1 subagent processes (#3700)
       ├── IxMcp.Agents.Events      subagent ledger: events, finals, graph, notifications
       └── IxMcp.MCP.Stdio       (only when IX_MCP_STDIO=1) the stdio transport
@@ -51,7 +52,7 @@ defmodule IxMcp.Application do
         # ledger that drains its lead mailbox.
         {AgentHarness, name: IxMcp.Agents.Harness, runner: IxMcp.Agents.CliRunner},
         {IxMcp.Agents.Events, harness: IxMcp.Agents.Harness}
-      ] ++ transport()
+      ] ++ issue_watch() ++ transport()
 
     Supervisor.start_link(children, strategy: :one_for_one, name: IxMcp.Supervisor)
   end
@@ -123,6 +124,16 @@ defmodule IxMcp.Application do
   # sweep of leftover `running` action rows). A safe implementation must
   # scope strictly to this instance's own jobs (by session), which needs a
   # durable instance identity that outlives a restart -- out of scope here.
+  # The issue feed announces into a user-facing transport and polls GitHub,
+  # so it rides the same flag as the transport: `mix test` and IEx sessions
+  # get neither (#3877).
+  defp issue_watch do
+    case System.get_env("IX_MCP_STDIO") do
+      "1" -> [IxMcp.IssueWatch]
+      _ -> []
+    end
+  end
+
   defp transport do
     case System.get_env("IX_MCP_STDIO") do
       "1" -> [IxMcp.MCP.Stdio]

--- a/packages/mcp-ex/lib/ix_mcp/issue_watch.ex
+++ b/packages/mcp-ex/lib/ix_mcp/issue_watch.ex
@@ -1,0 +1,144 @@
+defmodule IxMcp.IssueWatch do
+  @moduledoc """
+  Always-on feed of newly filed GitHub issues, announced on the channel the
+  way job finishes are. Background agents (retros, auto-fix dispatches) file
+  issues from sessions nobody watches, so without a push they sit unseen
+  until someone happens to run `gh issue list` (#3877). One loop per kernel
+  instance polls `gh search issues` for issues created since the last sweep
+  and pushes each new one as a `source="issues"` channel notification.
+
+  Watched owners come from `IX_MCP_ISSUE_WATCH_OWNERS` (comma-separated,
+  default `indexable-inc`); an empty value disables the feed. The loop
+  starts only alongside the stdio transport (`IxMcp.Application`), so
+  `mix test` and IEx sessions never poll GitHub.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias IxMcp.Cmd
+  alias IxMcp.MCP.Notifier
+
+  @default_owners ["indexable-inc"]
+  @interval_ms 60_000
+  # One page bounds a sweep; more issues than this filed inside one interval
+  # is a storm, and the next sweep's >= window picks up the remainder anyway.
+  @page_limit 50
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @impl true
+  def init(opts) do
+    owners = Keyword.get(opts, :owners, env_owners())
+    gh = Keyword.get(opts, :gh, default_gh())
+
+    cond do
+      owners == [] ->
+        :ignore
+
+      gh == nil ->
+        Logger.error("IssueWatch disabled: gh not found (no IX_MCP_GH, none on PATH)")
+        :ignore
+
+      true ->
+        state = %{
+          gh: gh,
+          owners: owners,
+          interval_ms: Keyword.get(opts, :interval_ms, @interval_ms),
+          since: DateTime.utc_now(:second),
+          seen: MapSet.new()
+        }
+
+        {:ok, schedule(state)}
+    end
+  end
+
+  @impl true
+  def handle_info(:poll, state) do
+    {:noreply, state |> sweep() |> schedule()}
+  end
+
+  defp schedule(state) do
+    Process.send_after(self(), :poll, state.interval_ms)
+    state
+  end
+
+  defp sweep(state) do
+    case search(state) do
+      {:ok, issues} ->
+        issues
+        |> Enum.reject(fn issue -> MapSet.member?(state.seen, issue["url"]) end)
+        |> Enum.each(&announce/1)
+
+        advance(state, issues)
+
+      {:error, detail} ->
+        # A failed sweep resolves itself next tick (gh hiccup, rate limit,
+        # network); log it rather than turn the channel into a heartbeat.
+        Logger.warning("IssueWatch sweep failed: #{detail}")
+        state
+    end
+  end
+
+  # created:>= re-reads the boundary second, so `seen` (the previous sweep's
+  # URLs) is what keeps a same-second issue from announcing twice.
+  defp search(state) do
+    args =
+      ["search", "issues", "--sort", "created", "--order", "asc"] ++
+        ["--limit", Integer.to_string(@page_limit)] ++
+        ["--created", ">=" <> DateTime.to_iso8601(state.since)] ++
+        ["--json", "number,title,url,repository,author,createdAt"] ++
+        Enum.flat_map(state.owners, fn owner -> ["--owner", owner] end)
+
+    case Cmd.run(state.gh, args, stderr_to_stdout: true) do
+      {out, 0} ->
+        case JSON.decode(out) do
+          {:ok, issues} when is_list(issues) -> {:ok, issues}
+          _ -> {:error, "unparseable gh output: #{String.slice(out, 0, 200)}"}
+        end
+
+      {out, _nonzero} ->
+        {:error, String.slice(out, 0, 400)}
+    end
+  end
+
+  defp announce(issue) do
+    repo = get_in(issue, ["repository", "nameWithOwner"]) || "?"
+    author = get_in(issue, ["author", "login"]) || "?"
+    ref = "#{repo}##{issue["number"]}"
+
+    Notifier.channel(
+      "issue filed: #{ref} by #{author}: #{issue["title"]}\n#{issue["url"]}",
+      %{"source" => "issues", "issue" => ref, "author" => author, "level" => "info"}
+    )
+  end
+
+  defp advance(state, []), do: state
+
+  defp advance(state, issues) do
+    since =
+      issues
+      |> Enum.map(fn issue ->
+        {:ok, created, _offset} = DateTime.from_iso8601(issue["createdAt"])
+        created
+      end)
+      |> Enum.max(DateTime)
+
+    %{state | since: since, seen: MapSet.new(issues, fn issue -> issue["url"] end)}
+  end
+
+  defp env_owners do
+    case System.get_env("IX_MCP_ISSUE_WATCH_OWNERS") do
+      nil -> @default_owners
+      value -> value |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+    end
+  end
+
+  defp default_gh do
+    System.get_env("IX_MCP_GH") || System.find_executable("gh")
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -52,7 +52,11 @@ defmodule IxMcp.MCP.Tools do
                                             CI? Pair it with `gh pr checks <pr>
                                             --watch --fail-fast`: checks alone hang
                                             forever on a CONFLICTING PR (dirty PRs
-                                            skip CI) and never show a merge (#3548)
+                                            skip CI) and never show a merge (#3548).
+                                            Issues need no watcher: every issue
+                                            filed in a watched org (default
+                                            indexable-inc) arrives unprompted as a
+                                            source="issues" channel notification
       Tui.act(uri, send_keys)               drive a federated TUI resource (optional
                                             peer arg)
       TuiLocal.spawn(cmd, args)             spawn a local PTY program (vim, less, a

--- a/packages/mcp-ex/test/ix_mcp/issue_watch_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/issue_watch_test.exs
@@ -1,0 +1,75 @@
+defmodule IxMcp.IssueWatchTest do
+  use ExUnit.Case, async: false
+
+  alias IxMcp.IssueWatch
+  alias IxMcp.MCP.Notifier
+
+  @moduletag :tmp_dir
+
+  test "empty owners disables the watcher" do
+    assert :ignore = IssueWatch.start_link(owners: [], name: nil)
+  end
+
+  test "announces a newly filed issue once", %{tmp_dir: dir} do
+    created = DateTime.utc_now() |> DateTime.add(60) |> DateTime.to_iso8601()
+
+    fixture = Path.join(dir, "issues.json")
+
+    File.write!(
+      fixture,
+      JSON.encode!([
+        %{
+          "number" => 3877,
+          "title" => "kernel: notify on issue filing",
+          "url" => "https://github.com/indexable-inc/index/issues/3877",
+          "repository" => %{"nameWithOwner" => "indexable-inc/index"},
+          "author" => %{"login" => "andrewgazelka"},
+          "createdAt" => created
+        }
+      ])
+    )
+
+    # A gh stand-in that answers every search with the same fixture: the
+    # first sweep must announce the issue, every later sweep must dedupe it.
+    gh = Path.join(dir, "gh")
+    File.write!(gh, "#!/bin/sh\nexec cat #{fixture}\n")
+    File.chmod!(gh, 0o755)
+
+    Notifier.register(self())
+    # register/1 is a cast; sync on the Notifier so the sweep's notify cast
+    # cannot be processed ahead of the registration.
+    _ = :sys.get_state(Notifier)
+
+    # Own name: under a kernel-launched shell IX_MCP_STDIO=1 leaks into
+    # mix test, so the application boot already registered the global
+    # IssueWatch and the default name collides.
+    start_supervised!(
+      {IssueWatch,
+       gh: gh, owners: ["indexable-inc"], interval_ms: 25, name: :issue_watch_under_test}
+    )
+
+    # Pin to the fixture's ref: a globally started IssueWatch (see above)
+    # could announce a real issue in this window.
+    assert_receive {:mcp_send,
+                    %{
+                      "method" => "notifications/claude/channel",
+                      "params" =>
+                        %{
+                          "meta" => %{"source" => "issues", "issue" => "indexable-inc/index#3877"}
+                        } =
+                          params
+                    }},
+                   5_000
+
+    assert %{"content" => content, "meta" => meta} = params
+    assert meta["author"] == "andrewgazelka"
+    assert content =~ "kernel: notify on issue filing"
+    assert content =~ "issues/3877"
+
+    # Several more sweeps run inside this window; the seen set must swallow
+    # the unchanged search result instead of re-announcing it.
+    refute_receive {:mcp_send,
+                    %{"params" => %{"meta" => %{"issue" => "indexable-inc/index#3877"}}}},
+                   200
+  end
+end


### PR DESCRIPTION
Closes #3877.

Job finishes and PR watches already push channel notifications; issues filed by background agents arrived silently. This adds `IxMcp.IssueWatch`, an always-on poller (`gh search issues --owner indexable-inc`, 60s interval) that announces each newly created issue as a `source="issues"` channel notification with repo#number, title, author, and url.

- Started only alongside the stdio transport, so `mix test` and IEx never poll GitHub.
- `IX_MCP_ISSUE_WATCH_OWNERS` (comma-separated) overrides the watched owners; empty disables.
- Sweep failures log and retry next tick instead of spamming the channel.
- `created:>=` re-reads the boundary second; the previous sweep's URL set dedupes it.

Tested: `mix test` 110/110 in packages/mcp-ex, including a new test driving a fake `gh` through a real Notifier transport (announce once, dedupe on later sweeps).

(sent by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `IxMcp.IssueWatch` to announce newly filed GitHub issues as channel notifications
> - Adds a new `IxMcp.IssueWatch` GenServer that periodically polls GitHub via the `gh` CLI for newly created issues, announcing each as a channel notification with `source='issues'` metadata.
> - The watcher is conditionally started in the supervision tree when `IX_MCP_STDIO=1` and self-disables when no owners are configured or `gh` is unavailable.
> - Owners are configured via `IX_MCP_ISSUE_WATCH_OWNERS` (comma-separated); defaults to `indexable-inc`. The `gh` binary can be overridden via `IX_MCP_GH`.
> - Deduplication prevents repeat announcements for issues sharing the same `createdAt` timestamp across consecutive sweeps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84b43d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->