### PR TITLE
mcp-ex: atomic issue pickup via the shared claim arbiter (#3880)

### DIFF
--- a/packages/mcp-ex/README.md
+++ b/packages/mcp-ex/README.md
@@ -69,6 +69,7 @@ list):
 | `Ix.trace()` | stack dump of every job's processes, from outside |
 | `Ix.restart()` | cancel jobs (sparing the calling cell), restart the workspace, restore bindings |
 | `PrWatch.start(pr, cwd, interval \\ 15, timeout \\ 3600)` | watch a PR via `gh`, notify on merge/close/timeout |
+| `Issues.pickup(3880)` | claim an issue atomically before working it (also `"owner/repo#n"`); a lost claim names the session that won |
 | `Tui.act(uri, send_keys, peer \\ nil)` | drive a federated TUI resource via `ix-resource-cli` |
 
 Because cells are separate BEAM processes, `Ix.trace/0` and `Ix.restart/0`
@@ -140,7 +141,7 @@ IxMcp.Supervisor (one_for_one)
 ├── IxMcp.Jobs.History     ordered record of every run
 ├── IxMcp.MCP.Notifier     server-initiated notification fan-out
 ├── IxMcp.PrWatch.Supervisor (Task.Supervisor) one task per PR watch
-├── IxMcp.IssueWatch       new-issue channel feed (stdio-gated, `gh search issues`)
+├── IxMcp.IssueWatch       new-issue + pickup-claim channel feed (stdio-gated, `gh search issues`)
 └── IxMcp.MCP.Stdio        newline-delimited JSON-RPC on stdin/stdout
 ```
 

--- a/packages/mcp-ex/lib/ix_mcp/action_log.ex
+++ b/packages/mcp-ex/lib/ix_mcp/action_log.ex
@@ -79,6 +79,16 @@ defmodule IxMcp.ActionLog do
   CREATE TABLE outbox (id INTEGER PRIMARY KEY, job_id TEXT, intent TEXT, status TEXT NOT NULL, elapsed_ms INTEGER, result TEXT, created_at TEXT NOT NULL, acked INTEGER NOT NULL DEFAULT 0)
   """
 
+  # index#3880: the arbiter for issue pickup. Every kernel instance on a host
+  # shares this database, so the UNIQUE(repo, number) constraint IS the
+  # atomic claim: the winning INSERT gets the row, every later attempt reads
+  # the winner back. Known limit, by design: the database is per host, so
+  # cross-machine claims race; the GitHub assignee mirror in `IxMcp.Issues`
+  # is not compare-and-set, so it stays a mirror, not the arbiter.
+  @create_issue_claims """
+  CREATE TABLE issue_claims (id INTEGER PRIMARY KEY, repo TEXT NOT NULL, number INTEGER NOT NULL, session_id INTEGER REFERENCES sessions(id), claimed_at TEXT NOT NULL, UNIQUE(repo, number))
+  """
+
   # index#3539: the schema version is stamped into SQLite's `PRAGMA
   # user_version` header field instead of being re-derived by column
   # sniffing on every open. Sniffing can only classify shapes this binary
@@ -89,8 +99,9 @@ defmodule IxMcp.ActionLog do
   # version makes older shapes migratable in order, the current shape a
   # no-op, and a future shape explicitly detectable. The ladder: 1 = the
   # flat #3512 log, 2 = the #3532 normalization, 3 = the #3536 live rows,
-  # 4 = the #3546 live cell line, 5 = the #3839 durable job ledger.
-  @user_version 5
+  # 4 = the #3546 live cell line, 5 = the #3839 durable job ledger,
+  # 6 = the #3880 issue-claim arbiter.
+  @user_version 6
 
   # Frozen historical DDL for the 1 -> 2 step: the actions shape exactly as
   # #3532 shipped it, before the live-row columns. A migration must never
@@ -150,6 +161,10 @@ defmodule IxMcp.ActionLog do
   # tables are simply created empty, so pre-#3839 rows are untouched.
   @migrate_v4_to_v5 [@create_jobs, @create_job_output, @create_outbox]
 
+  # A v5 database predates the issue-claim arbiter (#3880): the table is
+  # simply created empty.
+  @migrate_v5_to_v6 [@create_issue_claims]
+
   # Ordered migrations keyed by the user_version each upgrades FROM. Every
   # step runs in one immediate transaction that also stamps the version it
   # produces, so an interrupted migration leaves the previous consistent,
@@ -158,7 +173,8 @@ defmodule IxMcp.ActionLog do
     {1, @migrate_v1_to_v2},
     {2, @migrate_v2_to_v3},
     {3, @migrate_v3_to_v4},
-    {4, @migrate_v4_to_v5}
+    {4, @migrate_v4_to_v5},
+    {5, @migrate_v5_to_v6}
   ]
 
   @insert """
@@ -188,6 +204,12 @@ defmodule IxMcp.ActionLog do
   @select_job """
   SELECT id, intent, session_name, topic_name, code, status, watch, result, output_bytes, output_dropped, started_at, finished_at, elapsed_ms
   FROM jobs
+  """
+
+  @select_issue_claim """
+  SELECT c.id, c.repo, c.number, c.session_id, s.name, c.claimed_at
+  FROM issue_claims c
+  LEFT JOIN sessions s ON s.id = c.session_id
   """
 
   @type entry :: %{
@@ -232,6 +254,19 @@ defmodule IxMcp.ActionLog do
           started_at: String.t(),
           finished_at: String.t() | nil,
           elapsed_ms: non_neg_integer() | nil
+        }
+
+  @typedoc """
+  A recorded issue claim (#3880): `session` is the claiming sessions row's
+  name (nil when that session never named itself).
+  """
+  @type issue_claim :: %{
+          id: integer(),
+          repo: String.t(),
+          number: integer(),
+          session_id: integer() | nil,
+          session: String.t() | nil,
+          claimed_at: String.t()
         }
 
   @typedoc "A terminal-transition notification awaiting delivery (#3839)."
@@ -366,6 +401,40 @@ defmodule IxMcp.ActionLog do
   @spec recent_jobs(integer() | nil, pos_integer(), GenServer.server()) :: [job()]
   def recent_jobs(session_id, n \\ 20, server \\ __MODULE__) do
     GenServer.call(server, {:recent_jobs, session_id, n})
+  end
+
+  # -- issue-claim arbiter (#3880) --------------------------------------------
+
+  @doc """
+  Atomically claim `repo#number` for `session_id`. The shared database's
+  UNIQUE(repo, number) is the arbiter: the winning insert returns
+  `{:ok, claim}`, a conflict returns `{:error, winner}` with the standing
+  claim (including the winning session's name) so the loser can say who got
+  there first. `:disabled` when the log is degraded (#3539) -- with no
+  arbiter there is no claim to win.
+  """
+  @spec claim_issue(String.t(), integer(), integer() | nil, GenServer.server()) ::
+          {:ok, issue_claim()} | {:error, issue_claim()} | :disabled
+  def claim_issue(repo, number, session_id, server \\ __MODULE__)
+      when is_binary(repo) and is_integer(number) do
+    GenServer.call(server, {:claim_issue, repo, number, session_id, now()})
+  end
+
+  @doc """
+  Claims with id greater than `id`, oldest first. The cursor is the caller's
+  own watermark, per instance on purpose: several kernel instances share this
+  database and each must announce every claim to its own client, so a shared
+  announced flag (first sweeper wins) would silence all but one (#3880).
+  """
+  @spec issue_claims_after(integer(), GenServer.server()) :: [issue_claim()]
+  def issue_claims_after(id, server \\ __MODULE__) do
+    GenServer.call(server, {:issue_claims_after, id})
+  end
+
+  @doc "The highest issue-claim id (0 when none): a fresh watermark for `issue_claims_after/2`."
+  @spec last_issue_claim_id(GenServer.server()) :: integer()
+  def last_issue_claim_id(server \\ __MODULE__) do
+    GenServer.call(server, :last_issue_claim_id)
   end
 
   @doc """
@@ -645,6 +714,36 @@ defmodule IxMcp.ActionLog do
     {:reply, Enum.map(rows, &job_row_to_map/1), state}
   end
 
+  # The INSERT OR IGNORE plus the changes count is the whole race (#3880):
+  # a unique-constraint winner changes one row, every loser changes zero and
+  # reads the winner back. The single-writer GenServer serializes claims from
+  # this instance; claims from sibling instances serialize on SQLite itself.
+  def handle_call({:claim_issue, repo, number, session_id, at}, _from, %{conn: conn} = state) do
+    run(
+      conn,
+      "INSERT OR IGNORE INTO issue_claims (repo, number, session_id, claimed_at) VALUES (?, ?, ?, ?)",
+      [repo, number, session_id, at]
+    )
+
+    {:ok, changes} = Sqlite3.changes(conn)
+
+    [row] =
+      fetch(conn, @select_issue_claim <> " WHERE c.repo = ? AND c.number = ?", [repo, number])
+
+    claim = issue_claim_row_to_map(row)
+    {:reply, if(changes == 1, do: {:ok, claim}, else: {:error, claim}), state}
+  end
+
+  def handle_call({:issue_claims_after, id}, _from, %{conn: conn} = state) do
+    rows = fetch(conn, @select_issue_claim <> " WHERE c.id > ? ORDER BY c.id", [id])
+    {:reply, Enum.map(rows, &issue_claim_row_to_map/1), state}
+  end
+
+  def handle_call(:last_issue_claim_id, _from, %{conn: conn} = state) do
+    [[id]] = fetch(conn, "SELECT COALESCE(MAX(id), 0) FROM issue_claims", [])
+    {:reply, id, state}
+  end
+
   def handle_call({:unacked_outbox, session_id}, _from, %{conn: conn} = state) do
     {sql, params} =
       case session_id do
@@ -721,6 +820,7 @@ defmodule IxMcp.ActionLog do
           "status" not in columns -> 2
           "line" not in columns -> 3
           not table_exists?(conn, "jobs") -> 4
+          not table_exists?(conn, "issue_claims") -> 5
           true -> @user_version
         end
     end
@@ -741,6 +841,7 @@ defmodule IxMcp.ActionLog do
         @create_jobs,
         @create_job_output,
         @create_outbox,
+        @create_issue_claims,
         stamp(),
         "COMMIT"
       ]
@@ -764,6 +865,9 @@ defmodule IxMcp.ActionLog do
   defp disabled_reply({:create_topic, _session_id, _name, _at}), do: 0
   defp disabled_reply({:start_action, _action}), do: 0
   defp disabled_reply({:finish_job, _id, _status, _result, _at}), do: :already_final
+  defp disabled_reply({:claim_issue, _repo, _number, _session_id, _at}), do: :disabled
+  defp disabled_reply({:issue_claims_after, _id}), do: []
+  defp disabled_reply(:last_issue_claim_id), do: 0
   defp disabled_reply({:job, _id}), do: nil
   defp disabled_reply({:job_output, _id}), do: ""
   defp disabled_reply({:recent_jobs, _session_id, _n}), do: []
@@ -856,6 +960,17 @@ defmodule IxMcp.ActionLog do
       started_at: started_at,
       finished_at: finished_at,
       elapsed_ms: elapsed_ms
+    }
+  end
+
+  defp issue_claim_row_to_map([id, repo, number, session_id, session, claimed_at]) do
+    %{
+      id: id,
+      repo: repo,
+      number: number,
+      session_id: session_id,
+      session: session,
+      claimed_at: claimed_at
     }
   end
 

--- a/packages/mcp-ex/lib/ix_mcp/issue_watch.ex
+++ b/packages/mcp-ex/lib/ix_mcp/issue_watch.ex
@@ -11,12 +11,21 @@ defmodule IxMcp.IssueWatch do
   default `indexable-inc`); an empty value disables the feed. The loop
   starts only alongside the stdio transport (`IxMcp.Application`), so
   `mix test` and IEx sessions never poll GitHub.
+
+  The same sweep also announces issue pickups (#3880): claims sessions win
+  through `IxMcp.Issues.pickup/1` land in the shared actions.db, and each
+  sweep pushes the ones this instance has not yet announced as
+  `event="picked_up"` notifications. The cursor is a per-instance claim-id
+  watermark (starting at the newest claim on boot), NOT a shared announced
+  flag: every instance on the host must tell its own client, and a shared
+  flag would let the first sweeper silence all the others.
   """
 
   use GenServer
 
   require Logger
 
+  alias IxMcp.ActionLog
   alias IxMcp.Cmd
   alias IxMcp.MCP.Notifier
 
@@ -45,12 +54,18 @@ defmodule IxMcp.IssueWatch do
         :ignore
 
       true ->
+        action_log = Keyword.get(opts, :action_log, ActionLog)
+
         state = %{
           gh: gh,
           owners: owners,
           interval_ms: Keyword.get(opts, :interval_ms, @interval_ms),
           since: DateTime.utc_now(:second),
-          seen: MapSet.new()
+          seen: MapSet.new(),
+          action_log: action_log,
+          # Claims standing before this instance booted are old news; only
+          # pickups from here on announce (the filed-issue feed's since: now).
+          claims_since: ActionLog.last_issue_claim_id(action_log)
         }
 
         {:ok, schedule(state)}
@@ -59,7 +74,7 @@ defmodule IxMcp.IssueWatch do
 
   @impl true
   def handle_info(:poll, state) do
-    {:noreply, state |> sweep() |> schedule()}
+    {:noreply, state |> sweep() |> sweep_claims() |> schedule()}
   end
 
   defp schedule(state) do
@@ -104,6 +119,37 @@ defmodule IxMcp.IssueWatch do
       {out, _nonzero} ->
         {:error, String.slice(out, 0, 400)}
     end
+  end
+
+  # Pickup fan-out (#3880): read past the watermark, announce, advance. The
+  # claim rows come from the shared database, so this hears every session on
+  # the host, including this instance's own pickups (harmless: the picker
+  # already knows, and one notification tells its transcript too).
+  defp sweep_claims(state) do
+    case ActionLog.issue_claims_after(state.claims_since, state.action_log) do
+      [] ->
+        state
+
+      claims ->
+        Enum.each(claims, &announce_claim/1)
+        %{state | claims_since: claims |> Enum.map(& &1.id) |> Enum.max()}
+    end
+  end
+
+  defp announce_claim(claim) do
+    ref = "#{claim.repo}##{claim.number}"
+    label = claim.session || "##{claim.session_id || "?"}"
+
+    Notifier.channel(
+      "issue picked up: #{ref} by session #{label} at #{claim.claimed_at}",
+      %{
+        "source" => "issues",
+        "event" => "picked_up",
+        "issue" => ref,
+        "session" => label,
+        "level" => "info"
+      }
+    )
   end
 
   defp announce(issue) do

--- a/packages/mcp-ex/lib/ix_mcp/issues.ex
+++ b/packages/mcp-ex/lib/ix_mcp/issues.ex
@@ -1,0 +1,95 @@
+defmodule IxMcp.Issues do
+  @moduledoc """
+  Atomic issue pickup (#3880): `Issues.pickup/1` from any cell claims a
+  GitHub issue before a session starts working it, so two agents hearing the
+  same `source="issues"` announcement (#3877) cannot both take it. The
+  arbiter is the shared actions.db every kernel instance on a host already
+  opens (`IxMcp.ActionLog`): a UNIQUE(repo, number) insert either wins the
+  claim or reads back who beat this session to it. A won claim mirrors
+  itself to GitHub with `gh issue edit --add-assignee @me`, best effort --
+  visibility off-host, never arbitration -- and `IxMcp.IssueWatch` announces
+  it to every session on the host as an `event="picked_up"` channel
+  notification.
+
+  Known limit, by design: actions.db is per host, so claims race across
+  machines, and GitHub assignment is not compare-and-set, so it stays a
+  mirror. Revisit if the fleet needs cross-host claims.
+  """
+
+  alias IxMcp.ActionLog
+  alias IxMcp.Cmd
+  alias IxMcp.Session
+
+  @default_repo "indexable-inc/index"
+
+  @doc """
+  Claim an issue: a bare number claims it on `#{@default_repo}`, a
+  `"owner/repo#n"` string claims it anywhere. Returns `{:ok, detail}` when
+  this session won -- work the issue -- or `{:error, "claimed by session
+  <label> at <time>"}` when another session got there first: pick a
+  different issue.
+
+  Options exist for tests: `:gh` (the executable to mirror the claim with;
+  nil skips), `:action_log` (the arbiter server), `:session_id` (the
+  claiming sessions row).
+  """
+  @spec pickup(integer() | String.t(), keyword()) :: {:ok, String.t()} | {:error, String.t()}
+  def pickup(ref, opts \\ [])
+
+  def pickup(number, opts) when is_integer(number) and number > 0 do
+    claim(@default_repo, number, opts)
+  end
+
+  def pickup(ref, opts) when is_binary(ref) do
+    case Regex.run(~r{\A([\w.-]+/[\w.-]+)#(\d+)\z}, ref) do
+      [_, repo, number] ->
+        claim(repo, String.to_integer(number), opts)
+
+      nil ->
+        {:error, "unrecognized issue ref #{inspect(ref)}; pass an integer or \"owner/repo#n\""}
+    end
+  end
+
+  defp claim(repo, number, opts) do
+    log = Keyword.get(opts, :action_log, ActionLog)
+    session_id = Keyword.get_lazy(opts, :session_id, fn -> Session.ids().session_id end)
+
+    case ActionLog.claim_issue(repo, number, session_id, log) do
+      {:ok, claim} ->
+        {:ok, "claimed #{repo}##{number} at #{claim.claimed_at}#{assign(repo, number, opts)}"}
+
+      {:error, winner} ->
+        {:error, "claimed by session #{label(winner)} at #{winner.claimed_at}"}
+
+      :disabled ->
+        # No arbiter, no claim: pretending to win here is exactly the double
+        # pickup this module exists to prevent.
+        {:error, "action log disabled (#3539); no arbiter to claim through"}
+    end
+  end
+
+  # The GitHub mirror is best effort on purpose: the claim is already won in
+  # the arbiter, so a failed `gh` (offline, no auth, repo permissions) must
+  # not look like a lost claim. The outcome rides in the success detail.
+  defp assign(repo, number, opts) do
+    case Keyword.get_lazy(opts, :gh, &default_gh/0) do
+      nil ->
+        "; gh not found, GitHub assignee not mirrored"
+
+      gh ->
+        args = ["issue", "edit", Integer.to_string(number), "--repo", repo]
+
+        case Cmd.run(gh, args ++ ["--add-assignee", "@me"], stderr_to_stdout: true) do
+          {_out, 0} -> "; assigned @me on GitHub"
+          {out, _nonzero} -> "; GitHub assign failed (mirror only): #{String.slice(out, 0, 200)}"
+        end
+    end
+  end
+
+  defp label(%{session: nil, session_id: id}), do: "##{id || "?"}"
+  defp label(%{session: name}), do: name
+
+  defp default_gh do
+    System.get_env("IX_MCP_GH") || System.find_executable("gh")
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -57,6 +57,12 @@ defmodule IxMcp.MCP.Tools do
                                             filed in a watched org (default
                                             indexable-inc) arrives unprompted as a
                                             source="issues" channel notification
+      Issues.pickup(3880)                   claim an issue atomically BEFORE working
+                                            it (also "owner/repo#n"); won claims
+                                            assign @me on GitHub and announce as
+                                            event="picked_up"; a lost claim returns
+                                            {:error, "claimed by session ..."} --
+                                            pick a different issue
       Tui.act(uri, send_keys)               drive a federated TUI resource (optional
                                             peer arg)
       TuiLocal.spawn(cmd, args)             spawn a local PTY program (vim, less, a

--- a/packages/mcp-ex/lib/ix_mcp/workspace.ex
+++ b/packages/mcp-ex/lib/ix_mcp/workspace.ex
@@ -18,7 +18,7 @@ defmodule IxMcp.Workspace do
              "alias IxMcp.Read; alias IxMcp.Edit; alias IxMcp.PrWatch; alias IxMcp.Tui; " <>
              "alias IxMcp.TuiLocal; alias IxMcp.Gmail; alias IxMcp.Imsg; alias IxMcp.Contacts; " <>
              "alias IxMcp.Kernel, as: Ix; alias IxMcp.Agents; alias IxMcp.Memory; " <>
-             "alias IxMcp.Ask; alias IxMcp.Cmd"
+             "alias IxMcp.Ask; alias IxMcp.Cmd; alias IxMcp.Issues"
 
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do

--- a/packages/mcp-ex/test/action_log_test.exs
+++ b/packages/mcp-ex/test/action_log_test.exs
@@ -319,8 +319,8 @@ defmodule IxMcp.ActionLogTest do
     :ok = ActionLog.finish_action(action_id, "done", false, 3, log)
     assert [%{status: "done", stack: nil, line: nil} | _] = ActionLog.recent(10, log)
 
-    # The 2 -> 3 -> 4 -> 5 steps stamped the file on their way through (index#3539).
-    assert user_version(path) == 5
+    # The 2 -> 3 -> 4 -> 5 -> 6 steps stamped the file on their way through (index#3539).
+    assert user_version(path) == 6
   end
 
   test "a v1 database migrates losslessly to the normalized schema, once" do
@@ -404,8 +404,8 @@ defmodule IxMcp.ActionLogTest do
 
     stop_supervised!(:migrate)
 
-    # The ladder ran 1 -> 2 -> 3 -> 4 -> 5 and left the stamp behind (index#3539).
-    assert user_version(path) == 5
+    # The ladder ran 1 -> 2 -> 3 -> 4 -> 5 -> 6 and left the stamp behind (index#3539).
+    assert user_version(path) == 6
 
     # The migrated file is the v2 shape on disk: normalized columns, no v1
     # leftovers, and a reopen (no-op detection) does not duplicate rows.
@@ -441,7 +441,15 @@ defmodule IxMcp.ActionLogTest do
     :ok = Sqlite3.release(conn, statement)
 
     assert tables ==
-             [["actions"], ["job_output"], ["jobs"], ["outbox"], ["sessions"], ["topics"]]
+             [
+               ["actions"],
+               ["issue_claims"],
+               ["job_output"],
+               ["jobs"],
+               ["outbox"],
+               ["sessions"],
+               ["topics"]
+             ]
 
     :ok = Sqlite3.close(conn)
 
@@ -453,7 +461,7 @@ defmodule IxMcp.ActionLogTest do
   test "a fresh database is created stamped with the current schema version" do
     path = tmp_db()
     start_supervised!({ActionLog, path: path, name: :action_log_fresh_stamp})
-    assert user_version(path) == 5
+    assert user_version(path) == 6
   end
 
   test "an unstamped file already at the current schema is stamped, not rewritten" do
@@ -478,7 +486,7 @@ defmodule IxMcp.ActionLogTest do
 
     reopened = start_supervised!({ActionLog, path: path, name: :action_log_stamp_b})
     assert [%{intent: "keep"}] = ActionLog.recent(10, reopened)
-    assert user_version(path) == 5
+    assert user_version(path) == 6
   end
 
   test "an unstamped pre-line file (the #3536 shape) sniffs as v3 and gains the line column" do
@@ -503,7 +511,34 @@ defmodule IxMcp.ActionLogTest do
     log = start_supervised!({ActionLog, path: path, name: :action_log_pre_line})
 
     assert [%{intent: "pre-line row", status: "done", line: nil}] = ActionLog.recent(10, log)
-    assert user_version(path) == 5
+    assert user_version(path) == 6
+  end
+
+  test "the unique constraint arbitrates issue claims (#3880)" do
+    log = start_supervised!({ActionLog, path: ":memory:", name: :action_log_claims})
+
+    winner = ActionLog.create_session("winner", log)
+    loser = ActionLog.create_session(nil, log)
+
+    assert ActionLog.last_issue_claim_id(log) == 0
+
+    assert {:ok, claim} = ActionLog.claim_issue("indexable-inc/index", 3880, winner, log)
+    assert %{repo: "indexable-inc/index", number: 3880, session: "winner"} = claim
+    assert {:ok, %DateTime{}, 0} = DateTime.from_iso8601(claim.claimed_at)
+
+    # The loser reads the standing claim back, name included.
+    assert {:error, standing} = ActionLog.claim_issue("indexable-inc/index", 3880, loser, log)
+    assert standing.id == claim.id
+    assert standing.session == "winner"
+
+    # Same number on another repo is a different claim.
+    assert {:ok, other} = ActionLog.claim_issue("indexable-inc/ix", 3880, loser, log)
+    assert other.session == nil
+
+    # The watermark cursor sees exactly the claims past it, oldest first.
+    assert [%{number: 3880}, %{repo: "indexable-inc/ix"}] = ActionLog.issue_claims_after(0, log)
+    assert [%{repo: "indexable-inc/ix"}] = ActionLog.issue_claims_after(claim.id, log)
+    assert ActionLog.last_issue_claim_id(log) == other.id
   end
 
   test "a database stamped by a newer server disables logging instead of crashing" do
@@ -520,7 +555,7 @@ defmodule IxMcp.ActionLogTest do
 
     # The refusal names both versions, so the operator knows which side moves.
     assert output =~ "user_version 9000"
-    assert output =~ "supported 5"
+    assert output =~ "supported 6"
     assert output =~ "index#3539"
 
     # The server stays useful: writes are absorbed, reads answer empty.
@@ -538,6 +573,11 @@ defmodule IxMcp.ActionLogTest do
     assert ActionLog.recent(10, log) == []
     assert ActionLog.sessions(log) == []
     assert ActionLog.topics(log) == []
+
+    # With no arbiter there is no claim to win (#3880).
+    assert ActionLog.claim_issue("indexable-inc/index", 1, session_id, log) == :disabled
+    assert ActionLog.issue_claims_after(0, log) == []
+    assert ActionLog.last_issue_claim_id(log) == 0
 
     # The newer file is left exactly as found, for the newer server.
     assert user_version(path) == 9000

--- a/packages/mcp-ex/test/ix_mcp/issue_watch_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/issue_watch_test.exs
@@ -1,6 +1,7 @@
 defmodule IxMcp.IssueWatchTest do
   use ExUnit.Case, async: false
 
+  alias IxMcp.ActionLog
   alias IxMcp.IssueWatch
   alias IxMcp.MCP.Notifier
 
@@ -70,6 +71,58 @@ defmodule IxMcp.IssueWatchTest do
     # the unchanged search result instead of re-announcing it.
     refute_receive {:mcp_send,
                     %{"params" => %{"meta" => %{"issue" => "indexable-inc/index#3877"}}}},
+                   200
+  end
+
+  test "announces a pickup claim once, skipping claims that predate boot", %{tmp_dir: dir} do
+    # Own ActionLog instance: the sweep must be driven by this test's claims
+    # alone, not whatever the globally running log accumulates.
+    log = :"issue_watch_claims_log_#{System.unique_integer([:positive])}"
+    start_supervised!({ActionLog, path: ":memory:", name: log})
+
+    # gh answers every issue search empty; only the claims sweep speaks.
+    gh = Path.join(dir, "gh")
+    File.write!(gh, "#!/bin/sh\necho '[]'\n")
+    File.chmod!(gh, 0o755)
+
+    stale = ActionLog.create_session("stale", log)
+    {:ok, _claim} = ActionLog.claim_issue("indexable-inc/index", 4200, stale, log)
+
+    Notifier.register(self())
+    _ = :sys.get_state(Notifier)
+
+    start_supervised!(
+      {IssueWatch,
+       gh: gh,
+       owners: ["indexable-inc"],
+       interval_ms: 25,
+       name: :issue_watch_claims_under_test,
+       action_log: log}
+    )
+
+    claimer = ActionLog.create_session("claimer", log)
+    {:ok, _claim} = ActionLog.claim_issue("indexable-inc/index", 4201, claimer, log)
+
+    assert_receive {:mcp_send,
+                    %{
+                      "method" => "notifications/claude/channel",
+                      "params" =>
+                        %{
+                          "meta" => %{
+                            "source" => "issues",
+                            "event" => "picked_up",
+                            "issue" => "indexable-inc/index#4201"
+                          }
+                        } = params
+                    }},
+                   5_000
+
+    assert params["meta"]["session"] == "claimer"
+    assert params["content"] =~ "issue picked up: indexable-inc/index#4201"
+
+    # The watermark must swallow both the already-announced claim and the
+    # one standing before this watcher booted.
+    refute_receive {:mcp_send, %{"params" => %{"meta" => %{"event" => "picked_up"}}}},
                    200
   end
 end

--- a/packages/mcp-ex/test/ix_mcp/issues_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/issues_test.exs
@@ -1,0 +1,86 @@
+defmodule IxMcp.IssuesTest do
+  use ExUnit.Case, async: false
+
+  alias IxMcp.ActionLog
+  alias IxMcp.Issues
+
+  @moduletag :tmp_dir
+
+  # Own ActionLog instance (in-memory, own name): claims must never land in
+  # the globally running log, where a leaked IX_MCP_STDIO=1 application boot
+  # has a real IssueWatch sweeping (see issue_watch_test.exs).
+  setup do
+    name = :"issues_test_log_#{System.unique_integer([:positive])}"
+    start_supervised!({ActionLog, path: ":memory:", name: name})
+    %{log: name}
+  end
+
+  defp gh_stub(dir, script) do
+    gh = Path.join(dir, "gh")
+    File.write!(gh, "#!/bin/sh\n" <> script)
+    File.chmod!(gh, 0o755)
+    gh
+  end
+
+  test "won claim mirrors the assignee and reports the win", %{tmp_dir: dir, log: log} do
+    args_log = Path.join(dir, "args.log")
+    gh = gh_stub(dir, ~s(echo "$@" >> #{args_log}\n))
+    sid = ActionLog.create_session("picker", log)
+
+    assert {:ok, detail} =
+             Issues.pickup("indexable-inc/index#4001", action_log: log, session_id: sid, gh: gh)
+
+    assert detail =~ "claimed indexable-inc/index#4001"
+    assert detail =~ "assigned @me"
+
+    assert File.read!(args_log) =~
+             "issue edit 4001 --repo indexable-inc/index --add-assignee @me"
+  end
+
+  test "second pickup loses and names the winner", %{tmp_dir: dir, log: log} do
+    gh = gh_stub(dir, "exit 0\n")
+    winner = ActionLog.create_session("winner", log)
+    loser = ActionLog.create_session("loser", log)
+
+    assert {:ok, _detail} =
+             Issues.pickup("indexable-inc/index#4002",
+               action_log: log,
+               session_id: winner,
+               gh: gh
+             )
+
+    assert {:error, message} =
+             Issues.pickup("indexable-inc/index#4002", action_log: log, session_id: loser, gh: gh)
+
+    assert message =~ "claimed by session winner at "
+  end
+
+  test "an integer claims on the default repo", %{log: log} do
+    sid = ActionLog.create_session("picker", log)
+
+    assert {:ok, detail} = Issues.pickup(4003, action_log: log, session_id: sid, gh: nil)
+    assert detail =~ "claimed indexable-inc/index#4003"
+    assert detail =~ "not mirrored"
+
+    assert [%{repo: "indexable-inc/index", number: 4003}] = ActionLog.issue_claims_after(0, log)
+  end
+
+  test "a failed GitHub mirror does not lose a won claim", %{tmp_dir: dir, log: log} do
+    gh = gh_stub(dir, "echo no auth >&2\nexit 1\n")
+    sid = ActionLog.create_session("picker", log)
+
+    assert {:ok, detail} =
+             Issues.pickup("indexable-inc/index#4004", action_log: log, session_id: sid, gh: gh)
+
+    assert detail =~ "GitHub assign failed"
+    # The arbiter still holds the claim: a second attempt loses.
+    assert {:error, _message} =
+             Issues.pickup("indexable-inc/index#4004", action_log: log, session_id: sid, gh: gh)
+  end
+
+  test "a malformed ref is rejected without touching the arbiter", %{log: log} do
+    assert {:error, message} = Issues.pickup("not-a-ref", action_log: log, gh: nil)
+    assert message =~ ~s(pass an integer or "owner/repo#n")
+    assert [] = ActionLog.issue_claims_after(0, log)
+  end
+end


### PR DESCRIPTION
Implements #3880: atomically claim an issue before working it, so two sessions hearing the same new-issue announcement (#3877/#3879) cannot both take it.

- `Issues.pickup(3880)` / `Issues.pickup("owner/repo#n")` in the workspace prelude. The arbiter is the shared actions.db: a new `issue_claims` table (schema v6) with `UNIQUE(repo, number)`; the winning INSERT is the claim, a conflict returns `{:error, "claimed by session <label> at <time>"}`.
- A won claim mirrors `@me` onto the GitHub assignees via `gh issue edit`, best effort -- visibility, not arbitration.
- The IssueWatch sweep also announces new claims as `source="issues", event="picked_up"` channel notifications.

One deliberate change from the issue text: the sweep cursors claims with a per-instance watermark instead of a shared "announced" flag. The Notifier only reaches its own instance's client, so a shared flag would let the first sweeper mark a claim announced and silence every other session on the host -- the opposite of the intended fan-out.

Checks: `mix test` 117 tests 0 failures, `mix format --check-formatted` clean, `mix credo --strict` at the 5 pre-existing findings.

Closes #3880

(sent by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add atomic issue pickup via SQLite claim arbiter to `IxMcp.Issues`
> - Introduces `Issues.pickup/2` for atomically claiming GitHub issues, backed by a new `issue_claims` SQLite table with a `UNIQUE(repo, number)` constraint; the first caller wins and subsequent callers receive a loss message naming the winner.
> - Migrates `ActionLog` from schema v5 to v6, adding `claim_issue/4`, `issue_claims_after/2`, and `last_issue_claim_id/1` APIs.
> - On a winning claim, mirrors GitHub assignee via `gh issue edit --add-assignee @me`; GitHub failure does not affect arbitration outcome.
> - `IssueWatch` polls for new claims and emits `picked_up` notifications via the notifier channel, skipping claims that predate the watcher's boot watermark.
> - `Issues` is aliased in the workspace init bindings so cells can call `Issues.pickup/1` directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a5c392.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->