### PR TITLE
clone-detect: adopt ExDNA-style AST canonicalization (#3878)

### DIFF
--- a/packages/code/clone-detect/detect/src/tests/detection.rs
+++ b/packages/code/clone-detect/detect/src/tests/detection.rs
@@ -85,6 +85,35 @@ fn compute_total(x: i32, y: i32) -> i32 {
     );
 }
 
+/// Struct-literal field order is canonicalized before hashing (issue #3878),
+/// so a reordering that survives review as "different code" is still caught
+/// as a Type-2 clone end to end.
+#[test]
+fn type2_reordered_struct_literal_fields() {
+    let dir = TempDir::new().unwrap();
+    create_temp_file(
+        &dir,
+        "builders.rs",
+        r"
+fn build_user(name: u32, age: u32) -> User {
+    let user = User { name, age };
+    user
+}
+
+fn build_user_reordered(name: u32, age: u32) -> User {
+    let user = User { age, name };
+    user
+}
+",
+    );
+
+    let result = scan_and_run(&dir, &DetectConfig::default());
+    assert!(
+        result.stats.type2_groups > 0,
+        "reordered struct literal fields should hash as a Type-2 clone"
+    );
+}
+
 #[test]
 fn no_clones_unique_files() {
     let dir = TempDir::new().unwrap();

--- a/packages/code/clone-detect/hash/src/canon.rs
+++ b/packages/code/clone-detect/hash/src/canon.rs
@@ -1,0 +1,115 @@
+//! Per-language AST canonicalization applied ahead of the generic
+//! normalizer (issue #3878, modeled on elixir-vibe's ExDNA).
+//!
+//! Language knowledge lives here, keyed off [`Lang`]; the recursion in
+//! `normalize` only sees the canonical [`View`]. Semantically equivalent
+//! surface forms map onto one view, so they hash equal:
+//!
+//! - Elixir pipes become plain calls: `x |> f(a)` views as `f(x, a)`. Every
+//!   Elixir call is itself viewed as callee + flattened arguments so the two
+//!   spellings meet in the middle (which also unifies `f(x, a)` with the
+//!   paren-less `f x, a`).
+//! - Elixir keyword pairs hash order-insensitively: the `keywords` node
+//!   behind map/struct literals, keyword lists, and trailing keyword
+//!   arguments sorts its pairs by key text.
+//! - Rust struct literals likewise: `field_initializer_list` sorts its
+//!   initializers by field name.
+
+use ast_merge_ast::Tree;
+use ast_merge_langs::Lang;
+use tree_sitter::Node;
+
+/// Canonical shape for a node whose surface form should not affect its
+/// normalized hash.
+pub enum View<'t> {
+    /// Hash as a call: one callee followed by arguments, punctuation and the
+    /// pipe operator dropped.
+    Call {
+        target: Node<'t>,
+        args: Vec<Node<'t>>,
+    },
+    /// Hash the node's kind with these children in canonical order,
+    /// punctuation dropped.
+    Ordered(Vec<Node<'t>>),
+}
+
+#[must_use]
+pub fn view<'t>(lang: Lang, tree: &Tree, node: Node<'t>) -> Option<View<'t>> {
+    match lang {
+        Lang::Elixir => elixir(tree, node),
+        Lang::Rust => rust(tree, node),
+        _ => None,
+    }
+}
+
+fn elixir<'t>(tree: &Tree, node: Node<'t>) -> Option<View<'t>> {
+    match node.kind() {
+        "binary_operator" => pipe(tree, node),
+        "call" => call(node),
+        "keywords" => Some(sorted_by_key(tree, node, "key")),
+        _ => None,
+    }
+}
+
+/// `x |> f(a)` views as `f(x, a)`; a bare stage `x |> f` views as `f(x)`.
+/// Chains canonicalize recursively because the left operand of the outer
+/// pipe is the inner `binary_operator` node.
+fn pipe<'t>(tree: &Tree, node: Node<'t>) -> Option<View<'t>> {
+    let operator = node.child_by_field_name("operator")?;
+    if tree.node_text(operator) != "|>" {
+        return None;
+    }
+    let lhs = node.child_by_field_name("left")?;
+    let rhs = node.child_by_field_name("right")?;
+
+    if rhs.kind() == "call" {
+        let View::Call { target, mut args } = call(rhs)? else {
+            return None;
+        };
+        args.insert(0, lhs);
+        return Some(View::Call { target, args });
+    }
+    Some(View::Call {
+        target: rhs,
+        args: vec![lhs],
+    })
+}
+
+/// Flatten an Elixir `call` into callee + arguments: children of the
+/// `arguments` node are spliced in directly, and any trailing `do_block`
+/// rides along as a final argument.
+fn call(node: Node<'_>) -> Option<View<'_>> {
+    let target = node.child_by_field_name("target")?;
+    let mut args = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if child.id() == target.id() {
+            continue;
+        }
+        if child.kind() == "arguments" {
+            let mut arguments = child.walk();
+            args.extend(child.named_children(&mut arguments));
+        } else {
+            args.push(child);
+        }
+    }
+    Some(View::Call { target, args })
+}
+
+fn rust<'t>(tree: &Tree, node: Node<'t>) -> Option<View<'t>> {
+    (node.kind() == "field_initializer_list").then(|| sorted_by_key(tree, node, "field"))
+}
+
+/// Named children sorted by the text of their `key_field` child, falling
+/// back to the child's own text (Rust shorthand and base initializers have
+/// no `field` child). The sort is stable, so duplicate keys keep their
+/// source order.
+fn sorted_by_key<'t>(tree: &Tree, node: Node<'t>, key_field: &str) -> View<'t> {
+    let mut cursor = node.walk();
+    let mut children: Vec<Node<'t>> = node.named_children(&mut cursor).collect();
+    children.sort_by_key(|child| {
+        let key = child.child_by_field_name(key_field).unwrap_or(*child);
+        tree.node_text(key)
+    });
+    View::Ordered(children)
+}

--- a/packages/code/clone-detect/hash/src/canon.rs
+++ b/packages/code/clone-detect/hash/src/canon.rs
@@ -9,9 +9,10 @@
 //!   Elixir call is itself viewed as callee + flattened arguments so the two
 //!   spellings meet in the middle (which also unifies `f(x, a)` with the
 //!   paren-less `f x, a`).
-//! - Elixir keyword pairs hash order-insensitively: the `keywords` node
-//!   behind map/struct literals, keyword lists, and trailing keyword
-//!   arguments sorts its pairs by key text.
+//! - Elixir keyword pairs inside map/struct literals hash
+//!   order-insensitively. Bare keyword lists and trailing keyword arguments
+//!   stay verbatim: they are ordered data (pattern matches and
+//!   `Keyword.pop_first/2` consume them positionally).
 //! - Rust struct literals likewise: `field_initializer_list` sorts its
 //!   initializers by field name.
 
@@ -45,10 +46,21 @@ pub fn view<'t>(lang: Lang, tree: &Tree, node: Node<'t>) -> Option<View<'t>> {
 fn elixir<'t>(tree: &Tree, node: Node<'t>) -> Option<View<'t>> {
     match node.kind() {
         "binary_operator" => pipe(tree, node),
-        "call" => call(node),
-        "keywords" => Some(sorted_by_key(tree, node, "key")),
+        "call" => {
+            let (target, args) = call_parts(node)?;
+            Some(View::Call { target, args })
+        }
+        "keywords" => keywords(tree, node),
         _ => None,
     }
+}
+
+/// Keyword pairs sort only inside map/struct literals (`map_content`
+/// parent), where order is semantically irrelevant. A `list` or `arguments`
+/// parent means an ordered keyword list, hashed verbatim so reordered
+/// pipelines and option lists stay distinct (#3885 review).
+fn keywords<'t>(tree: &Tree, node: Node<'t>) -> Option<View<'t>> {
+    (node.parent()?.kind() == "map_content").then(|| sorted_by_key(tree, node, "key"))
 }
 
 /// `x |> f(a)` views as `f(x, a)`; a bare stage `x |> f` views as `f(x)`.
@@ -63,9 +75,7 @@ fn pipe<'t>(tree: &Tree, node: Node<'t>) -> Option<View<'t>> {
     let rhs = node.child_by_field_name("right")?;
 
     if rhs.kind() == "call" {
-        let View::Call { target, mut args } = call(rhs)? else {
-            return None;
-        };
+        let (target, mut args) = call_parts(rhs)?;
         args.insert(0, lhs);
         return Some(View::Call { target, args });
     }
@@ -78,7 +88,7 @@ fn pipe<'t>(tree: &Tree, node: Node<'t>) -> Option<View<'t>> {
 /// Flatten an Elixir `call` into callee + arguments: children of the
 /// `arguments` node are spliced in directly, and any trailing `do_block`
 /// rides along as a final argument.
-fn call(node: Node<'_>) -> Option<View<'_>> {
+fn call_parts(node: Node<'_>) -> Option<(Node<'_>, Vec<Node<'_>>)> {
     let target = node.child_by_field_name("target")?;
     let mut args = Vec::new();
     let mut cursor = node.walk();
@@ -93,7 +103,7 @@ fn call(node: Node<'_>) -> Option<View<'_>> {
             args.push(child);
         }
     }
-    Some(View::Call { target, args })
+    Some((target, args))
 }
 
 fn rust<'t>(tree: &Tree, node: Node<'t>) -> Option<View<'t>> {
@@ -104,6 +114,14 @@ fn rust<'t>(tree: &Tree, node: Node<'t>) -> Option<View<'t>> {
 /// back to the child's own text (Rust shorthand and base initializers have
 /// no `field` child). The sort is stable, so duplicate keys keep their
 /// source order.
+///
+/// The sort key is raw source text, evaluated before identifier
+/// renumbering, which trades away one Type-II case on purpose: a clone that
+/// consistently renames the keys themselves (two different Rust struct
+/// types) can reorder under sorting and hash apart. That is a missed clone,
+/// never a false match; sorting on normalized keys would need a renumbering
+/// pre-pass whose numbering itself depends on traversal order (#3885
+/// review).
 fn sorted_by_key<'t>(tree: &Tree, node: Node<'t>, key_field: &str) -> View<'t> {
     let mut cursor = node.walk();
     let mut children: Vec<Node<'t>> = node.named_children(&mut cursor).collect();

--- a/packages/code/clone-detect/hash/src/extract.rs
+++ b/packages/code/clone-detect/hash/src/extract.rs
@@ -2,6 +2,7 @@ use std::hash::{Hash, Hasher};
 
 use ast_merge_ast::Tree;
 pub use ast_merge_ast::compute;
+use ast_merge_langs::Lang;
 use rustc_hash::FxHasher;
 
 use crate::{
@@ -51,15 +52,20 @@ pub struct Dual {
 }
 
 #[must_use]
-pub fn dual(tree: &Tree, node: tree_sitter::Node<'_>) -> Dual {
+pub fn dual(tree: &Tree, lang: Lang, node: tree_sitter::Node<'_>) -> Dual {
     Dual {
         content: compute(tree, node),
-        normalized: normalize::hash(tree, node),
+        normalized: normalize::hash(tree, lang, node),
     }
 }
 
 #[must_use]
-pub fn significant_nodes(tree: &Tree, min_lines: usize, min_nodes: usize) -> Vec<NodeInfo> {
+pub fn significant_nodes(
+    tree: &Tree,
+    lang: Lang,
+    min_lines: usize,
+    min_nodes: usize,
+) -> Vec<NodeInfo> {
     let mut results = Vec::new();
 
     for node in tree.preorder() {
@@ -84,9 +90,9 @@ pub fn significant_nodes(tree: &Tree, min_lines: usize, min_nodes: usize) -> Vec
         let Dual {
             content: content_hash,
             normalized: normalized_hash,
-        } = dual(tree, node);
+        } = dual(tree, lang, node);
 
-        let children = collect_children(tree, node);
+        let children = collect_children(tree, lang, node);
         let subtree_features = collect_subtree_features(tree, node);
 
         results.push(NodeInfo {
@@ -107,13 +113,13 @@ pub fn significant_nodes(tree: &Tree, min_lines: usize, min_nodes: usize) -> Vec
 
 /// Collect detailed info for each direct named child of a node.
 /// Preserves ordering for statement-sequence detection.
-fn collect_children(tree: &Tree, node: tree_sitter::Node<'_>) -> Vec<ChildInfo> {
+fn collect_children(tree: &Tree, lang: Lang, node: tree_sitter::Node<'_>) -> Vec<ChildInfo> {
     let mut children = Vec::new();
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
         children.push(ChildInfo {
             kind: child.kind(),
-            normalized_hash: normalize::hash(tree, child),
+            normalized_hash: normalize::hash(tree, lang, child),
             byte_range: child.byte_range(),
             start_line: child.start_position().row,
             end_line: child.end_position().row,
@@ -128,6 +134,11 @@ fn collect_children(tree: &Tree, node: tree_sitter::Node<'_>) -> Vec<ChildInfo> 
 /// (kind + normalized leaf content). Then adds bigrams of consecutive tokens
 /// for structural context. The combined unigram+bigram set captures both
 /// local node types and parent-child/sibling relationships.
+///
+/// Stays verbatim (no per-language canonical views): the features feed the
+/// fuzzy Type-3 similarity metric, where a dropped pipe operator or reordered
+/// keyword pair shifts a handful of unigrams/bigrams instead of gating an
+/// exact hash match.
 ///
 /// Complexity: O(n) where n = number of nodes in subtree.
 fn collect_subtree_features(tree: &Tree, node: tree_sitter::Node<'_>) -> Vec<u64> {

--- a/packages/code/clone-detect/hash/src/lib.rs
+++ b/packages/code/clone-detect/hash/src/lib.rs
@@ -1,3 +1,4 @@
+mod canon;
 mod extract;
 pub mod kinds;
 mod normalize;

--- a/packages/code/clone-detect/hash/src/normalize.rs
+++ b/packages/code/clone-detect/hash/src/normalize.rs
@@ -12,8 +12,9 @@ use crate::{
 const LITERAL_PLACEHOLDER: u64 = 0xDEAD_BEEF;
 
 /// Virtual node kind hashed in place of a grammar kind for canonical calls.
-/// Tree-sitter kind names never contain `:`, so a canonical call cannot
-/// collide with a verbatim node.
+/// Anonymous token kinds do contain colons (`":"`, `"::"`), but no
+/// tree-sitter kind equals the full string `canon:call`, so a canonical
+/// call cannot collide with a verbatim node.
 const CANON_CALL_KIND: &str = "canon:call";
 
 #[must_use]

--- a/packages/code/clone-detect/hash/src/normalize.rs
+++ b/packages/code/clone-detect/hash/src/normalize.rs
@@ -1,19 +1,29 @@
 use std::hash::{Hash, Hasher};
 
 use ast_merge_ast::Tree;
+use ast_merge_langs::Lang;
 use rustc_hash::{FxHashMap, FxHasher};
 
-use crate::kinds::{is_identifier, is_normalizable};
+use crate::{
+    canon::{self, View},
+    kinds::{is_identifier, is_normalizable},
+};
 
 const LITERAL_PLACEHOLDER: u64 = 0xDEAD_BEEF;
 
+/// Virtual node kind hashed in place of a grammar kind for canonical calls.
+/// Tree-sitter kind names never contain `:`, so a canonical call cannot
+/// collide with a verbatim node.
+const CANON_CALL_KIND: &str = "canon:call";
+
 #[must_use]
-pub fn hash(tree: &Tree, node: tree_sitter::Node<'_>) -> u64 {
+pub fn hash(tree: &Tree, lang: Lang, node: tree_sitter::Node<'_>) -> u64 {
     let mut hasher = FxHasher::default();
     let mut state = State::default();
     recursive(
         &mut Context {
             tree,
+            lang,
             hasher: &mut hasher,
             state: &mut state,
         },
@@ -40,11 +50,33 @@ impl<'a> State<'a> {
 
 struct Context<'a, 'b> {
     tree: &'a Tree,
+    lang: Lang,
     hasher: &'b mut FxHasher,
     state: &'b mut State<'a>,
 }
 
 fn recursive(ctx: &mut Context<'_, '_>, node: tree_sitter::Node<'_>) {
+    match canon::view(ctx.lang, ctx.tree, node) {
+        Some(View::Call { target, args }) => {
+            CANON_CALL_KIND.hash(ctx.hasher);
+            recursive(ctx, target);
+            args.len().hash(ctx.hasher);
+            for arg in args {
+                recursive(ctx, arg);
+            }
+        }
+        Some(View::Ordered(children)) => {
+            node.kind().hash(ctx.hasher);
+            children.len().hash(ctx.hasher);
+            for child in children {
+                recursive(ctx, child);
+            }
+        }
+        None => verbatim(ctx, node),
+    }
+}
+
+fn verbatim(ctx: &mut Context<'_, '_>, node: tree_sitter::Node<'_>) {
     let kind = node.kind();
     kind.hash(ctx.hasher);
 

--- a/packages/code/clone-detect/hash/src/tests/extract.rs
+++ b/packages/code/clone-detect/hash/src/tests/extract.rs
@@ -1,4 +1,6 @@
-use super::helpers::{parse_python, parse_rust};
+use ast_merge_langs::Lang;
+
+use super::helpers::{parse, parse_rust};
 use crate::significant_nodes;
 
 #[test]
@@ -20,7 +22,7 @@ struct Foo {
 ";
 
     let tree = parse_rust(source);
-    let nodes = significant_nodes(&tree, 3, 5);
+    let nodes = significant_nodes(&tree, Lang::Rust, 3, 5);
 
     assert!(!nodes.is_empty());
     for node in &nodes {
@@ -33,7 +35,7 @@ struct Foo {
 fn empty_file() {
     let source = "";
     let tree = parse_rust(source);
-    let nodes = significant_nodes(&tree, 3, 5);
+    let nodes = significant_nodes(&tree, Lang::Rust, 3, 5);
     assert!(nodes.is_empty());
 }
 
@@ -41,7 +43,7 @@ fn empty_file() {
 fn only_small_functions() {
     let source = "fn a() {} fn b() {} fn c() {}";
     let tree = parse_rust(source);
-    let nodes = significant_nodes(&tree, 5, 10);
+    let nodes = significant_nodes(&tree, Lang::Rust, 5, 10);
 
     assert!(nodes.is_empty());
 }
@@ -50,7 +52,7 @@ fn only_small_functions() {
 fn significant_nodes_cover_rust_impls_and_python_classes() {
     let cases = [
         (
-            parse_rust as fn(&str) -> ast_merge_ast::Tree,
+            Lang::Rust,
             r"
 impl Foo {
     fn method1(&self) {
@@ -68,7 +70,7 @@ impl Foo {
 ",
         ),
         (
-            parse_python as fn(&str) -> ast_merge_ast::Tree,
+            Lang::Python,
             r"
 def small():
     pass
@@ -87,9 +89,9 @@ class Foo:
         ),
     ];
 
-    for (parse, source) in cases {
-        let tree = parse(source);
-        assert!(!significant_nodes(&tree, 3, 5).is_empty());
+    for (lang, source) in cases {
+        let tree = parse(lang, source);
+        assert!(!significant_nodes(&tree, lang, 3, 5).is_empty());
     }
 }
 
@@ -104,7 +106,7 @@ fn test_function() {
 }
 ";
     let tree = parse_rust(source);
-    let nodes = significant_nodes(&tree, 3, 5);
+    let nodes = significant_nodes(&tree, Lang::Rust, 3, 5);
 
     assert!(!nodes.is_empty());
     let node = nodes.first().unwrap();

--- a/packages/code/clone-detect/hash/src/tests/helpers.rs
+++ b/packages/code/clone-detect/hash/src/tests/helpers.rs
@@ -1,19 +1,16 @@
 use ast_merge_ast::Tree;
 use ast_merge_langs::Lang;
 
+pub fn parse(lang: Lang, source: &str) -> Tree {
+    ast_merge_ast::tree(source, &lang.to_tree_sitter()).unwrap().tree
+}
+
 pub fn parse_rust(source: &str) -> Tree {
-    let lang = Lang::Rust.to_tree_sitter();
-    ast_merge_ast::tree(source, &lang).unwrap().tree
+    parse(Lang::Rust, source)
 }
 
 pub fn parse_js(source: &str) -> Tree {
-    let lang = Lang::JavaScript.to_tree_sitter();
-    ast_merge_ast::tree(source, &lang).unwrap().tree
-}
-
-pub fn parse_python(source: &str) -> Tree {
-    let lang = Lang::Python.to_tree_sitter();
-    ast_merge_ast::tree(source, &lang).unwrap().tree
+    parse(Lang::JavaScript, source)
 }
 
 pub struct HashPair {

--- a/packages/code/clone-detect/hash/src/tests/normalized.rs
+++ b/packages/code/clone-detect/hash/src/tests/normalized.rs
@@ -170,11 +170,19 @@ fn canonicalized_hash_relations() {
             true,
         ),
         (
-            "elixir trailing keyword argument order",
+            // Ordered data: only map/struct keyword pairs sort (#3885 review).
+            "elixir trailing keyword arguments stay ordered",
             Lang::Elixir,
             "f(x, a: 1, b: 2)",
             "f(x, b: 2, a: 1)",
-            true,
+            false,
+        ),
+        (
+            "elixir bare keyword lists stay ordered",
+            Lang::Elixir,
+            "[a: x, b: y]",
+            "[b: y, a: x]",
+            false,
         ),
         (
             "rust struct literal field order",

--- a/packages/code/clone-detect/hash/src/tests/normalized.rs
+++ b/packages/code/clone-detect/hash/src/tests/normalized.rs
@@ -1,7 +1,16 @@
-use super::helpers::{pair_hashes, parse_js, parse_python, parse_rust};
+use ast_merge_langs::Lang;
+
+use super::helpers::{parse, parse_rust};
 use crate::{Dual, dual, hash as normalized};
 
-type Parser = fn(&str) -> ast_merge_ast::Tree;
+fn assert_hash_relations(cases: &[(&str, Lang, &str, &str, bool)]) {
+    for &(name, lang, left, right, equal) in cases {
+        let (left, right) = (parse(lang, left), parse(lang, right));
+        let left = normalized(&left, lang, left.root_node());
+        let right = normalized(&right, lang, right.root_node());
+        assert_eq!(left == right, equal, "{name}");
+    }
+}
 
 #[test]
 #[allow(
@@ -9,80 +18,80 @@ type Parser = fn(&str) -> ast_merge_ast::Tree;
     reason = "the cases form one readable normalization behavior table"
 )]
 fn normalized_hash_relations() {
-    let cases: &[(&str, Parser, &str, &str, bool)] = &[
+    assert_hash_relations(&[
         (
             "renamed functions",
-            parse_rust,
+            Lang::Rust,
             "fn foo() { let x = 1; }",
             "fn bar() { let y = 1; }",
             true,
         ),
         (
             "different structure",
-            parse_rust,
+            Lang::Rust,
             "fn foo() { let x = 1; }",
             "fn foo() { let x = 1; let y = 2; }",
             false,
         ),
         (
             "swapped identifiers",
-            parse_rust,
+            Lang::Rust,
             "fn f() { a + b }",
             "fn f() { b + a }",
             true,
         ),
         (
             "different operators",
-            parse_rust,
+            Lang::Rust,
             "fn f() { a + b }",
             "fn f() { a - b }",
             false,
         ),
         (
             "inconsistent identifier mapping",
-            parse_rust,
+            Lang::Rust,
             "fn f() { x + x }",
             "fn f() { x + y }",
             false,
         ),
         (
             "different argument counts",
-            parse_rust,
+            Lang::Rust,
             "fn f(a: i32) { a }",
             "fn f(a: i32, b: i32) { a }",
             false,
         ),
         (
             "different types",
-            parse_rust,
+            Lang::Rust,
             "fn f(a: i32) { a }",
             "fn f(a: i64) { a }",
             false,
         ),
         (
             "JavaScript rename",
-            parse_js,
+            Lang::JavaScript,
             "function add(a, b) { return a + b; }",
             "function sum(x, y) { return x + y; }",
             true,
         ),
         (
             "Python rename",
-            parse_python,
+            Lang::Python,
             "def add(a, b):\n    return a + b",
             "def sum(x, y):\n    return x + y",
             true,
         ),
         (
             "closure rename",
-            parse_rust,
+            Lang::Rust,
             "fn f() { let add = |a, b| a + b; }",
             "fn g() { let sum = |x, y| x + y; }",
             true,
         ),
         (
             "complex function rename",
-            parse_rust,
+            Lang::Rust,
             r"fn calculate(a: i32, b: i32) -> i32 {
                 let sum = a + b;
                 let product = a * b;
@@ -97,25 +106,112 @@ fn normalized_hash_relations() {
         ),
         (
             "nested function rename",
-            parse_rust,
+            Lang::Rust,
             "fn outer() { fn inner() { let x = 1; } }",
             "fn wrapper() { fn nested() { let y = 1; } }",
             true,
         ),
         (
             "recursive function rename",
-            parse_rust,
+            Lang::Rust,
             "fn factorial(n: i32) -> i32 { if n <= 1 { 1 } else { n * factorial(n - 1) } }",
             "fn fact(x: i32) -> i32 { if x <= 1 { 1 } else { x * fact(x - 1) } }",
             true,
         ),
-    ];
+    ]);
+}
 
-    for &(name, parse, left, right, equal) in cases {
-        let pair = pair_hashes(parse, normalized, left, right);
-        let (left, right) = (pair.left, pair.right);
-        assert_eq!(left == right, equal, "{name}");
-    }
+/// Per-language canonical views (`canon`): Elixir pipes hash like plain
+/// calls, and keyword/struct-literal field order is hashed order-insensitively
+/// (issue #3878).
+#[test]
+fn canonicalized_hash_relations() {
+    assert_hash_relations(&[
+        (
+            "elixir pipe hashes like plain call",
+            Lang::Elixir,
+            "x |> f(a)",
+            "f(x, a)",
+            true,
+        ),
+        (
+            "elixir bare pipe stage",
+            Lang::Elixir,
+            "x |> f",
+            "f(x)",
+            true,
+        ),
+        (
+            "elixir pipe chain",
+            Lang::Elixir,
+            "x |> f(a) |> g(b)",
+            "g(f(x, a), b)",
+            true,
+        ),
+        (
+            "elixir qualified pipe",
+            Lang::Elixir,
+            "x |> Mod.f(a)",
+            "Mod.f(x, a)",
+            true,
+        ),
+        (
+            "elixir map key order",
+            Lang::Elixir,
+            "%{name: x, age: y}",
+            "%{age: y, name: x}",
+            true,
+        ),
+        (
+            "elixir struct field order",
+            Lang::Elixir,
+            "%User{name: x, age: y}",
+            "%User{age: y, name: x}",
+            true,
+        ),
+        (
+            "elixir trailing keyword argument order",
+            Lang::Elixir,
+            "f(x, a: 1, b: 2)",
+            "f(x, b: 2, a: 1)",
+            true,
+        ),
+        (
+            "rust struct literal field order",
+            Lang::Rust,
+            "fn f() { let u = User { name: 1, age: 2 }; }",
+            "fn f() { let u = User { age: 2, name: 1 }; }",
+            true,
+        ),
+        (
+            "elixir pipe arity still distinguishes",
+            Lang::Elixir,
+            "x |> f(a)",
+            "f(x)",
+            false,
+        ),
+        (
+            "elixir different keys still distinguish",
+            Lang::Elixir,
+            "%{name: x, age: y}",
+            "%{name: x, size: y}",
+            false,
+        ),
+        (
+            "elixir keyword vs positional argument",
+            Lang::Elixir,
+            "f(x, a: 1)",
+            "f(x, 1)",
+            false,
+        ),
+        (
+            "rust different field values still distinguish",
+            Lang::Rust,
+            "fn f() { let u = User { name: a, age: b }; }",
+            "fn f() { let u = User { name: a.c, age: b }; }",
+            false,
+        ),
+    ]);
 }
 
 #[test]
@@ -124,7 +220,7 @@ fn dual_returns_both() {
     let Dual {
         content,
         normalized,
-    } = dual(&tree, tree.root_node());
+    } = dual(&tree, Lang::Rust, tree.root_node());
     assert_ne!(content, 0);
     assert_ne!(normalized, 0);
 }
@@ -133,8 +229,8 @@ fn dual_returns_both() {
 fn dual_separates_content_from_normalized_identity() {
     let left = parse_rust("fn foo() { let x = 1; }");
     let right = parse_rust("fn bar() { let y = 1; }");
-    let left = dual(&left, left.root_node());
-    let right = dual(&right, right.root_node());
+    let left = dual(&left, Lang::Rust, left.root_node());
+    let right = dual(&right, Lang::Rust, right.root_node());
     assert_ne!(left.content, right.content);
     assert_eq!(left.normalized, right.normalized);
 }
@@ -142,14 +238,14 @@ fn dual_separates_content_from_normalized_identity() {
 #[test]
 fn empty_function_has_a_hash() {
     let tree = parse_rust("fn empty() {}");
-    assert_ne!(normalized(&tree, tree.root_node()), 0);
+    assert_ne!(normalized(&tree, Lang::Rust, tree.root_node()), 0);
 }
 
 #[test]
 fn normalized_hash_is_deterministic() {
     let tree = parse_rust("fn foo() { let x = 1; let y = 2; x + y }");
-    let expected = normalized(&tree, tree.root_node());
+    let expected = normalized(&tree, Lang::Rust, tree.root_node());
     for _ in 0..2 {
-        assert_eq!(normalized(&tree, tree.root_node()), expected);
+        assert_eq!(normalized(&tree, Lang::Rust, tree.root_node()), expected);
     }
 }

--- a/packages/code/clone-detect/scanner/src/scan.rs
+++ b/packages/code/clone-detect/scanner/src/scan.rs
@@ -219,7 +219,12 @@ impl Scanner {
             return Ok(None);
         }
 
-        let nodes = significant_nodes(&tree.tree, self.config.min_lines, self.config.min_nodes)
+        let nodes = significant_nodes(
+            &tree.tree,
+            language,
+            self.config.min_lines,
+            self.config.min_nodes,
+        )
             .into_iter()
             .filter(|node| !pragma_info.is_ignored(&node.byte_range))
             .collect();

--- a/packages/site/src/lib/updates/clone-detect-canonicalization.svx
+++ b/packages/site/src/lib/updates/clone-detect-canonicalization.svx
@@ -1,0 +1,49 @@
+---
+id: clone-detect-canonicalization
+postedAt: 2026-07-21T12:00:00-07:00
+title: "Clone detection sees through Elixir pipes and field order"
+tags: [rust, lint, tooling]
+links:
+  - label: "#3878: adopt ExDNA-style AST canonicalization"
+    href: https://github.com/indexable-inc/index/issues/3878
+  - label: "elixir-vibe/ex_dna, where these normalizations come from"
+    href: https://github.com/elixir-vibe/ex_dna
+---
+
+The clone ratchet (`nix run .#clone`) hashes each code fragment after
+Type-II normalization -- identifiers renumbered, literals replaced by a
+placeholder -- so renaming a variable does not hide a copy-paste. But the
+hash still followed the parse tree literally, so surface rewrites that any
+reviewer reads as the same code produced different hashes and escaped the
+gate: `x |> f(a)` versus `f(x, a)` in Elixir, or a struct literal with its
+fields listed in a different order.
+
+The hash crate now runs a per-language canonicalization pass ahead of the
+generic normalizer, adopted from elixir-vibe's ExDNA. Language knowledge
+lives in one seam (`clone-hash`'s `canon` module) keyed off the detected
+language; the generic recursion only sees canonical views:
+
+- **Elixir pipes hash as plain calls.** `x |> f(a)` views as `f(x, a)`,
+  bare stages (`x |> f`) as `f(x)`, and chains fold up recursively. Every
+  Elixir call is viewed as callee plus flattened arguments, which also
+  unifies `f(x, a)` with the paren-less `f x, a`.
+- **Keyword and struct-literal field order is ignored.** Elixir `keywords`
+  nodes (map and struct literals, keyword lists, trailing keyword
+  arguments) and Rust `field_initializer_list` nodes hash their pairs
+  sorted by key text, so `%User{name: x, age: y}` matches
+  `%User{age: y, name: x}` and `User { age, name }` matches
+  `User { name, age }`.
+
+Each rewrite carries a fixture pair proving the clone is now caught and a
+negative case proving genuinely different code still hashes apart; the
+Rust field-order case is also covered end to end through the detector.
+
+Two ExDNA ideas were deliberately left out. Multi-clause `def` grouping
+does not fit the fragment model, which reports single AST nodes, not
+synthetic spans over sibling clauses. And it would be premature anyway:
+Elixir currently yields zero significant nodes in the scanner (none of the
+tree-sitter-elixir kinds are in the significance list), so the ratchet
+parses Elixir but gates none of it. Lighting that up is a separate change
+with its own budget consequences. Tree-wide duplication measured 0.3619%
+before and 0.3617% after -- the canonical hashes reveal no pre-existing
+clone groups in this repo, and the 0.45% ceiling is untouched.

--- a/packages/site/src/lib/updates/clone-detect-canonicalization.svx
+++ b/packages/site/src/lib/updates/clone-detect-canonicalization.svx
@@ -27,12 +27,13 @@ language; the generic recursion only sees canonical views:
   bare stages (`x |> f`) as `f(x)`, and chains fold up recursively. Every
   Elixir call is viewed as callee plus flattened arguments, which also
   unifies `f(x, a)` with the paren-less `f x, a`.
-- **Keyword and struct-literal field order is ignored.** Elixir `keywords`
-  nodes (map and struct literals, keyword lists, trailing keyword
-  arguments) and Rust `field_initializer_list` nodes hash their pairs
-  sorted by key text, so `%User{name: x, age: y}` matches
+- **Map and struct field order is ignored.** Elixir `keywords` nodes
+  inside map and struct literals and Rust `field_initializer_list` nodes
+  hash their pairs sorted by key text, so `%User{name: x, age: y}` matches
   `%User{age: y, name: x}` and `User { age, name }` matches
-  `User { name, age }`.
+  `User { name, age }`. Bare keyword lists and trailing keyword arguments
+  stay ordered; they are positional data in Elixir (pattern matches,
+  `Keyword.pop_first/2`), so reordering them is a semantic change.
 
 Each rewrite carries a fixture pair proving the clone is now caught and a
 negative case proving genuinely different code still hashes apart; the


### PR DESCRIPTION
Implements the weight-carrying subset of #3878's ExDNA-style canonicalizations as a per-language seam in `clone-hash` (`canon` module, keyed off `Lang`), applied ahead of the generic Type-II normalizer.

## Implemented

- **Elixir pipe canonicalization**: `x |> f(a)` hashes like `f(x, a)`; bare stages (`x |> f` -> `f(x)`) and chains fold recursively. Every Elixir `call` is viewed as callee + flattened arguments so both spellings meet in the middle (also unifying `f(x, a)` with paren-less `f x, a`).
- **Keyword/struct/map field-order normalization**: Elixir `keywords` nodes (map/struct literals, keyword lists, trailing keyword args) and Rust `field_initializer_list` hash their pairs sorted by key text (stable sort, so duplicate keys keep source order).

Each normalization has positive fixture pairs (clone now caught) and negative cases (different code still distinct) in `hash/src/tests/normalized.rs` (`canonicalized_hash_relations`), plus an end-to-end detector test for the Rust field-order case (`type2_reordered_struct_literal_fields`). Repro-first: the fixture table was written and shown failing against a no-op seam before the views were implemented.

## Skipped, and why

- **Multi-clause def grouping**: does not fit the fragment model, which reports single AST nodes -- grouping consecutive same-name/arity clauses needs synthetic multi-node fragments. Also moot today, see below.
- **Boolean operator normalization** (`&&` vs `and`): not in the task subset.

## Found along the way

Elixir currently yields **zero** significant nodes: none of the tree-sitter-elixir kinds (`call`, `do_block`, `stab_clause`, `anonymous_function`, ...) are in `kinds.rs::SIGNIFICANT`, so the ratchet parses Elixir but gates none of it. Deliberately not fixed here -- lighting Elixir up would surface clones inside the Elixir packages another in-flight change touches, and it is a significance-policy change, not canonicalization. The canonical hashes are exercised at the hash layer and will take effect the moment Elixir kinds become significant.

## Measurements

`nix run .#clone -- . | jq .stats.duplication_pct`:

- before: **0.36185803021227364**
- after: **0.36168708572065944**

No new clone groups in gated code (instance file sets are identical before/after; the tiny drop is the added test code growing the denominator). The `clone.toml` budget (0.45) is untouched per its ratchet comment.

Verified locally: `cargo nextest run` on all five clone-detect crates (142 tests), `nix run .#lint` (all 13 stages incl. the clone gate).

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ExDNA-style AST canonicalization to clone-detect for Elixir and Rust
> - Introduces a new [`canon`](https://github.com/indexable-inc/index/pull/3885/files#diff-5d34f1acbb9184f7400822b6c53b1bd88c8e13aba75e2e133dd8d32ecff06a3f) module that maps language-specific AST nodes to canonical views before hashing, so surface-level syntactic differences don't prevent clone detection.
> - Elixir pipe expressions (`x |> f(a)`) are hashed as equivalent to their desugared call form (`f(x, a)`), and keyword pairs inside map/struct literals are sorted so field order is ignored.
> - Rust `field_initializer_list` nodes are hashed with fields in sorted order, so struct literals with reordered fields are detected as Type-2 clones.
> - `normalize::hash`, `extract::significant_nodes`, and the scanner all accept `Lang` and thread it through to canonicalization.
> - Behavioral Change: normalized hashes for Elixir and Rust nodes may differ from prior values, changing clone equality outcomes for affected constructs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ccfd0c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->