### PR TITLE
mcp-ex: kernel Edit worktree guard; action-log contention no longer kills jobs

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/action_log.ex
+++ b/packages/mcp-ex/lib/ix_mcp/action_log.ex
@@ -35,7 +35,17 @@ defmodule IxMcp.ActionLog do
   session (observed live), while a call makes the row durable before the
   tool response ships; one SQLite insert is negligible against MCP wire
   overhead. A failed open or write crashes this process loudly and the
-  supervisor reopens the log.
+  supervisor reopens the log -- except transient `SQLITE_BUSY` (#3874):
+  several server instances share this database, so a sibling holding the
+  write lock is normal operation, not a fault. sqlite itself waits it out
+  (`PRAGMA busy_timeout`) and a bounded retry covers the rest; before that,
+  one busy write match-crashed the GenServer, the exit propagated into
+  whichever process sat in `GenServer.call` (a job's output flush, an
+  exec's `start_action`), and under sustained contention the crash loop
+  could exhaust the root supervisor's restart intensity and take the whole
+  kernel -- and every running job -- down with it. The client API absorbs
+  the restart blip too: `call/3` retries a call that died with the server,
+  so callers survive an ActionLog restart instead of inheriting its exit.
   """
 
   use GenServer
@@ -103,10 +113,27 @@ defmodule IxMcp.ActionLog do
   # 6 = the #3880 issue-claim arbiter.
   @user_version 6
 
-  # How long a statement waits for a sibling instance's write lock before
-  # sqlite gives up with :busy and step!/fetch crash with a diagnosis
-  # (#3890). The NIF's own default is 2s, which live contention outlived.
-  @busy_timeout_ms 5_000
+  # SQLITE_BUSY tolerance (#3874). The pragma makes sqlite wait out a
+  # sibling instance's write lock inside the NIF; the bounded retry on top
+  # covers the starvation window where the timeout still expires. Only
+  # after both does a write crash loudly (a stuck-forever database is a
+  # real fault, not contention).
+  @busy_timeout_ms Application.compile_env(:ix_mcp, :busy_timeout_ms, 5_000)
+  @busy_retries 3
+  @busy_retry_sleep_ms 100
+
+  # How long the client API keeps retrying a call whose server died
+  # mid-request or is restarting (#3874). The supervisor brings the log
+  # back within milliseconds; this only needs to outlive the blip.
+  @call_retries 20
+  @call_retry_sleep_ms 100
+
+  # Callers must outwait the server's own worst case, not the default 5s:
+  # one statement can legitimately occupy the single-writer GenServer for
+  # busy_timeout x retries (a slow sibling holding the lock), and a caller
+  # that times out at exactly @busy_timeout_ms would die with the same
+  # symptom #3874 fixed, just as a timeout-exit instead of a crash-exit.
+  @call_timeout_ms 30_000
 
   # Frozen historical DDL for the 1 -> 2 step: the actions shape exactly as
   # #3532 shipped it, before the live-row columns. A migration must never
@@ -292,25 +319,25 @@ defmodule IxMcp.ActionLog do
   @doc "Insert a sessions row (name may be nil); returns its id."
   @spec create_session(String.t() | nil, GenServer.server()) :: integer()
   def create_session(name, server \\ __MODULE__) do
-    GenServer.call(server, {:create_session, name, now()})
+    call(server, {:create_session, name, now()})
   end
 
   @doc "Set an existing session row's name."
   @spec rename_session(integer(), String.t(), GenServer.server()) :: :ok
   def rename_session(id, name, server \\ __MODULE__) do
-    GenServer.call(server, {:rename_session, id, name})
+    call(server, {:rename_session, id, name})
   end
 
   @doc "Insert a topics row under `session_id`; returns its id."
   @spec create_topic(integer(), String.t(), GenServer.server()) :: integer()
   def create_topic(session_id, name, server \\ __MODULE__) do
-    GenServer.call(server, {:create_topic, session_id, name, now()})
+    call(server, {:create_topic, session_id, name, now()})
   end
 
   @doc "Insert an action row as `running` before the call executes; returns its id."
   @spec start_action(map(), GenServer.server()) :: integer()
   def start_action(action, server \\ __MODULE__) do
-    GenServer.call(server, {:start_action, Map.put(action, :at, now())})
+    call(server, {:start_action, Map.put(action, :at, now())})
   end
 
   @doc "Finalize a running action row; a no-op when it already finished."
@@ -318,7 +345,7 @@ defmodule IxMcp.ActionLog do
           :ok
   def finish_action(id, status, is_error, elapsed_ms, server \\ __MODULE__)
       when status in ["done", "failed", "cancelled"] do
-    GenServer.call(server, {:finish_action, id, status, is_error, elapsed_ms})
+    call(server, {:finish_action, id, status, is_error, elapsed_ms})
   end
 
   @doc """
@@ -328,13 +355,13 @@ defmodule IxMcp.ActionLog do
   """
   @spec update_stack(integer(), String.t(), pos_integer() | nil, GenServer.server()) :: :ok
   def update_stack(id, stack_json, line, server \\ __MODULE__) do
-    GenServer.call(server, {:update_stack, id, stack_json, line, now()})
+    call(server, {:update_stack, id, stack_json, line, now()})
   end
 
   @doc "Latest `n` recorded actions, newest first, with session/topic names joined in."
   @spec recent(pos_integer(), GenServer.server()) :: [entry()]
   def recent(n \\ 20, server \\ __MODULE__) do
-    GenServer.call(server, {:recent, n})
+    call(server, {:recent, n})
   end
 
   @doc "All sessions rows, oldest first."
@@ -342,14 +369,14 @@ defmodule IxMcp.ActionLog do
           %{id: integer(), name: String.t() | nil, started_at: String.t()}
         ]
   def sessions(server \\ __MODULE__) do
-    GenServer.call(server, :sessions)
+    call(server, :sessions)
   end
 
   @doc "All topics rows, oldest first."
   @spec topics(GenServer.server()) ::
           [%{id: integer(), session_id: integer(), name: String.t(), started_at: String.t()}]
   def topics(server \\ __MODULE__) do
-    GenServer.call(server, :topics)
+    call(server, :topics)
   end
 
   # -- durable job ledger (#3839) --------------------------------------------
@@ -357,13 +384,15 @@ defmodule IxMcp.ActionLog do
   @doc "Insert a `jobs` row as `running` when a job starts; idempotent per id."
   @spec job_started(job_start(), GenServer.server()) :: :ok
   def job_started(job, server \\ __MODULE__) do
-    GenServer.call(server, {:job_started, job})
+    call(server, {:job_started, job})
   end
 
   @doc """
-  Append output `chunks` (`[{seq, chunk}]`) to a job, recording `dropped`
-  bytes discarded by the per-job cap. Batched by the job process so the hot
-  path is not one call per `put_chars`.
+  Append output `chunks` (`[{seq, chunk}]`) to a job, recording
+  `dropped_total` -- the job's running total of bytes discarded by the
+  per-job cap, an absolute value so a retried batch cannot double-count
+  (#3874). Batched by the job process so the hot path is not one call per
+  `put_chars`.
   """
   @spec append_job_output(
           String.t(),
@@ -372,8 +401,8 @@ defmodule IxMcp.ActionLog do
           GenServer.server()
         ) ::
           :ok
-  def append_job_output(id, chunks, dropped \\ 0, server \\ __MODULE__) do
-    GenServer.call(server, {:append_job_output, id, chunks, dropped})
+  def append_job_output(id, chunks, dropped_total \\ 0, server \\ __MODULE__) do
+    call(server, {:append_job_output, id, chunks, dropped_total})
   end
 
   @doc """
@@ -387,25 +416,25 @@ defmodule IxMcp.ActionLog do
           {:notify, outbox()} | :already_final
   def finish_job(id, status, result, server \\ __MODULE__)
       when status in [:done, :failed, :cancelled, :killed] do
-    GenServer.call(server, {:finish_job, id, Atom.to_string(status), result, now()})
+    call(server, {:finish_job, id, Atom.to_string(status), result, now()})
   end
 
   @doc "The recorded job row, or nil."
   @spec job(String.t(), GenServer.server()) :: job() | nil
   def job(id, server \\ __MODULE__) do
-    GenServer.call(server, {:job, id})
+    call(server, {:job, id})
   end
 
   @doc "The full recorded output of a job, from the durable table."
   @spec job_output(String.t(), GenServer.server()) :: binary()
   def job_output(id, server \\ __MODULE__) do
-    GenServer.call(server, {:job_output, id})
+    call(server, {:job_output, id})
   end
 
   @doc "Recent jobs for a session (nil = all), newest first."
   @spec recent_jobs(integer() | nil, pos_integer(), GenServer.server()) :: [job()]
   def recent_jobs(session_id, n \\ 20, server \\ __MODULE__) do
-    GenServer.call(server, {:recent_jobs, session_id, n})
+    call(server, {:recent_jobs, session_id, n})
   end
 
   # -- issue-claim arbiter (#3880) --------------------------------------------
@@ -450,7 +479,7 @@ defmodule IxMcp.ActionLog do
   """
   @spec unacked_outbox(integer() | nil, GenServer.server()) :: [outbox()]
   def unacked_outbox(session_id \\ nil, server \\ __MODULE__) do
-    GenServer.call(server, {:unacked_outbox, session_id})
+    call(server, {:unacked_outbox, session_id})
   end
 
   @doc """
@@ -460,7 +489,36 @@ defmodule IxMcp.ActionLog do
   """
   @spec ack_outbox([integer()], GenServer.server()) :: non_neg_integer()
   def ack_outbox(ids, server \\ __MODULE__) do
-    GenServer.call(server, {:ack_outbox, ids})
+    call(server, {:ack_outbox, ids})
+  end
+
+  # Every public function funnels through here (#3874). When the server dies
+  # mid-request -- historically a SQLITE_BUSY badmatch under a sibling's
+  # write lock -- the exit propagated into whichever process was calling:
+  # job control processes died mid-flush and vanished from the registry,
+  # and the reaper died and forgot every monitor it held. The supervisor
+  # restarts the log within milliseconds, so a bounded retry absorbs the
+  # blip. A timeout is not retried (the request may still be executing);
+  # exhaustion re-raises the exit, keeping a truly-down log loud. A rare
+  # side effect is acceptable double-logging: a retried insert whose first
+  # attempt committed before the server died writes a second row (job-ledger
+  # writes are idempotent by key; a duplicate session/action row is only a
+  # cosmetic log artifact).
+  defp call(server, request), do: call(server, request, @call_retries)
+
+  defp call(server, request, attempts) do
+    GenServer.call(server, request, @call_timeout_ms)
+  catch
+    :exit, {:timeout, _call} = reason ->
+      exit(reason)
+
+    :exit, reason ->
+      if attempts > 0 do
+        Process.sleep(@call_retry_sleep_ms)
+        call(server, request, attempts - 1)
+      else
+        exit(reason)
+      end
   end
 
   @doc """
@@ -483,14 +541,7 @@ defmodule IxMcp.ActionLog do
     if path != ":memory:", do: File.mkdir_p!(Path.dirname(path))
 
     {:ok, conn} = Sqlite3.open(path)
-
-    # Several server instances share one database file, so a step can find a
-    # sibling holding the write lock. The NIF opens with a 2s busy handler; a
-    # lock outliving it surfaced as :busy and badmatch-crashed run/3, taking
-    # the calling job down with it (#3890). Wait longer here, and let
-    # step!/fetch turn a still-busy result into a descriptive crash. The
-    # option exists so the regression test can shrink the wait.
-    :ok = Sqlite3.set_busy_timeout(conn, Keyword.get(opts, :busy_timeout_ms, @busy_timeout_ms))
+    :ok = Sqlite3.execute(conn, "PRAGMA busy_timeout = #{@busy_timeout_ms}")
 
     # index#3539: on 2026-07-17 a server binary match-crashed right here
     # against an action log written under a newer schema, and the failed
@@ -560,7 +611,7 @@ defmodule IxMcp.ActionLog do
         action.arguments
       ])
 
-    :done = step!(conn, insert, "insert action")
+    :ok = step!(conn, insert)
     {:ok, id} = Sqlite3.last_insert_rowid(conn)
     {:reply, id, state}
   end
@@ -624,9 +675,14 @@ defmodule IxMcp.ActionLog do
     {:reply, :ok, state}
   end
 
-  def handle_call({:append_job_output, id, chunks, dropped}, _from, %{conn: conn} = state) do
-    :ok = Sqlite3.execute(conn, "BEGIN IMMEDIATE")
+  def handle_call({:append_job_output, id, chunks, dropped_total}, _from, %{conn: conn} = state) do
+    :ok = execute!(conn, "BEGIN IMMEDIATE")
 
+    # A batch can arrive twice (#3874): the job retries a flush whose reply
+    # was lost, and the client seam retries a call whose server died after
+    # committing. The rows are idempotent by (job_id, seq); the counters
+    # must be too, so bytes count only rows this insert actually added and
+    # the drop total is an absolute high-water mark, not a delta.
     added =
       Enum.reduce(chunks, 0, fn {seq, chunk}, acc ->
         run(conn, "INSERT OR IGNORE INTO job_output (job_id, seq, chunk) VALUES (?, ?, ?)", [
@@ -635,16 +691,17 @@ defmodule IxMcp.ActionLog do
           chunk
         ])
 
-        acc + byte_size(chunk)
+        {:ok, inserted} = Sqlite3.changes(conn)
+        acc + inserted * byte_size(chunk)
       end)
 
     run(
       conn,
-      "UPDATE jobs SET output_bytes = output_bytes + ?, output_dropped = output_dropped + ? WHERE id = ?",
-      [added, dropped, id]
+      "UPDATE jobs SET output_bytes = output_bytes + ?, output_dropped = MAX(output_dropped, ?) WHERE id = ?",
+      [added, dropped_total, id]
     )
 
-    :ok = Sqlite3.execute(conn, "COMMIT")
+    :ok = execute!(conn, "COMMIT")
     {:reply, :ok, state}
   end
 
@@ -667,7 +724,7 @@ defmodule IxMcp.ActionLog do
         [[action_id, intent, started_at]] ->
           elapsed = elapsed_ms(started_at, at)
           is_error = if status in ["failed", "killed"], do: 1, else: 0
-          :ok = Sqlite3.execute(conn, "BEGIN IMMEDIATE")
+          :ok = execute!(conn, "BEGIN IMMEDIATE")
 
           run(
             conn,
@@ -686,7 +743,7 @@ defmodule IxMcp.ActionLog do
           )
 
           {:ok, outbox_id} = Sqlite3.last_insert_rowid(conn)
-          :ok = Sqlite3.execute(conn, "COMMIT")
+          :ok = execute!(conn, "COMMIT")
 
           {:notify,
            %{
@@ -896,48 +953,94 @@ defmodule IxMcp.ActionLog do
   end
 
   defp execute_all(conn, statements) do
-    Enum.each(statements, fn statement -> :ok = Sqlite3.execute(conn, statement) end)
+    Enum.each(statements, fn statement -> :ok = execute!(conn, statement) end)
   end
 
   defp run(conn, sql, params) do
     {:ok, statement} = Sqlite3.prepare(conn, sql)
     :ok = Sqlite3.bind(statement, params)
-    :done = step!(conn, statement, sql)
+    :ok = step!(conn, statement)
     :ok = Sqlite3.release(conn, statement)
-  end
-
-  # :busy after the connection's busy timeout (set at open) is a legitimate
-  # runtime state -- a sibling instance still holds the write lock -- not a
-  # programming error, so it fails with a diagnosis instead of a bare
-  # badmatch (#3890). No retry: the NIF already waited the full bound, and
-  # the supervisor reopens the log after the crash.
-  defp step!(conn, statement, sql) do
-    case Sqlite3.step(conn, statement) do
-      :busy ->
-        raise "action log write still blocked after the busy-timeout wait (#3890): #{sql}"
-
-      result ->
-        result
-    end
   end
 
   defp fetch(conn, sql, params) do
     {:ok, statement} = Sqlite3.prepare(conn, sql)
     :ok = Sqlite3.bind(statement, params)
+    rows = fetch_all!(conn, statement)
+    :ok = Sqlite3.release(conn, statement)
+    rows
+  end
 
-    case Sqlite3.fetch_all(conn, statement) do
-      {:ok, rows} ->
-        :ok = Sqlite3.release(conn, statement)
-        rows
+  # -- SQLITE_BUSY tolerance (#3874) ------------------------------------------
+  # sqlite already waits `@busy_timeout_ms` inside the NIF before reporting
+  # busy; these bounded retries only cover the starvation window where that
+  # timeout still expires under a slow sibling. Anything else stays a loud
+  # crash, unchanged.
 
-      # fetch_all reports a lock outliving the busy wait as this string.
-      {:error, "Database busy"} ->
-        raise "action log read still blocked after the busy-timeout wait (#3890): #{sql}"
+  defp step!(conn, statement), do: step!(conn, statement, @busy_retries)
 
-      {:error, reason} ->
-        raise "action log read failed: #{inspect(reason)}: #{sql}"
+  defp step!(conn, statement, attempts) do
+    case Sqlite3.step(conn, statement) do
+      :done ->
+        :ok
+
+      :busy when attempts > 0 ->
+        Process.sleep(@busy_retry_sleep_ms)
+        step!(conn, statement, attempts - 1)
+
+      :busy ->
+        raise "action log write still blocked after the busy-timeout wait and retries (#3890)"
+
+      other ->
+        raise "action log write failed: #{inspect(other)}"
     end
   end
+
+  defp execute!(conn, sql), do: execute!(conn, sql, @busy_retries)
+
+  defp execute!(conn, sql, attempts) do
+    case Sqlite3.execute(conn, sql) do
+      :ok ->
+        :ok
+
+      {:error, reason} when attempts > 0 ->
+        if busy?(reason) do
+          Process.sleep(@busy_retry_sleep_ms)
+          execute!(conn, sql, attempts - 1)
+        else
+          raise "action log execute failed: #{inspect(reason)}"
+        end
+
+      {:error, reason} ->
+        raise "action log execute failed: #{inspect(reason)}"
+    end
+  end
+
+  defp fetch_all!(conn, statement), do: fetch_all!(conn, statement, @busy_retries)
+
+  defp fetch_all!(conn, statement, attempts) do
+    case Sqlite3.fetch_all(conn, statement) do
+      {:ok, rows} ->
+        rows
+
+      {:error, reason} when attempts > 0 ->
+        if busy?(reason) do
+          Process.sleep(@busy_retry_sleep_ms)
+          fetch_all!(conn, statement, attempts - 1)
+        else
+          raise "action log read failed: #{inspect(reason)}"
+        end
+
+      {:error, reason} ->
+        raise "action log read failed: #{inspect(reason)}"
+    end
+  end
+
+  defp busy?(reason) when is_binary(reason) do
+    reason =~ "database is locked" or reason =~ "database table is locked"
+  end
+
+  defp busy?(_reason), do: false
 
   defp state_home do
     System.get_env("XDG_STATE_HOME") || Path.join(System.user_home!(), ".local/state")

--- a/packages/mcp-ex/lib/ix_mcp/application.ex
+++ b/packages/mcp-ex/lib/ix_mcp/application.ex
@@ -54,7 +54,19 @@ defmodule IxMcp.Application do
         {IxMcp.Agents.Events, harness: IxMcp.Agents.Harness}
       ] ++ issue_watch() ++ transport()
 
-    Supervisor.start_link(children, strategy: :one_for_one, name: IxMcp.Supervisor)
+    # max_restarts above the default 3-in-5s (#3874): ActionLog's callers
+    # now retry across its restarts, so a persistent fault there (disk
+    # full, I/O error -- transient SQLITE_BUSY no longer crashes at all)
+    # gets re-triggered quickly by the retries. The extra headroom keeps a
+    # single faulting child from taking the whole kernel -- and every
+    # running job -- down before the retries give up; a child that still
+    # cannot hold up its part after ten restarts is a real fault and the
+    # loud whole-app death stays.
+    Supervisor.start_link(children,
+      strategy: :one_for_one,
+      max_restarts: 10,
+      name: IxMcp.Supervisor
+    )
   end
 
   # index#3539: without ERL_CRASH_DUMP the BEAM writes erl_crash.dump into

--- a/packages/mcp-ex/lib/ix_mcp/edit.ex
+++ b/packages/mcp-ex/lib/ix_mcp/edit.ex
@@ -10,7 +10,14 @@ defmodule IxMcp.Edit do
   native stale-read guard is subsumed by exactness: content that drifted
   since `old_string` was copied no longer matches, so the call raises
   instead of clobbering.
+
+  Writes honor the primary-checkout worktree guard (#3871): the same
+  denylist the claude-code PreToolUse hook enforces for the native Edit and
+  Write tools applies here, because kernel writes never pass through hooks.
+  See `guard_primary_checkout!/1`.
   """
+
+  alias IxMcp.Cmd
 
   # Lines of context around the edited region in the success snippet.
   @snippet_context 4
@@ -24,6 +31,7 @@ defmodule IxMcp.Edit do
   """
   @spec replace(Path.t(), String.t(), String.t(), keyword()) :: String.t()
   def replace(path, old_string, new_string, opts \\ []) do
+    guard_primary_checkout!(path)
     replace_all = Keyword.get(opts, :replace_all, false)
     validate_strings!(old_string, new_string)
 
@@ -58,6 +66,7 @@ defmodule IxMcp.Edit do
   """
   @spec write(Path.t(), String.t()) :: String.t()
   def write(path, content) do
+    guard_primary_checkout!(path)
     existed = File.exists?(path)
     File.mkdir_p!(Path.dirname(path))
     File.write!(path, content)
@@ -67,6 +76,121 @@ defmodule IxMcp.Edit do
     else
       "File created successfully at: #{path}"
     end
+  end
+
+  # -- primary-checkout worktree guard (#3871) --------------------------------
+
+  # The claude-code home-manager module ships a PreToolUse hook
+  # (packages/agent/claude-hooks `worktree-guard`) that denies native
+  # Edit/Write under the configured primary-checkout globs. Kernel writes
+  # bypass hooks entirely, so the same policy is enforced here at the
+  # blessed write seam, with the same knobs and the same message: an
+  # operator `CLAUDE_CODE_PRIMARY_CHECKOUTS` wins over the provisioned
+  # `IX_DEFAULT_PRIMARY_CHECKOUTS` (colon-separated globs, empty disables),
+  # `CLAUDE_CODE_DISABLE_WORKTREE_GUARD` is the kill switch, and a linked
+  # worktree is always allowed. App env `:primary_checkouts` pins the globs
+  # for tests, the same seam shape as `:actions_db`.
+  # A relative path resolves against this process's cwd (`Path.expand`);
+  # the hook resolves against the tool payload's cwd, which for kernel
+  # writes is the same server process.
+  defp guard_primary_checkout!(path) do
+    globs = primary_checkouts()
+
+    if globs != [] and not guard_disabled?() do
+      case protected_toplevel(Path.expand(path), globs) do
+        nil ->
+          :ok
+
+        toplevel ->
+          raise ArgumentError,
+                "Refusing to edit #{toplevel}: it is a primary checkout, not a worktree, " <>
+                  "and other work may be in flight there. Create a dedicated worktree " <>
+                  "(`git -C #{toplevel} worktree add <dir> -b <branch> origin/main`) and " <>
+                  "edit the file there instead. Reads are always fine."
+      end
+    end
+
+    :ok
+  end
+
+  defp guard_disabled? do
+    case System.get_env("CLAUDE_CODE_DISABLE_WORKTREE_GUARD") do
+      nil -> false
+      "" -> false
+      _set -> true
+    end
+  end
+
+  defp primary_checkouts do
+    case Application.get_env(:ix_mcp, :primary_checkouts) do
+      nil ->
+        (System.get_env("CLAUDE_CODE_PRIMARY_CHECKOUTS") ||
+           System.get_env("IX_DEFAULT_PRIMARY_CHECKOUTS") || "")
+        |> String.split(":", trim: true)
+
+      globs ->
+        globs
+    end
+  end
+
+  # The target's repo toplevel when it is a protected primary checkout, nil
+  # when the write is fine (outside any git repo, in a linked worktree, or
+  # in a toplevel no glob matches). A new file's parent may not exist yet,
+  # so the nearest existing ancestor's repo decides, exactly like the hook.
+  defp protected_toplevel(target, globs) do
+    dir = target |> Path.dirname() |> nearest_existing_dir()
+
+    with {:ok, gitdir} <- rev_parse(dir, "--git-dir"),
+         {:ok, common} <- rev_parse(dir, "--git-common-dir"),
+         # Linked worktree: private git-dir differs from the shared common dir.
+         true <- gitdir == common,
+         {:ok, toplevel} <- rev_parse(dir, "--show-toplevel"),
+         true <- Enum.any?(globs, &glob_match?(&1, toplevel)) do
+      toplevel
+    else
+      _allowed -> nil
+    end
+  end
+
+  defp nearest_existing_dir("/"), do: "/"
+
+  defp nearest_existing_dir(dir) do
+    if File.dir?(dir), do: dir, else: dir |> Path.dirname() |> nearest_existing_dir()
+  end
+
+  # Only stdout is parsed, matching the hook: merging stderr in would let
+  # git warning chatter corrupt the compared paths and fail the guard open.
+  defp rev_parse(dir, what) do
+    git = System.get_env("IX_GIT") || "git"
+
+    case Cmd.run(git, ["-C", dir, "rev-parse", "--path-format=absolute", what]) do
+      {out, 0} ->
+        case String.trim(out) do
+          "" -> :error
+          resolved -> {:ok, resolved}
+        end
+
+      _not_a_repo ->
+        :error
+    end
+  end
+
+  # Shell case-glob semantics, matching the hook's matcher: `*` crosses `/`
+  # and `?` matches any one character, judged against the whole toplevel.
+  # `[...]` character classes are NOT translated (they match literally);
+  # the house patterns are slash-and-star only, and a divergence here fails
+  # toward the hook still denying the native tools.
+  defp glob_match?(pattern, string) do
+    regex =
+      pattern
+      |> String.graphemes()
+      |> Enum.map_join(fn
+        "*" -> ".*"
+        "?" -> "."
+        ch -> Regex.escape(ch)
+      end)
+
+    Regex.match?(Regex.compile!("\\A" <> regex <> "\\z"), string)
   end
 
   defp validate_strings!(old_string, new_string) do

--- a/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
@@ -22,6 +22,14 @@ defmodule IxMcp.Jobs.Job do
   control process itself (which trapping cannot catch) is caught by the
   single reaper (`IxMcp.Jobs.Reaper`), which writes the `killed` transition
   from outside.
+
+  The durable ledger must never take a job down with it (#3874): every
+  `ActionLog` call from this process goes through `safe_log/1`, which
+  absorbs the exit a caller inherits when the log dies mid-request (the
+  log's own client API already retries across the restart blip). A failed
+  output flush leaves the hot buffer unflushed for the next tick; a failed
+  terminal transition re-arms itself (`:record_terminal`) until the ledger
+  takes it, so the notification is delayed, never lost.
   """
 
   use GenServer, restart: :temporary
@@ -35,6 +43,8 @@ defmodule IxMcp.Jobs.Job do
   alias IxMcp.Session
   alias IxMcp.Workspace
 
+  require Logger
+
   # How often a running exec's eval process is stack-sampled into the action
   # log (Process.info(pid, :current_stacktrace) -- external, works on a
   # wedged process). Tests shrink it via app env to keep the suite fast.
@@ -44,6 +54,11 @@ defmodule IxMcp.Jobs.Job do
   # durable `job_output` table. A hard kill loses at most this window of the
   # very latest output (already-flushed output survives, which is the point).
   @flush_interval_ms Application.compile_env(:ix_mcp, :output_flush_interval_ms, 250)
+
+  # How long a job waits before retrying a terminal transition the ledger
+  # could not take (#3874). The log restarts in milliseconds; a second is
+  # generous without spamming a genuinely stuck database.
+  @terminal_retry_ms 1_000
 
   # Per-job output cap. Beyond it, output is dropped (head kept) and the drop
   # is recorded, so one runaway cell cannot fill the ledger. 8 MiB is far
@@ -70,6 +85,7 @@ defmodule IxMcp.Jobs.Job do
     :finished_mono,
     :result,
     status: :running,
+    terminal_recorded: false,
     diagnostics: [],
     subscribers: [],
     flushed_seq: nil,
@@ -98,6 +114,7 @@ defmodule IxMcp.Jobs.Job do
           finished_mono: integer() | nil,
           result: {:value, term()} | {:failure, String.t()} | nil,
           status: status(),
+          terminal_recorded: boolean(),
           diagnostics: [String.t()],
           subscribers: [pid()],
           flushed_seq: integer() | nil,
@@ -211,18 +228,23 @@ defmodule IxMcp.Jobs.Job do
   @impl true
   def handle_continue(:spawn_eval, state) do
     # Record the durable jobs row and arm the reaper before anything can die,
-    # so a death in the first instants is still finalized (#3839).
-    ActionLog.job_started(%{
-      id: state.id,
-      session_id: state.session_id,
-      action_id: state.action_id,
-      intent: state.intent,
-      session_name: state.session,
-      topic_name: state.topic,
-      code: state.code,
-      watch: state.watch,
-      started_at: DateTime.to_iso8601(state.started_at)
-    })
+    # so a death in the first instants is still finalized (#3839). A ledger
+    # outage must not abort the job itself (#3874): without the row, later
+    # reads degrade to the hot buffer, which beats dying before the eval
+    # even starts.
+    safe_log(fn ->
+      ActionLog.job_started(%{
+        id: state.id,
+        session_id: state.session_id,
+        action_id: state.action_id,
+        intent: state.intent,
+        session_name: state.session,
+        topic_name: state.topic,
+        code: state.code,
+        watch: state.watch,
+        started_at: DateTime.to_iso8601(state.started_at)
+      })
+    end)
 
     Reaper.watch(state.id, self())
 
@@ -361,6 +383,15 @@ defmodule IxMcp.Jobs.Job do
   # death).
   def handle_info({:EXIT, _pid, _reason}, state), do: {:noreply, state}
 
+  def handle_info(:record_terminal, %{terminal_recorded: false, status: status} = state)
+      when status != :running do
+    # Catch up the output the failed pre-terminal flush left behind, then
+    # retry the transition itself (#3874).
+    {:noreply, state |> flush() |> record_terminal()}
+  end
+
+  def handle_info(:record_terminal, state), do: {:noreply, state}
+
   def handle_info(:flush, %{status: :running} = state) do
     state = %{flush(state) | flush_scheduled: true}
     schedule_flush()
@@ -381,7 +412,7 @@ defmodule IxMcp.Jobs.Job do
           end
 
         stack = JSON.encode!(Enum.map(shown, &Exception.format_stacktrace_entry/1))
-        ActionLog.update_stack(state.action_id, stack, cell_line(frames))
+        safe_log(fn -> ActionLog.update_stack(state.action_id, stack, cell_line(frames)) end)
 
       nil ->
         :ok
@@ -416,20 +447,36 @@ defmodule IxMcp.Jobs.Job do
     # Persist all captured output before the transition, so a reader that
     # sees the job finish finds its output already complete on disk.
     state = flush(state)
-
-    # The one atomic terminal transition: jobs row + actions row + outbox,
-    # committed together (#3839). Whoever writes it first wins; the reaper's
-    # racing `killed` attempt then no-ops.
-    case ActionLog.finish_job(state.id, status, render_result(state)) do
-      {:notify, outbox} -> Notifier.publish(outbox)
-      :already_final -> :ok
-    end
-
-    Reaper.reported(state.id)
+    state = record_terminal(state)
 
     summary = build_summary(state)
     Enum.each(state.subscribers, fn pid -> send(pid, {:ix_job_finished, state.id, summary}) end)
     %{state | subscribers: []}
+  end
+
+  # The one atomic terminal transition: jobs row + actions row + outbox,
+  # committed together (#3839). Whoever writes it first wins; the reaper's
+  # racing `killed` attempt then no-ops. When the ledger is unavailable the
+  # transition re-arms itself (#3874) -- the reaper stays armed until it
+  # lands, so even this process dying in the window is still finalized.
+  defp record_terminal(state) do
+    recorded =
+      safe_log(fn -> ActionLog.finish_job(state.id, state.status, render_result(state)) end)
+
+    case recorded do
+      {:ok, {:notify, outbox}} ->
+        Notifier.publish(outbox)
+        Reaper.reported(state.id)
+        %{state | terminal_recorded: true}
+
+      {:ok, :already_final} ->
+        Reaper.reported(state.id)
+        %{state | terminal_recorded: true}
+
+      :unavailable ->
+        Process.send_after(self(), :record_terminal, @terminal_retry_ms)
+        state
+    end
   end
 
   # Capture one output chunk into the hot buffer, honoring the per-job cap.
@@ -462,9 +509,20 @@ defmodule IxMcp.Jobs.Job do
       rows ->
         rows = Enum.sort(rows)
         dropped_now = :counters.get(state.counter, 2)
-        ActionLog.append_job_output(state.id, rows, dropped_now - state.flushed_dropped)
-        {last_seq, _} = List.last(rows)
-        %{state | flushed_seq: last_seq, flushed_dropped: dropped_now}
+
+        append =
+          safe_log(fn -> ActionLog.append_job_output(state.id, rows, dropped_now) end)
+
+        case append do
+          {:ok, :ok} ->
+            {last_seq, _} = List.last(rows)
+            %{state | flushed_seq: last_seq, flushed_dropped: dropped_now}
+
+          # Nothing advanced: the same rows are still in the hot buffer and
+          # the next tick retries the whole batch (idempotent per seq).
+          :unavailable ->
+            state
+        end
     end
   end
 
@@ -473,12 +531,28 @@ defmodule IxMcp.Jobs.Job do
   defp maybe_flush_dropped(state) do
     dropped_now = :counters.get(state.counter, 2)
 
-    if dropped_now > state.flushed_dropped do
-      ActionLog.append_job_output(state.id, [], dropped_now - state.flushed_dropped)
+    with true <- dropped_now > state.flushed_dropped,
+         {:ok, :ok} <-
+           safe_log(fn -> ActionLog.append_job_output(state.id, [], dropped_now) end) do
       %{state | flushed_dropped: dropped_now}
     else
-      state
+      _unchanged -> state
     end
+  end
+
+  # Run one ActionLog write, absorbing the exit inherited when the log dies
+  # mid-request (#3874): the ledger degrades, the job survives. The log's
+  # client API has already retried across the supervisor restart by the
+  # time this fires, so a hit here means the log is truly down.
+  defp safe_log(fun) do
+    {:ok, fun.()}
+  catch
+    :exit, reason ->
+      Logger.warning(
+        "job #{inspect(self())}: action log unavailable: #{inspect(reason, limit: 5)}"
+      )
+
+      :unavailable
   end
 
   defp schedule_flush, do: Process.send_after(self(), :flush, @flush_interval_ms)

--- a/packages/mcp-ex/lib/ix_mcp/jobs/reaper.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs/reaper.ex
@@ -21,6 +21,15 @@ defmodule IxMcp.Jobs.Reaper do
   alias IxMcp.ActionLog
   alias IxMcp.MCP.Notifier
 
+  require Logger
+
+  # Retry cadence for a `killed` transition the ledger could not take
+  # (#3874). The reaper's monitor map is the only record of which jobs are
+  # still guarded, so this process must never die over a ledger call: it
+  # re-arms the write instead.
+  @finalize_retries 10
+  @finalize_retry_ms 1_000
+
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
@@ -66,16 +75,33 @@ defmodule IxMcp.Jobs.Reaper do
     ids = if id, do: Map.delete(state.ids, id), else: state.ids
 
     if id do
-      case ActionLog.finish_job(
-             id,
-             :killed,
-             "killed: " <> inspect(reason, limit: 25, printable_limit: 2_000)
-           ) do
-        {:notify, outbox} -> Notifier.publish(outbox)
-        :already_final -> :ok
-      end
+      result = "killed: " <> inspect(reason, limit: 25, printable_limit: 2_000)
+      finalize(id, result, @finalize_retries)
     end
 
     {:noreply, %{state | refs: refs, ids: ids}}
+  end
+
+  def handle_info({:finalize, id, result, attempts}, state) do
+    finalize(id, result, attempts)
+    {:noreply, state}
+  end
+
+  # Drive the ledger terminal for a job that died unreported. An exit from
+  # the ledger call (it died mid-request, #3874) must not crash the reaper
+  # -- that would drop every monitor it holds -- so the attempt re-arms
+  # itself instead.
+  defp finalize(id, result, attempts) do
+    case ActionLog.finish_job(id, :killed, result) do
+      {:notify, outbox} -> Notifier.publish(outbox)
+      :already_final -> :ok
+    end
+  catch
+    :exit, reason ->
+      if attempts > 0 do
+        Process.send_after(self(), {:finalize, id, result, attempts - 1}, @finalize_retry_ms)
+      else
+        Logger.error("reaper: job #{id} terminal write lost: #{inspect(reason, limit: 5)}")
+      end
   end
 end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/notifier.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/notifier.ex
@@ -78,19 +78,26 @@ defmodule IxMcp.MCP.Notifier do
   end
 
   def handle_cast({:publish, outbox}, state) do
-    # Claim the row before delivering: a register-replay may already have
-    # delivered and acked it (both paths run in this process, but in
-    # nondeterministic mailbox order), so the ack flip is the single arbiter
-    # that prevents announcing the same finish twice (#3839). With no
-    # transport connected we neither deliver nor claim -- the row waits for
+    # Deliver before acking (#3874). The old order claimed the ack first as
+    # the dedup arbiter, but the log's client API now retries a call whose
+    # server died mid-request: an ack that committed without a reply looks
+    # already-claimed on retry, and skipping delivery on that evidence
+    # would silence the notification permanently -- the exact silence the
+    # outbox exists to prevent. Publish and register-replay both run in
+    # this process, so checking the row is still unacked before delivering
+    # keeps the same-finish dedup (#3839) race-free; the residual worst
+    # case is a duplicate announce, which beats a lost one. With no
+    # transport connected we neither deliver nor ack -- the row waits for
     # replay.
-    if state.transports != [] and ActionLog.ack_outbox([outbox.id]) > 0 do
+    if state.transports != [] and unacked?(outbox.id) do
       {content, meta} = render(outbox)
 
       deliver(state.transports, "notifications/claude/channel", %{
         "content" => content,
         "meta" => meta
       })
+
+      ack_all([outbox.id])
     end
 
     {:noreply, state}
@@ -111,7 +118,7 @@ defmodule IxMcp.MCP.Notifier do
   # this instance's session, so a transport connecting here never drains a
   # sibling instance's notifications out of the shared database.
   defp replay_unacked(transports) do
-    case ActionLog.unacked_outbox(Session.ids().session_id) do
+    case unacked_rows(Session.ids().session_id) do
       [] ->
         :ok
 
@@ -125,8 +132,30 @@ defmodule IxMcp.MCP.Notifier do
           "meta" => meta
         })
 
-        ActionLog.ack_outbox(Enum.map(rows, & &1.id))
+        rows |> Enum.map(& &1.id) |> ack_all()
     end
+  end
+
+  defp unacked_rows(session_id) do
+    ActionLog.unacked_outbox(session_id)
+  catch
+    :exit, _reason -> []
+  end
+
+  defp ack_all(ids) do
+    ActionLog.ack_outbox(ids)
+  catch
+    :exit, _reason -> 0
+  end
+
+  # The ledger interactions must never crash the notifier: its state is the
+  # live transport registry, and losing it silences every future
+  # notification until the transports reconnect (#3874). A row whose ack
+  # was lost stays unacked and may replay as a duplicate later -- accepted.
+  defp unacked?(outbox_id) do
+    Enum.any?(ActionLog.unacked_outbox(), &(&1.id == outbox_id))
+  catch
+    :exit, _reason -> false
   end
 
   defp deliver(transports, method, params) do

--- a/packages/mcp-ex/test/ix_mcp/action_log_busy_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/action_log_busy_test.exs
@@ -1,0 +1,74 @@
+defmodule IxMcp.ActionLogBusyTest do
+  @moduledoc """
+  Regression for #3874: several server instances share one action-log
+  database, so a sibling holding the write lock is normal operation. Ledger
+  writes must wait it out; before the fix they match-crashed the GenServer
+  (`{:badmatch, :busy}` in start_action, `{:badmatch, {:error, "database is
+  locked"}}` in the job-ledger transaction).
+  """
+  use ExUnit.Case, async: true
+
+  alias Exqlite.Sqlite3
+  alias IxMcp.ActionLog
+
+  @moduletag :tmp_dir
+
+  setup %{tmp_dir: dir} do
+    path = Path.join(dir, "actions.db")
+    name = :"action_log_busy_#{System.unique_integer([:positive])}"
+    log = start_supervised!({ActionLog, path: path, name: name})
+
+    # A second connection standing in for a concurrent server instance.
+    {:ok, holder} = Sqlite3.open(path)
+
+    %{log: log, name: name, holder: holder}
+  end
+
+  test "start_action waits out a held write lock instead of crashing", ctx do
+    sid = ActionLog.create_session("busy", ctx.name)
+    :ok = Sqlite3.execute(ctx.holder, "BEGIN IMMEDIATE")
+
+    task =
+      Task.async(fn ->
+        ActionLog.start_action(
+          %{session_id: sid, topic_id: nil, tool: "exec", intent: "busy", arguments: "{}"},
+          ctx.name
+        )
+      end)
+
+    # Let the insert actually hit the held lock before releasing it.
+    Process.sleep(150)
+    :ok = Sqlite3.execute(ctx.holder, "COMMIT")
+
+    assert is_integer(Task.await(task, 10_000))
+    assert Process.alive?(ctx.log)
+  end
+
+  test "the job-ledger transaction waits out a held write lock", ctx do
+    :ok = ActionLog.job_started(job_start("j1"), ctx.name)
+    :ok = Sqlite3.execute(ctx.holder, "BEGIN IMMEDIATE")
+
+    task = Task.async(fn -> ActionLog.append_job_output("j1", [{1, "chunk"}], 0, ctx.name) end)
+
+    Process.sleep(150)
+    :ok = Sqlite3.execute(ctx.holder, "COMMIT")
+
+    assert :ok = Task.await(task, 10_000)
+    assert Process.alive?(ctx.log)
+    assert ActionLog.job_output("j1", ctx.name) == "chunk"
+  end
+
+  defp job_start(id) do
+    %{
+      id: id,
+      session_id: nil,
+      action_id: nil,
+      intent: nil,
+      session_name: nil,
+      topic_name: nil,
+      code: ":ok",
+      watch: false,
+      started_at: DateTime.to_iso8601(DateTime.utc_now())
+    }
+  end
+end

--- a/packages/mcp-ex/test/ix_mcp/edit_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/edit_test.exs
@@ -70,4 +70,93 @@ defmodule IxMcp.EditTest do
       assert File.read!(path) == "two"
     end
   end
+
+  describe "primary-checkout worktree guard (#3871)" do
+    setup %{tmp_dir: dir} do
+      primary = Path.join(dir, "primary")
+      File.mkdir_p!(primary)
+      git!(primary, ["init"])
+
+      # git resolves symlinks (macOS /tmp -> /private/tmp), so globs must be
+      # built from the toplevel git reports, not from the raw tmp_dir. `*`
+      # crosses `/` in the hook's matcher, so one glob over the resolved tmp
+      # root covers every repo this test creates under it.
+      toplevel =
+        primary
+        |> git!(["rev-parse", "--path-format=absolute", "--show-toplevel"])
+        |> String.trim()
+
+      Application.put_env(:ix_mcp, :primary_checkouts, [Path.dirname(toplevel) <> "/*"])
+      on_exit(fn -> Application.delete_env(:ix_mcp, :primary_checkouts) end)
+
+      %{primary: toplevel}
+    end
+
+    test "write under a configured primary checkout raises and writes nothing", %{
+      primary: primary
+    } do
+      target = Path.join(primary, "notes.txt")
+
+      assert_raise ArgumentError, ~r/primary checkout, not a worktree/, fn ->
+        Edit.write(target, "nope\n")
+      end
+
+      refute File.exists?(target)
+
+      # A new file whose parents do not exist yet is judged by the nearest
+      # existing ancestor, exactly like the hook.
+      deep = Path.join([primary, "not", "yet", "there.txt"])
+
+      assert_raise ArgumentError, ~r/use a worktree|worktree add/, fn ->
+        Edit.write(deep, "nope\n")
+      end
+
+      refute File.exists?(deep)
+    end
+
+    test "replace under a configured primary checkout raises", %{primary: primary} do
+      target = Path.join(primary, "existing.txt")
+      File.write!(target, "alpha\n")
+
+      assert_raise ArgumentError, ~r/primary checkout, not a worktree/, fn ->
+        Edit.replace(target, "alpha", "beta")
+      end
+
+      assert File.read!(target) == "alpha\n"
+    end
+
+    test "a linked worktree of the protected checkout stays writable", %{
+      tmp_dir: dir,
+      primary: primary
+    } do
+      git!(primary, [
+        "-c",
+        "user.name=t",
+        "-c",
+        "user.email=t@t.invalid",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "init"
+      ])
+
+      wt = Path.join(dir, "wt")
+      git!(primary, ["worktree", "add", wt])
+
+      message = Edit.write(Path.join(wt, "notes.txt"), "fine\n")
+      assert message =~ "File created successfully"
+    end
+
+    test "a matching path outside any git repo stays writable", %{tmp_dir: dir} do
+      plain = Path.join(dir, "plain")
+      File.mkdir_p!(plain)
+
+      assert Edit.write(Path.join(plain, "notes.txt"), "fine\n") =~ "File created successfully"
+    end
+  end
+
+  defp git!(dir, args) do
+    {out, 0} = System.cmd("git", args, cd: dir, stderr_to_stdout: true)
+    out
+  end
 end

--- a/packages/mcp-ex/test/ix_mcp/jobs_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/jobs_test.exs
@@ -265,6 +265,70 @@ defmodule IxMcp.JobsTest do
     refute Enum.any?(ActionLog.unacked_outbox(), &(&1.job_id == id))
   end
 
+  test "a running job survives an ActionLog crash mid-flush (#3874)" do
+    # File-backed ledger for this test: the suite's default :memory:
+    # database would come back empty after the crash-restart and prove
+    # nothing about durability.
+    path = Path.join(System.tmp_dir!(), "ix-jobs-3874-#{System.unique_integer([:positive])}.db")
+    previous = Application.get_env(:ix_mcp, :actions_db)
+    Application.put_env(:ix_mcp, :actions_db, path)
+    restart_action_log()
+
+    on_exit(fn ->
+      Application.put_env(:ix_mcp, :actions_db, previous)
+      restart_action_log()
+      File.rm(path)
+    end)
+
+    {summary, _out} =
+      Jobs.run(
+        "for i <- 1..40 do IO.puts(\"tick \#{i}\"); Process.sleep(25) end; :ok",
+        budget: 0.05,
+        intent: "ticker"
+      )
+
+    assert summary.running
+    {:ok, control} = Jobs.lookup(summary.id)
+    ref = Process.monitor(control)
+
+    # Suspend the log so the next output flush parks inside GenServer.call,
+    # then kill it: the incident shape (#3874) -- that call exit used to
+    # take the job control process, its registry entry, and any terminal
+    # notification down with it.
+    log = Process.whereis(ActionLog)
+    :sys.suspend(log)
+    Process.sleep(100)
+    Process.exit(log, :kill)
+
+    final = Jobs.await(summary.id, 10_000)
+    assert final.status == :done
+    refute_received {:DOWN, ^ref, :process, ^control, _reason}
+    assert {:ok, _pid} = Jobs.lookup(summary.id)
+
+    # The restarted log caught the terminal transition and the output.
+    assert %{status: :done} =
+             eventually(fn ->
+               case ActionLog.job(summary.id) do
+                 %{status: :done} = job -> job
+                 _not_yet -> nil
+               end
+             end)
+
+    assert Jobs.tail(summary.id, 2) =~ "tick 40"
+  end
+
+  # Graceful stop/start through the supervisor: unlike a kill, this does
+  # not count against restart intensity, so the test's one real crash is
+  # the only one on the books. Session restarts too: its lazily-created
+  # session/topic row ids belong to the previous database, and stale ids
+  # would leave every later row orphaned from the joins (recent/history).
+  defp restart_action_log do
+    :ok = Supervisor.terminate_child(IxMcp.Supervisor, ActionLog)
+    {:ok, _pid} = Supervisor.restart_child(IxMcp.Supervisor, ActionLog)
+    :ok = Supervisor.terminate_child(IxMcp.Supervisor, Session)
+    {:ok, _pid} = Supervisor.restart_child(IxMcp.Supervisor, Session)
+  end
+
   defp eventually(probe, tries \\ 50) do
     case probe.() do
       nil when tries > 0 ->

--- a/packages/site/src/lib/updates/kernel-edit-guard-durable-jobs.svx
+++ b/packages/site/src/lib/updates/kernel-edit-guard-durable-jobs.svx
@@ -1,0 +1,19 @@
+---
+id: kernel-edit-guard-durable-jobs
+postedAt: 2026-07-21T17:30:00-07:00
+title: "Kernel Edit honors the worktree guard; jobs survive action-log crashes"
+tags: [kernel, mcp-ex, jobs, claude-code]
+links:
+  - label: index#3871 (Edit guard bypass)
+    href: https://github.com/indexable-inc/index/issues/3871
+  - label: index#3874 (SQLITE_BUSY / vanishing jobs)
+    href: https://github.com/indexable-inc/index/issues/3874
+---
+
+Two kernel defects observed under normal multi-agent load on 2026-07-21, fixed at their seams.
+
+Kernel writes now honor the primary-checkout worktree guard (#3871). The claude-code wrapper's PreToolUse hook denies native Edit/Write under the `primaryCheckouts` globs, but `Edit.write`/`Edit.replace` in an exec cell never pass through hooks, and a background agent used exactly that gap to dirty a primary `main` checkout. The kernel's Edit module enforces the same denylist itself: same glob knobs (`CLAUDE_CODE_PRIMARY_CHECKOUTS` over `IX_DEFAULT_PRIMARY_CHECKOUTS`, colon-separated), same linked-worktree escape hatch, same kill switch, same refusal message. The workstation profile states the glob list once and feeds both consumers -- the hook wrapper and, via a device-level session variable, every kernel the agents spawn.
+
+The action log no longer dies over a busy database, and jobs no longer die over the action log (#3874). Several kernel instances share one SQLite action log; a sibling holding the write lock returned `SQLITE_BUSY`, which match-crashed the ActionLog GenServer. The exit propagated into every caller: a running `cargo test` job's control process died mid output-flush, vanished from the registry with its terminal notification, and under sustained contention the crash loop could exhaust the root supervisor and take the whole kernel down. Now sqlite waits out contention (`busy_timeout` plus a bounded retry), the ActionLog client API absorbs the restart blip instead of forwarding the exit, job processes treat ledger writes as degradable (a failed flush retries next tick, a failed terminal transition re-arms until it lands), and the reaper never crashes over a ledger call -- its monitor map is the only record of which jobs are still guarded. Regression tests hold a write transaction from a second connection and kill the log mid-flush; the job finishes, stays in the registry, and the durable row lands after the restart.
+
+*Written by Claude Code (Fable 5), an AI coding agent.*

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -101,6 +101,16 @@
   # WEAVE_MEMORY_STORE session variable both derive from it.
   memoryStore = "${config.home.homeDirectory}/.config/nix/claude/memory/.weave";
 
+  # One statement of the protected primary checkouts: the claude-code
+  # wrapper's worktree-guard hook and the kernel's Edit guard
+  # (IX_DEFAULT_PRIMARY_CHECKOUTS session variable, index#3871) both derive
+  # from it. The package default is `/home/*/{index,ix}` (Linux fleet); on
+  # this Mac the long-lived checkouts live under ~/Projects.
+  primaryCheckouts = [
+    "/Users/*/Projects/*/index"
+    "/Users/*/Projects/*/ix"
+  ];
+
   # SessionStart memory digest: the derived replacement for the retired
   # MEMORY.md flat index (index#3849). One-shot weave queries against the
   # private store; stdout becomes session context via the wrappers'
@@ -207,13 +217,9 @@
     # `skills` option (see programs.claude-code below). Hooks are baked by the
     # package itself; agents/commands ride bare via the module. Nothing else
     # used the plugin, so no `pluginDirs` here anymore.
-    # The worktree-guard's protected primary checkouts. The package default is
-    # `/home/*/{index,ix}` (Linux fleet); on this Mac the long-lived checkouts
-    # live under ~/Projects, so point the guard there.
-    primaryCheckouts = [
-      "/Users/*/Projects/*/index"
-      "/Users/*/Projects/*/ix"
-    ];
+    # The worktree-guard's protected primary checkouts (shared statement in
+    # the let above, which also feeds the kernel's Edit guard, index#3871).
+    inherit primaryCheckouts;
     # Personal settings keys (memory dir, plugins, marketplaces), merged into
     # the wrapper's computed render between the house defaults and the
     # controlled keys; the module materializes the result into the writable
@@ -480,6 +486,16 @@ in {
       # for the same reason as IX_MCP_HOST: inherited by claude/codex and
       # every kernel they spawn.
       WEAVE_MEMORY_STORE = memoryStore;
+
+      # The primary-checkout globs the kernel's Edit guard enforces
+      # (index#3871), the same list the claude-code wrapper bakes into its
+      # worktree-guard hook. Device-level for the same reason as
+      # WEAVE_MEMORY_STORE: hooks never see kernel writes, so the kernel
+      # needs the denylist in its own environment, and inheriting one
+      # statement beats a per-server env override. Same name and
+      # colon-separated shape the hook binary reads; an operator
+      # CLAUDE_CODE_PRIMARY_CHECKOUTS still overrides both consumers.
+      IX_DEFAULT_PRIMARY_CHECKOUTS = lib.concatStringsSep ":" primaryCheckouts;
 
       # Skim configuration
       SKIM_CTRL_T_COMMAND = "fd --type f --hidden --follow";


### PR DESCRIPTION
Fixes #3871
Fixes #3874

Two kernel defects observed under normal multi-agent load on 2026-07-21, fixed in one branch because they are small and adjacent (both are "the kernel bypasses a guarantee the rest of the platform relies on").

## #3871 — kernel Edit bypasses the primary-checkout worktree guard

`Edit.write`/`Edit.replace` never pass through the claude-code PreToolUse hook, so the `primaryCheckouts` denylist did not apply to kernel writes. The Edit module now enforces the guard itself, mirroring `claude-hooks worktree-guard` exactly:

- env chain `CLAUDE_CODE_PRIMARY_CHECKOUTS` (operator override) then `IX_DEFAULT_PRIMARY_CHECKOUTS` (provisioned), colon-separated globs, empty disables; `CLAUDE_CODE_DISABLE_WORKTREE_GUARD` kill switch; app env `:primary_checkouts` as the test seam (same shape as `:actions_db`)
- target judged by its repo toplevel (`git rev-parse --path-format=absolute`, nearest existing ancestor for not-yet-created files); a linked worktree (git-dir != git-common-dir) is always allowed; glob `*` crosses `/`; stdout-only parsing; same refusal message
- provisioning follows the WEAVE_MEMORY_STORE pattern: the workstation profile states the glob list once and feeds both the hook wrapper and a device-level `IX_DEFAULT_PRIMARY_CHECKOUTS` session variable inherited by every kernel the agents spawn (the kernel is a stdio MCP child, so it sees the login env; machines that never set the variable simply keep hook-only enforcement)

Regression tests: write/replace under a configured glob raise and write nothing (including the nearest-existing-ancestor path), a linked worktree of the protected checkout stays writable, a matching non-repo path stays writable.

## #3874 — ActionLog dies on SQLITE_BUSY and running jobs vanish

Reproduced both incident signatures before fixing (throwaway file db, second connection holding `BEGIN IMMEDIATE`):

```
REPRO1 CRASH: {{{:badmatch, :busy}, [{IxMcp.ActionLog, :handle_call, ...}]}, {GenServer, :call, [:repro_log, ...]}}   # action_log.ex:481, start_action
REPRO2 JOB DIED: {:killed, {GenServer, :call, [IxMcp.ActionLog, ...]}}   # job control process, mid output-flush
REPRO2 registry lookup: {:error, :not_found}
REPRO2 tail error: %ArgumentError{message: "no such job: \"b3ee1547\""}
```

After the fix, the same script: the log survives the held lock (a permanent holder surfaces as a loud caller timeout, not a server crash), and the killed-log run prints `job survived the ActionLog kill`, `registry lookup: {:ok, pid}`, `tail: "tick 100\n"`.

**Supervision judgment** (asked in the issue): the shape itself is right — jobs are *not* linked under any subtree ActionLog can take down; everything is `one_for_one` siblings. The lethal couplings were behavioral: (a) every job control process synchronously calls ActionLog (output flush each 250 ms, stack sample each 1 s), and a `GenServer.call` inherits the server's death as an exit that `trap_exit` cannot catch — that is what killed the job and its registry entry; (b) the Reaper's own `finish_job` call could kill the Reaper, whose state is the only record of which jobs are guarded; (c) an ActionLog crash loop (3-in-5s, trivially hit at 1 Hz sampling under a held lock) exhausted the root supervisor and took the whole kernel down. Fixed at those seams rather than by restructuring the tree:

- **contention is not a fault**: `PRAGMA busy_timeout` plus bounded busy retries in the write/read helpers; retried batches are counter-idempotent (`changes()`-based byte accounting, absolute drop totals)
- **restart blips are absorbed at the client seam**: `ActionLog.call/3` retries a call whose server died (never timeouts), with a 30 s call timeout so callers outwait the server's worst-case busy occupancy instead of dying at 5 s with the original symptom
- **jobs treat the ledger as degradable**: `safe_log/1` wraps every ActionLog write from a job — a failed flush leaves the hot buffer unflushed for the next tick, a failed terminal transition re-arms (`:record_terminal`) until it lands, so the announcement is delayed, never lost
- **the reaper never dies over the ledger**: failed finalizations re-arm with bounded retries
- **the notifier delivers before acking**: with retried acks, ack-first could mistake "my ack committed without a reply" for "someone else announced this" and go permanently silent; a rare duplicate announce beats a lost one
- **root supervisor headroom**: `max_restarts: 10`, since client retries re-trigger a genuinely faulting child faster than before; a child that cannot hold up after ten restarts still fails the app loudly

Regression tests: `start_action` and the job-ledger transaction wait out a held write lock from a second connection; a running job survives an ActionLog kill mid-flush (file-backed ledger), stays in the registry, finishes `:done`, and its durable row and output land after the restart.

Follow-up worth considering (not in scope): `PRAGMA journal_mode=WAL` on the shared db would remove most cross-instance reader/writer contention at the root.

Local verification: `mix test` 115 tests 0 failures, `mix credo --strict` clean, `mix compile --warnings-as-errors` clean, `nix run .#lint` all green. `packages/mcp-ex/lib/ix_mcp/memory.ex` untouched (concurrent #3870).

Written by Claude Code (Fable 5), an AI coding agent, including this description.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard Edit operations against primary checkouts and make ActionLog contention non-fatal
> - Adds a worktree guard to `IxMcp.Edit` that rejects `write` and `replace` on paths under configured primary checkout repos unless the target is in a linked worktree; controlled via `CLAUDE_CODE_PRIMARY_CHECKOUTS`/`IX_DEFAULT_PRIMARY_CHECKOUTS` and `CLAUDE_CODE_DISABLE_WORKTREE_GUARD`.
> - Adds SQLITE_BUSY retry logic throughout `IxMcp.ActionLog` (via `PRAGMA busy_timeout` and bounded retries in `step!`, `execute!`, `fetch_all!`) so SQLite contention no longer crashes the server.
> - Jobs and Reaper wrap all `ActionLog` calls in `safe_log/1` / exit-catching helpers so a ledger crash or restart causes delayed retries rather than lost output or terminal transitions.
> - Notification delivery in `IxMcp.MCP.Notifier` now delivers before acking to avoid permanent notification loss on ack-commit-without-reply scenarios.
> - `append_job_output` is now idempotent per `(job_id, seq)` using `INSERT OR IGNORE`; `output_dropped` tracks the max reported total rather than a running delta.
> - Behavioral Change: public `ActionLog` calls now use a 30s timeout with client-side retries; supervisors allow up to 10 restarts per window.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 964d311.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->