### PR TITLE
mcp-ex: session directory and cross-session messaging (#3881)

### DIFF
--- a/packages/mcp-ex/README.md
+++ b/packages/mcp-ex/README.md
@@ -70,6 +70,8 @@ list):
 | `Ix.restart()` | cancel jobs (sparing the calling cell), restart the workspace, restore bindings |
 | `PrWatch.start(pr, cwd, interval \\ 15, timeout \\ 3600)` | watch a PR via `gh`, notify on merge/close/timeout |
 | `Issues.pickup(3880)` | claim an issue atomically before working it (also `"owner/repo#n"`); a lost claim names the session that won |
+| `Sessions.list()` | the session directory: every kernel instance on this host, with heartbeat liveness |
+| `Sessions.send(id_or_name, text)` | message another session (`Sessions.broadcast/1` for all); arrives as a `source="sessions"` channel event within seconds |
 | `Tui.act(uri, send_keys, peer \\ nil)` | drive a federated TUI resource via `ix-resource-cli` |
 
 Because cells are separate BEAM processes, `Ix.trace/0` and `Ix.restart/0`
@@ -142,6 +144,7 @@ IxMcp.Supervisor (one_for_one)
 ├── IxMcp.MCP.Notifier     server-initiated notification fan-out
 ├── IxMcp.PrWatch.Supervisor (Task.Supervisor) one task per PR watch
 ├── IxMcp.IssueWatch       new-issue + pickup-claim channel feed (stdio-gated, `gh search issues`)
+├── IxMcp.SessionWatch     session heartbeat + cross-session message delivery (stdio-gated)
 └── IxMcp.MCP.Stdio        newline-delimited JSON-RPC on stdin/stdout
 ```
 

--- a/packages/mcp-ex/lib/ix_mcp/action_log.ex
+++ b/packages/mcp-ex/lib/ix_mcp/action_log.ex
@@ -61,7 +61,7 @@ defmodule IxMcp.ActionLog do
   # The schema is a published contract (#3532): the action-log UI is built
   # against these exact tables, so changes here must be coordinated.
   @create_sessions """
-  CREATE TABLE sessions (id INTEGER PRIMARY KEY, name TEXT, started_at TEXT NOT NULL)
+  CREATE TABLE sessions (id INTEGER PRIMARY KEY, name TEXT, started_at TEXT NOT NULL, last_seen_at TEXT)
   """
 
   @create_topics """
@@ -102,6 +102,15 @@ defmodule IxMcp.ActionLog do
   CREATE TABLE issue_claims (id INTEGER PRIMARY KEY, repo TEXT NOT NULL, number INTEGER NOT NULL, session_id INTEGER REFERENCES sessions(id), claimed_at TEXT NOT NULL, UNIQUE(repo, number))
   """
 
+  # index#3881: the per-host bus between kernel instances. A NULL to_session
+  # is a broadcast. Delivery is each instance's own business: `IxMcp.SessionWatch`
+  # sweeps rows addressed to its session (or to everyone) past a per-instance
+  # watermark -- the claim-feed cursor pattern (#3880), and per instance for
+  # the same reason: every instance must deliver to its own client.
+  @create_session_messages """
+  CREATE TABLE session_messages (id INTEGER PRIMARY KEY, from_session INTEGER NOT NULL REFERENCES sessions(id), to_session INTEGER REFERENCES sessions(id), body TEXT NOT NULL, created_at TEXT NOT NULL)
+  """
+
   # index#3539: the schema version is stamped into SQLite's `PRAGMA
   # user_version` header field instead of being re-derived by column
   # sniffing on every open. Sniffing can only classify shapes this binary
@@ -113,8 +122,9 @@ defmodule IxMcp.ActionLog do
   # no-op, and a future shape explicitly detectable. The ladder: 1 = the
   # flat #3512 log, 2 = the #3532 normalization, 3 = the #3536 live rows,
   # 4 = the #3546 live cell line, 5 = the #3839 durable job ledger,
-  # 6 = the #3880 issue-claim arbiter.
-  @user_version 6
+  # 6 = the #3880 issue-claim arbiter, 7 = the #3881 session heartbeat and
+  # message bus.
+  @user_version 7
 
   # How long a statement waits for a sibling instance's write lock before
   # step!/fetch/execute! give up and crash with a diagnosis (#3890). A
@@ -171,6 +181,12 @@ defmodule IxMcp.ActionLog do
   CREATE TABLE actions (id INTEGER PRIMARY KEY, at TEXT NOT NULL, session_id INTEGER NOT NULL REFERENCES sessions(id), topic_id INTEGER REFERENCES topics(id), tool TEXT NOT NULL, intent TEXT, arguments TEXT NOT NULL, is_error INTEGER NOT NULL, elapsed_ms INTEGER NOT NULL)
   """
 
+  # Same freeze for sessions: the shape #3532 shipped, before the #3881
+  # last_seen_at heartbeat column (which the 6 -> 7 step adds).
+  @create_sessions_v2 """
+  CREATE TABLE sessions (id INTEGER PRIMARY KEY, name TEXT, started_at TEXT NOT NULL)
+  """
+
   # The v1 shape kept session/topic as TEXT per action row. The backfill
   # makes one session per distinct v1 session string (NULLs collapse into
   # one unnamed session, hence the NULL-safe `IS` joins), one topic per
@@ -179,7 +195,7 @@ defmodule IxMcp.ActionLog do
   # stand in for the started_at v1 never stored.
   @migrate_v1_to_v2 [
     "ALTER TABLE actions RENAME TO actions_v1",
-    @create_sessions,
+    @create_sessions_v2,
     @create_topics,
     @create_actions_v2,
     """
@@ -225,6 +241,14 @@ defmodule IxMcp.ActionLog do
   # simply created empty.
   @migrate_v5_to_v6 [@create_issue_claims]
 
+  # A v6 database predates the session heartbeat and message bus (#3881):
+  # existing sessions gain a NULL last_seen_at (they never heartbeat), and
+  # the messages table is created empty.
+  @migrate_v6_to_v7 [
+    "ALTER TABLE sessions ADD COLUMN last_seen_at TEXT",
+    @create_session_messages
+  ]
+
   # Ordered migrations keyed by the user_version each upgrades FROM. Every
   # step runs in one immediate transaction that also stamps the version it
   # produces, so an interrupted migration leaves the previous consistent,
@@ -234,7 +258,8 @@ defmodule IxMcp.ActionLog do
     {2, @migrate_v2_to_v3},
     {3, @migrate_v3_to_v4},
     {4, @migrate_v4_to_v5},
-    {5, @migrate_v5_to_v6}
+    {5, @migrate_v5_to_v6},
+    {6, @migrate_v6_to_v7}
   ]
 
   @insert """
@@ -270,6 +295,21 @@ defmodule IxMcp.ActionLog do
   SELECT c.id, c.repo, c.number, c.session_id, s.name, c.claimed_at
   FROM issue_claims c
   LEFT JOIN sessions s ON s.id = c.session_id
+  """
+
+  @select_session_message """
+  SELECT m.id, m.from_session, s.name, m.to_session, m.body, m.created_at
+  FROM session_messages m
+  LEFT JOIN sessions s ON s.id = m.from_session
+  """
+
+  # The latest topics row is the session's current topic: topics are a
+  # timeline (#3532), so the newest row per session is what it works on now.
+  @select_directory """
+  SELECT s.id, s.name,
+         (SELECT t.name FROM topics t WHERE t.session_id = s.id ORDER BY t.id DESC LIMIT 1),
+         s.started_at, s.last_seen_at
+  FROM sessions s ORDER BY s.id
   """
 
   @type entry :: %{
@@ -327,6 +367,33 @@ defmodule IxMcp.ActionLog do
           session_id: integer() | nil,
           session: String.t() | nil,
           claimed_at: String.t()
+        }
+
+  @typedoc """
+  A cross-session message (#3881): `from` is the sending sessions row's name
+  (nil when that session never named itself); a nil `to_session` is a
+  broadcast.
+  """
+  @type session_message :: %{
+          id: integer(),
+          from_session: integer(),
+          from: String.t() | nil,
+          to_session: integer() | nil,
+          body: String.t(),
+          created_at: String.t()
+        }
+
+  @typedoc """
+  A session-directory row (#3881): `topic` is the session's latest topics
+  row, `last_seen_at` its heartbeat (nil = it never heartbeat: a pre-#3881
+  row or an instance that never ran the watch).
+  """
+  @type directory_entry :: %{
+          id: integer(),
+          name: String.t() | nil,
+          topic: String.t() | nil,
+          started_at: String.t(),
+          last_seen_at: String.t() | nil
         }
 
   @typedoc "A terminal-transition notification awaiting delivery (#3839)."
@@ -500,6 +567,56 @@ defmodule IxMcp.ActionLog do
   @spec last_issue_claim_id(GenServer.server()) :: integer()
   def last_issue_claim_id(server \\ __MODULE__) do
     call(server, :last_issue_claim_id)
+  end
+
+  # -- session directory + message bus (#3881) --------------------------------
+
+  @doc """
+  Stamp `session_id`'s liveness heartbeat (`last_seen_at = now`). Stamped on
+  transport register (`IxMcp.MCP.Notifier`) and on every `IxMcp.SessionWatch`
+  tick, so the directory can tell a live instance from a dead one's row.
+  """
+  @spec heartbeat_session(integer(), GenServer.server()) :: :ok
+  def heartbeat_session(session_id, server \\ __MODULE__) when is_integer(session_id) do
+    GenServer.call(server, {:heartbeat_session, session_id, now()})
+  end
+
+  @doc """
+  Every sessions row joined with its current topic and heartbeat, oldest
+  first: the raw directory `IxMcp.Sessions.list/1` filters and flags.
+  """
+  @spec session_directory(GenServer.server()) :: [directory_entry()]
+  def session_directory(server \\ __MODULE__) do
+    GenServer.call(server, :session_directory)
+  end
+
+  @doc """
+  Record a message from `from_session` to `to_session` (nil = broadcast).
+  Returns the recorded message; `:disabled` when the log is degraded (#3539)
+  -- with no shared database there is no bus to carry it.
+  """
+  @spec send_session_message(integer(), integer() | nil, String.t(), GenServer.server()) ::
+          {:ok, session_message()} | :disabled
+  def send_session_message(from_session, to_session, body, server \\ __MODULE__)
+      when is_integer(from_session) and is_binary(body) do
+    GenServer.call(server, {:send_session_message, from_session, to_session, body, now()})
+  end
+
+  @doc """
+  Messages for `session_id` past the `id` watermark, oldest first: rows
+  addressed to it plus broadcasts, never its own sends. The cursor is per
+  instance for the same reason as `issue_claims_after/2`: every instance
+  must deliver to its own client (#3880).
+  """
+  @spec session_messages_after(integer(), integer(), GenServer.server()) :: [session_message()]
+  def session_messages_after(id, session_id, server \\ __MODULE__) do
+    GenServer.call(server, {:session_messages_after, id, session_id})
+  end
+
+  @doc "The highest session-message id (0 when none): a fresh watermark for `session_messages_after/3`."
+  @spec last_session_message_id(GenServer.server()) :: integer()
+  def last_session_message_id(server \\ __MODULE__) do
+    GenServer.call(server, :last_session_message_id)
   end
 
   @doc """
@@ -881,6 +998,49 @@ defmodule IxMcp.ActionLog do
     {:reply, id, state}
   end
 
+  def handle_call({:heartbeat_session, session_id, at}, _from, %{db: db} = state) do
+    run(db, "UPDATE sessions SET last_seen_at = ? WHERE id = ?", [at, session_id])
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:session_directory, _from, %{db: db} = state) do
+    entries =
+      for [id, name, topic, started_at, last_seen_at] <- fetch(db, @select_directory, []) do
+        %{id: id, name: name, topic: topic, started_at: started_at, last_seen_at: last_seen_at}
+      end
+
+    {:reply, entries, state}
+  end
+
+  def handle_call({:send_session_message, from, to, body, at}, _from, %{db: db} = state) do
+    run(
+      db,
+      "INSERT INTO session_messages (from_session, to_session, body, created_at) VALUES (?, ?, ?, ?)",
+      [from, to, body, at]
+    )
+
+    {:ok, id} = Sqlite3.last_insert_rowid(db.conn)
+    [row] = fetch(db, @select_session_message <> " WHERE m.id = ?", [id])
+    {:reply, {:ok, session_message_row_to_map(row)}, state}
+  end
+
+  def handle_call({:session_messages_after, id, session_id}, _from, %{db: db} = state) do
+    rows =
+      fetch(
+        db,
+        @select_session_message <>
+          " WHERE m.id > ? AND m.from_session != ? AND (m.to_session IS NULL OR m.to_session = ?) ORDER BY m.id",
+        [id, session_id, session_id]
+      )
+
+    {:reply, Enum.map(rows, &session_message_row_to_map/1), state}
+  end
+
+  def handle_call(:last_session_message_id, _from, %{db: db} = state) do
+    [[id]] = fetch(db, "SELECT COALESCE(MAX(id), 0) FROM session_messages", [])
+    {:reply, id, state}
+  end
+
   def handle_call({:unacked_outbox, session_id}, _from, %{db: db} = state) do
     {sql, params} =
       case session_id do
@@ -948,18 +1108,22 @@ defmodule IxMcp.ActionLog do
 
   defp unstamped_version(db) do
     case table_columns(db, "actions") do
-      [] ->
-        :fresh
+      [] -> :fresh
+      columns -> sniff_version(db, columns)
+    end
+  end
 
-      columns ->
-        cond do
-          "session_id" not in columns -> 1
-          "status" not in columns -> 2
-          "line" not in columns -> 3
-          not table_exists?(db, "jobs") -> 4
-          not table_exists?(db, "issue_claims") -> 5
-          true -> @user_version
-        end
+  # Ordered shape probes, oldest first: the first missing piece names the
+  # version the file stopped at.
+  defp sniff_version(db, columns) do
+    cond do
+      "session_id" not in columns -> 1
+      "status" not in columns -> 2
+      "line" not in columns -> 3
+      not table_exists?(db, "jobs") -> 4
+      not table_exists?(db, "issue_claims") -> 5
+      not table_exists?(db, "session_messages") -> 6
+      true -> @user_version
     end
   end
 
@@ -979,6 +1143,7 @@ defmodule IxMcp.ActionLog do
         @create_job_output,
         @create_outbox,
         @create_issue_claims,
+        @create_session_messages,
         stamp(),
         "COMMIT"
       ]
@@ -1005,6 +1170,11 @@ defmodule IxMcp.ActionLog do
   defp disabled_reply({:claim_issue, _repo, _number, _session_id, _at}), do: :disabled
   defp disabled_reply({:issue_claims_after, _id}), do: []
   defp disabled_reply(:last_issue_claim_id), do: 0
+  defp disabled_reply({:heartbeat_session, _session_id, _at}), do: :ok
+  defp disabled_reply(:session_directory), do: []
+  defp disabled_reply({:send_session_message, _from, _to, _body, _at}), do: :disabled
+  defp disabled_reply({:session_messages_after, _id, _session_id}), do: []
+  defp disabled_reply(:last_session_message_id), do: 0
   defp disabled_reply({:job, _id}), do: nil
   defp disabled_reply({:job_output, _id}), do: ""
   defp disabled_reply({:recent_jobs, _session_id, _n}), do: []
@@ -1166,6 +1336,17 @@ defmodule IxMcp.ActionLog do
       started_at: started_at,
       finished_at: finished_at,
       elapsed_ms: elapsed_ms
+    }
+  end
+
+  defp session_message_row_to_map([id, from_session, from, to_session, body, created_at]) do
+    %{
+      id: id,
+      from_session: from_session,
+      from: from,
+      to_session: to_session,
+      body: body,
+      created_at: created_at
     }
   end
 

--- a/packages/mcp-ex/lib/ix_mcp/application.ex
+++ b/packages/mcp-ex/lib/ix_mcp/application.ex
@@ -15,6 +15,7 @@ defmodule IxMcp.Application do
       │   └── IxMcp.Jobs.Job*   runs one evaluation in a monitored process
       ├── IxMcp.PrWatch.Supervisor (Task.Supervisor)  one task per PR watch
       ├── IxMcp.IssueWatch      (only when IX_MCP_STDIO=1) new-issue channel feed
+      ├── IxMcp.SessionWatch    (only when IX_MCP_STDIO=1) heartbeat + cross-session message delivery
       ├── IxMcp.Agents.Harness     (AgentHarness) depth-1 subagent processes (#3700)
       ├── IxMcp.Agents.Events      subagent ledger: events, finals, graph, notifications
       └── IxMcp.MCP.Stdio       (only when IX_MCP_STDIO=1) the stdio transport
@@ -144,10 +145,12 @@ defmodule IxMcp.Application do
   # durable instance identity that outlives a restart -- out of scope here.
   # The issue feed announces into a user-facing transport and polls GitHub,
   # so it rides the same flag as the transport: `mix test` and IEx sessions
-  # get neither (#3877).
+  # get neither (#3877). The session watch (#3881) rides it too: its
+  # heartbeat would otherwise register every test run in the directory and
+  # its delivery loop would announce into a transport that is not there.
   defp issue_watch do
     case System.get_env("IX_MCP_STDIO") do
-      "1" -> [IxMcp.IssueWatch]
+      "1" -> [IxMcp.IssueWatch, IxMcp.SessionWatch]
       _ -> []
     end
   end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/notifier.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/notifier.ex
@@ -73,6 +73,9 @@ defmodule IxMcp.MCP.Notifier do
   def handle_cast({:register, transport}, state) do
     Process.monitor(transport)
     state = %{state | transports: [transport | state.transports]}
+    # A connecting transport is proof of life: stamp the session-directory
+    # heartbeat (#3881) here, without waiting for the first watch tick.
+    ActionLog.heartbeat_session(Session.ids().session_id)
     replay_unacked([transport])
     {:noreply, state}
   end

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -66,6 +66,17 @@ defmodule IxMcp.MCP.Tools do
                                             event="picked_up"; a lost claim returns
                                             {:error, "claimed by session ..."} --
                                             pick a different issue
+      Sessions.list()                       the session directory: every kernel
+                                            instance on this host with its name,
+                                            topic, and heartbeat liveness -- check
+                                            who else is working before delegating
+                                            or duplicating another session's work
+      Sessions.send(12, "text")             message another session by directory id
+                                            (or unique live name); it lands in that
+                                            agent's context as a source="sessions"
+                                            channel event, sender named, within
+                                            seconds. Sessions.broadcast("text")
+                                            reaches every session on the host
       Tui.act(uri, send_keys)               drive a federated TUI resource (optional
                                             peer arg)
       TuiLocal.spawn(cmd, args)             spawn a local PTY program (vim, less, a

--- a/packages/mcp-ex/lib/ix_mcp/session_watch.ex
+++ b/packages/mcp-ex/lib/ix_mcp/session_watch.ex
@@ -1,0 +1,101 @@
+defmodule IxMcp.SessionWatch do
+  @moduledoc """
+  This instance's liveness heartbeat and message delivery loop (#3881).
+  Every tick -- seconds, because messaging is a conversation -- it stamps
+  the session's `last_seen_at` in the shared actions.db and sweeps
+  `session_messages` past a per-instance watermark, pushing each row
+  addressed to this session (or broadcast) into the agent's context as a
+  `source="sessions"` channel notification naming the sender.
+
+  Deliberately its own GenServer rather than a bolt-on to `IxMcp.IssueWatch`:
+  that loop's 60s cadence is set by GitHub polling politeness, while this
+  one talks only to the local SQLite, where seconds cost nothing. It starts
+  only alongside the stdio transport (`IxMcp.Application`), so `mix test`
+  and IEx sessions neither heartbeat nor deliver.
+
+  The watermark starts at the newest message on boot. That skips only
+  broadcasts from before this instance existed -- old news, the claim
+  feed's exact call (#3880) -- because addressed mail cannot predate its
+  address: sessions rows are per instance and never reused, so a message to
+  this session's id can only be written after this instance created the row.
+  """
+
+  use GenServer
+
+  alias IxMcp.ActionLog
+  alias IxMcp.MCP.Notifier
+  alias IxMcp.Session
+
+  @interval_ms 3_000
+  # The channel event should carry the message, not become the whole
+  # transcript: an essay still arrives truncated, with the sender's id to
+  # ask for the rest.
+  @max_body_bytes 2_000
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @impl true
+  def init(opts) do
+    action_log = Keyword.get(opts, :action_log, ActionLog)
+    # Resolving the id creates the sessions row when nothing acted yet:
+    # starting the watch is what makes this instance a directory citizen.
+    session_id = Keyword.get_lazy(opts, :session_id, fn -> Session.ids().session_id end)
+
+    state = %{
+      action_log: action_log,
+      session_id: session_id,
+      interval_ms: Keyword.get(opts, :interval_ms, @interval_ms),
+      cursor: ActionLog.last_session_message_id(action_log)
+    }
+
+    # Stamp now, not one tick from now: the instance is live from boot.
+    :ok = ActionLog.heartbeat_session(session_id, action_log)
+    {:ok, schedule(state)}
+  end
+
+  @impl true
+  def handle_info(:tick, state) do
+    :ok = ActionLog.heartbeat_session(state.session_id, state.action_log)
+    {:noreply, state |> sweep() |> schedule()}
+  end
+
+  defp schedule(state) do
+    Process.send_after(self(), :tick, state.interval_ms)
+    state
+  end
+
+  # Deliver everything past the watermark and advance it as one fold: the
+  # cursor stays monotone with no empty-sweep special case.
+  defp sweep(state) do
+    state.cursor
+    |> ActionLog.session_messages_after(state.session_id, state.action_log)
+    |> Enum.reduce(state, fn message, acc ->
+      announce(message)
+      %{acc | cursor: max(acc.cursor, message.id)}
+    end)
+  end
+
+  defp announce(message) do
+    from = label(message)
+    scope = if message.to_session, do: "you", else: "broadcast"
+
+    Notifier.channel(
+      "message from session #{from} (to #{scope}):\n" <>
+        "#{String.slice(message.body, 0, @max_body_bytes)}\n" <>
+        "reply: Sessions.send(#{message.from_session}, \"...\")",
+      %{
+        "source" => "sessions",
+        "from" => from,
+        "from_id" => message.from_session,
+        "to" => scope,
+        "level" => "info"
+      }
+    )
+  end
+
+  defp label(%{from: nil, from_session: id}), do: "##{id}"
+  defp label(%{from: name, from_session: id}), do: "#{name} (##{id})"
+end

--- a/packages/mcp-ex/lib/ix_mcp/sessions.ex
+++ b/packages/mcp-ex/lib/ix_mcp/sessions.ex
@@ -1,0 +1,173 @@
+defmodule IxMcp.Sessions do
+  @moduledoc """
+  The session directory and cross-session message bus (#3881). Kernel
+  instances on a host already share one actions.db (#3880 made it the claim
+  arbiter); this makes the agents riding them visible and addressable.
+  `list/1` is the directory: each instance's sessions row joined with its
+  current topic and a liveness heartbeat, so a cell can see who else is
+  working before delegating or duplicating something another session
+  already took. `send/3` addresses one session (by id, or by name when the
+  name is unambiguous) and `broadcast/2` all of them: rows in the shared
+  `session_messages` table, which every instance's `IxMcp.SessionWatch`
+  sweeps and delivers into its agent's context as `source="sessions"`
+  channel notifications within a few seconds.
+
+  Same scope limit as the claim arbiter: the shared database is the bus, so
+  the directory and messaging are per host. Cross-host messaging would ride
+  the fleet, out of scope here (#3881).
+  """
+
+  alias IxMcp.ActionLog
+  alias IxMcp.Session
+
+  # A live instance heartbeats every SessionWatch tick (seconds) and on
+  # transport register; half a minute of silence means gone, not slow.
+  # Generous on purpose: cells run in their own processes, so even a kernel
+  # full of wedged jobs keeps ticking -- only a dead one stops.
+  @fresh_within_s 30
+
+  @typedoc "A directory row: the recorded session plus the computed flags."
+  @type entry :: %{
+          id: integer(),
+          name: String.t() | nil,
+          topic: String.t() | nil,
+          started_at: String.t(),
+          last_seen_at: String.t() | nil,
+          live: boolean(),
+          self: boolean()
+        }
+
+  @doc """
+  The session directory: rows with a heartbeat plus this session, freshest
+  first, each flagged `live:` (heartbeat within #{@fresh_within_s}s) and
+  `self:`. Rows that never heartbeat are dead history (pre-#3881 instances,
+  one-shot connections) and stay hidden; `all: true` includes them.
+
+  Options exist for tests: `:action_log` (the shared log), `:session_id`
+  (this session's row), `:now` (the liveness clock).
+  """
+  @spec list(keyword()) :: [entry()]
+  def list(opts \\ []) do
+    log = Keyword.get(opts, :action_log, ActionLog)
+    self_id = Keyword.get_lazy(opts, :session_id, fn -> Session.ids().session_id end)
+    now = Keyword.get_lazy(opts, :now, &DateTime.utc_now/0)
+
+    ActionLog.session_directory(log)
+    |> Enum.filter(fn row ->
+      Keyword.get(opts, :all, false) or row.last_seen_at != nil or row.id == self_id
+    end)
+    |> Enum.map(fn row ->
+      row
+      |> Map.put(:live, live?(row, now))
+      |> Map.put(:self, row.id == self_id)
+    end)
+    |> Enum.sort_by(fn row -> row.last_seen_at || "" end, :desc)
+  end
+
+  @doc """
+  Message another session: an integer sends to that directory id, a string
+  to the unique session with that name (ambiguity is an error naming the
+  candidates -- use the id). Returns `{:ok, detail}`; a stale target is
+  still sent to, but the detail says its heartbeat stopped, because a dead
+  instance never reads its mail.
+
+  Same test options as `list/1`.
+  """
+  @spec send(integer() | String.t(), String.t(), keyword()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  def send(target, text, opts \\ []) when is_binary(text) do
+    log = Keyword.get(opts, :action_log, ActionLog)
+    self_id = Keyword.get_lazy(opts, :session_id, fn -> Session.ids().session_id end)
+    now = Keyword.get_lazy(opts, :now, &DateTime.utc_now/0)
+
+    with {:ok, row} <- resolve(target, self_id, log, now) do
+      case ActionLog.send_session_message(self_id, row.id, text, log) do
+        {:ok, message} ->
+          {:ok, "sent to session #{label(row)} at #{message.created_at}" <> stale_note(row, now)}
+
+        :disabled ->
+          {:error, "action log disabled (#3539); no shared database to carry the message"}
+      end
+    end
+  end
+
+  @doc """
+  Message every session on the host (a NULL `to_session` row): each live
+  instance's sweep delivers it. Same test options as `list/1`.
+  """
+  @spec broadcast(String.t(), keyword()) :: {:ok, String.t()} | {:error, String.t()}
+  def broadcast(text, opts \\ []) when is_binary(text) do
+    log = Keyword.get(opts, :action_log, ActionLog)
+    self_id = Keyword.get_lazy(opts, :session_id, fn -> Session.ids().session_id end)
+
+    case ActionLog.send_session_message(self_id, nil, text, log) do
+      {:ok, message} ->
+        peers =
+          opts
+          |> Keyword.merge(action_log: log, session_id: self_id)
+          |> list()
+          |> Enum.count(fn row -> row.live and not row.self end)
+
+        {:ok, "broadcast at #{message.created_at}; #{peers} live peer(s) will hear it"}
+
+      :disabled ->
+        {:error, "action log disabled (#3539); no shared database to carry the message"}
+    end
+  end
+
+  defp resolve(id, self_id, log, _now) when is_integer(id) do
+    cond do
+      id == self_id ->
+        {:error, "session #{id} is this session; message a peer from Sessions.list()"}
+
+      row = Enum.find(ActionLog.session_directory(log), fn row -> row.id == id end) ->
+        {:ok, row}
+
+      true ->
+        {:error, "no session #{id} in the directory; Sessions.list() shows who is here"}
+    end
+  end
+
+  # A name resolves against live sessions first: names recur across an
+  # instance's many lifetimes, but only one incarnation heartbeats. With no
+  # live match a single stale one is still unambiguous; several matches in
+  # the same liveness tier need the id.
+  defp resolve(name, self_id, log, now) when is_binary(name) do
+    matches =
+      ActionLog.session_directory(log)
+      |> Enum.filter(fn row -> row.name == name and row.id != self_id end)
+
+    case {Enum.filter(matches, &live?(&1, now)), matches} do
+      {[row], _} -> {:ok, row}
+      {[], []} -> {:error, "no session named #{inspect(name)}; Sessions.list() shows who is here"}
+      {[], [row]} -> {:ok, row}
+      {[], stale} -> {:error, ambiguous(name, stale)}
+      {live, _} -> {:error, ambiguous(name, live)}
+    end
+  end
+
+  defp ambiguous(name, rows) do
+    ids = Enum.map_join(rows, ", ", fn row -> "#{row.id} (last seen #{row.last_seen_at})" end)
+    "#{inspect(name)} names sessions #{ids}; send to the id instead"
+  end
+
+  defp label(%{name: nil, id: id}), do: "##{id}"
+  defp label(%{name: name, id: id}), do: "#{name} (##{id})"
+
+  defp stale_note(row, now) do
+    if live?(row, now) do
+      ""
+    else
+      "; its heartbeat stopped (last seen #{row.last_seen_at || "never"}), it may never read this"
+    end
+  end
+
+  defp live?(%{last_seen_at: nil}, _now), do: false
+
+  defp live?(%{last_seen_at: at}, now) do
+    case DateTime.from_iso8601(at) do
+      {:ok, seen, _offset} -> DateTime.diff(now, seen) <= @fresh_within_s
+      _ -> false
+    end
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/workspace.ex
+++ b/packages/mcp-ex/lib/ix_mcp/workspace.ex
@@ -18,7 +18,7 @@ defmodule IxMcp.Workspace do
              "alias IxMcp.Read; alias IxMcp.Edit; alias IxMcp.PrWatch; alias IxMcp.Tui; " <>
              "alias IxMcp.TuiLocal; alias IxMcp.Gmail; alias IxMcp.Imsg; alias IxMcp.Contacts; " <>
              "alias IxMcp.Kernel, as: Ix; alias IxMcp.Agents; alias IxMcp.Memory; " <>
-             "alias IxMcp.Ask; alias IxMcp.Cmd; alias IxMcp.Issues"
+             "alias IxMcp.Ask; alias IxMcp.Cmd; alias IxMcp.Issues; alias IxMcp.Sessions"
 
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do

--- a/packages/mcp-ex/test/action_log_test.exs
+++ b/packages/mcp-ex/test/action_log_test.exs
@@ -319,8 +319,8 @@ defmodule IxMcp.ActionLogTest do
     :ok = ActionLog.finish_action(action_id, "done", false, 3, log)
     assert [%{status: "done", stack: nil, line: nil} | _] = ActionLog.recent(10, log)
 
-    # The 2 -> 3 -> 4 -> 5 -> 6 steps stamped the file on their way through (index#3539).
-    assert user_version(path) == 6
+    # The 2 -> ... -> 7 steps stamped the file on their way through (index#3539).
+    assert user_version(path) == 7
   end
 
   test "a v1 database migrates losslessly to the normalized schema, once" do
@@ -403,8 +403,8 @@ defmodule IxMcp.ActionLogTest do
 
     stop_supervised!(:migrate)
 
-    # The ladder ran 1 -> 2 -> 3 -> 4 -> 5 -> 6 and left the stamp behind (index#3539).
-    assert user_version(path) == 6
+    # The ladder ran 1 -> 2 -> ... -> 7 and left the stamp behind (index#3539).
+    assert user_version(path) == 7
 
     # The migrated file is the v2 shape on disk: normalized columns, no v1
     # leftovers, and a reopen (no-op detection) does not duplicate rows.
@@ -446,6 +446,7 @@ defmodule IxMcp.ActionLogTest do
                ["job_output"],
                ["jobs"],
                ["outbox"],
+               ["session_messages"],
                ["sessions"],
                ["topics"]
              ]
@@ -471,7 +472,7 @@ defmodule IxMcp.ActionLogTest do
   test "a fresh database is created stamped with the current schema version" do
     path = tmp_db()
     start_supervised!({ActionLog, path: path, name: :action_log_fresh_stamp})
-    assert user_version(path) == 6
+    assert user_version(path) == 7
   end
 
   test "an unstamped file already at the current schema is stamped, not rewritten" do
@@ -496,7 +497,7 @@ defmodule IxMcp.ActionLogTest do
 
     reopened = start_supervised!({ActionLog, path: path, name: :action_log_stamp_b})
     assert [%{intent: "keep"}] = ActionLog.recent(10, reopened)
-    assert user_version(path) == 6
+    assert user_version(path) == 7
   end
 
   test "an unstamped pre-line file (the #3536 shape) sniffs as v3 and gains the line column" do
@@ -521,7 +522,7 @@ defmodule IxMcp.ActionLogTest do
     log = start_supervised!({ActionLog, path: path, name: :action_log_pre_line})
 
     assert [%{intent: "pre-line row", status: "done", line: nil}] = ActionLog.recent(10, log)
-    assert user_version(path) == 6
+    assert user_version(path) == 7
   end
 
   test "the unique constraint arbitrates issue claims (#3880)" do
@@ -571,6 +572,53 @@ defmodule IxMcp.ActionLogTest do
     assert standing.id == claim.id
   end
 
+  test "the message cursor delivers addressed mail and broadcasts, never own sends (#3881)" do
+    log = start_supervised!({ActionLog, path: ":memory:", name: :action_log_messages})
+
+    alice = ActionLog.create_session("alice", log)
+    bob = ActionLog.create_session("bob", log)
+    carol = ActionLog.create_session(nil, log)
+
+    assert ActionLog.last_session_message_id(log) == 0
+
+    assert {:ok, direct} = ActionLog.send_session_message(alice, bob, "for bob", log)
+    assert %{from: "alice", from_session: ^alice, to_session: ^bob, body: "for bob"} = direct
+    assert {:ok, %DateTime{}, 0} = DateTime.from_iso8601(direct.created_at)
+
+    assert {:ok, blast} = ActionLog.send_session_message(carol, nil, "for everyone", log)
+    assert %{from: nil, to_session: nil} = blast
+
+    # Bob hears both; carol hears nothing (the direct row is not hers and a
+    # sender never hears her own broadcast); alice hears the broadcast only.
+    assert [%{body: "for bob"}, %{body: "for everyone"}] =
+             ActionLog.session_messages_after(0, bob, log)
+
+    assert [] = ActionLog.session_messages_after(0, carol, log)
+    assert [%{body: "for everyone", from: nil}] = ActionLog.session_messages_after(0, alice, log)
+
+    # The watermark cursor sees exactly the rows past it.
+    assert [%{body: "for everyone"}] = ActionLog.session_messages_after(direct.id, bob, log)
+    assert ActionLog.last_session_message_id(log) == blast.id
+  end
+
+  test "the heartbeat stamps the directory and the directory joins the current topic (#3881)" do
+    log = start_supervised!({ActionLog, path: ":memory:", name: :action_log_directory})
+
+    quiet = ActionLog.create_session("quiet", log)
+    busy = ActionLog.create_session("busy", log)
+    _first = ActionLog.create_topic(busy, "warmup", log)
+    _second = ActionLog.create_topic(busy, "the real work", log)
+
+    assert [%{id: ^quiet, last_seen_at: nil, topic: nil}, before_beat] =
+             ActionLog.session_directory(log)
+
+    assert %{id: ^busy, name: "busy", topic: "the real work", last_seen_at: nil} = before_beat
+
+    :ok = ActionLog.heartbeat_session(busy, log)
+    [_quiet, beaten] = ActionLog.session_directory(log)
+    assert {:ok, %DateTime{}, 0} = DateTime.from_iso8601(beaten.last_seen_at)
+  end
+
   test "a database stamped by a newer server disables logging instead of crashing" do
     path = tmp_db()
 
@@ -585,7 +633,7 @@ defmodule IxMcp.ActionLogTest do
 
     # The refusal names both versions, so the operator knows which side moves.
     assert output =~ "user_version 9000"
-    assert output =~ "supported 6"
+    assert output =~ "supported 7"
     assert output =~ "index#3539"
 
     # The server stays useful: writes are absorbed, reads answer empty.
@@ -608,6 +656,13 @@ defmodule IxMcp.ActionLogTest do
     assert ActionLog.claim_issue("indexable-inc/index", 1, session_id, log) == :disabled
     assert ActionLog.issue_claims_after(0, log) == []
     assert ActionLog.last_issue_claim_id(log) == 0
+
+    # And no bus to carry a message (#3881).
+    assert ActionLog.heartbeat_session(session_id, log) == :ok
+    assert ActionLog.session_directory(log) == []
+    assert ActionLog.send_session_message(session_id, nil, "hello?", log) == :disabled
+    assert ActionLog.session_messages_after(0, session_id, log) == []
+    assert ActionLog.last_session_message_id(log) == 0
 
     # The newer file is left exactly as found, for the newer server.
     assert user_version(path) == 9000

--- a/packages/mcp-ex/test/ix_mcp/session_watch_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/session_watch_test.exs
@@ -1,0 +1,109 @@
+defmodule IxMcp.SessionWatchTest do
+  use ExUnit.Case, async: false
+
+  alias IxMcp.ActionLog
+  alias IxMcp.MCP.Notifier
+  alias IxMcp.SessionWatch
+
+  # Own ActionLog instance and own watcher name: under a kernel-launched
+  # shell IX_MCP_STDIO=1 leaks into mix test, so the application boot already
+  # runs a global SessionWatch against the global log (see
+  # issue_watch_test.exs); every assertion pins to this test's fixtures.
+  setup do
+    name = :"session_watch_log_#{System.unique_integer([:positive])}"
+    start_supervised!({ActionLog, path: ":memory:", name: name})
+    %{log: name}
+  end
+
+  test "delivers addressed mail and broadcasts once, skipping pre-boot traffic", %{log: log} do
+    me = ActionLog.create_session("watcher", log)
+    sender = ActionLog.create_session("dispatcher", log)
+
+    # Traffic standing before the watch boots is old news: the watermark
+    # must swallow it (the claim feed's exact call, #3880).
+    {:ok, _pre} = ActionLog.send_session_message(sender, nil, "pre-boot broadcast", log)
+
+    Notifier.register(self())
+    # register/1 is a cast; sync on the Notifier so the sweep's notify cast
+    # cannot be processed ahead of the registration.
+    _ = :sys.get_state(Notifier)
+
+    start_supervised!(
+      {SessionWatch,
+       action_log: log, session_id: me, interval_ms: 25, name: :session_watch_under_test}
+    )
+
+    {:ok, _direct} = ActionLog.send_session_message(sender, me, "argazelka-fixture direct", log)
+    {:ok, _blast} = ActionLog.send_session_message(sender, nil, "argazelka-fixture blast", log)
+
+    assert_receive {:mcp_send,
+                    %{
+                      "method" => "notifications/claude/channel",
+                      "params" =>
+                        %{
+                          "meta" => %{
+                            "source" => "sessions",
+                            "from" => "dispatcher (#" <> _,
+                            "to" => "you"
+                          }
+                        } = direct_params
+                    }},
+                   5_000
+
+    assert direct_params["content"] =~ "argazelka-fixture direct"
+    assert direct_params["content"] =~ "message from session dispatcher"
+    assert direct_params["content"] =~ "reply: Sessions.send(#{sender}"
+    assert direct_params["meta"]["from_id"] == sender
+
+    assert_receive {:mcp_send, %{"params" => %{"meta" => %{"to" => "broadcast"}} = blast_params}},
+                   5_000
+
+    assert blast_params["content"] =~ "argazelka-fixture blast"
+
+    # Several more sweeps run inside this window; the watermark must swallow
+    # both delivered rows and the pre-boot one instead of re-announcing.
+    refute_receive {:mcp_send,
+                    %{"params" => %{"meta" => %{"source" => "sessions", "from_id" => ^sender}}}},
+                   200
+  end
+
+  test "never delivers the session's own sends", %{log: log} do
+    me = ActionLog.create_session("soliloquist", log)
+
+    Notifier.register(self())
+    _ = :sys.get_state(Notifier)
+
+    start_supervised!(
+      {SessionWatch,
+       action_log: log, session_id: me, interval_ms: 25, name: :session_watch_own_sends}
+    )
+
+    {:ok, _blast} = ActionLog.send_session_message(me, nil, "soliloquist-fixture", log)
+
+    refute_receive {:mcp_send,
+                    %{"params" => %{"meta" => %{"source" => "sessions", "from_id" => ^me}}}},
+                   200
+  end
+
+  test "stamps the heartbeat at boot and keeps stamping on ticks", %{log: log} do
+    me = ActionLog.create_session("beater", log)
+
+    start_supervised!(
+      {SessionWatch,
+       action_log: log, session_id: me, interval_ms: 25, name: :session_watch_heartbeat}
+    )
+
+    assert %{last_seen_at: first} =
+             ActionLog.session_directory(log) |> Enum.find(&(&1.id == me))
+
+    assert {:ok, %DateTime{}, 0} = DateTime.from_iso8601(first)
+
+    # A later tick moves the stamp forward.
+    Process.sleep(50)
+
+    assert %{last_seen_at: second} =
+             ActionLog.session_directory(log) |> Enum.find(&(&1.id == me))
+
+    assert second >= first
+  end
+end

--- a/packages/mcp-ex/test/ix_mcp/sessions_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/sessions_test.exs
@@ -1,0 +1,118 @@
+defmodule IxMcp.SessionsTest do
+  use ExUnit.Case, async: false
+
+  alias IxMcp.ActionLog
+  alias IxMcp.Sessions
+
+  # Own ActionLog instance (in-memory, own name): directory rows and messages
+  # must never land in the globally running log, where a leaked
+  # IX_MCP_STDIO=1 application boot has a real SessionWatch sweeping (see
+  # issue_watch_test.exs for the same gotcha).
+  setup do
+    name = :"sessions_test_log_#{System.unique_integer([:positive])}"
+    start_supervised!({ActionLog, path: ":memory:", name: name})
+    %{log: name}
+  end
+
+  defp beat(log, id), do: :ok = ActionLog.heartbeat_session(id, log)
+
+  test "list shows heartbeat rows with liveness flags and hides dead history", %{log: log} do
+    me = ActionLog.create_session("me", log)
+    peer = ActionLog.create_session("peer", log)
+    stale = ActionLog.create_session("stale", log)
+    _dead = ActionLog.create_session("never-heartbeat", log)
+
+    beat(log, me)
+    beat(log, peer)
+    beat(log, stale)
+
+    # Liveness is measured against the caller's clock: an hour from now the
+    # fresh stamps have gone stale.
+    now = DateTime.utc_now()
+    later = DateTime.add(now, 3600)
+
+    rows = Sessions.list(action_log: log, session_id: me, now: now)
+    assert Enum.map(rows, & &1.name) |> Enum.sort() == ["me", "peer", "stale"]
+    assert %{live: true, self: true} = Enum.find(rows, &(&1.id == me))
+    assert %{live: true, self: false} = Enum.find(rows, &(&1.id == peer))
+
+    assert Sessions.list(action_log: log, session_id: me, now: later)
+           |> Enum.all?(&(not &1.live))
+
+    # all: true exposes the row that never heartbeat.
+    assert Sessions.list(action_log: log, session_id: me, now: now, all: true)
+           |> Enum.any?(&(&1.name == "never-heartbeat"))
+  end
+
+  test "list includes this session even before its first heartbeat", %{log: log} do
+    me = ActionLog.create_session("just-born", log)
+
+    assert [%{id: ^me, self: true, live: false}] =
+             Sessions.list(action_log: log, session_id: me)
+  end
+
+  test "send by id records the message; self and unknown ids are rejected", %{log: log} do
+    me = ActionLog.create_session("me", log)
+    peer = ActionLog.create_session("peer", log)
+    beat(log, peer)
+
+    assert {:ok, detail} = Sessions.send(peer, "take the retro", action_log: log, session_id: me)
+    assert detail =~ "sent to session peer (##{peer})"
+
+    assert [%{body: "take the retro", from: "me"}] =
+             ActionLog.session_messages_after(0, peer, log)
+
+    assert {:error, message} = Sessions.send(me, "hi me", action_log: log, session_id: me)
+    assert message =~ "is this session"
+
+    assert {:error, message} = Sessions.send(999, "hi?", action_log: log, session_id: me)
+    assert message =~ "no session 999"
+  end
+
+  test "send to a stale target still records, but says so", %{log: log} do
+    me = ActionLog.create_session("me", log)
+    gone = ActionLog.create_session("gone", log)
+    beat(log, gone)
+
+    later = DateTime.utc_now() |> DateTime.add(3600)
+
+    assert {:ok, detail} =
+             Sessions.send(gone, "anyone there?", action_log: log, session_id: me, now: later)
+
+    assert detail =~ "heartbeat stopped"
+    assert [%{body: "anyone there?"}] = ActionLog.session_messages_after(0, gone, log)
+  end
+
+  test "a name resolves to the one live session; ambiguity demands the id", %{log: log} do
+    me = ActionLog.create_session("me", log)
+    old = ActionLog.create_session("worker", log)
+    current = ActionLog.create_session("worker", log)
+    beat(log, current)
+
+    # Two rows share the name, but only one is live: unambiguous.
+    assert {:ok, _detail} = Sessions.send("worker", "ping", action_log: log, session_id: me)
+    assert [%{body: "ping"}] = ActionLog.session_messages_after(0, current, log)
+    assert [] = ActionLog.session_messages_after(0, old, log)
+
+    # Both live: the name no longer picks one.
+    beat(log, old)
+    assert {:error, message} = Sessions.send("worker", "ping", action_log: log, session_id: me)
+    assert message =~ "send to the id instead"
+
+    assert {:error, message} = Sessions.send("nobody", "ping", action_log: log, session_id: me)
+    assert message =~ ~s(no session named "nobody")
+  end
+
+  test "broadcast records a NULL recipient and counts live peers", %{log: log} do
+    me = ActionLog.create_session("me", log)
+    peer = ActionLog.create_session("peer", log)
+    beat(log, me)
+    beat(log, peer)
+
+    assert {:ok, detail} = Sessions.broadcast("stand-up in 5", action_log: log, session_id: me)
+    assert detail =~ "1 live peer(s)"
+
+    assert [%{body: "stand-up in 5", to_session: nil}] =
+             ActionLog.session_messages_after(0, peer, log)
+  end
+end


### PR DESCRIPTION
Closes #3881.

Kernel instances on a host share actions.db (#3880 made it the claim arbiter); agents riding them still could not see or address each other. This makes the log's `sessions` table a live directory and adds a message bus on top:

- `Sessions.list()` in the workspace prelude: every instance's sessions row joined with its current topic and a `last_seen_at` heartbeat, flagged live (fresh within 30s) vs stale, self marked. Rows that never heartbeat are dead history and stay hidden (`all: true` shows them).
- `Sessions.send(id_or_name, text)` / `Sessions.broadcast(text)`: rows in a new `session_messages` table (schema v7, NULL `to_session` = broadcast). A name resolves only when unambiguous -- one live match wins; several matches name their ids and demand the id.
- Delivery: `IxMcp.SessionWatch`, a dedicated GenServer (its own loop, not a bolt-on to IssueWatch: that cadence is set by GitHub politeness, this one talks only to local SQLite) ticks every 3s, stamps the heartbeat, and sweeps messages past a per-instance watermark into `source="sessions"` channel notifications naming the sender. Stdio-gated like IssueWatch. The transport register in Notifier also stamps the heartbeat, so an instance is live from connect.
- Migration follows the ladder exactly: v6 -> v7 adds `sessions.last_seen_at` and `session_messages`; the v1->v2 step now uses a frozen `@create_sessions_v2` so history stays history.

Two deliberate calls beyond the issue text: a session never hears its own sends (the sender's transcript already has them), and the delivery watermark starts at the newest message on boot -- addressed mail cannot predate its session row (rows are per instance, never reused), so the skip drops only pre-boot broadcasts, the claim feed's exact call.

Checks: `mix test` 128 tests 0 failures (117 on main), `mix format --check-formatted` clean, `MIX_ENV=test mix credo --strict` at the 5 pre-existing findings.

(sent by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add session directory and cross-session messaging to mcp-ex
> - Adds a `session_messages` table and `last_seen_at` column to the `ActionLog` SQLite schema (v6→v7 migration) to support message storage and session liveness tracking.
> - Adds a new `IxMcp.SessionWatch` GenServer that periodically heartbeats the session and delivers addressed and broadcast messages via the notifier, skipping any messages sent before boot.
> - Adds `IxMcp.Sessions` API with `list/1`, `send/3`, and `broadcast/2`, available in-cell as `Sessions.*` without qualification; `send/3` resolves targets by id or name with ambiguity and self-send checks.
> - Registers `IxMcp.SessionWatch` in the supervisor tree alongside `IxMcp.IssueWatch` when `IX_MCP_STDIO=1`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30b4937.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->