### PR TITLE
mcp-ex: wait out sqlite write contention in the action log

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/action_log.ex
+++ b/packages/mcp-ex/lib/ix_mcp/action_log.ex
@@ -103,6 +103,11 @@ defmodule IxMcp.ActionLog do
   # 6 = the #3880 issue-claim arbiter.
   @user_version 6
 
+  # How long a statement waits for a sibling instance's write lock before
+  # sqlite gives up with :busy and step!/fetch crash with a diagnosis
+  # (#3890). The NIF's own default is 2s, which live contention outlived.
+  @busy_timeout_ms 5_000
+
   # Frozen historical DDL for the 1 -> 2 step: the actions shape exactly as
   # #3532 shipped it, before the live-row columns. A migration must never
   # borrow the current @create_actions, or editing today's schema would
@@ -479,6 +484,14 @@ defmodule IxMcp.ActionLog do
 
     {:ok, conn} = Sqlite3.open(path)
 
+    # Several server instances share one database file, so a step can find a
+    # sibling holding the write lock. The NIF opens with a 2s busy handler; a
+    # lock outliving it surfaced as :busy and badmatch-crashed run/3, taking
+    # the calling job down with it (#3890). Wait longer here, and let
+    # step!/fetch turn a still-busy result into a descriptive crash. The
+    # option exists so the regression test can shrink the wait.
+    :ok = Sqlite3.set_busy_timeout(conn, Keyword.get(opts, :busy_timeout_ms, @busy_timeout_ms))
+
     # index#3539: on 2026-07-17 a server binary match-crashed right here
     # against an action log written under a newer schema, and the failed
     # child took the whole application down -- every tool call died over a
@@ -547,7 +560,7 @@ defmodule IxMcp.ActionLog do
         action.arguments
       ])
 
-    :done = Sqlite3.step(conn, insert)
+    :done = step!(conn, insert, "insert action")
     {:ok, id} = Sqlite3.last_insert_rowid(conn)
     {:reply, id, state}
   end
@@ -889,16 +902,41 @@ defmodule IxMcp.ActionLog do
   defp run(conn, sql, params) do
     {:ok, statement} = Sqlite3.prepare(conn, sql)
     :ok = Sqlite3.bind(statement, params)
-    :done = Sqlite3.step(conn, statement)
+    :done = step!(conn, statement, sql)
     :ok = Sqlite3.release(conn, statement)
+  end
+
+  # :busy after the connection's busy timeout (set at open) is a legitimate
+  # runtime state -- a sibling instance still holds the write lock -- not a
+  # programming error, so it fails with a diagnosis instead of a bare
+  # badmatch (#3890). No retry: the NIF already waited the full bound, and
+  # the supervisor reopens the log after the crash.
+  defp step!(conn, statement, sql) do
+    case Sqlite3.step(conn, statement) do
+      :busy ->
+        raise "action log write still blocked after the busy-timeout wait (#3890): #{sql}"
+
+      result ->
+        result
+    end
   end
 
   defp fetch(conn, sql, params) do
     {:ok, statement} = Sqlite3.prepare(conn, sql)
     :ok = Sqlite3.bind(statement, params)
-    {:ok, rows} = Sqlite3.fetch_all(conn, statement)
-    :ok = Sqlite3.release(conn, statement)
-    rows
+
+    case Sqlite3.fetch_all(conn, statement) do
+      {:ok, rows} ->
+        :ok = Sqlite3.release(conn, statement)
+        rows
+
+      # fetch_all reports a lock outliving the busy wait as this string.
+      {:error, "Database busy"} ->
+        raise "action log read still blocked after the busy-timeout wait (#3890): #{sql}"
+
+      {:error, reason} ->
+        raise "action log read failed: #{inspect(reason)}: #{sql}"
+    end
   end
 
   defp state_home do

--- a/packages/mcp-ex/lib/ix_mcp/issue_watch.ex
+++ b/packages/mcp-ex/lib/ix_mcp/issue_watch.ex
@@ -23,11 +23,11 @@ defmodule IxMcp.IssueWatch do
 
   use GenServer
 
-  require Logger
-
   alias IxMcp.ActionLog
   alias IxMcp.Cmd
   alias IxMcp.MCP.Notifier
+
+  require Logger
 
   @default_owners ["indexable-inc"]
   @interval_ms 60_000

--- a/packages/mcp-ex/test/action_log_test.exs
+++ b/packages/mcp-ex/test/action_log_test.exs
@@ -599,4 +599,49 @@ defmodule IxMcp.ActionLogTest do
     :ok = Sqlite3.close(conn)
     assert tables == []
   end
+
+  # Several server instances share one database file, so a write can land
+  # while a sibling holds the write lock. SQLite reports that as :busy, which
+  # used to badmatch in run/3 and kill the log and the calling job (#3890).
+  test "a write blocked by a sibling's transaction waits the lock out instead of crashing" do
+    path = tmp_db()
+    log = start_supervised!({ActionLog, path: path, name: :action_log_busy_wait})
+    session_id = ActionLog.create_session("busy", log)
+
+    {:ok, blocker} = Sqlite3.open(path)
+    :ok = Sqlite3.execute(blocker, "BEGIN IMMEDIATE")
+
+    release =
+      Task.async(fn ->
+        Process.sleep(300)
+        :ok = Sqlite3.execute(blocker, "ROLLBACK")
+      end)
+
+    assert :ok = ActionLog.rename_session(session_id, "survived", log)
+    assert Task.await(release) == :ok
+    :ok = Sqlite3.close(blocker)
+  end
+
+  test "a lock outliving the bounded busy wait fails loudly, not with a badmatch (#3890)" do
+    path = tmp_db()
+
+    log =
+      start_supervised!(
+        {ActionLog, path: path, name: :action_log_busy_bound, busy_timeout_ms: 20}
+      )
+
+    {:ok, blocker} = Sqlite3.open(path)
+    :ok = Sqlite3.execute(blocker, "BEGIN IMMEDIATE")
+    ref = Process.monitor(log)
+
+    capture_log(fn ->
+      assert catch_exit(ActionLog.create_session("never", log))
+      assert_receive {:DOWN, ^ref, :process, _pid, {%RuntimeError{message: message}, _stack}}
+      assert message =~ "busy"
+      assert message =~ "3890"
+    end)
+
+    :ok = Sqlite3.execute(blocker, "ROLLBACK")
+    :ok = Sqlite3.close(blocker)
+  end
 end

--- a/packages/site/src/lib/updates/action-log-busy-wait.svx
+++ b/packages/site/src/lib/updates/action-log-busy-wait.svx
@@ -1,0 +1,23 @@
+---
+id: action-log-busy-wait
+postedAt: 2026-07-21T17:30:00-07:00
+title: Kernel action log waits out sqlite write contention instead of killing the job
+tags: [kernel, mcp, sqlite, reliability]
+links:
+  - label: issue #3890
+    href: https://github.com/indexable-inc/index/issues/3890
+  - label: ActionLog
+    href: https://github.com/indexable-inc/index/blob/main/packages/mcp-ex/lib/ix_mcp/action_log.ex
+---
+
+Every kernel instance on a machine appends to one shared `actions.db`. When two
+jobs wrote at once, sqlite could report `:busy` to one of them after exqlite's
+default 2-second wait, and the ActionLog GenServer crashed on a bare pattern
+match -- taking the caller's job down over a log write nothing on the hot path
+reads.
+
+The connection now opens with a 5-second busy timeout, and a step that still
+comes back `:busy` after that bound fails with an error naming the blocked
+statement instead of a `badmatch`. There are no unbounded retries: the wait is
+the bound, the supervisor reopens the log after a crash, and concurrent jobs no
+longer die to each other's write locks.


### PR DESCRIPTION
The ActionLog GenServer badmatch-crashed on `:busy` from `Sqlite3.step/2` when a sibling kernel instance held the write lock on the shared `actions.db` past exqlite's default 2s busy wait, killing the log and the calling job (`update_stack` path in the issue).

Fix, at the source:
- open the connection with `Sqlite3.set_busy_timeout(conn, 5_000)` (exqlite 0.39 exposes it natively; `busy_timeout_ms` opt exists so the regression test can shrink the wait)
- `step!/3` and `fetch/3` turn a residual `:busy` into a descriptive raise naming the blocked statement and #3890, instead of a bare badmatch; no unbounded retries -- the timeout is the bound, and the supervisor reopens the log after a crash

Repro: new test holds `BEGIN IMMEDIATE` on the db file from a second connection. Before the fix it reproduces the exact crash from the issue (`{{:badmatch, :busy}, [{IxMcp.ActionLog, :run, 3, ...}]}`); after, a lock released within the wait is survived, and a lock outliving the bound fails with the diagnostic error.

Also fixes a pre-existing credo failure in `issue_watch.ex` (alias/require order) that made `nix build .#mcp-ex.tests.elixir` red on origin/main itself -- verified against a pristine main checkout.

Verified locally: `mix test` (122 tests, 0 failures), `nix build .#mcp-ex.tests.elixir --no-link`, `nix run .#lint` (13/13).

Fixes #3890

(sent by an AI agent via Claude Code)



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle SQLite write contention in `IxMcp.ActionLog` with a busy timeout
> - Configures a 5-second SQLite busy timeout on connection open via `Sqlite3.set_busy_timeout/2`, overridable via the `:busy_timeout_ms` start option.
> - Adds a `step!/3` helper and reworks `fetch/2` to raise descriptive `RuntimeError` messages (referencing issue #3890) when a lock persists past the timeout, replacing bare badmatch crashes.
> - Adds two tests: one verifying a blocked write waits and succeeds, one verifying that a lock outlasting the timeout raises a `RuntimeError` with 'busy' and '3890' rather than a badmatch.
> - Risk: GenServer processes that previously crashed on `:busy` badmatches will now crash with a `RuntimeError`; behavior under contention changes from unpredictable to explicit failure after the timeout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7cf5eec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->