### PR TITLE
mcp: embed CLI binding (#3905)

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1709,6 +1709,11 @@
       lint-fixed = lintFix.fixed;
       lint-fix-patch = lintFix.patch;
       site-dev = site.passthru.devServer;
+      # Embedding duplicate-code finder CLI (index#3905): the ix-mcp kernel's
+      # bundled `embed` module run as `python -m embed` on the same pinned
+      # interpreter, so `nix run .#embed -- dupes . --k 40 --json` sees the
+      # same torch/MPS runtime and parquet cache as in-kernel `import embed`.
+      embed = repoPackages.mcp.passthru.embedCli;
       update-mods = updateMods;
       update-loaders = updateLoaders;
       inherit update;

--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -682,7 +682,8 @@
   # (src/<name>/module.nix, plus ix_notebook_mcp/module.nix for the server
   # package itself). Same discovery idiom as packages/registry.nix's
   # package.nix walk. Each module.nix is a function returning
-  # `{ module, darwinOnly ? false, tests ? {} }`; its formals are fed by
+  # `{ module, darwinOnly ? false, tests ? {} }` (embed also returns `cli`,
+  # which the assembly surfaces as `passthru.embedCli`); its formals are fed by
   # intersection from `moduleScope`, so a module file declares exactly the
   # slice of this assembly it uses: shared helpers, third-party pins, and
   # sibling modules under their `<name>Module` bindings (which is how a
@@ -727,6 +728,11 @@
         nuPyModule
         privateSessionModule
         distillerModule
+        # The shipped interpreter, for module-owned artifacts that must run on
+        # the exact env the kernels run (embed's CLI). Anything built over it
+        # rides the whole bundled closure, so per-module tests should prefer
+        # `bundledTestPython` unless the artifact under test IS that closure.
+        mcpPython
         ;
       testsRoot = ./tests;
     }
@@ -744,6 +750,10 @@
   # The assembly below reaches a few discovered modules by name.
   ixNotebookMcpModule = bundledModule "ix_notebook_mcp";
   claudeHistoryModule = bundledModule "claude_history";
+  # The embed battery's CLI (index#3905), defined next to its module in
+  # src/embed/module.nix and surfaced as `nix run .#embed` through
+  # lib/per-system.nix.
+  embedCli = bundledEntries.embed.cli;
   bundledModuleTests = lib.mergeAttrsList (
     map (entry: entry.tests or {}) (builtins.attrValues bundledEntries)
   );
@@ -1551,6 +1561,7 @@ in
     passthru =
       (old.passthru or {})
       // {
+        inherit embedCli;
         tests =
           {
             inherit

--- a/packages/mcp/src/embed/embed/__init__.py
+++ b/packages/mcp/src/embed/embed/__init__.py
@@ -21,6 +21,9 @@ process, no HTTP seam.
 * :func:`dupes` -- the one-call duplicate-code finder: :func:`ensure` a root,
   then mine the top pairs among that root's own chunks only.
 
+The same surface is a CLI on the same bundled interpreter for Elixir/shell
+callers: ``nix run .#embed -- dupes . --k 40 --json`` (index#3905).
+
 The cache is one parquet file per model revision at
 ``~/.cache/index-embed/<model_rev>.parquet`` (columns ``hash``, ``path``,
 ``embedding: array[f32, 1024]``); a model bump changes the revision and so

--- a/packages/mcp/src/embed/embed/__main__.py
+++ b/packages/mcp/src/embed/embed/__main__.py
@@ -1,0 +1,90 @@
+"""The embed battery as a CLI: ``python -m embed`` / ``nix run .#embed``.
+
+One subcommand per public function (``dupes`` / ``pairs`` / ``similar`` /
+``ensure``), so Elixir and shell callers reach the duplicate-code finder
+without a Python kernel (index#3905). Human-readable polars tables by default;
+``--json`` emits one row-oriented JSON document. An :class:`embed.EmbedError`
+prints to stderr and exits 1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import polars as pl
+
+import embed
+
+
+def _emit(frame: pl.DataFrame, *, as_json: bool) -> None:
+    """Render ``frame``: one JSON document, or the full (untruncated) table."""
+    if as_json:
+        sys.stdout.write(frame.write_json() + "\n")
+        return
+    with pl.Config(tbl_rows=frame.height, fmt_str_lengths=120):
+        print(frame)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="embed",
+        description="Embedding-based duplicate-code finder and semantic code search "
+        "over the ix-mcp parquet cache.",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    dupes = commands.add_parser("dupes", help="top duplicate function pairs under a root")
+    dupes.add_argument("root", nargs="?", default=".", help="repo root to chunk and mine (default: .)")
+    dupes.add_argument("--k", type=int, default=20, help="pairs to report (default: 20)")
+
+    pairs = commands.add_parser("pairs", help="top pairs across the whole cache (every repo ever embedded)")
+    pairs.add_argument("--k", type=int, default=10, help="pairs to report (default: 10)")
+
+    similar = commands.add_parser("similar", help="cached chunks nearest a query text or file")
+    query = similar.add_mutually_exclusive_group(required=True)
+    query.add_argument("query", nargs="?", help="query text")
+    query.add_argument("--file", help="file whose contents are the query")
+    similar.add_argument("--k", type=int, default=10, help="chunks to report (default: 10)")
+
+    ensure = commands.add_parser("ensure", help="chunk a root and embed the cache misses")
+    ensure.add_argument("root", nargs="?", default=".", help="repo root to chunk and embed (default: .)")
+
+    for sub in (dupes, pairs, similar, ensure):
+        sub.add_argument("--json", action="store_true", help="one row-oriented JSON document instead of a table")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    command: str = args.command
+    try:
+        if command == "dupes":
+            frame = embed.dupes(args.root, k=args.k)
+        elif command == "pairs":
+            frame = embed.pairs(k=args.k)
+        elif command == "similar":
+            if args.file is None:
+                query: str = args.query
+            else:
+                # Read here rather than passing the path through: embed.similar's
+                # path sniffing embeds a missing path as literal query text, and
+                # an explicit --file must fail loudly instead.
+                try:
+                    query = Path(args.file).expanduser().read_text(encoding="utf-8")
+                except OSError as exc:
+                    print(f"embed: cannot read --file {args.file}: {exc}", file=sys.stderr)
+                    return 1
+            frame = embed.similar(query, k=args.k)
+        else:  # ensure; hash/path only: text and embedding are cache payload, not report
+            frame = embed.ensure(args.root).select("hash", "path")
+    except embed.EmbedError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+    _emit(frame, as_json=args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/mcp/src/embed/module.nix
+++ b/packages/mcp/src/embed/module.nix
@@ -1,6 +1,8 @@
 {
   bundledSource,
   importTest,
+  lib,
+  mcpPython,
   pkgs,
 }: let
   # `embed`: Python-native code embeddings (chunk / embed / parquet cache /
@@ -27,11 +29,58 @@
   # `embed` imports everywhere (its torch/MPS runtime loads lazily inside the
   # embedding calls), so the import test runs on Linux too.
   embedBundled = importTest [embedModule] "embed" "import embed; print('embed-ok', embed.__version__)";
+  # The battery's CLI (index#3905): `python -m embed` on the exact interpreter
+  # the kernels run (`mcpPython`, not a per-module test env), so the torch/MPS
+  # runtime and the per-model-revision parquet cache behave identically to the
+  # in-kernel `import embed` path. Surfaced as `nix run .#embed` through
+  # lib/per-system.nix via the package's `passthru.embedCli`; Elixir callers
+  # shell out to it (`embed dupes <root> --k 40 --json`).
+  embedCli =
+    pkgs.runCommand "ix-mcp-embed-cli"
+    {
+      nativeBuildInputs = [pkgs.makeWrapper];
+      strictDeps = true;
+      meta = {
+        description = "Embedding duplicate-code finder and semantic code search (the bundled `embed` module as a CLI)";
+        mainProgram = "embed";
+      };
+    }
+    ''
+      mkdir -p $out/bin
+      makeWrapper ${lib.getExe mcpPython} $out/bin/embed \
+        --add-flags "-m embed"
+    '';
+  # The CLI boundary, provable offline: `--help` exits 0, and a missing root
+  # fails loudly (EmbedError on stderr, nonzero exit) before any model or
+  # cache is touched. Runs against the shipped wrapper itself, so it rides
+  # `mcpPython`'s closure by construction -- the artifact under test is the
+  # whole-interpreter wrapper, not this module's test env.
+  embedCliSmoke =
+    pkgs.runCommand "ix-mcp-embed-cli-smoke"
+    {
+      nativeBuildInputs = [embedCli];
+      strictDeps = true;
+    }
+    ''
+      embed --help >/dev/null
+      if embed dupes /does-not-exist --json 2>stderr; then
+        echo "embed dupes on a missing root should exit nonzero" >&2
+        exit 1
+      fi
+      grep -q "is not a directory" stderr || {
+        echo "expected the EmbedError message on stderr, got:" >&2
+        cat stderr >&2
+        exit 1
+      }
+      mkdir -p "$out"
+    '';
 in {
   module = embedModule;
+  cli = embedCli;
   tests = {
     inherit
       embedBundled
+      embedCliSmoke
       ;
   };
 }

--- a/packages/site/src/lib/updates/embed-cli.svx
+++ b/packages/site/src/lib/updates/embed-cli.svx
@@ -1,0 +1,19 @@
+---
+id: embed-cli
+postedAt: 2026-07-21T12:00:00-07:00
+title: "The embedding duplicate-code finder is now a CLI: nix run .#embed"
+tags: [mcp, embeddings, cli]
+links:
+  - label: issue #3905
+    href: https://github.com/indexable-inc/index/issues/3905
+  - label: embed module
+    href: https://github.com/indexable-inc/index/blob/main/packages/mcp/src/embed/embed/__init__.py
+---
+
+The `embed` battery (chunk, embed, parquet cache, similarity search) was only reachable as a Python module inside the ix-mcp kernel. It is now also a command, so Elixir and shell callers can mine semantic duplicates without a kernel:
+
+```sh
+nix run .#embed -- dupes . --k 40 --json
+```
+
+Subcommands mirror the module surface: `dupes` (top duplicate function pairs under a root), `pairs` (top pairs across the whole cache), `similar` (cached chunks nearest a query text or `--file`), and `ensure` (chunk a root and embed the cache misses). Output is a polars table by default; `--json` emits one row-oriented JSON document. The wrapper runs `python -m embed` on the exact interpreter bundled into the kernel, so the torch/MPS runtime and the per-model-revision parquet cache behave identically to in-kernel `import embed`. From Elixir: `Cmd.run("embed", ["dupes", root, "--k", "40", "--json"])`.


### PR DESCRIPTION
Fixes #3905.

`embed.dupes` (the embedding duplicate-code finder in `packages/mcp/src/embed`) was reachable only as a Python module inside the ix-mcp kernel. This adds a CLI binding so Elixir and shell callers can use it:

- `packages/mcp/src/embed/embed/__main__.py`: argparse subcommands `dupes` (root, `--k`, default 20), `pairs` (`--k`), `similar` (query or `--file`, `--k`), `ensure` (root). Polars table by default, `--json` emits one row-oriented JSON document, `EmbedError` goes to stderr with exit 1.
- `packages/mcp/default.nix`: `embedCli`, a makeWrapper over the existing bundled `mcpPython` interpreter (`-m embed`), exposed via `passthru.embedCli`; plus `embedCliSmoke`, an offline test of the CLI boundary. No module duplication: the same `embedModule` / interpreter wiring as the kernel, so torch/MPS and the parquet cache behave identically.
- `lib/per-system.nix`: `embed = repoPackages.mcp.passthru.embedCli`, so `nix run .#embed -- dupes . --k 40 --json` works (same pattern as `site-dev`).
- One docstring line in the embed module pointing at the CLI, and a site updates entry (`packages/site/src/lib/updates/embed-cli.svx`).

Verified locally on aarch64-darwin:
- `nix build .#mcp.passthru.tests.strictTypecheck` (zuban --strict + ruff ANN now cover `__main__.py`) and `.#mcp.passthru.tests.embedCliSmoke`: green.
- `nix run .#lint`: 13/13.
- Live: `nix run .#embed -- dupes packages/mcp/src/embed --k 5 --json` emits one JSON document on the real MPS model; `similar` renders the human table; a bad root exits 1 with the EmbedError on stderr.

(sent by an AI agent via Claude Code, model fable)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `embed` CLI binding for duplicate-code search subcommands
> - Adds [`packages/mcp/src/embed/embed/__main__.py`](https://github.com/indexable-inc/index/pull/3913/files#diff-b2d5fa621a55075d8f383e069eb38a34e1b00c47aa465a07ccf481a1c8699832) implementing subcommands `dupes`, `pairs`, `similar`, and `ensure` via argparse, with `--json` and `--file` options and stderr/exit-1 error handling.
> - [`packages/mcp/src/embed/module.nix`](https://github.com/indexable-inc/index/pull/3913/files#diff-9b8ac88c837159c3e61d7120328d49e3e512f7f8cab11e683cfcf89dbe754312) builds an `embed` wrapper using `makeWrapper` around the bundled `mcpPython` interpreter and adds a smoke test verifying `--help` and error output.
> - [`packages/mcp/default.nix`](https://github.com/indexable-inc/index/pull/3913/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) exposes `passthru.embedCli` and [`lib/per-system.nix`](https://github.com/indexable-inc/index/pull/3913/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) wires it to `nix run .#embed`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 201f54f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->