### PR TITLE
nu-py: fold near-identical sibling functions (#3912)

### DIFF
--- a/packages/nu-py/src/lib.rs
+++ b/packages/nu-py/src/lib.rs
@@ -1081,6 +1081,15 @@ mod tests {
         )
     }
 
+    /// Eval `source` on a fresh engine expecting it to fail, and hand back
+    /// nushell's rendered diagnostic for the caller to assert against.
+    fn eval_failure_diagnostic(source: &str, expectation: &str) -> EvalError {
+        let (mut inner, interrupt, job) = test_inner();
+        inner
+            .eval(source, None, None, None, &interrupt, &job, true)
+            .expect_err(expectation)
+    }
+
     #[test]
     fn intermediate_pipeline_values_are_returned_not_dropped() {
         let (mut inner, interrupt, job) = test_inner();
@@ -1222,35 +1231,17 @@ mod tests {
 
     #[test]
     fn intermediate_failure_aborts_the_eval() {
-        let (mut inner, interrupt, job) = test_inner();
-        let diagnostic = inner
-            .eval(
-                "error make {msg: 'boom'}; 'after'",
-                None,
-                None,
-                None,
-                &interrupt,
-                &job,
-                true,
-            )
-            .expect_err("an intermediate failure must abort");
+        let diagnostic = eval_failure_diagnostic(
+            "error make {msg: 'boom'}; 'after'",
+            "an intermediate failure must abort",
+        );
         assert!(diagnostic.contains("boom"), "diagnostic: {diagnostic}");
     }
 
     #[test]
     fn eval_failure_without_redirection_argv_stays_unannotated() {
-        let (mut inner, interrupt, job) = test_inner();
-        let diagnostic = inner
-            .eval(
-                "error make {msg: 'boom'}",
-                None,
-                None,
-                None,
-                &interrupt,
-                &job,
-                true,
-            )
-            .expect_err("error make must fail the eval");
+        let diagnostic =
+            eval_failure_diagnostic("error make {msg: 'boom'}", "error make must fail the eval");
         assert!(
             !diagnostic.contains("out+err>|"),
             "spurious hint: {diagnostic}"


### PR DESCRIPTION
## What

Folds the two near-identical eval-failure tests in packages/nu-py/src/lib.rs into one parameterized helper, closing the T3 clone pair flagged in #3912 (similarity 0.98).

intermediate_failure_aborts_the_eval and eval_failure_without_redirection_argv_stays_unannotated shared the same skeleton: build test_inner(), eval a source with no input, expect_err, assert on the diagnostic. That skeleton is now eval_failure_diagnostic(source, expectation); each test keeps its own name and its own assertion, so the two distinct behaviors stay pinned.

## Behavior

Identical. Pure test-code dedup.

## Verification

- cargo test -p nu-py: 15/15 pass, including both migrated tests.
- cargo fmt -p nu-py -- --check: clean.
- nix run .#clone -- .: duplicated_lines 2216 -> 2201, duplication_pct 0.36191% -> 0.35946%, T3 groups 80 -> 79. Global gate PASS (<= 0.365%).
- clone diff gate vs origin/main: PASS (0/15 changed lines duplicated).

## AI attribution

Authored by Claude Code (model: opus).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract `eval_failure_diagnostic` helper in `nu-py` tests to reduce duplication
> Adds a shared `eval_failure_diagnostic` helper in [lib.rs](https://github.com/indexable-inc/index/pull/3915/files#diff-424ce210c45fc8f162c45814067651d48d245471a2e86b63c39b71c370ffe7fe) that initializes a fresh engine, runs an eval expected to fail, and returns the rendered diagnostic. Two existing tests are refactored to use this helper instead of inlining the setup and error extraction logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a1ded8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->