### PR TITLE
google: dedupe calendar/gmail T1 clone and py internal twin (#3911)

### DIFF
--- a/packages/google/auth/src/api_error.rs
+++ b/packages/google/auth/src/api_error.rs
@@ -1,0 +1,52 @@
+//! Google's standard REST error envelope.
+//!
+//! Every Google API the repo wraps reports failures as
+//! `{"error": {"code": …, "message": …, …}}`. The typed clients (calendar,
+//! gmail) share this one extractor so each keeps its `check_status` seam
+//! without a local copy of the envelope types (#3911).
+
+use serde::Deserialize;
+
+/// The Google API error envelope: `{"error": {"code": …, "message": …}}`.
+#[derive(Deserialize)]
+struct ApiErrorBody {
+    error: ApiErrorDetail,
+}
+
+#[derive(Deserialize)]
+struct ApiErrorDetail {
+    message: String,
+}
+
+/// The human message from a Google error body, or the (truncated) raw body
+/// when the envelope is absent.
+#[must_use]
+pub fn api_message(body: &str) -> String {
+    serde_json::from_str::<ApiErrorBody>(body).map_or_else(
+        |_| {
+            let trimmed = body.trim();
+            let mut message: String = trimmed.chars().take(500).collect();
+            if message.len() < trimmed.len() {
+                message.push('…');
+            }
+            message
+        },
+        |envelope| envelope.error.message,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::api_message;
+
+    #[test]
+    fn api_message_prefers_the_error_envelope() {
+        let body = r#"{"error":{"code":403,"message":"Insufficient Permission","status":"PERMISSION_DENIED"}}"#;
+        assert_eq!(api_message(body), "Insufficient Permission");
+    }
+
+    #[test]
+    fn api_message_falls_back_to_the_raw_body() {
+        assert_eq!(api_message(" upstream exploded "), "upstream exploded");
+    }
+}

--- a/packages/google/auth/src/lib.rs
+++ b/packages/google/auth/src/lib.rs
@@ -17,9 +17,11 @@
 //! [`Authenticator`] carries the scopes its caller needs and refuses to mint
 //! an access token if the stored grant is missing any of them.
 
+mod api_error;
 mod error;
 pub mod scopes;
 
+pub use crate::api_error::api_message;
 pub use crate::error::{Error, Result};
 
 use std::path::{Path, PathBuf};

--- a/packages/google/calendar/src/lib.rs
+++ b/packages/google/calendar/src/lib.rs
@@ -21,6 +21,7 @@ pub use model::{
     SendUpdates,
 };
 
+use google_auth::api_message;
 use serde::Deserialize;
 use snafu::ResultExt as _;
 use url::Url;
@@ -45,17 +46,6 @@ struct EventsPage {
     items: Vec<Event>,
     #[serde(default)]
     next_page_token: Option<String>,
-}
-
-/// The Google API error envelope: `{"error": {"code": …, "message": …}}`.
-#[derive(Deserialize)]
-struct ApiErrorBody {
-    error: ApiErrorDetail,
-}
-
-#[derive(Deserialize)]
-struct ApiErrorDetail {
-    message: String,
 }
 
 /// Calendar API client over an [`Authenticator`].
@@ -258,36 +248,4 @@ async fn decode<T: serde::de::DeserializeOwned>(response: reqwest::Response) -> 
         .json()
         .await
         .context(HttpSnafu)
-}
-
-/// The human message from a Google error body, or the (truncated) raw body
-/// when the envelope is absent.
-fn api_message(body: &str) -> String {
-    serde_json::from_str::<ApiErrorBody>(body).map_or_else(
-        |_| {
-            let trimmed = body.trim();
-            let mut message: String = trimmed.chars().take(500).collect();
-            if message.len() < trimmed.len() {
-                message.push('…');
-            }
-            message
-        },
-        |envelope| envelope.error.message,
-    )
-}
-
-#[cfg(test)]
-mod tests {
-    use super::api_message;
-
-    #[test]
-    fn api_message_prefers_the_error_envelope() {
-        let body = r#"{"error":{"code":404,"message":"Not Found","errors":[]}}"#;
-        assert_eq!(api_message(body), "Not Found");
-    }
-
-    #[test]
-    fn api_message_falls_back_to_the_raw_body() {
-        assert_eq!(api_message(" upstream exploded "), "upstream exploded");
-    }
 }

--- a/packages/google/gmail/src/lib.rs
+++ b/packages/google/gmail/src/lib.rs
@@ -37,7 +37,7 @@ pub use model::{
 };
 pub use threads::ThreadStub;
 
-use serde::Deserialize;
+use google_auth::api_message;
 use snafu::ResultExt as _;
 use url::Url;
 
@@ -71,18 +71,6 @@ impl<T> PageParts<T> {
             next_page_token,
         }
     }
-}
-
-/// The Gmail / Google API error envelope:
-/// `{"error": {"code": …, "message": …, "status": …, "errors": [...]}}`.
-#[derive(Deserialize)]
-struct ApiErrorBody {
-    error: ApiErrorDetail,
-}
-
-#[derive(Deserialize)]
-struct ApiErrorDetail {
-    message: String,
 }
 
 /// Gmail API client over an [`Authenticator`].
@@ -253,36 +241,4 @@ pub(crate) async fn send_no_body(builder: reqwest::RequestBuilder) -> Result<()>
     let response = builder.send().await.context(HttpSnafu)?;
     check_status(response).await?;
     Ok(())
-}
-
-/// The human message from a Google error body, or the (truncated) raw body
-/// when the envelope is absent.
-fn api_message(body: &str) -> String {
-    serde_json::from_str::<ApiErrorBody>(body).map_or_else(
-        |_| {
-            let trimmed = body.trim();
-            let mut message: String = trimmed.chars().take(500).collect();
-            if message.len() < trimmed.len() {
-                message.push('…');
-            }
-            message
-        },
-        |envelope| envelope.error.message,
-    )
-}
-
-#[cfg(test)]
-mod tests {
-    use super::api_message;
-
-    #[test]
-    fn api_message_prefers_the_error_envelope() {
-        let body = r#"{"error":{"code":403,"message":"Insufficient Permission","status":"PERMISSION_DENIED"}}"#;
-        assert_eq!(api_message(body), "Insufficient Permission");
-    }
-
-    #[test]
-    fn api_message_falls_back_to_the_raw_body() {
-        assert_eq!(api_message(" gmail blew up "), "gmail blew up");
-    }
 }

--- a/packages/google/py/src/lib.rs
+++ b/packages/google/py/src/lib.rs
@@ -313,6 +313,10 @@ impl GmailClient {
 
     /// Fetch one thread (with its messages) by id.
     #[pyo3(signature = (thread_id, format = None))]
+    // clone:ignore -- pyo3 twin of `get_message`: the shared logic already
+    // lives in `gmail_resource_future`; what remains is the per-method
+    // Python binding declaration, which cannot merge without changing the
+    // Python API (#3911).
     fn get_thread<'py>(
         &self,
         py: Python<'py>,


### PR DESCRIPTION
Fixes the two clone hits from #3911.

**T1: `api_message` duplicated across calendar and gmail.** The Google REST error-envelope extractor (`api_message` plus the `ApiErrorBody`/`ApiErrorDetail` wire types and its unit tests) now lives in `google-auth`, the crate both clients already depend on, as a small `api_error` module re-exported at the crate root. Both `check_status` seams call the shared copy; no new crate, no Cargo.toml changes. The auth crate is nominally OAuth, but it is the one shared Google seam, and the envelope is Google-wide rather than per-API, so it fits there better than a 13-line crate would.

**T2: `get_message`/`get_thread` twins in the py binding.** The issue asks for a merge into one parameterized function, but that merge already happened in #2618: both wrappers delegate to `gmail_resource_future`. What the scanner still flags is the per-method pyo3 declaration (signature attribute, argument list, one delegating call), which cannot merge further without changing the Python API. This marks the twin `clone:ignore` with that justification, the same treatment the minecraft protocol bindings use for deliberately parallel binding surfaces.

Verification:

- `cargo test -p google-auth -p google-calendar -p google-gmail`: all green, including `api_errors_carry_status_and_google_message`, which exercises the moved helper through `check_status`; the moved unit tests now run in `google-auth`.
- `cargo check -p ix-google-py -p google-mcp`: dependents compile.
- `nix run .#clone -- .`: both #3911 instances gone; `duplicated_lines` 2216 -> 2189, global gate passes with more headroom (0.3575% vs 0.365% budget). The remaining calendar/gmail `check_status` block pair predates this PR (present in the baseline scan) and is out of #3911's scope.
- `nix run .#clone -- . --diff`: diff gate passes (no duplication on changed lines).
- `nix run .#lint`: green.

(authored by an AI agent via Claude Code, model fable)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate `api_message` error parsing into shared `google_auth` crate
> Extracts the duplicated Google API error envelope parsing logic from the calendar and gmail crates into a single `api_message` function in [api_error.rs](https://github.com/indexable-inc/index/pull/3916/files#diff-34ac9cd350d1661c367ebdf4cfc3a8bb82c879e77de1cb631f690af8ee817527), then re-exports it via `google_auth`. Both [calendar/src/lib.rs](https://github.com/indexable-inc/index/pull/3916/files#diff-e5b83f34fea2988d86c072dd388eec328dd24de71b7131864eeb18f20634b358) and [gmail/src/lib.rs](https://github.com/indexable-inc/index/pull/3916/files#diff-2471193b89033699d7b73b74ca60119959c5c826cd0facf98c89bf23e78e42a2) now import `google_auth::api_message` and drop their local copies of `ApiErrorBody`, `ApiErrorDetail`, and the associated tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9526c1d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->