### PR TITLE
evals: dedupe shared data/scoring helpers (#3908)

### DIFF
--- a/clone.toml
+++ b/clone.toml
@@ -50,7 +50,12 @@ ignore = [
 # 2026-07-21 (#3901): lowered 0.37 -> 0.365. The 26-line NIF-binding test
 # scaffolding triplicate (plumb/tui/unibind eventually+poll) is now one staged
 # helper; measured 0.3623%. The mix.exs pair stays in the scan.
+#
+# 2026-07-22 (#3908): lowered 0.365 -> 0.36. The eval to_dict/to_json/as_dict
+# type2 triple is gone (dead method deleted, pure field dumps now
+# dataclasses.asdict); measured 0.3593%. The 13-line _read_lines type1 twin
+# stays in the scan as a documented pair (see both data.py docstrings).
 [budget]
-global_pct = 0.365
+global_pct = 0.36
 diff_pct = 0.0
 diff_base = "origin/main"

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/agent.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/agent.py
@@ -54,15 +54,6 @@ class RunMetrics:
     output_tokens: int = 0
     cost_usd: float = 0.0
 
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "duration_ms": self.duration_ms,
-            "num_turns": self.num_turns,
-            "input_tokens": self.input_tokens,
-            "output_tokens": self.output_tokens,
-            "cost_usd": self.cost_usd,
-        }
-
 
 @dataclass(frozen=True, slots=True)
 class RunOutput:

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/core.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/core.py
@@ -9,7 +9,7 @@ share one command.
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 from .judge import Judge
@@ -56,10 +56,8 @@ class EvalReport:
     longest_streak: int | None = None
 
     def to_json(self) -> dict[str, object]:
-        return {
-            "name": self.name,
-            "headline": self.headline,
-            "summary": self.summary,
-            "longest_streak": self.longest_streak,
-            "cases": self.cases,
-        }
+        """Every field except the rendered ``table``, so adding a field cannot
+        silently leave it out of the JSON report."""
+        data = asdict(self)
+        del data["table"]
+        return data

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/data.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/data.py
@@ -3,6 +3,11 @@
 The datasets are data, not code: one JSON object per line so a diff shows exactly
 which behavior rubric or task changed. See ``datasets/behaviors.jsonl`` and
 ``datasets/tasks.jsonl``.
+
+``_read_lines`` is a deliberate twin of ``search_eval.data._read_lines`` (#3908):
+the eval harnesses ship as independent uv projects and ``buildUvApplication``
+has no local path-dependency seam, so keeping 13 lines in sync is cheaper than
+inventing one. If it grows, share it instead.
 """
 
 from __future__ import annotations

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/first_principles_eval.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/first_principles_eval.py
@@ -23,7 +23,7 @@ import stat
 import subprocess
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 from . import sandbox as sb
@@ -74,23 +74,6 @@ class FpResult:
     cost_usd: float = 0.0
     transcript: str = ""
     steps: list[dict[str, object]] = field(default_factory=list)
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "case_id": self.case_id,
-            "rollout": self.rollout,
-            "verdict": self.verdict,
-            "validated": self.validated,
-            "answer": self.answer,
-            "evidence": self.evidence,
-            "error": self.error,
-            "duration_ms": self.duration_ms,
-            "input_tokens": self.input_tokens,
-            "output_tokens": self.output_tokens,
-            "cost_usd": self.cost_usd,
-            "transcript": self.transcript,
-            "steps": self.steps,
-        }
 
 
 def _load_cases(override: Path | None = None) -> list[FpCase]:
@@ -279,7 +262,7 @@ def run(ctx: EvalContext, *, cases_path: Path | None = None) -> EvalReport:
         headline=headline,
         summary=summary,
         table=_render(results, validated=validated, scored=len(scored), errored=errored, headline=headline, sandbox=ctx.sandbox),
-        cases=[r.to_dict() for r in results],
+        cases=[asdict(r) for r in results],
     )
 
 

--- a/packages/agent/system-prompt-eval/src/system_prompt_eval/reverse_engineering_eval.py
+++ b/packages/agent/system-prompt-eval/src/system_prompt_eval/reverse_engineering_eval.py
@@ -20,7 +20,7 @@ import shutil
 import subprocess
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 from . import sandbox as sb
@@ -77,22 +77,6 @@ class ReResult:
     cost_usd: float = 0.0
     transcript: str = ""
     steps: list[dict[str, object]] = field(default_factory=list)
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "case_id": self.case_id,
-            "rollout": self.rollout,
-            "reverse_engineered": self.reverse_engineered,
-            "evidence": self.evidence,
-            "answer": self.answer,
-            "error": self.error,
-            "duration_ms": self.duration_ms,
-            "input_tokens": self.input_tokens,
-            "output_tokens": self.output_tokens,
-            "cost_usd": self.cost_usd,
-            "transcript": self.transcript,
-            "steps": self.steps,
-        }
 
 
 def _pinned_binary(ctx: EvalContext) -> Path:
@@ -226,7 +210,7 @@ def run(ctx: EvalContext, *, cases_path: Path | None = None) -> EvalReport:
         headline=headline,
         summary=summary,
         table=_render(results, did=did, scored=len(scored), errored=errored, headline=headline, binary=binary),
-        cases=[r.to_dict() for r in results],
+        cases=[asdict(r) for r in results],
     )
 
 

--- a/packages/search/search-eval/src/search_eval/data.py
+++ b/packages/search/search-eval/src/search_eval/data.py
@@ -3,6 +3,11 @@
 The datasets are data, not code: one JSON object per line so a diff shows
 exactly which query or task changed. See ``datasets/retrieval.jsonl`` and
 ``datasets/tasks.jsonl``.
+
+``_read_lines`` is a deliberate twin of ``system_prompt_eval.data._read_lines``
+(#3908): the eval harnesses ship as independent uv projects and
+``buildUvApplication`` has no local path-dependency seam, so keeping 13 lines in
+sync is cheaper than inventing one. If it grows, share it instead.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Fixes #3908 (dedup sweep, from the 2026-07-21 repo-wide `nix run .#clone` scan).

**Type-2 triple** (`RunMetrics.to_dict` = `EvalReport.to_json` = `RetrievalScores.as_dict`, 8 lines each): the shared implementation already exists in the stdlib, so no new helper.

- `RunMetrics.to_dict` had no callers — every consumer reads the fields directly — so it is deleted.
- `EvalReport.to_json` is now `dataclasses.asdict` minus the rendered `table`. Besides killing the clone, this means a new report field cannot be silently dropped from the JSON output (the old hand-rolled dict was exactly that bug waiting to happen; `longest_streak` had already been bolted on once).
- `FpResult.to_dict` / `ReResult.to_dict` in the same package were the same pure field dump (unflagged only because they diverge by one key), so they are deleted too; their single call sites use `asdict(r)` directly.
- `RetrievalScores.as_dict` stays: mapping field names to display keys (`ndcg_at_10` -> `"ndcg@10"`) is real logic, and a lone instance forms no clone group.

**Type-1 twin** (`_read_lines`, 13 identical lines across the two `data.py`): stays, now documented in both docstrings. The two harnesses ship as independent uv projects; `buildUvApplication` has no local path-dependency seam (the wheelhouse builds from `uv.lock` registry entries only, `uv export --no-emit-project`, fileset limited to `srcRoot`), so a shared package means inventing that infrastructure for 13 lines — more machinery than the two consumers need. If the shared surface grows, that is the moment to build the seam.

**Ratchet**: `clone.toml` lowers 0.365 -> 0.36 (measured 0.3593%, was 0.3619%; `duplicated_lines` 2216 -> 2200), dated note added per the file's convention.

Verified: `nix build` of both packages (zuban `--strict` + ruff gates) and all four passthru tests (`scoring`, `metrics`, 2x `printsHelp`) pass; `nix run .#clone -- .` global gate PASS at the new budget.

(authored by an AI agent via Claude Code, model fable)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace custom `to_dict()` methods with `dataclasses.asdict()` in evals
> Removes hand-written `to_dict()` methods from `RunMetrics`, `FpResult`, and `ReResult` dataclasses in the `system-prompt-eval` package, replacing call sites with `dataclasses.asdict()`. Also updates `EvalReport.to_json()` to use `asdict(self)` and adds docstrings to both `data.py` modules explaining why `_read_lines` is intentionally duplicated across packages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d8e854.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->