### PR TITLE
sqlmerge: dedupe twin merge test bodies (#3910)

### DIFF
--- a/packages/sqlmerge/tests/merge.rs
+++ b/packages/sqlmerge/tests/merge.rs
@@ -108,6 +108,29 @@ fn seeded_users() -> Fixture {
     f
 }
 
+/// Both sides insert the same new PK (7) with different values; merge under
+/// `policy` and assert the surviving row is exactly the `winner`'s: its `name`
+/// is `winner`, its `score` is `score`, and no duplicate row remains.
+fn assert_conflicting_insert_resolves(policy: &str, winner: &str, score: i64) {
+    let f = seeded_users();
+    build(&f.ours, "INSERT INTO users VALUES (7, 'ours', 70);");
+    build(&f.theirs, "INSERT INTO users VALUES (7, 'theirs', 77);");
+    f.run_with(&policies(policy))
+        .expect("policy resolves the insert conflict");
+    assert_eq!(
+        read_text(&f.ours, "SELECT name FROM users WHERE id = 7"),
+        winner
+    );
+    assert_eq!(
+        read_int(&f.ours, "SELECT score FROM users WHERE id = 7"),
+        score
+    );
+    assert_eq!(
+        read_int(&f.ours, "SELECT count(*) FROM users WHERE id = 7"),
+        1
+    );
+}
+
 #[test]
 fn non_overlapping_row_edits_merge_clean() {
     let f = seeded_users();
@@ -416,21 +439,7 @@ fn theirs_policy_takes_their_value_on_data_conflict() {
 /// different values) is `REPLACEd` with theirs.
 #[test]
 fn theirs_policy_replaces_conflicting_insert() {
-    let f = seeded_users();
-    build(&f.ours, "INSERT INTO users VALUES (7, 'ours', 70);");
-    build(&f.theirs, "INSERT INTO users VALUES (7, 'theirs', 77);");
-
-    f.run_with(&policies("[policies]\n\"users\" = \"theirs\"\n"))
-        .expect("theirs policy resolves the insert conflict");
-
-    assert_eq!(
-        read_text(&f.ours, "SELECT name FROM users WHERE id = 7"),
-        "theirs"
-    );
-    assert_eq!(
-        read_int(&f.ours, "SELECT score FROM users WHERE id = 7"),
-        77
-    );
+    assert_conflicting_insert_resolves("[policies]\n\"users\" = \"theirs\"\n", "theirs", 77);
 }
 
 #[test]
@@ -464,21 +473,7 @@ fn policies_abort_conflicts_they_cannot_legally_resolve() {
 /// ours (the incoming insert is omitted).
 #[test]
 fn append_only_keeps_ours_on_conflicting_insert() {
-    let f = seeded_users();
-    build(&f.ours, "INSERT INTO users VALUES (8, 'ours', 80);");
-    build(&f.theirs, "INSERT INTO users VALUES (8, 'theirs', 88);");
-
-    f.run_with(&policies("[policies]\n\"users\" = \"append-only\"\n"))
-        .expect("append-only omits the conflicting insert");
-
-    assert_eq!(
-        read_text(&f.ours, "SELECT name FROM users WHERE id = 8"),
-        "ours"
-    );
-    assert_eq!(
-        read_int(&f.ours, "SELECT count(*) FROM users WHERE id = 8"),
-        1
-    );
+    assert_conflicting_insert_resolves("[policies]\n\"users\" = \"append-only\"\n", "ours", 70);
 }
 
 /// A glob applies the policy to matching tables and leaves the rest on the


### PR DESCRIPTION
## What

The two conflicting-INSERT policy tests in `packages/sqlmerge/tests/merge.rs`
(`theirs_policy_replaces_conflicting_insert` and
`append_only_keeps_ours_on_conflicting_insert`) were a 17-line Type-2 clone:
identical seed/insert/merge scaffolding differing only in the policy, the
expected surviving row, and one follow-up assertion.

This extracts `assert_conflicting_insert_resolves(policy, winner, score)`, which
runs the shared setup + merge and asserts the surviving PK-7 row is exactly the
winner's (`name`, `score`, and no duplicate row). Each `#[test]` keeps its
intent-revealing name and doc comment, collapsing to a single-line helper call —
below the clone detector's 8-line floor, so no residual clone remains between
them.

## Behavior

Identical. The two original assertions are preserved and unified into the
helper; all three checks hold under each policy (`theirs` REPLACEs with theirs'
row; `append-only` keeps ours and omits the incoming insert).

## Verification

- `cargo test -p sqlmerge --test merge`: 18 passed.
- `nix run .#clone -- .`: `duplicated_lines` 2216 -> 2199, `type2_groups`
  94 -> 93; global gate passes (0.3591% < 0.365% budget).
- `nix run .#clone -- . --diff origin/main`: diff gate passes
  (`diff_pct` 0.0, 0 of 25 changed lines overlap any clone).

Closes #3910.

AI-authored-by: Claude Code (model: opus)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate conflicting insert test bodies in sqlmerge with a shared helper
> Introduces `assert_conflicting_insert_resolves` in [merge.rs](https://github.com/indexable-inc/index/pull/3920/files#diff-ed7844415ab9e1cb2b1dab1127b3b4d5afb428d4c8d5f1e1b82ead7209032897), a reusable helper that sets up a conflicting insert on PK 7 in both `ours` and `theirs` databases, runs merge with a given policy, and asserts the winner's name, score, and row uniqueness. The `theirs_policy_replaces_conflicting_insert` and `append_only_keeps_ours_on_conflicting_insert` tests are updated to use this helper, removing duplicate inline setup and adding a score assertion that was previously missing from `append_only_keeps_ours_on_conflicting_insert`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ff2aa1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->