### PR TITLE
clone-detect: share the type3/pipeline test helper (#3909)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,6 +1894,11 @@ dependencies = [
 [[package]]
 name = "clone-test-support"
 version = "0.1.0"
+dependencies = [
+ "clone-detect",
+ "clone-scanner",
+ "tempfile",
+]
 
 [[package]]
 name = "cmake"

--- a/packages/code/clone-detect/detect/Cargo.toml
+++ b/packages/code/clone-detect/detect/Cargo.toml
@@ -15,7 +15,7 @@ serde_json.workspace = true
 
 [dev-dependencies]
 clone-scanner = { workspace = true, features = ["test-support"] }
-clone-test-support.workspace = true
+clone-test-support = { workspace = true, features = ["detect"] }
 tempfile.workspace = true
 
 [lints]

--- a/packages/code/clone-detect/detect/src/tests/helpers.rs
+++ b/packages/code/clone-detect/detect/src/tests/helpers.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clone_scanner::Config;
 use tempfile::TempDir;
 
-use crate::{DetectConfig, DetectionResult, Kind, instances};
+use crate::{DetectConfig, DetectionResult, instances};
 
 pub fn create_temp_file(dir: &TempDir, name: &str, content: &str) -> PathBuf {
     clone_test_support::write_file(dir.path(), name, content)
@@ -19,26 +19,4 @@ pub fn scan_and_run(dir: &TempDir, detect_config: &DetectConfig) -> DetectionRes
     let scanner = clone_scanner::Scanner::new(test_scan_config());
     let scan = scanner.directory(dir.path()).unwrap();
     instances(&scan, detect_config)
-}
-
-pub fn assert_no_overlapping_fragments(result: &DetectionResult, selected: impl Fn(&Kind) -> bool) {
-    for group in result
-        .instances
-        .iter()
-        .filter(|group| selected(&group.clone_type))
-    {
-        for (index, left) in group.fragments.iter().enumerate() {
-            for right in group.fragments.iter().skip(index + 1) {
-                let same_file = left.file == right.file;
-                let left_starts_before_right_ends = left.byte_range.start < right.byte_range.end;
-                let right_starts_before_left_ends = right.byte_range.start < left.byte_range.end;
-                let overlaps =
-                    same_file && left_starts_before_right_ends && right_starts_before_left_ends;
-                assert!(
-                    !overlaps,
-                    "clone group compared overlapping fragments: {group:?}"
-                );
-            }
-        }
-    }
 }

--- a/packages/code/clone-detect/detect/src/tests/pipeline.rs
+++ b/packages/code/clone-detect/detect/src/tests/pipeline.rs
@@ -1,6 +1,6 @@
 use tempfile::TempDir;
 
-use super::helpers::{assert_no_overlapping_fragments, create_temp_file, scan_and_run};
+use super::helpers::{create_temp_file, scan_and_run};
 use crate::DetectConfig;
 
 #[test]
@@ -80,33 +80,6 @@ fn aggregate_values(values: Vec<i32>) -> i32 {
     let result = scan_and_run(&dir, &config);
 
     assert_eq!(result.stats.files_scanned, 2);
-}
-
-#[test]
-fn sequences_never_compare_overlapping_regions_of_one_file() {
-    let dir = TempDir::new().unwrap();
-    let code = r#"
-fn process(values: &[i32]) -> i32 {
-    let mut total = 0;
-    for value in values {
-        total += value;
-    }
-    println!("{total}");
-    total
-}
-"#;
-    create_temp_file(&dir, "nested.rs", code);
-
-    let result = scan_and_run(
-        &dir,
-        &DetectConfig {
-            enable_sequences: true,
-            sequence_window_size: 2,
-            ..DetectConfig::default()
-        },
-    );
-
-    assert_no_overlapping_fragments(&result, |kind| matches!(kind, crate::Kind::Sequence { .. }));
 }
 
 #[test]

--- a/packages/code/clone-detect/detect/src/tests/type3.rs
+++ b/packages/code/clone-detect/detect/src/tests/type3.rs
@@ -1,6 +1,6 @@
 use tempfile::TempDir;
 
-use super::helpers::{assert_no_overlapping_fragments, create_temp_file, scan_and_run};
+use super::helpers::{create_temp_file, scan_and_run};
 use crate::{DetectConfig, DetectionResult, Kind, Type3Metric};
 
 /// The original function for the moderately-Type-3 fixture.
@@ -142,32 +142,4 @@ fn threshold_controls_type3_reporting() {
         Type3Metric::Overlap,
         1.0
     )));
-}
-
-#[test]
-fn groups_never_compare_overlapping_regions_of_one_file() {
-    let dir = TempDir::new().unwrap();
-    let code = r"
-fn process(values: &[i32]) -> i32 {
-    let mut total = 0;
-    for value in values {
-        if *value > 0 {
-            total += value;
-        }
-    }
-    total
-}
-";
-    create_temp_file(&dir, "nested.rs", code);
-
-    let result = scan_and_run(
-        &dir,
-        &DetectConfig {
-            enable_type3: true,
-            type3_threshold: 0.5,
-            ..DetectConfig::default()
-        },
-    );
-
-    assert_no_overlapping_fragments(&result, |kind| matches!(kind, Kind::Type3 { .. }));
 }

--- a/packages/code/clone-detect/detect/tests/no_self_overlap.rs
+++ b/packages/code/clone-detect/detect/tests/no_self_overlap.rs
@@ -1,0 +1,63 @@
+//! The detector must never pair two overlapping byte ranges of a single file
+//! against each other. This invariant holds for every detection mode; each
+//! case below crafts a one-file fixture that gives its detector within-file
+//! candidates, driven through
+//! [`clone_test_support::assert_single_file_has_no_overlapping_fragments`].
+
+use clone_detect::{DetectConfig, Kind};
+use clone_test_support::assert_single_file_has_no_overlapping_fragments;
+
+/// A nested function whose subtrees give the Type-3 detector overlapping
+/// same-file candidates.
+const TYPE3_FIXTURE: &str = r"
+fn process(values: &[i32]) -> i32 {
+    let mut total = 0;
+    for value in values {
+        if *value > 0 {
+            total += value;
+        }
+    }
+    total
+}
+";
+
+/// A function with a run of statements that gives the sequence detector
+/// overlapping same-file windows.
+const SEQUENCE_FIXTURE: &str = r#"
+fn process(values: &[i32]) -> i32 {
+    let mut total = 0;
+    for value in values {
+        total += value;
+    }
+    println!("{total}");
+    total
+}
+"#;
+
+#[test]
+fn detectors_never_compare_overlapping_regions_of_one_file() {
+    let cases: [(&str, DetectConfig, fn(&Kind) -> bool); 2] = [
+        (
+            TYPE3_FIXTURE,
+            DetectConfig {
+                enable_type3: true,
+                type3_threshold: 0.5,
+                ..DetectConfig::default()
+            },
+            |kind| matches!(kind, Kind::Type3 { .. }),
+        ),
+        (
+            SEQUENCE_FIXTURE,
+            DetectConfig {
+                enable_sequences: true,
+                sequence_window_size: 2,
+                ..DetectConfig::default()
+            },
+            |kind| matches!(kind, Kind::Sequence { .. }),
+        ),
+    ];
+
+    for (code, config, selected) in cases {
+        assert_single_file_has_no_overlapping_fragments(code, &config, selected);
+    }
+}

--- a/packages/code/clone-detect/test-support/Cargo.toml
+++ b/packages/code/clone-detect/test-support/Cargo.toml
@@ -5,5 +5,16 @@ edition.workspace = true
 publish = false
 description = "Shared filesystem fixtures for clone detector tests"
 
+[dependencies]
+clone-detect = { workspace = true, optional = true }
+clone-scanner = { workspace = true, optional = true, features = ["test-support"] }
+tempfile = { workspace = true, optional = true }
+
+[features]
+# Helpers that drive the detector end to end. Kept optional so lower layers
+# (e.g. the scanner) can reuse the filesystem fixtures without pulling in
+# clone-detect, which sits above them.
+detect = ["dep:clone-detect", "dep:clone-scanner", "dep:tempfile"]
+
 [lints]
 workspace = true

--- a/packages/code/clone-detect/test-support/src/lib.rs
+++ b/packages/code/clone-detect/test-support/src/lib.rs
@@ -17,6 +17,53 @@ pub fn write_file(root: &Path, relative: &str, content: &str) -> PathBuf {
     path
 }
 
+/// Scan a single-file fixture and assert the detector never pairs two
+/// overlapping byte ranges of that one file within a selected clone kind.
+///
+/// The fixture `code` is written to one file, scanned with the test scanner
+/// config, and analyzed with `config`. `selected` picks which clone kinds the
+/// invariant applies to (e.g. Type-3 groups or statement sequences).
+///
+/// # Panics
+///
+/// Panics if the scan fails, or if a selected clone group compares two
+/// fragments from the same file whose byte ranges overlap.
+#[cfg(feature = "detect")]
+pub fn assert_single_file_has_no_overlapping_fragments(
+    code: &str,
+    config: &clone_detect::DetectConfig,
+    selected: impl Fn(&clone_detect::Kind) -> bool,
+) {
+    let dir = tempfile::TempDir::new().expect("create temp dir");
+    let _ = write_file(dir.path(), "nested.rs", code);
+
+    let scanner = clone_scanner::Scanner::new(clone_scanner::Config::for_tests());
+    let scan = scanner
+        .directory(dir.path())
+        .expect("scan fixture directory");
+    let result = clone_detect::instances(&scan, config);
+
+    for group in result
+        .instances
+        .iter()
+        .filter(|group| selected(&group.clone_type))
+    {
+        for (index, left) in group.fragments.iter().enumerate() {
+            for right in group.fragments.iter().skip(index + 1) {
+                let same_file = left.file == right.file;
+                let left_starts_before_right_ends = left.byte_range.start < right.byte_range.end;
+                let right_starts_before_left_ends = right.byte_range.start < left.byte_range.end;
+                let overlaps =
+                    same_file && left_starts_before_right_ends && right_starts_before_left_ends;
+                assert!(
+                    !overlaps,
+                    "clone group compared overlapping fragments: {group:?}"
+                );
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::write_file;


### PR DESCRIPTION
## What

`type3.rs` and `pipeline.rs` each carried a "no self-overlap" test whose bodies were 25-line duplicates (T3 0.95): identical fixture-scan-assert shell, differing only in the fixture source, the `DetectConfig`, and the clone `Kind`.

- Move that shell into the `clone-test-support` crate as `assert_single_file_has_no_overlapping_fragments`, gated behind a new optional `detect` feature. The gate keeps lower layers (the scanner) reusing the filesystem fixtures without pulling in `clone-detect`, which sits above them.
- Drive both cases from one table-driven integration test (`detect/tests/no_self_overlap.rs`). Because the crate-under-test's own unit tests build a second `clone_detect` instance, the helper can only be called from an integration test, where types unify against the same lib build the helper links.
- Remove the now-unused `assert_no_overlapping_fragments` helper.

Both cases keep their distinct fixture, config, and kind filter, so each still exercises its own detector path.

## Verify

- `cargo test -p clone-detect -p clone-test-support -p clone-scanner` passes.
- `nix run .#clone -- .`: `duplicated_lines` 2216 -> 2191, `type3_groups` 80 -> 79, global gate PASS (0.3578% <= 0.3650%). The duplicate is eliminated, not relocated (`no_self_overlap.rs` is not flagged).

Fixes #3909.

AI-generated with [Claude Code](https://claude.com/claude-code) (model opus)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate overlapping-region tests for clone-detect into a shared test-support helper
> - Moves `assert_no_overlapping_fragments` out of the `detect` crate's internal test helpers and into a new `assert_single_file_has_no_overlapping_fragments` function in [test-support/src/lib.rs](https://github.com/indexable-inc/index/pull/3921/files#diff-445beaadaca40b0a0aa353b07f27b28afafd3c62392a0b93ed374a136ecf5675), gated behind a new `detect` feature flag.
> - Replaces two separate per-detector tests (Type-3 and sequence) with a single consolidated integration test in [no_self_overlap.rs](https://github.com/indexable-inc/index/pull/3921/files#diff-95ddd127dd35924c854fb044a949d658aeac675e4d4b9d114c908a21c939d72b) that covers both detectors.
> - The `detect` dev-dependency in [detect/Cargo.toml](https://github.com/indexable-inc/index/pull/3921/files#diff-fde5cf4abcecd721fb5e9e3e226676ac5eb418fc507a8bde8dd241fed46ad405) now opts into the new `detect` feature of `clone-test-support`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1329a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->