### PR TITLE
claude-hooks: dedupe friction/retro shared helpers (#3906)

### DIFF
--- a/packages/agent/claude-hooks/src/friction.rs
+++ b/packages/agent/claude-hooks/src/friction.rs
@@ -31,12 +31,13 @@ use std::ffi::OsString;
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
 use std::os::fd::AsRawFd as _;
-use std::os::unix::process::CommandExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
+
+use crate::worker;
 
 // Linear "Shitty" project (slug b30ae521fda7) and its team (ENG). UUIDs pinned
 // so hook time needs no lookup round-trip.
@@ -87,9 +88,18 @@ fn state_dir() -> PathBuf {
     if let Some(dir) = std::env::var_os("FRICTION_STATE_DIR").filter(|v| !v.is_empty()) {
         return PathBuf::from(dir);
     }
-    let home = std::env::var_os("HOME").map_or_else(|| PathBuf::from("/var/empty"), PathBuf::from);
-    home.join(".claude/.friction-state")
+    crate::home().join(".claude/.friction-state")
 }
+
+/// This hook's detached-worker identity: `claude-hooks friction-report
+/// --analyze`, payload in `FRICTION_PAYLOAD`, log in `<state>/friction.log`.
+const WORKER: worker::Worker = worker::Worker {
+    subcommand: "friction-report",
+    flag: "--analyze",
+    payload_env: "FRICTION_PAYLOAD",
+    log_file: "friction.log",
+    state_dir,
+};
 
 fn model() -> String {
     env_or("FRICTION_MODEL", DEFAULT_MODEL)
@@ -107,19 +117,7 @@ fn min_delta_chars() -> usize {
 /// Timestamped line appended to `<state>/friction.log`; best-effort, never
 /// raises. This is the only output channel: nothing ever touches stdout/stderr.
 fn log(msg: &str) {
-    let dir = state_dir();
-    if fs::create_dir_all(&dir).is_err() {
-        return;
-    }
-    let Ok(mut f) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(dir.join("friction.log"))
-    else {
-        return;
-    };
-    let ts = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S");
-    let _ = writeln!(f, "{ts} {msg}");
+    WORKER.log(msg);
 }
 
 // --- per-session state ---
@@ -374,7 +372,7 @@ fn ask_model(delta: &str, cwd: Option<&str>) -> Vec<Item> {
     .stderr(Stdio::null());
     // start_new_session: new session AND process group (pgid == pid), so a
     // timeout can killpg the whole node tree, not just the direct child.
-    set_new_session(&mut cmd);
+    worker::set_new_session(&mut cmd);
 
     let mut child = match cmd.spawn() {
         Ok(c) => c,
@@ -515,7 +513,7 @@ fn linear_key() -> Option<String> {
 /// and returns false.
 fn file_issue(key: &str, item: &Item, session: &str, cwd: &str) -> bool {
     let model = model();
-    let host = hostname();
+    let host = crate::hostname();
     let description = format!(
         "{}\n\n---\n- kind: `{}`\n- session: `{}`\n- cwd: `{}`\n- host: `{}`\n\n_Filed automatically by the friction-report Stop hook (model: {}; sent by an AI agent via Claude Code)._",
         item.description.trim(),
@@ -580,19 +578,6 @@ fn file_issue(key: &str, item: &Item, session: &str, cwd: &str) -> bool {
     let dumped = serde_json::to_string(&res).unwrap_or_default();
     log(&format!("issueCreate failed: {}", take_chars(&dumped, 500)));
     false
-}
-
-/// Shared with `retro.rs` (its dispatch stamps the origin host into the
-/// delegated retro prompt). `pub`, not `pub(crate)`: the module is private, so
-/// the two are equivalent and clippy's `redundant_pub_crate` prefers `pub`.
-pub fn hostname() -> String {
-    Command::new("hostname")
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_owned())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "unknown".to_owned())
 }
 
 fn normalize_title(title: &str) -> String {
@@ -779,21 +764,12 @@ pub fn friction_report() {
     if !is_ix_contributor() {
         return;
     }
-    if std::env::args().skip(1).any(|a| a == "--analyze") {
-        // Detached worker: payload rides in the env. Any crash logs only.
-        let Some(raw) = std::env::var_os("FRICTION_PAYLOAD") else {
-            return;
-        };
-        let Some(raw) = raw.to_str() else { return };
-        let Ok(payload) = serde_json::from_str::<Value>(raw) else {
-            log("analyze: unparseable FRICTION_PAYLOAD");
-            return;
-        };
-        analyze(&payload);
+    // Detached worker: payload rides in the env. Any crash logs only.
+    if WORKER.run_worker(analyze) {
         return;
     }
 
-    let Some(input) = read_stdin() else {
+    let Some(input) = crate::read_stdin() else {
         return;
     };
     let Ok(payload) = serde_json::from_str::<Value>(&input) else {
@@ -836,13 +812,7 @@ pub fn friction_report() {
         return;
     }
 
-    detach_analyze(&payload);
-}
-
-fn read_stdin() -> Option<String> {
-    let mut buf = String::new();
-    std::io::stdin().read_to_string(&mut buf).ok()?;
-    Some(buf)
+    WORKER.detach(&payload);
 }
 
 /// True when `basename(s) == s` and s is not `.`/`..` — i.e. a plain filename
@@ -859,61 +829,6 @@ fn is_plain_component(s: &str) -> bool {
 fn is_scratch_cwd(cwd: &str) -> bool {
     let path = cwd.strip_prefix("/private").unwrap_or(cwd);
     path == "/tmp" || path.starts_with("/tmp/") || path.starts_with("/var/folders/")
-}
-
-/// Re-spawn THIS binary as `friction-report --analyze`, detached (new session,
-/// stdin=/dev/null, stdout+stderr appended to friction.log), so Stop returns
-/// immediately. Best-effort: any failure is silent.
-fn detach_analyze(payload: &Value) {
-    let Ok(exe) = std::env::current_exe() else {
-        return;
-    };
-    let Ok(payload_json) = serde_json::to_string(payload) else {
-        return;
-    };
-    let dir = state_dir();
-    if fs::create_dir_all(&dir).is_err() {
-        return;
-    }
-    let Ok(logf) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(dir.join("friction.log"))
-    else {
-        return;
-    };
-    let Ok(logf2) = logf.try_clone() else {
-        return;
-    };
-
-    let mut detach = Command::new(exe);
-    detach
-        .args(["friction-report", "--analyze"])
-        .env("FRICTION_PAYLOAD", payload_json)
-        .stdin(Stdio::null())
-        .stdout(Stdio::from(logf))
-        .stderr(Stdio::from(logf2));
-    // start_new_session: own session so it outlives the hook's process tree.
-    set_new_session(&mut detach);
-    let _ = detach.spawn();
-    // We deliberately do NOT wait: the child owns the slow work.
-}
-
-/// `start_new_session=True` equivalent: call `setsid()` in the child between
-/// fork and exec, putting it in a brand-new session and process group (pgid ==
-/// pid), detached from the controlling terminal. Shared with `retro.rs`, whose
-/// dispatch worker detaches the same way.
-pub fn set_new_session(cmd: &mut Command) {
-    // SAFETY: setsid is async-signal-safe and the only thing we do in the
-    // child before exec; no allocation, no shared-state mutation.
-    unsafe {
-        cmd.pre_exec(|| {
-            if libc::setsid() == -1 {
-                return Err(std::io::Error::last_os_error());
-            }
-            Ok(())
-        });
-    }
 }
 
 #[cfg(test)]

--- a/packages/agent/claude-hooks/src/main.rs
+++ b/packages/agent/claude-hooks/src/main.rs
@@ -16,6 +16,7 @@ mod retro;
 mod review;
 mod session_banner;
 mod wakeup;
+mod worker;
 
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
@@ -99,6 +100,19 @@ fn main() -> ExitCode {
 }
 
 // --- shared helpers ---
+
+/// Best-effort machine hostname, stamped into friction issues and retro
+/// prompts for attribution; `"unknown"` when the `hostname` binary is missing
+/// or prints nothing.
+pub(crate) fn hostname() -> String {
+    Command::new("hostname")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_owned())
+}
 
 /// True when an env var is present and non-empty (the kill-switch convention).
 pub(crate) fn flag_set(name: &str) -> bool {

--- a/packages/agent/claude-hooks/src/retro.rs
+++ b/packages/agent/claude-hooks/src/retro.rs
@@ -33,15 +33,16 @@
 //! shares the loop-guard and background-work suppression policy with
 //! `review-gate` so a forced continuation can never wedge it.
 
-use std::fs::{self, OpenOptions};
+use std::fs;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as B64;
 use serde_json::{Value, json};
+
+use crate::worker;
 
 /// Below this many tool calls a session is a trivial one-question interaction not
 /// worth a retro. Overridable for tests and tuning.
@@ -84,6 +85,16 @@ fn state_dir() -> PathBuf {
         .filter(|v| !v.is_empty())
         .map_or_else(|| crate::home().join(".claude/.retro-state"), PathBuf::from)
 }
+
+/// This hook's detached-worker identity: `claude-hooks retro-gate --dispatch`,
+/// payload in `RETRO_PAYLOAD`, log in `<state>/retro.log`.
+const WORKER: worker::Worker = worker::Worker {
+    subcommand: "retro-gate",
+    flag: "--dispatch",
+    payload_env: "RETRO_PAYLOAD",
+    log_file: "retro.log",
+    state_dir,
+};
 
 fn min_tool_calls() -> usize {
     std::env::var("CLAUDE_RETRO_MIN_TOOL_CALLS")
@@ -135,21 +146,9 @@ fn read_key_file(path: &Path) -> Option<String> {
 
 /// Timestamped line appended to `<state>/retro.log`; best-effort, never raises.
 /// This is the dispatch half's only output channel: nothing ever touches
-/// stdout/stderr (mirrors `friction.rs`).
+/// stdout/stderr.
 fn log(msg: &str) {
-    let dir = state_dir();
-    if fs::create_dir_all(&dir).is_err() {
-        return;
-    }
-    let Ok(mut f) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(dir.join("retro.log"))
-    else {
-        return;
-    };
-    let ts = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S");
-    let _ = writeln!(f, "{ts} {msg}");
+    WORKER.log(msg);
 }
 
 /// What the Stop gate should do this turn, decided from the payload alone (no
@@ -232,17 +231,8 @@ pub fn retro_gate() {
     if crate::flag_set("CLAUDE_CODE_DISABLE_RETRO_GATE") {
         return;
     }
-    if std::env::args().skip(1).any(|a| a == "--dispatch") {
-        // Detached worker: payload rides in the env. Any failure logs only.
-        let Some(raw) = std::env::var_os("RETRO_PAYLOAD") else {
-            return;
-        };
-        let Some(raw) = raw.to_str() else { return };
-        let Ok(payload) = serde_json::from_str::<Value>(raw) else {
-            log("dispatch: unparseable RETRO_PAYLOAD");
-            return;
-        };
-        dispatch(&payload);
+    // Detached worker: payload rides in the env. Any failure logs only.
+    if WORKER.run_worker(dispatch) {
         return;
     }
 
@@ -304,48 +294,9 @@ pub fn retro_gate() {
         return;
     }
 
-    detach_dispatch(&payload);
+    WORKER.detach(&payload);
     // Nothing on stdout: Stop is allowed immediately; the detached worker owns
     // the slow work and survives terminal close (own session via setsid).
-}
-
-/// Re-spawn THIS binary as `retro-gate --dispatch`, detached (new session,
-/// stdin=/dev/null, stdout+stderr appended to retro.log), so Stop returns
-/// immediately. Best-effort: any failure is silent. Same shape as
-/// `friction::detach_analyze`.
-fn detach_dispatch(payload: &Value) {
-    let Ok(exe) = std::env::current_exe() else {
-        return;
-    };
-    let Ok(payload_json) = serde_json::to_string(payload) else {
-        return;
-    };
-    let dir = state_dir();
-    if fs::create_dir_all(&dir).is_err() {
-        return;
-    }
-    let Ok(logf) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(dir.join("retro.log"))
-    else {
-        return;
-    };
-    let Ok(logf2) = logf.try_clone() else {
-        return;
-    };
-
-    let mut detach = Command::new(exe);
-    detach
-        .args(["retro-gate", "--dispatch"])
-        .env("RETRO_PAYLOAD", payload_json)
-        .stdin(Stdio::null())
-        .stdout(Stdio::from(logf))
-        .stderr(Stdio::from(logf2));
-    // start_new_session: own session so it outlives the hook's process tree.
-    crate::friction::set_new_session(&mut detach);
-    let _ = detach.spawn();
-    // We deliberately do NOT wait: the child owns the slow work.
 }
 
 // --- detached dispatch half ---
@@ -438,7 +389,7 @@ fn dispatch(payload: &Value) {
         }
     }
 
-    let prompt = retro_prompt(&session, cwd, &crate::friction::hostname());
+    let prompt = retro_prompt(&session, cwd, &crate::hostname());
     let code = finalize_code(&var, &prompt);
     let Some(result) = client.call_tool(
         "python_exec",

--- a/packages/agent/claude-hooks/src/worker.rs
+++ b/packages/agent/claude-hooks/src/worker.rs
@@ -1,0 +1,150 @@
+//! The detached-worker protocol shared by the out-of-band Stop hooks
+//! (`friction-report --analyze`, `retro-gate --dispatch`).
+//!
+//! Both hooks split the same way: the foreground half must never block Stop,
+//! so it re-spawns THIS SAME binary detached — new session via `setsid`,
+//! stdin `/dev/null`, stdout+stderr appended to the hook's log — with the
+//! Stop payload riding an env var, and returns immediately. The detached half
+//! recognizes its argv flag, reads the payload back out of the env, and owns
+//! the slow work. Everything here is best-effort and silent (fail OPEN): the
+//! log file under the hook's state dir is the only output channel.
+//!
+//! Each hook declares its identity once as a [`Worker`] const; the protocol
+//! lives here so the two halves can never drift apart per hook.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write as _;
+use std::os::unix::process::CommandExt as _;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use serde_json::Value;
+
+/// One hook's detached-worker identity: everything that differs between the
+/// hooks that share this protocol.
+pub struct Worker {
+    /// Subcommand of the detached half: `claude-hooks <subcommand> <flag>`.
+    pub subcommand: &'static str,
+    /// Argv flag that selects the detached half (e.g. `--analyze`).
+    pub flag: &'static str,
+    /// Env var the JSON payload rides in between the two halves.
+    pub payload_env: &'static str,
+    /// Log file name inside the hook's state dir.
+    pub log_file: &'static str,
+    /// The hook's state dir (each hook's own env-overridable location).
+    pub state_dir: fn() -> PathBuf,
+}
+
+impl Worker {
+    /// The worker's name in log lines: the flag without its dashes.
+    fn name(&self) -> &'static str {
+        self.flag.trim_start_matches('-')
+    }
+
+    /// Timestamped line appended to the hook's log; best-effort, never raises.
+    /// This is the only output channel: nothing ever touches stdout/stderr.
+    pub fn log(&self, msg: &str) {
+        let dir = (self.state_dir)();
+        if fs::create_dir_all(&dir).is_err() {
+            return;
+        }
+        let Ok(mut f) = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(dir.join(self.log_file))
+        else {
+            return;
+        };
+        let ts = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S");
+        let _ = writeln!(f, "{ts} {msg}");
+    }
+
+    /// When argv selects the detached-worker half, read the payload back out
+    /// of the env and run `work` on it. True means this process was the
+    /// worker and the caller must return immediately, payload or not; false
+    /// means it is the foreground half.
+    pub fn run_worker(&self, work: impl FnOnce(&Value)) -> bool {
+        if !self.invoked() {
+            return false;
+        }
+        if let Some(payload) = self.payload_from_env() {
+            work(&payload);
+        }
+        true
+    }
+
+    /// True when argv selects the detached-worker half.
+    fn invoked(&self) -> bool {
+        std::env::args().skip(1).any(|a| a == self.flag)
+    }
+
+    /// The detached half's payload, read back from the env: silently `None`
+    /// when the var is missing or not UTF-8, logged when unparseable.
+    fn payload_from_env(&self) -> Option<Value> {
+        let raw = std::env::var_os(self.payload_env)?;
+        let raw = raw.to_str()?;
+        let Ok(payload) = serde_json::from_str::<Value>(raw) else {
+            self.log(&format!(
+                "{}: unparseable {}",
+                self.name(),
+                self.payload_env
+            ));
+            return None;
+        };
+        Some(payload)
+    }
+
+    /// Re-spawn THIS binary as `<subcommand> <flag>`, detached (new session,
+    /// stdin=/dev/null, stdout+stderr appended to the hook's log), so Stop
+    /// returns immediately. Best-effort: any failure is silent.
+    pub fn detach(&self, payload: &Value) {
+        let Ok(exe) = std::env::current_exe() else {
+            return;
+        };
+        let Ok(payload_json) = serde_json::to_string(payload) else {
+            return;
+        };
+        let dir = (self.state_dir)();
+        if fs::create_dir_all(&dir).is_err() {
+            return;
+        }
+        let Ok(logf) = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(dir.join(self.log_file))
+        else {
+            return;
+        };
+        let Ok(logf2) = logf.try_clone() else {
+            return;
+        };
+
+        let mut cmd = Command::new(exe);
+        cmd.args([self.subcommand, self.flag])
+            .env(self.payload_env, payload_json)
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(logf))
+            .stderr(Stdio::from(logf2));
+        // start_new_session: own session so it outlives the hook's process tree.
+        set_new_session(&mut cmd);
+        let _ = cmd.spawn();
+        // We deliberately do NOT wait: the child owns the slow work.
+    }
+}
+
+/// `start_new_session=True` equivalent: call `setsid()` in the child between
+/// fork and exec, putting it in a brand-new session and process group (pgid ==
+/// pid), detached from the controlling terminal. Used by [`Worker::detach`]
+/// and by `friction`'s model child, whose timeout `killpg`s the whole tree.
+pub fn set_new_session(cmd: &mut Command) {
+    // SAFETY: setsid is async-signal-safe and the only thing we do in the
+    // child before exec; no allocation, no shared-state mutation.
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}


### PR DESCRIPTION
Fixes #3906.

`friction-report` and `retro-gate` each carried a private copy of the same detached-worker protocol, flagged by the repo clone sweep as three T2/T3 twins (34+15+13 impact lines):

- `detach_analyze` / `detach_dispatch`: setsid re-spawn of this binary with the payload in an env var, hook log as stdout/stderr (T3 0.98)
- the module-local `log`: timestamped append into the hook's state dir (T2)
- the `--analyze` / `--dispatch` argv branch that reads the payload back and runs the worker (T2)

One concept, one implementation: a new private `worker` module owns the protocol as a `worker::Worker` identity struct (`subcommand`, `flag`, `payload_env`, `log_file`, `state_dir`), which each hook declares once as a `const WORKER`. The argv branch folds into `Worker::run_worker`, `set_new_session` moves in from friction.rs, `hostname` moves to the crate-root shared helpers, and friction's byte-identical private `read_stdin` dies in favor of `crate::read_stdin`.

Behavior is unchanged on every path: same argv, env vars, log file names, and fail-open silence.

Verification:

- `cargo test -p claude-hooks`: 49 passed
- `nix run .#clone -- .`: duplicated_lines 2216 -> 2154 (-62, exactly the three flagged instances); global gate 0.3619% -> 0.3518%, PASS
- `nix run .#clone -- . --diff`: PASS, 0/203 changed lines duplicated (base origin/main@bb24d40d)
- the one remaining claude-hooks instance (`retro.rs` = `review.rs` gate tests, impact 10) pre-exists on main and is outside #3906's scope

Written by an AI agent via Claude Code (model: fable).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate detached-worker helpers in `claude-hooks` into a shared `worker` module
> - Extracts a new [worker.rs](https://github.com/indexable-inc/index/pull/3922/files#diff-d9a3ce28447b5762d6f0df0bfe0d8c8113d90df21559ce87f0bb830d8ede26cb) module with a `Worker` struct that centralizes detached-worker identity, logging, payload dispatch, and background spawning.
> - Both [friction.rs](https://github.com/indexable-inc/index/pull/3922/files#diff-fe250a9c7871a0c5ed6f2d35c985d21db58b58e112c24e1cbaddf0c55c90900b) and [retro.rs](https://github.com/indexable-inc/index/pull/3922/files#diff-4819dd4460ea10e11838a63e273dbee2952e91ed014ae847fcea85a3ee3a0e8c) replace their local `detach`, `log`, `set_new_session`, `read_stdin`, and `hostname` helpers with calls to `worker::Worker` methods or crate-level utilities.
> - A crate-level `hostname()` is added to [main.rs](https://github.com/indexable-inc/index/pull/3922/files#diff-2d219c1873e0f6f8db7cbd30aeabac405d384c224e26f89100fa1eafed6c62eb) replacing the module-local copies.
> - Behavioral Change: `friction`'s state directory is now derived from `crate::home()` rather than a manual `HOME` env read with `/var/empty` fallback, which may change the effective path used for reading and writing friction state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ea0998.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->