### PR TITLE
mcp-ex: Memory.semantic -- embedding recall over a resident weave process (#3868)

### DIFF
--- a/packages/mcp-ex/README.md
+++ b/packages/mcp-ex/README.md
@@ -65,7 +65,7 @@ list):
 | in-cell callable | what it does |
 |---|---|
 | `Read.file(path, first \\ nil, last \\ nil)` | a file, optionally a 1-based line range |
-| `Memory.remember(slug, desc, opts)` | durable memory facts in the weave store at `WEAVE_MEMORY_STORE`; `supersedes:`/`relates:` write typed edges for `Memory.graph/1`; recall rich rows via `Memory.recall/2` (regex) or `Memory.query/1` (Datalog); `Memory.verify/2` records re-check receipts |
+| `Memory.remember(slug, desc, opts)` | durable memory facts in the weave store at `WEAVE_MEMORY_STORE`; `supersedes:`/`relates:` write typed edges for `Memory.graph/1`; recall rich rows via `Memory.recall/2` (regex), `Memory.semantic/2` (embedding similarity, a resident `weave recall --stdin`), or `Memory.query/1` (Datalog); `Memory.verify/2` records re-check receipts |
 | `Ix.trace()` | stack dump of every job's processes, from outside |
 | `Ix.restart()` | cancel jobs (sparing the calling cell), restart the workspace, restore bindings |
 | `PrWatch.start(pr, cwd, interval \\ 15, timeout \\ 3600)` | watch a PR via `gh`, notify on merge/close/timeout |

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -97,7 +97,11 @@ defmodule IxMcp.MCP.Tools do
                                             walks. Recall with
                                             Memory.recall("regex") -- whole-word
                                             rows with id, time, type, topic,
-                                            handle, body -- or raw Datalog via
+                                            handle, body -- with
+                                            Memory.semantic("question") -- the
+                                            same rows plus similarity, ranked by
+                                            embedding when no word matches --
+                                            or raw Datalog via
                                             Memory.query/1. Memory.verify(slug)
                                             records a re-check receipt;
                                             Memory.retract(id) kills a wrong

--- a/packages/mcp-ex/lib/ix_mcp/memory.ex
+++ b/packages/mcp-ex/lib/ix_mcp/memory.ex
@@ -3,7 +3,10 @@ defmodule IxMcp.Memory do
   Durable agent memory over a weave store (append-only fact journal with
   Datalog-derived views), aliased in the workspace prelude as `Memory`.
   Every call is a one-shot `weave` CLI invocation against the store named
-  by the WEAVE_MEMORY_STORE environment variable; there is no daemon. A
+  by the WEAVE_MEMORY_STORE environment variable; no daemon owns the
+  store. The one resident process is `semantic/2`'s embedding recall
+  (`IxMcp.Memory.Semantic` keeps `weave recall --stdin` warm because
+  model load dominates its latency; it opens the store read-only). A
   host without the env set gets a loud error naming the knob and pays
   nothing otherwise.
 
@@ -19,7 +22,10 @@ defmodule IxMcp.Memory do
   edited: newer facts win, `retract/1` kills a wrong one.
   """
 
+  alias IxMcp.Memory.Semantic
+
   @recall_limit 20
+  @semantic_limit 8
 
   @doc """
   Save a memory: `Memory.remember("slug", "hook", type: "project",
@@ -104,22 +110,45 @@ defmodule IxMcp.Memory do
 
     attrs = attrs(Enum.map(hits, & &1["E"]))
 
-    for %{"E" => entity, "D" => desc, "I" => id, "S" => seq, "T" => time} <-
-          Enum.uniq_by(hits, & &1["E"]) do
-      entity_attrs = Map.get(attrs, entity, %{})
+    for %{"E" => entity} = row <- Enum.uniq_by(hits, & &1["E"]) do
+      enriched_row(entity, row, Map.get(attrs, entity, %{}))
+    end
+  end
 
-      %{
-        entity: entity,
-        id: id,
-        seq: seq,
-        time: DateTime.from_unix!(time, :millisecond),
-        desc: desc,
-        type: newest_value(entity_attrs, "mem/type"),
-        topic: live_values(entity_attrs, "mem/topic"),
-        handle: newest_value(entity_attrs, "mem/handle"),
-        body: body_text(entity_attrs),
-        verified_at: newest_value(entity_attrs, "mem/verified-at")
-      }
+  @doc """
+  Embedding-similarity recall: ranks entities by exact cosine between the
+  query and their composed documents (qwen3-embedding-4b by default,
+  WEAVE_EMBED_MODEL overrides), so it finds what `recall/2` misses when
+  no word matches. `limit: 8` entry points by default.
+
+  Rows are `recall/2`'s enriched shape plus `similarity` (cosine, higher
+  is closer), best first. A hit without `mem/desc` (the store embeds
+  non-`mem:` entities too) keeps `entity` and `similarity`, borrows the
+  embedded document's label as `desc`, and carries the fact-derived
+  fields as nil. Superseded memories never surface: weave drops
+  `mem/supersedes` targets from the search matrix.
+
+  The first call pays the model load (~1.2s warm-cache); later calls
+  ride the resident `weave recall --stdin` process (~76ms, see
+  `IxMcp.Memory.Semantic`). Needs a weave with semantic recall
+  (indexable-inc/weave#339).
+  """
+  @spec semantic(String.t(), keyword()) :: [map()]
+  def semantic(query, opts \\ []) do
+    opts = Keyword.validate!(opts, limit: @semantic_limit)
+    entries = Semantic.entries(query, Keyword.fetch!(opts, :limit))
+    entities = Enum.map(entries, & &1["entity"])
+    descs = desc_rows(entities)
+    attrs = attrs(entities)
+
+    for %{"entity" => entity, "similarity" => similarity} = entry <- entries do
+      row =
+        case descs do
+          %{^entity => desc_row} -> enriched_row(entity, desc_row, Map.get(attrs, entity, %{}))
+          _ -> label_row(entity, entry["label"])
+        end
+
+      Map.put(row, :similarity, similarity)
     end
   end
 
@@ -189,15 +218,9 @@ defmodule IxMcp.Memory do
   defp attrs([]), do: %{}
 
   defp attrs(entities) do
-    anchor =
-      entities
-      |> Enum.uniq()
-      |> Enum.map_join("|", &Regex.escape/1)
-      |> then(&dl_string("^(?:#{&1})$"))
-
     rows =
       query("""
-      attr(S, E, A, V) :- fact(E, A, V), fact_id(I, E, A, V), fact_seq(I, S), regex(E, "#{anchor}"), regex(A, "^mem/").
+      attr(S, E, A, V) :- fact(E, A, V), fact_id(I, E, A, V), fact_seq(I, S), regex(E, "#{anchor(entities)}"), regex(A, "^mem/").
       ?- attr(S, E, A, V).
       """)
 
@@ -206,6 +229,67 @@ defmodule IxMcp.Memory do
     |> Map.new(fn {entity, entity_rows} ->
       {entity, Enum.group_by(entity_rows, & &1["A"], &{&1["S"], &1["V"]})}
     end)
+  end
+
+  # The `mem/desc` anchor rows (id, seq, time, hook) for exactly these
+  # entities, keyed by entity: semantic hits arrive as bare ids, unlike
+  # recall's regex hits, which carry their row already.
+  @spec desc_rows([String.t()]) :: %{String.t() => map()}
+  defp desc_rows([]), do: %{}
+
+  defp desc_rows(entities) do
+    rows =
+      query("""
+      row(S, T, I, E, D) :- latest(E, "mem/desc", D), fact_id(I, E, "mem/desc", D), fact_seq(I, S), fact_time(I, T), regex(E, "#{anchor(entities)}").
+      ?- row(S, T, I, E, D).
+      """)
+
+    Map.new(rows, &{&1["E"], &1})
+  end
+
+  # The rich row recall/2 and semantic/2 share: identity fields from the
+  # mem/desc anchor fact, the rest from the entity's live mem/ attributes.
+  @spec enriched_row(String.t(), map(), %{String.t() => [{integer(), String.t()}]}) :: map()
+  defp enriched_row(entity, %{"D" => desc, "I" => id, "S" => seq, "T" => time}, entity_attrs) do
+    %{
+      entity: entity,
+      id: id,
+      seq: seq,
+      time: DateTime.from_unix!(time, :millisecond),
+      desc: desc,
+      type: newest_value(entity_attrs, "mem/type"),
+      topic: live_values(entity_attrs, "mem/topic"),
+      handle: newest_value(entity_attrs, "mem/handle"),
+      body: body_text(entity_attrs),
+      verified_at: newest_value(entity_attrs, "mem/verified-at")
+    }
+  end
+
+  # Same shape for a semantic hit that has no mem/desc fact, so callers
+  # can treat every row uniformly.
+  @spec label_row(String.t(), String.t() | nil) :: map()
+  defp label_row(entity, label) do
+    %{
+      entity: entity,
+      id: nil,
+      seq: nil,
+      time: nil,
+      desc: label,
+      type: nil,
+      topic: [],
+      handle: nil,
+      body: nil,
+      verified_at: nil
+    }
+  end
+
+  # Regex matching exactly these entity ids, escaped for a Datalog string.
+  @spec anchor([String.t()]) :: String.t()
+  defp anchor(entities) do
+    entities
+    |> Enum.uniq()
+    |> Enum.map_join("|", &Regex.escape/1)
+    |> then(&dl_string("^(?:#{&1})$"))
   end
 
   @spec body_text(%{String.t() => [{integer(), String.t()}]}) :: String.t() | nil
@@ -263,18 +347,24 @@ defmodule IxMcp.Memory do
     "#{System.get_env("USER") || "unknown"}@#{host}"
   end
 
+  @doc false
+  @spec store!() :: String.t()
+  def store! do
+    System.get_env("WEAVE_MEMORY_STORE") ||
+      raise "WEAVE_MEMORY_STORE is unset: point it at a weave store " <>
+              "(create one with `weave --store <dir> init`) to enable Memory"
+  end
+
+  @doc false
+  @spec weave_bin!() :: String.t()
+  def weave_bin! do
+    System.get_env("WEAVE_BIN") || System.find_executable("weave") ||
+      raise "weave binary not found: install weave on PATH or set WEAVE_BIN"
+  end
+
   @spec run!([String.t()]) :: String.t()
   defp run!(args) do
-    store =
-      System.get_env("WEAVE_MEMORY_STORE") ||
-        raise "WEAVE_MEMORY_STORE is unset: point it at a weave store " <>
-                "(create one with `weave --store <dir> init`) to enable Memory"
-
-    bin =
-      System.get_env("WEAVE_BIN") || System.find_executable("weave") ||
-        raise "weave binary not found: install weave on PATH or set WEAVE_BIN"
-
-    case System.cmd(bin, ["--store", store] ++ args, stderr_to_stdout: true) do
+    case System.cmd(weave_bin!(), ["--store", store!()] ++ args, stderr_to_stdout: true) do
       {out, 0} -> out
       {out, code} -> raise "weave #{Enum.join(args, " ")} exited #{code}: #{out}"
     end

--- a/packages/mcp-ex/lib/ix_mcp/memory/semantic.ex
+++ b/packages/mcp-ex/lib/ix_mcp/memory/semantic.ex
@@ -1,0 +1,173 @@
+defmodule IxMcp.Memory.Semantic do
+  @moduledoc """
+  Owner of the resident `weave recall --stdin` process behind
+  `IxMcp.Memory.semantic/2`.
+
+  Loading the embedding model dominates semantic recall (~1.2s for the
+  default qwen3-embedding-4b against ~76ms per warm query, #3868), so
+  instead of paying it per call the first query starts `weave recall`
+  with `--stdin`, which answers its positional query and then keeps the
+  model resident, answering one more recall per stdin line with one JSON
+  object per line. This server owns that port and serializes queries
+  over it.
+
+  The port is keyed by the resolved binary, store, and entry budget: a
+  changed WEAVE_BIN / WEAVE_MEMORY_STORE (tests point these at throwaway
+  stores) or a limit above the running budget retires the old process
+  for a fresh one, and a port whose weave died (killed, store deleted)
+  is respawned on the next query instead of wedging the server.
+  """
+
+  use GenServer
+
+  alias IxMcp.Memory
+
+  # `--limit` is fixed at spawn (stdin lines carry only query text), so
+  # the port over-fetches and `entries/2` truncates; exact brute-force
+  # cosine scores every document regardless, so the surplus entries cost
+  # only JSON size.
+  @entry_budget 64
+
+  # The first answer pays the model load (plus embedding any documents
+  # the sidecar is missing); resident answers are sub-second.
+  @first_answer_ms 120_000
+  @answer_ms 30_000
+
+  @typep state() ::
+           %{port: port(), key: {String.t(), String.t(), pos_integer()}, buffer: binary()}
+           | nil
+
+  @doc """
+  Scored semantic entry points for `query`: up to `limit` maps shaped
+  `%{"entity" => id, "similarity" => cosine, "label" => hook-or-nil}`,
+  best first, exactly as `weave recall` emitted them.
+  """
+  @spec entries(String.t(), pos_integer()) :: [map()]
+  def entries(query, limit) do
+    # Stdin frames one query per line, so multi-line queries flatten.
+    query =
+      case query |> String.replace(~r/\s+/, " ") |> String.trim() do
+        "" -> raise ArgumentError, "semantic recall needs a non-empty query"
+        flat -> flat
+      end
+
+    case GenServer.call(server(), {:recall, query, limit}, :infinity) do
+      {:ok, entries} -> Enum.take(entries, limit)
+      {:error, message} -> raise message
+    end
+  end
+
+  @impl GenServer
+  def init(nil), do: {:ok, nil}
+
+  @impl GenServer
+  def handle_call({:recall, query, limit}, _from, state) do
+    {entries, next} = recall(state, query, limit)
+    {:reply, {:ok, entries}, next}
+  rescue
+    error ->
+      close(state)
+      {:reply, {:error, Exception.message(error)}, nil}
+  end
+
+  # A retired or crashed weave leaves {:data, ...} / {:exit_status, ...}
+  # noise behind; dropping it keeps the mailbox from growing forever.
+  @impl GenServer
+  def handle_info({port, _payload}, state) when is_port(port), do: {:noreply, state}
+
+  # Started lazily and unsupervised on purpose: Memory also works from a
+  # plain IEx with no IxMcp application tree running. The race loser
+  # adopts the winner's pid.
+  @spec server() :: pid()
+  defp server do
+    case GenServer.start(__MODULE__, nil, name: __MODULE__) do
+      {:ok, pid} -> pid
+      {:error, {:already_started, pid}} -> pid
+    end
+  end
+
+  @spec recall(state(), String.t(), pos_integer()) :: {[map()], state()}
+  defp recall(nil, query, limit) do
+    {bin, store, budget} = key = {Memory.weave_bin!(), Memory.store!(), max(limit, @entry_budget)}
+
+    port =
+      Port.open({:spawn_executable, bin}, [
+        :binary,
+        :exit_status,
+        args: [
+          "--store",
+          store,
+          "recall",
+          "--limit",
+          Integer.to_string(budget),
+          "--no-expand",
+          "--stdin",
+          "--",
+          query
+        ]
+      ])
+
+    try do
+      {line, buffer} = read_answer(port, "", @first_answer_ms)
+      {decode_entries(line), %{port: port, key: key, buffer: buffer}}
+    rescue
+      # The port is not in any state yet, so a failed first answer must
+      # release it here or the loaded model would linger unreachable.
+      error ->
+        close(%{port: port})
+        reraise error, __STACKTRACE__
+    end
+  end
+
+  defp recall(%{port: port, key: {bin, store, budget}, buffer: buffer} = state, query, limit) do
+    if {bin, store} == {Memory.weave_bin!(), Memory.store!()} and limit <= budget and
+         Port.info(port) != nil do
+      Port.command(port, query <> "\n")
+      {line, rest} = read_answer(port, buffer, @answer_ms)
+      {decode_entries(line), %{state | buffer: rest}}
+    else
+      close(state)
+      recall(nil, query, limit)
+    end
+  end
+
+  @spec read_answer(port(), binary(), pos_integer()) :: {binary(), binary()}
+  defp read_answer(port, buffer, timeout) do
+    case String.split(buffer, "\n", parts: 2) do
+      [line, rest] ->
+        {line, rest}
+
+      [_incomplete] ->
+        receive do
+          {^port, {:data, data}} ->
+            read_answer(port, buffer <> data, timeout)
+
+          {^port, {:exit_status, status}} ->
+            raise "weave recall exited #{status} before answering: the binary needs " <>
+                    "semantic recall (indexable-inc/weave#339+); its stderr went to this console"
+        after
+          timeout -> raise "weave recall: no answer within #{timeout}ms"
+        end
+    end
+  end
+
+  @spec decode_entries(binary()) :: [map()]
+  defp decode_entries(line) do
+    case JSON.decode(line) do
+      {:ok, %{"entries" => entries}} -> entries
+      _ -> raise "weave recall emitted an unexpected answer line: #{inspect(line)}"
+    end
+  end
+
+  @spec close(state()) :: :ok
+  defp close(nil), do: :ok
+
+  defp close(%{port: port}) do
+    # Closing stdin is the protocol's EOF: weave exits on it.
+    Port.close(port)
+    :ok
+  catch
+    # Already closed (weave exited first): nothing left to release.
+    :error, :badarg -> :ok
+  end
+end

--- a/packages/mcp-ex/test/fixtures/weave_mock.exs
+++ b/packages/mcp-ex/test/fixtures/weave_mock.exs
@@ -1,0 +1,72 @@
+#!/usr/bin/env elixir
+# Mock weave for IxMcp.Memory.Semantic plumbing tests: enough of the
+# `recall --stdin` NDJSON protocol and the two `query` programs
+# Memory.semantic/2 issues to run without the real binary (whose default
+# model is a 2.4GB download). Appends "spawn <query>" / "line <query>" to
+# $WEAVE_MOCK_LOG so tests can count process starts vs resident answers.
+# An .exs rather than a shell script: new shell is fenced (#3823).
+#
+# This mock is a CLI stand-in: stdout is its whole interface, not a
+# debugging leftover, so the IO.puts gate does not apply here.
+# credo:disable-for-this-file Credo.Check.Refactor.IoPuts
+defmodule WeaveMock do
+  def log(line) do
+    case System.get_env("WEAVE_MOCK_LOG") do
+      nil -> :ok
+      path -> File.write!(path, line <> "\n", [:append])
+    end
+  end
+
+  def answer(load_ms) do
+    IO.puts(
+      ~s({"model":"fixture-64","entries":[) <>
+        ~s({"entity":"mem:alpha","similarity":0.91,"label":"alpha hook"},) <>
+        ~s({"entity":"note:orphan","similarity":0.42,"label":"orphan label"}],) <>
+        ~s("expansion":null,"load_ms":#{load_ms},"embed_ms":1})
+    )
+  end
+
+  def run(args) do
+    # Both subcommands carry what the mock needs as the final argument:
+    # `query` its Datalog program, `recall` its positional query.
+    last = List.last(args)
+
+    case Enum.find(args, &(&1 in ["recall", "query"])) do
+      "query" ->
+        rows =
+          if String.contains?(last, "attr(") do
+            ~s({"rows":[{"S":1,"E":"mem:alpha","A":"mem/desc","V":"alpha hook"},) <>
+              ~s({"S":2,"E":"mem:alpha","A":"mem/type","V":"project"},) <>
+              ~s({"S":3,"E":"mem:alpha","A":"mem/topic","V":"nix"}]})
+          else
+            ~s({"rows":[{"S":3,"T":1750000000000,"I":"blake3:aaaa",) <>
+              ~s("E":"mem:alpha","D":"alpha hook"}]})
+          end
+
+        IO.puts(rows)
+
+      "recall" ->
+        log("spawn #{last}")
+        answer(42)
+
+        :stdio
+        |> IO.stream(:line)
+        |> Enum.each(fn line ->
+          case String.trim_trailing(line, "\n") do
+            "" ->
+              :ok
+
+            query ->
+              log("line #{query}")
+              answer("null")
+          end
+        end)
+
+      _other ->
+        IO.puts(:stderr, "mock weave: unhandled args: #{inspect(args)}")
+        System.halt(64)
+    end
+  end
+end
+
+WeaveMock.run(System.argv())

--- a/packages/mcp-ex/test/ix_mcp/memory/semantic_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/memory/semantic_test.exs
@@ -1,0 +1,197 @@
+defmodule IxMcp.Memory.SemanticTest do
+  # Mutates process-global env and drives the singleton port owner, so
+  # never async. The weave binary is mocked (test/fixtures/weave_mock.exs):
+  # these tests pin the plumbing -- the NDJSON --stdin protocol, the
+  # fact join, residency, and respawn keying -- and run everywhere,
+  # because the real recall path needs a weave with #339 and its default
+  # model is a 2.4GB Hugging Face download; the real-binary round trip
+  # lives in IxMcp.Memory.SemanticIntegrationTest below.
+  use ExUnit.Case, async: false
+
+  alias IxMcp.Memory
+
+  @mock Path.expand("../../fixtures/weave_mock.exs", __DIR__)
+  @env ~w(WEAVE_MEMORY_STORE WEAVE_BIN WEAVE_MOCK_LOG)
+
+  setup do
+    previous = Map.new(@env, &{&1, System.get_env(&1)})
+
+    store =
+      Path.join(System.tmp_dir!(), "ix-semantic-test-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(store)
+    log = Path.join(store, "mock.log")
+    System.put_env("WEAVE_MEMORY_STORE", store)
+    System.put_env("WEAVE_BIN", @mock)
+    System.put_env("WEAVE_MOCK_LOG", log)
+    stop_port_owner()
+
+    on_exit(fn ->
+      stop_port_owner()
+
+      for {key, value} <- previous do
+        if value, do: System.put_env(key, value), else: System.delete_env(key)
+      end
+
+      File.rm_rf!(store)
+    end)
+
+    {:ok, store: store, log: log}
+  end
+
+  test "hits join to facts and ride one resident process", %{log: log} do
+    assert [alpha, orphan] = Memory.semantic("what broke the build", limit: 2)
+
+    assert alpha.entity == "mem:alpha"
+    assert alpha.similarity == 0.91
+    assert alpha.desc == "alpha hook"
+    assert alpha.type == "project"
+    assert alpha.topic == ["nix"]
+    assert alpha.id == "blake3:aaaa"
+    assert alpha.seq == 3
+    assert %DateTime{} = alpha.time
+
+    # A hit without mem/desc keeps its score and document label only.
+    assert orphan == %{
+             entity: "note:orphan",
+             similarity: 0.42,
+             desc: "orphan label",
+             id: nil,
+             seq: nil,
+             time: nil,
+             type: nil,
+             topic: [],
+             handle: nil,
+             body: nil,
+             verified_at: nil
+           }
+
+    # limit truncates client-side: the port over-fetches at a fixed -k.
+    assert [%{entity: "mem:alpha"}] = Memory.semantic("second question", limit: 1)
+
+    # Multi-line queries flatten to fit the one-query-per-line protocol.
+    assert [_, _] = Memory.semantic("third\n  question")
+
+    # One spawn (the positional query), then resident stdin answers.
+    assert mock_events(log) == [
+             "spawn what broke the build",
+             "line second question",
+             "line third question"
+           ]
+  end
+
+  test "a changed store retires the resident process", %{log: log, store: store} do
+    assert [_, _] = Memory.semantic("first")
+
+    other = store <> "-b"
+    File.mkdir_p!(other)
+    on_exit(fn -> File.rm_rf!(other) end)
+    System.put_env("WEAVE_MEMORY_STORE", other)
+
+    assert [_, _] = Memory.semantic("second")
+    assert mock_events(log) == ["spawn first", "spawn second"]
+  end
+
+  test "a blank query is rejected before any spawn", %{log: log} do
+    assert_raise ArgumentError, ~r/non-empty/, fn -> Memory.semantic(" \n ") end
+    assert mock_events(log) == []
+  end
+
+  defp stop_port_owner do
+    case Process.whereis(IxMcp.Memory.Semantic) do
+      nil -> :ok
+      pid -> GenServer.stop(pid)
+    end
+  end
+
+  defp mock_events(log) do
+    case File.read(log) do
+      {:ok, content} -> String.split(content, "\n", trim: true)
+      {:error, :enoent} -> []
+    end
+  end
+end
+
+weave = System.get_env("WEAVE_BIN") || System.find_executable("weave")
+
+# The real-binary round trip runs only where a weave with semantic recall
+# (indexable-inc/weave#339) is installed; like IxMcp.MemoryTest it
+# compiles away in the sandboxed nix check, where weave is not staged.
+# The fixture embedder (deterministic hash, no model fetch, no GPU) makes
+# a throwaway store embeddable without the default model's 2.4GB
+# download, so what this asserts is the plumbing -- ranking, joining,
+# residency -- not retrieval quality.
+if weave && match?({_, 0}, System.cmd(weave, ["recall", "--help"], stderr_to_stdout: true)) do
+  defmodule IxMcp.Memory.SemanticIntegrationTest do
+    use ExUnit.Case, async: false
+
+    alias IxMcp.Memory
+
+    @weave weave
+    @env ~w(WEAVE_MEMORY_STORE WEAVE_BIN WEAVE_EMBED_MODEL)
+
+    setup do
+      previous = Map.new(@env, &{&1, System.get_env(&1)})
+
+      store =
+        Path.join(System.tmp_dir!(), "ix-semantic-int-#{System.unique_integer([:positive])}")
+
+      {_, 0} = System.cmd(@weave, ["--store", store, "init"])
+      System.put_env("WEAVE_MEMORY_STORE", store)
+      System.put_env("WEAVE_BIN", @weave)
+      System.put_env("WEAVE_EMBED_MODEL", "fixture")
+      stop_port_owner()
+
+      on_exit(fn ->
+        stop_port_owner()
+
+        for {key, value} <- previous do
+          if value, do: System.put_env(key, value), else: System.delete_env(key)
+        end
+
+        File.rm_rf!(store)
+      end)
+
+      :ok
+    end
+
+    test "ranks remembered memories and joins the enriched fields" do
+      Memory.remember("gpu-lore", "metal shader debugging notes",
+        type: "reference",
+        topic: ["gpu"],
+        handle: "xcrun metal"
+      )
+
+      Memory.remember("nix-lint", "run the repo lint before committing")
+
+      rows = Memory.semantic("debugging shaders on metal")
+
+      # `weave init` seeds demo entities (agent:main, prefab:*), so the
+      # store embeds more documents than the two remembered here.
+      entities = Enum.map(rows, & &1.entity)
+      assert "mem:gpu-lore" in entities
+      assert "mem:nix-lint" in entities
+      assert Enum.all?(rows, &is_float(&1.similarity))
+
+      similarities = Enum.map(rows, & &1.similarity)
+      assert similarities == Enum.sort(similarities, :desc)
+
+      row = Enum.find(rows, &(&1.entity == "mem:gpu-lore"))
+      assert row.desc == "metal shader debugging notes"
+      assert row.type == "reference"
+      assert row.topic == ["gpu"]
+      assert row.handle == "xcrun metal"
+      assert String.starts_with?(row.id, "blake3:")
+
+      # The second query rides the already-loaded resident process.
+      assert [_ | _] = Memory.semantic("lint gate", limit: 1)
+    end
+
+    defp stop_port_owner do
+      case Process.whereis(IxMcp.Memory.Semantic) do
+        nil -> :ok
+        pid -> GenServer.stop(pid)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #3868 (the remaining ix-mcp half; the weave half shipped in indexable-inc/weave#339).

`Memory.semantic(query, limit: k)` ranks memories by exact cosine between the query embedding and each entity's composed document, then joins the hits back to their `mem/` facts, returning `recall/2`'s enriched rows (id, seq, time, desc, type, topic, handle, body, verified_at) plus `similarity`. Superseded memories never surface (weave drops `mem/supersedes` targets from the search matrix, #3866).

Resident mode: model load dominates (~1.2s warm-cache load vs ~76ms per query for qwen3-embedding-4b), so a lazily started GenServer (`IxMcp.Memory.Semantic`) owns one long-lived `weave recall --stdin` port and serializes queries over its one-JSON-line-per-answer protocol. The port is keyed by resolved binary + store + entry budget: env changes (throwaway test stores) or a larger limit retire it; a dead weave respawns on the next call. First call pays the load, later calls are warm.

Measured against the live store (925 docs, M5 Max): cold call 12.3s (2.5s model load + re-embedding 3 stale docs), warm call 138ms, hits relevant and enriched.

Tests: the mock-binary suite (`test/fixtures/weave_mock.exs`, an .exs because new shell is fenced, #3823) pins the NDJSON `--stdin` protocol, the fact join, residency, and respawn keying, and runs everywhere. The real-binary round trip (`SemanticIntegrationTest`) uses weave's `fixture` embedder on a throwaway store -- deterministic hash embeddings, no model download, no GPU -- and gates on a recall-capable weave, compiling away in the sandboxed nix check like the existing `MemoryTest` (weave is not staged there).

Also: tools.ex kernel instructions and the README mention semantic recall next to regex recall.

Local gates: `mix test` (133, 0 failures), `mix credo --strict --config-file lib/elixir/credo.exs` (0 issues), `mix compile --warnings-as-errors`, `mix format --check-formatted`, `nix run .#lint` all green.

*(PR by an AI agent, Fable 5 (claude-fable-5) via Claude Code)*



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Memory.semantic/2` embedding recall via a resident `weave recall --stdin` process
> - Adds `IxMcp.Memory.semantic/2` to [memory.ex](https://github.com/indexable-inc/index/pull/3923/files#diff-63ccf8ddac0a59f7258e2446185a73d0df7e308afe53db21f428df0fcb411c22), which returns up to 8 enriched memory rows ranked by embedding similarity, each including a `:similarity` score.
> - Introduces `IxMcp.Memory.Semantic` in [semantic.ex](https://github.com/indexable-inc/index/pull/3923/files#diff-6a9399f5abbde71caa756f2b1d83ad262717655d48546a0d49d133a1cb30b058), a GenServer that keeps a `weave recall --stdin` subprocess warm and reuses it across calls, lazily spawning or respawning when the store or binary changes.
> - Adds `desc_rows/1`, `enriched_row/3`, `label_row/2`, and `anchor/1` helpers to support building uniform result rows for semantic hits, with or without a `mem/desc` fact.
> - Extracts `store!/0` and `weave_bin!/0` as public (doc-false) config helpers and refactors `run!/2` to use them.
> - Risk: the resident port process introduces long-lived subprocess state; a crashed or stale port triggers a respawn, but timeouts raise rather than returning a fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 752669d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->