### PR TITLE
rust: fix nightly clippy nursery gate breakage (#3892)

### DIFF
--- a/packages/mirror/src/generate.rs
+++ b/packages/mirror/src/generate.rs
@@ -155,6 +155,9 @@ fn dependency_closure(workspace: &Workspace, primary: &str) -> Result<BTreeMap<S
     Ok(closure)
 }
 
+/// One hero variant's renderer: (crate name, tagline) to SVG text.
+type HeroRender = fn(&str, Option<&str>) -> String;
+
 /// Compose the mirror README, synthesizing `assets/hero.svg` and its
 /// `assets/hero-dark.svg` twin first when the package ships no README of
 /// its own; a curated README references its own pair (already copied with
@@ -162,7 +165,7 @@ fn dependency_closure(workspace: &Workspace, primary: &str) -> Result<BTreeMap<S
 fn write_readme(out: &Path, package_dir: &Path, package: &readme::Package<'_>) -> Result<()> {
     let existing = fs::read_to_string(package_dir.join("README.md")).ok();
     if existing.is_none() {
-        let heroes: [(&str, fn(&str, Option<&str>) -> String); 2] = [
+        let heroes: [(&str, HeroRender); 2] = [
             (readme::HERO_PATH, readme::hero_svg),
             (readme::HERO_DARK_PATH, readme::hero_dark_svg),
         ];

--- a/packages/mirror/src/readme.rs
+++ b/packages/mirror/src/readme.rs
@@ -21,7 +21,7 @@ pub const HERO_PATH: &str = "assets/hero.svg";
 
 /// The hero's committed dark twin, selected by the README's `<picture>`
 /// source: Safari never evaluates `prefers-color-scheme` inside an SVG
-/// loaded via `<img>` (WebKit bug 199134), so the embedded query alone
+/// loaded via `<img>` (`WebKit` bug 199134), so the embedded query alone
 /// renders the light palette for Safari readers on GitHub's dark theme.
 pub const HERO_DARK_PATH: &str = "assets/hero-dark.svg";
 
@@ -224,7 +224,7 @@ fn usage(pkg: &Package<'_>) -> String {
 /// per-package art to maintain). Adapts via its embedded
 /// `prefers-color-scheme` CSS when opened directly; README embedding also
 /// needs `hero_dark_svg`, because Safari never evaluates that query inside
-/// an SVG loaded via `<img>` (WebKit bug 199134).
+/// an SVG loaded via `<img>` (`WebKit` bug 199134).
 pub fn hero_svg(name: &str, tagline: Option<&str>) -> String {
     hero_svg_styled(name, tagline, Scheme::Light)
 }
@@ -236,6 +236,7 @@ pub fn hero_dark_svg(name: &str, tagline: Option<&str>) -> String {
     hero_svg_styled(name, tagline, Scheme::Dark)
 }
 
+#[derive(Clone, Copy)]
 enum Scheme {
     Light,
     Dark,

--- a/packages/tui/vt/ix-vt/src/lib.rs
+++ b/packages/tui/vt/ix-vt/src/lib.rs
@@ -275,9 +275,11 @@ pub enum ScrollViewport {
 }
 
 /// The mouse-reporting flavor an application has requested via DEC private
-/// modes 9/1000/1002/1003 (see [`Terminal::mouse_reporting`]). The variants
-/// are ordered by how much the application asked to see; when several modes
-/// are set at once the strongest wins, matching how terminals dispatch.
+/// modes 9/1000/1002/1003 (see [`Terminal::mouse_reporting`]).
+///
+/// The variants are ordered by how much the application asked to see; when
+/// several modes are set at once the strongest wins, matching how terminals
+/// dispatch.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MouseReporting {
     /// No mouse mode set: the terminal owns the mouse (scrollback, selection).

--- a/packages/tui/vt/ix-vt/tests/hyperlink.rs
+++ b/packages/tui/vt/ix-vt/tests/hyperlink.rs
@@ -1,7 +1,7 @@
 //! OSC 8 hyperlink URI exposure through the render state (index#3835).
 //!
 //! The anchor text deliberately differs from the URI ("click me" vs
-//! https://example.com), the exact case plain-URL detection cannot cover
+//! <https://example.com>), the exact case plain-URL detection cannot cover
 //! (indexable-inc/ix#8008). Exercises the fork's C API end-to-end against
 //! the real patched library: per-cell URIs on anchor cells, `None`
 //! elsewhere, distinct adjacent links kept apart, and the copied URI

--- a/packages/usage/cli/src/main.rs
+++ b/packages/usage/cli/src/main.rs
@@ -109,15 +109,17 @@ struct Status {
 
 fn read_status() -> anyhow::Result<Status> {
     let consent = consent::resolve()?;
-    let mut last_upload_ms = None;
-    let mut install_id = None;
-    if let Some(db) = paths::db_path().filter(|db| db.exists()) {
-        let conn = store::open(&db)?;
-        last_upload_ms = store::meta_get(&conn, "last_upload_ms")?
-            .map(|value| value.parse::<i64>())
-            .transpose()?;
-        install_id = store::meta_get(&conn, "install_id")?;
-    }
+    let db = paths::db_path().filter(|db| db.exists());
+    let (last_upload_ms, install_id) = match db {
+        Some(db) => {
+            let conn = store::open(&db)?;
+            let last_upload_ms = store::meta_get(&conn, "last_upload_ms")?
+                .map(|value| value.parse::<i64>())
+                .transpose()?;
+            (last_upload_ms, store::meta_get(&conn, "install_id")?)
+        }
+        None => (None, None),
+    };
     Ok(Status {
         upload_enabled: consent.upload,
         source: consent.source.as_str(),
@@ -214,7 +216,7 @@ fn errors(json: bool, limit: u32) -> anyhow::Result<()> {
         "SELECT {ERROR_COLUMNS} FROM errors ORDER BY id DESC LIMIT ?1"
     ))?;
     let rows = stmt
-        .query_map([limit], |row| map_error_row(row))?
+        .query_map([limit], map_error_row)?
         .collect::<Result<Vec<_>, _>>()?;
     if json {
         println!("{}", serde_json::to_string_pretty(&rows)?);
@@ -242,7 +244,7 @@ fn error_by_id(id: i64, json: bool) -> anyhow::Result<()> {
         .query_row(
             &format!("SELECT {ERROR_COLUMNS} FROM errors WHERE id = ?1"),
             [id],
-            |row| map_error_row(row),
+            map_error_row,
         )
         .with_context(|| format!("no captured failure with id {id}"))?;
     if json {

--- a/packages/usage/wrap/src/main.rs
+++ b/packages/usage/wrap/src/main.rs
@@ -4,7 +4,7 @@
 //! wrapper spawns the real target with inherited stdio and argv0, stays out
 //! of the way (ctrl-C reaches the child, SIGTERM is forwarded), and after
 //! the child exits appends one line to the local spool: a single `O_APPEND`
-//! write, no locks, no SQLite on the hot path. It then exits with the
+//! write, no locks, no `SQLite` on the hot path. It then exits with the
 //! child's status (`128 + signal` for signal deaths).
 //!
 //! Failure policy: anything telemetry-internal is dropped silently
@@ -62,7 +62,7 @@ const COMPACT_THRESHOLD_BYTES: u64 = 256 * 1024;
 /// Minimum spacing between detached upload kicks. The uploader enforces the
 /// real 24h cadence; this only avoids spawning a kick process per
 /// invocation.
-const KICK_INTERVAL: Duration = Duration::from_secs(6 * 3600);
+const KICK_INTERVAL: Duration = Duration::from_hours(6);
 
 fn main() {
     let spec = load_spec().unwrap_or_else(|err| {
@@ -88,10 +88,10 @@ fn load_spec() -> Result<Spec, String> {
 
 /// The target command with our argv, argv0, environment, and stdio.
 fn build_command(spec: &Spec) -> Command {
-    let mut args = std::env::args_os();
-    let arg0 = args.next();
+    let mut forwarded = std::env::args_os();
+    let arg0 = forwarded.next();
     let mut command = Command::new(&spec.target);
-    command.args(args);
+    command.args(forwarded);
     // The spec must not leak: a target that spawns other wrapped tools would
     // otherwise record them under this spec's package.
     command.env_remove("IX_USAGE_SPEC");
@@ -269,13 +269,11 @@ fn marker_stale(marker: &Path) -> bool {
     let fresh = std::fs::metadata(marker)
         .and_then(|meta| meta.modified())
         .map(|modified| matches!(modified.elapsed(), Ok(age) if age < KICK_INTERVAL));
-    match fresh {
-        Ok(true) => false,
-        // Missing marker, unreadable mtime, or an mtime in the future: treat
-        // as stale and reset it.
-        Ok(false) | Err(_) => {
-            let _ = std::fs::write(marker, b"");
-            true
-        }
+    if matches!(fresh, Ok(true)) {
+        return false;
     }
+    // Missing marker, unreadable mtime, or an mtime in the future: treat as
+    // stale and reset it.
+    let _ = std::fs::write(marker, b"");
+    true
 }

--- a/packages/usage/wrap/tests/wrap.rs
+++ b/packages/usage/wrap/tests/wrap.rs
@@ -4,6 +4,14 @@
 use std::path::PathBuf;
 use std::process::{Command, Output};
 
+/// The `counts` row for the demo package: how many wrapped invocations ran
+/// and how many exited nonzero.
+#[derive(Debug, PartialEq, Eq)]
+struct Counts {
+    invocations: i64,
+    nonzero_exits: i64,
+}
+
 struct Harness {
     dir: tempfile::TempDir,
 }
@@ -42,16 +50,41 @@ impl Harness {
         command
     }
 
-    fn counts(&self) -> (i64, i64) {
+    fn counts(&self) -> Counts {
         ix_usage_core::store::compact(&self.state_dir()).expect("compact");
         let conn = ix_usage_core::store::open(&self.state_dir().join("usage.db")).expect("open db");
         conn.query_row(
             "SELECT invocations, nonzero_exits FROM counts
              WHERE pkg = 'demo-pkg' AND version = '1.2.3'",
             [],
-            |row| Ok((row.get(0)?, row.get(1)?)),
+            |row| {
+                Ok(Counts {
+                    invocations: row.get(0)?,
+                    nonzero_exits: row.get(1)?,
+                })
+            },
         )
         .expect("counts row")
+    }
+
+    #[track_caller]
+    fn assert_counts(&self, invocations: i64, nonzero_exits: i64) {
+        assert_eq!(
+            self.counts(),
+            Counts {
+                invocations,
+                nonzero_exits,
+            }
+        );
+    }
+
+    /// Run the wrapped shell and assert the pass-through exit code and
+    /// stdout in one place, returning the output for extra assertions.
+    fn run_expecting(&self, args: &[&str], code: i32, stdout: &[u8]) -> Output {
+        let output = self.run(args);
+        assert_eq!(output.status.code(), Some(code));
+        assert_eq!(output.stdout, stdout);
+        output
     }
 
     fn error_rows(&self) -> i64 {
@@ -64,23 +97,19 @@ impl Harness {
 #[test]
 fn passes_through_exit_code_stdout_and_records_failure() {
     let harness = Harness::new("observe");
-    let output = harness.run(&["-c", "printf hello; exit 7"]);
-    assert_eq!(output.status.code(), Some(7));
-    assert_eq!(output.stdout, b"hello");
+    let output = harness.run_expecting(&["-c", "printf hello; exit 7"], 7, b"hello");
     assert_eq!(output.stderr, b"", "wrapper must not write to stderr");
 
-    assert_eq!(harness.counts(), (1, 1));
+    harness.assert_counts(1, 1);
     assert_eq!(harness.error_rows(), 1);
 }
 
 #[test]
 fn success_records_count_without_error_row() {
     let harness = Harness::new("observe");
-    let output = harness.run(&["-c", "printf ok"]);
-    assert_eq!(output.status.code(), Some(0));
-    assert_eq!(output.stdout, b"ok");
+    harness.run_expecting(&["-c", "printf ok"], 0, b"ok");
 
-    assert_eq!(harness.counts(), (1, 0));
+    harness.assert_counts(1, 0);
     assert_eq!(harness.error_rows(), 0);
 }
 
@@ -90,18 +119,16 @@ fn signal_death_maps_to_128_plus_signal() {
     let output = harness.run(&["-c", "kill -TERM $$"]);
     assert_eq!(output.status.code(), Some(143), "SIGTERM death is 128+15");
 
-    assert_eq!(harness.counts(), (1, 1));
+    harness.assert_counts(1, 1);
 }
 
 #[test]
 fn count_only_execs_and_records_invocation_only() {
     let harness = Harness::new("count-only");
-    let output = harness.run(&["-c", "printf fast; exit 5"]);
-    assert_eq!(output.status.code(), Some(5));
-    assert_eq!(output.stdout, b"fast");
+    harness.run_expecting(&["-c", "printf fast; exit 5"], 5, b"fast");
 
     // Exit is unknown by design in count-only mode.
-    assert_eq!(harness.counts(), (1, 0));
+    harness.assert_counts(1, 0);
     assert_eq!(harness.error_rows(), 0);
 }
 
@@ -112,7 +139,7 @@ fn repeated_runs_accumulate() {
         assert_eq!(harness.run(&["-c", "exit 0"]).status.code(), Some(0));
     }
     assert_eq!(harness.run(&["-c", "exit 1"]).status.code(), Some(1));
-    assert_eq!(harness.counts(), (6, 1));
+    harness.assert_counts(6, 1);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #3892. Main's flake-check has been red since the nightly-2026-05-27 bump; this unblocks the merge-queued PRs behind it.

Of the issue's six lanes: `rust-usage-core` (an eval bug, not a lint) was fixed on main by b02d6a3f while this PR was in flight, and `rust-ast-merge-diff.clippy` by 8602743e. This PR fixes the remaining four clippy lanes, one commit:

- **rust-ix-vt.clippy** — split the `MouseReporting` doc's first paragraph (`too_long_first_doc_paragraph`, the lint quoted in the issue); angle-bracket a bare URL in `tests/hyperlink.rs` (`doc_markdown`).
- **rust-mirror.clippy** — `HeroRender` type alias for the fn-pointer array (`type_complexity`); backtick WebKit (`doc_markdown`); `derive(Copy)` for `Scheme` (`needless_pass_by_value`).
- **rust-ix-wrap.clippy** — rename the argv iterator away from `arg0` (`similar_names`); backtick SQLite (`doc_markdown`); `Duration::from_hours(6)` (`duration_suboptimal_units`); early return in `marker_stale` (`single_match_else`, hidden behind CI's abort); named `Counts` struct in the test harness (`anonymous_tuple_return_type`).
- **rust-ix-usage.clippy** — bind `(last_upload_ms, install_id)` from one match (`useless_let_if_seq`); pass `map_error_row` directly (`redundant_closure`).

Every lint is satisfied in code — no `allow`s, no workspace-level opt-outs.

Verified on aarch64-darwin with the repo's forked clippy (llm-clippy 0.1.97, same nightly): `cargo clippy --all-targets` green for all six crates; `cargo test` green for the host-buildable ones (ix-vt links against libghostty-vt, absent locally; its change is doc-only); `nix run .#lint` 13/13.


The first push tripped the clone-detect diff gate (0% new-duplication budget): the `Counts` assertions repeated a 7-line block five times, and touching two already-near-clone mode tests pulled them into the gate. The wrap test harness now carries `assert_counts` and `run_expecting` helpers; whole-tree duplication drops 0.3627% -> 0.3613% and `clone . --diff` passes 0/80 locally.

(sent by an AI agent via Claude Code, model fable)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nightly Clippy nursery linting errors across multiple packages
> - Adds a `HeroRender` type alias in [generate.rs](https://github.com/indexable-inc/index/pull/3925/files#diff-eb76890030eef7672f2b30fc0babd791e3c96bdca264a7247a6aaec91b5cfae7) to satisfy Clippy's complaint about complex inline function types in array literals.
> - Derives `Clone, Copy` on the `Scheme` enum in [readme.rs](https://github.com/indexable-inc/index/pull/3925/files#diff-a91611e7a3f3deeb727c42d7958cec72171cc39acd9d6363803c6f1c75532f0f) and wraps identifiers in backticks in doc comments.
> - Refactors [usage/wrap/src/main.rs](https://github.com/indexable-inc/index/pull/3925/files#diff-614a86b7da57e76b4a737a0b533f8f6c2c306d6009549ef32a27c979659a187a): uses `Duration::from_hours(6)` instead of `Duration::from_secs(6 * 3600)`, rewrites `marker_stale` with an early return, and renames variables in `build_command`.
> - Simplifies query callbacks in [usage/cli/src/main.rs](https://github.com/indexable-inc/index/pull/3925/files#diff-69528877f1491ed989abbe5d0756a088b47525524a755ab1926b6701e691acc7) by passing `map_error_row` directly instead of wrapping it in closures.
> - Adds test helpers (`Counts` struct, `assert_counts`, `run_expecting`) in [wrap.rs](https://github.com/indexable-inc/index/pull/3925/files#diff-a004b7782a7ea0faedf935f6a2dfef834135d3e328df362f0b0b3179d432744d) to reduce duplication in wrap integration tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10198a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->