### PR TITLE
rust: clear the clone-hash clippy and mcp serverTools gate reds (#3892)

### DIFF
--- a/packages/mcp/default.nix
+++ b/packages/mcp/default.nix
@@ -1369,10 +1369,12 @@
     "import asyncio; from ix_notebook_mcp.tools import mcp; "
     + "names = sorted(t.name for t in asyncio.run(mcp.list_tools())); "
     # This set drifts silently: session_set_name (#1615) and kernel_restart
-    # (#2349) each joined the surface without updating it, and the stale drv
-    # kept passing from cache on main until this package's inputs changed and
-    # forced a rebuild. When adding a tool, add it here in the same change.
-    + "expected = {'python_exec','pr_watch','read','kernel_trace','kernel_restart','tui_act','session_set_name','topic_set','reply'}; "
+    # (#2349) each joined the surface without updating it, dropping the read
+    # tool (#3503) left it listed here, and each time the stale drv kept
+    # passing from cache on main until this package's inputs changed and
+    # forced a rebuild. When adding or removing a tool, update it in the same
+    # change.
+    + "expected = {'python_exec','pr_watch','kernel_trace','kernel_restart','tui_act','session_set_name','topic_set','reply'}; "
     + "assert set(names) == expected, ('tool surface drifted: %r' % (names,)); "
     + "from ix_notebook_mcp import registry; instr = mcp._mcp_server.instructions; "
     + "assert 'root=' not in instr, 'a parameter/signature leaked into the instructions'; "


### PR DESCRIPTION
Refs #3892 — follow-up to #3925: after it merged, main's gate still had two red x86_64-linux lanes (`rust-clone-hash.clippy`, `rust-mcp.serverTools`), visible on the #3925 head run.

- **rust-clone-hash.clippy** — b02d6a3f made the packageName-keyed per-crate clippy lookups hit for crates the gate previously missed, surfacing nightly-bump fallout in clone-hash: drop unneeded raw-string hashes in `tests/extract.rs` (`needless_raw_string_hashes`), backtick ExDNA in `canon.rs` (`doc_markdown`), and return a named `CallParts` struct from `call_parts` (`anonymous_tuple_return_type`). No `allow`s.
- **rust-mcp.serverTools** — the expected tool-surface set still listed `read`, but #3503 (9096a1ea) dropped the read tool a week after the set was last rewritten; the stale drv kept passing from cache until the 07-21 module split changed the package inputs and forced a rebuild — the same silent-drift mode the comment above the set already documents from #1615/#2349. `read` is removed from the set and the comment now covers removals too.

Verified on aarch64-darwin: forked-clippy green for clone-hash (`--all-targets`), `cargo test -p clone-hash` 18/18, `nix run .#lint` 13/13, clone diff gate 0/20 vs origin/main. serverTools is Linux-only; this PR's flake-check is its verification.

(sent by an AI agent via Claude Code, model fable)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP server tools build-time assertion by removing 'read' from expected tool set
> Updates the inline Python assertion in [default.nix](https://github.com/indexable-inc/index/pull/3935/files#diff-1620bd0b79c426472be159dd458dcedbb31de6b35b9507d98c31d4aed67e08db) to remove `'read'` from the expected set of tool names, resolving assertion failures caused by the tool's absence. Comments are updated to flag prior drift and remind maintainers to update the set when tools are added or removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84b918c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->