### PR TITLE
clone-hash: fix nightly clippy pedantic/anonymous-tuple breakage

### DIFF
--- a/packages/code/clone-detect/hash/src/canon.rs
+++ b/packages/code/clone-detect/hash/src/canon.rs
@@ -1,5 +1,5 @@
 //! Per-language AST canonicalization applied ahead of the generic
-//! normalizer (issue #3878, modeled on elixir-vibe's ExDNA).
+//! normalizer (issue #3878, modeled on elixir-vibe's `ExDNA`).
 //!
 //! Language knowledge lives here, keyed off [`Lang`]; the recursion in
 //! `normalize` only sees the canonical [`View`]. Semantically equivalent
@@ -47,7 +47,7 @@ fn elixir<'t>(tree: &Tree, node: Node<'t>) -> Option<View<'t>> {
     match node.kind() {
         "binary_operator" => pipe(tree, node),
         "call" => {
-            let (target, args) = call_parts(node)?;
+            let CallParts { target, args } = call_parts(node)?;
             Some(View::Call { target, args })
         }
         "keywords" => keywords(tree, node),
@@ -75,7 +75,7 @@ fn pipe<'t>(tree: &Tree, node: Node<'t>) -> Option<View<'t>> {
     let rhs = node.child_by_field_name("right")?;
 
     if rhs.kind() == "call" {
-        let (target, mut args) = call_parts(rhs)?;
+        let CallParts { target, mut args } = call_parts(rhs)?;
         args.insert(0, lhs);
         return Some(View::Call { target, args });
     }
@@ -85,10 +85,17 @@ fn pipe<'t>(tree: &Tree, node: Node<'t>) -> Option<View<'t>> {
     })
 }
 
+/// An Elixir `call` split into callee and flattened arguments, the pieces a
+/// [`View::Call`] is built from.
+struct CallParts<'t> {
+    target: Node<'t>,
+    args: Vec<Node<'t>>,
+}
+
 /// Flatten an Elixir `call` into callee + arguments: children of the
 /// `arguments` node are spliced in directly, and any trailing `do_block`
 /// rides along as a final argument.
-fn call_parts(node: Node<'_>) -> Option<(Node<'_>, Vec<Node<'_>>)> {
+fn call_parts(node: Node<'_>) -> Option<CallParts<'_>> {
     let target = node.child_by_field_name("target")?;
     let mut args = Vec::new();
     let mut cursor = node.walk();
@@ -103,7 +110,7 @@ fn call_parts(node: Node<'_>) -> Option<(Node<'_>, Vec<Node<'_>>)> {
             args.push(child);
         }
     }
-    Some((target, args))
+    Some(CallParts { target, args })
 }
 
 fn rust<'t>(tree: &Tree, node: Node<'t>) -> Option<View<'t>> {

--- a/packages/code/clone-detect/hash/src/tests/extract.rs
+++ b/packages/code/clone-detect/hash/src/tests/extract.rs
@@ -101,7 +101,7 @@ class Foo:
 // returned nothing and the ratchet silently skipped all Elixir.
 #[test]
 fn elixir_defs_case_clauses_and_fns_are_significant() {
-    let source = r#"
+    let source = r"
 defmodule M do
   def classify(input) do
     case input do
@@ -121,7 +121,7 @@ defmodule M do
     end)
   end
 end
-"#;
+";
     let tree = parse(Lang::Elixir, source);
     assert!(!significant_nodes(&tree, Lang::Elixir, 3, 5).is_empty());
 }


### PR DESCRIPTION
Main's flake-check has been red since the #3878 canonicalizer landed; after #3925 fixed the bulk, `clone_hash-clippy` is the sole remaining failing derivation (`nix log /nix/store/1yld6a1w...-clone_hash-clippy-0.1.0.drv`): three lints under the llm-clippy gate.

- `needless_raw_string_hashes`: the Elixir source snippet in `src/tests/extract.rs` has no quotes, so `r#"..."#` drops to `r"..."`.
- `doc_markdown`: `ExDNA` gets backticks in the `canon.rs` module doc.
- `anonymous_tuple_return_type`: `call_parts` now returns a named `CallParts { target, args }` struct, the pieces a `View::Call` is built from.

Verified: `cargo test -p clone-hash --lib` (18 passed) and `nix build .#ciChecks.x86_64-linux.rust-clone-hash.clippy` exits 0.

Blocks nothing else; unblocks every open PR's flake-check, including #3922.

Written by an AI agent via Claude Code (model: fable).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nightly Clippy pedantic lint errors in clone-detect hash canonicalization
> - Replaces the anonymous tuple return type `Option<(Node<'_>, Vec<Node<'_>>)>` in `call_parts` with a named `CallParts<'t>` struct in [canon.rs](https://github.com/indexable-inc/index/pull/3936/files#diff-5d34f1acbb9184f7400822b6c53b1bd88c8e13aba75e2e133dd8d32ecff06a3f) to satisfy the `clippy::type_complexity` / anonymous-tuple pedantic lint.
> - Updates call sites in `canon.elixir` and `canon.pipe` to destructure `CallParts { target, args }` instead of tuple patterns.
> - Simplifies raw string literal delimiters in [extract.rs](https://github.com/indexable-inc/index/pull/3936/files#diff-f68706e9982f4f744112289d4b1d2392ae5fdde2f22857d684ff4949e92cc976) from `r#"..."#` to `r"..."` to satisfy nightly Clippy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b55a8c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->