### PR TITLE
agent: point browser work at agent-browser and vendor its skill

### DIFF
--- a/lib/skills.nix
+++ b/lib/skills.nix
@@ -4,7 +4,8 @@
 }: let
   # Auto-discover skill directories under paths.skills. Each subdirectory is a
   # Claude Code skill (a directory containing a SKILL.md, and optionally
-  # assets/ and references/ subdirectories).
+  # assets/ and references/ subdirectories). `vendoredSources` below adds
+  # skills that ship inside packaged upstreams.
   entries = builtins.readDir paths.skills;
 
   skillNames = lib.sort lib.lessThan (
@@ -13,7 +14,25 @@
 
   sources = lib.genAttrs skillNames (name: paths.skills + "/${name}");
 
-  allSkills = skillNames;
+  # Skills vendored from packaged upstreams: the package already ships a
+  # plugin-ready skill directory, so the catalog derives it from the pin
+  # instead of committing a copy that drifts from the installed binary.
+  # Values are functions of the consumer's package set (this file has no
+  # `pkgs`), resolved inside `mkSkillsDir`. agent-browser's directory is
+  # upstream's discovery stub: it sends the agent to
+  # `agent-browser skills get core`, which the CLI serves byte-matched to
+  # its own version, so the stub itself never goes stale.
+  vendoredSources = {
+    agent-browser = pkgs: "${pkgs.agent-browser}/skills/agent-browser";
+  };
+
+  vendoredNames = lib.attrNames vendoredSources;
+
+  vendorCollisions = lib.intersectLists skillNames vendoredNames;
+
+  allSkills = assert lib.assertMsg (vendorCollisions == [])
+  "skills: vendored skill name(s) shadow repo skills: ${lib.concatStringsSep ", " vendorCollisions}";
+    lib.sort lib.lessThan (skillNames ++ vendoredNames);
 
   partitioned = lib.partition (lib.hasPrefix "antithesis") allSkills;
 
@@ -35,7 +54,7 @@
     farm = pkgs.linkFarm "claude-skills-farm" (
       (map (name: {
           inherit name;
-          path = sources.${name};
+          path = sources.${name} or (vendoredSources.${name} pkgs);
         })
         names)
       ++ (lib.mapAttrsToList (name: path: {inherit name path;}) extraSkills)
@@ -67,7 +86,9 @@ in {
   Each value is the path to a Claude Code skill directory (containing
   `SKILL.md`, and optionally `assets/` and `references/`). Discovered
   automatically from `paths.skills`, so adding a directory there is the
-  only step needed to publish a new shared skill.
+  only step needed to publish a new shared skill. Vendored skills are not
+  here: their paths depend on the consumer's package set, so `mkSkillsDir`
+  resolves them from `vendoredSources`.
   */
   inherit sources;
 

--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -263,6 +263,27 @@
     };
   }
   {
+    browserAutomation = {
+      topics = ["tooling"];
+      text = ''
+        Browser and web-app work goes through `agent-browser` (vercel-labs):
+        take a `snapshot` and act on its `@eN` refs, not screenshots or DOM
+        dumps. Read `agent-browser skills get core` before the first
+        command; the CLI serves guides matched to its own version
+        (`skills list` for electron, slack, dogfood and friends).
+      '';
+      reason = ''
+        agent-browser ships in every dev environment (lib/dev/base) and the
+        workstation profile, yet no rule or skill pointed at it. Upstream
+        keeps the usage guide inside the CLI, byte-matched to the installed
+        binary, so the rule points there instead of restating a recipe that
+        would drift; the vendored agent-browser skill (lib/skills.nix)
+        carries upstream's discovery stub for the same content
+        (index#3939).
+      '';
+    };
+  }
+  {
     indexKernel = {
       topics = ["tooling"];
       text = ''

--- a/packages/site/src/lib/updates/agent-browser-skill.svx
+++ b/packages/site/src/lib/updates/agent-browser-skill.svx
@@ -1,0 +1,15 @@
+---
+id: agent-browser-skill
+postedAt: 2026-07-21T12:00:00-07:00
+title: "Browser work routes through agent-browser; its skill is vendored from the pin"
+tags: [agent, skills, prompt]
+links:
+  - label: issue
+    href: https://github.com/indexable-inc/index/issues/3939
+  - label: vercel-labs/agent-browser
+    href: https://github.com/vercel-labs/agent-browser
+---
+
+The house prompt now has a `browserAutomation` rule: browser and web-app work goes through `agent-browser` (vercel-labs), acting on `snapshot` accessibility refs (`@e1`, `@e2`, ...) instead of screenshots or DOM dumps, and agents read `agent-browser skills get core` before the first command. Upstream serves that guide from the CLI itself, byte-matched to the installed version, so the prompt points at it rather than restating a recipe that would drift.
+
+The skill catalog (`lib/skills.nix`) grew a `vendoredSources` seam for skills that ship inside packaged upstreams. The nixpkgs `agent-browser` package installs upstream's discovery stub at `skills/agent-browser/`, so the catalog links it straight from `pkgs.agent-browser`: no committed copy, and every consumer (the SessionStart materializer, the wrapper's skills dir, the `/index:` plugin) picks it up automatically. A name collision with a repo skill fails the build instead of silently shadowing.


### PR DESCRIPTION
Fixes #3939.

## What

- New `browserAutomation` prompt rule (`packages/agent/prompt/rules.nix`): browser and web-app work goes through `agent-browser` (vercel-labs), acting on `snapshot` `@eN` refs, with `agent-browser skills get core` read before the first command. Upstream serves that guide from the CLI byte-matched to the installed version, so the rule points at it instead of restating a recipe that would drift.
- `lib/skills.nix` grows a `vendoredSources` seam: skills that ship inside packaged upstreams are linked from the pin. The nixpkgs `agent-browser` package installs upstream's discovery stub at `$out/skills/agent-browser`, so the catalog derives the skill from `pkgs.agent-browser`; every consumer (SessionStart materializer, wrapper skills dir, `/index:` plugin) picks it up with no committed copy. A vendored name colliding with a repo skill fails the build.
- Site update entry `agent-browser-skill.svx`.

## Verified

- `nix run .#lint`: exit 0.
- `nix build .#skills .#claude-plugin`: both outputs contain `agent-browser/SKILL.md` (upstream stub, `hidden: true` frontmatter intact), 0 symlinks after materialization.
- Rendered system prompt (`packages/agent/prompt` eval) contains the new rule.

Not verified: full CI matrix; darwin + linux both build `pkgs.agent-browser` already via `lib/dev/base`, so plugin closure growth is the pre-existing package.

(PR by an AI agent via Claude Code, Claude Fable 5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Point browser work at agent-browser and vendor its skill in the agent prompt
> - Adds vendored skill support to [lib/skills.nix](https://github.com/indexable-inc/index/pull/3941/files#diff-428ee5e3be6c505b0f0f5281befa8ff4f4781677535ca7d023a26abf60a97066): a `vendoredSources` attribute maps skill names to path-resolving functions evaluated against the consumer's `pkgs`, with a build-time assertion that vendored names don't collide with repo-discovered skills.
> - Adds a `browserAutomation` rule to the agent prompt in [packages/agent/prompt/rules.nix](https://github.com/indexable-inc/index/pull/3941/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5), instructing the agent to route browser and web-app tasks through `agent-browser` and consult its CLI-served skills guide.
> - Adds a site update post in [packages/site/src/lib/updates/agent-browser-skill.svx](https://github.com/indexable-inc/index/pull/3941/files#diff-6aebf8e86c65c2981dd35abedfd77077eb14aa9b756c52a821994ac328a1e1ab) describing these changes for the updates feed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4798cba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->