### PR TITLE
lib: wrap exported homeModules with _file for source attribution

### DIFF
--- a/lib/home-modules.nix
+++ b/lib/home-modules.nix
@@ -11,12 +11,21 @@
   home-manager,
   nixpkgs,
 }: let
+  # Modules exported as applied values (`import <path> args`) give the module
+  # system no file to record, so a consumer's `definitionsWithLocations`
+  # attributes every definition to the importing file (#3938). Wrapping with
+  # `_file` restores the module's own source; the inner module keeps its own
+  # `key`, so instance dedup is unchanged.
+  importApply = file: args: {
+    _file = file;
+    imports = [(import file args)];
+  };
   # One instance shared by every wiring site (the workstation profile and
   # homeModules.provenance); the module's `key` also dedups the instances a
   # consumer combines, but there is no reason to make them re-apply the
   # walker.
-  provenanceHomeModule = import (paths.modules + "/home/provenance.nix") {inherit (ix) provenance;};
-  mutableFilesHomeModule = import (paths.modules + "/home/mutable-files.nix") {
+  provenanceHomeModule = importApply (paths.modules + "/home/provenance.nix") {inherit (ix) provenance;};
+  mutableFilesHomeModule = importApply (paths.modules + "/home/mutable-files.nix") {
     inherit indexPackages;
     portableServicesModule = ix.portableServices.homeModule;
   };
@@ -24,20 +33,20 @@
   # agents from structured attrs, pinned binaries, idempotent ssh apply).
   # One instance shared by homeModules.macos-guests and the personal darwin
   # profile. See modules/home/macos-guests.nix.
-  macosGuestsHomeModule = import (paths.modules + "/home/macos-guests.nix") {
+  macosGuestsHomeModule = importApply (paths.modules + "/home/macos-guests.nix") {
     inherit indexPackages ix;
   };
-  claudeCodeHomeModule = import (paths.packagesRoot + "/agent/home-manager/claude-code.nix") {
+  claudeCodeHomeModule = importApply (paths.packagesRoot + "/agent/home-manager/claude-code.nix") {
     inherit indexPackages;
     promptModule = paths.packagesRoot + "/agent/prompt";
     mutableJsonModule = ix.mutableJson.homeModule;
   };
-  codexHomeModule = import (paths.packagesRoot + "/agent/home-manager/codex.nix") {
+  codexHomeModule = importApply (paths.packagesRoot + "/agent/home-manager/codex.nix") {
     inherit indexPackages;
     promptModule = paths.packagesRoot + "/agent/prompt";
   };
   personal = import ./profiles.nix {
-    inherit lib ix paths indexPackages home-manager nixpkgs;
+    inherit lib ix paths indexPackages home-manager nixpkgs importApply;
     claudeCodeModule = claudeCodeHomeModule;
     codexModule = codexHomeModule;
     mutableFilesModule = mutableFilesHomeModule;
@@ -58,18 +67,18 @@ in {
     # closure so `whence </etc/...>` answers from /run/current-system with
     # zero eval. Set `provenance.rev = self.rev or self.dirtyRev or null`
     # in the consuming flake. See modules/darwin/provenance.nix.
-    provenance = import (paths.modules + "/darwin/provenance.nix") {inherit (ix) provenance;};
+    provenance = importApply (paths.modules + "/darwin/provenance.nix") {inherit (ix) provenance;};
     # System-level (root, /etc) adapter for declarative-but-writable files:
     # same model as homeModules.mutable-files, state under
     # /var/db/index-delta, boot-time reseed daemon. See
     # modules/darwin/mutable-files.nix.
-    mutable-files = import (paths.modules + "/darwin/mutable-files.nix") {
+    mutable-files = importApply (paths.modules + "/darwin/mutable-files.nix") {
       inherit indexPackages;
     };
     # Fabric Ray worker for macs (index#3192): join the fleet cluster as a
     # worker behind `services.ix-ray.enable`, same pinned ports and env as
     # the NixOS module. See modules/darwin/ray.nix.
-    ray = import (paths.modules + "/darwin/ray.nix") {indexLib = ix;};
+    ray = importApply (paths.modules + "/darwin/ray.nix") {indexLib = ix;};
     # Declarative NFS automounts via macOS autofs: each entry renders a
     # direct-map line, /etc/auto_master gains the include idempotently, and
     # activation reloads automountd. See modules/darwin/nfs.nix.
@@ -91,7 +100,7 @@ in {
     # auto-attach the remote's mux. Import it and set
     # `programs.mux.enable = true`; needs an nvim config shipping a `mux`
     # lua module. See modules/home/mux.nix.
-    mux = import (paths.modules + "/home/mux.nix") {inherit ix;};
+    mux = importApply (paths.modules + "/home/mux.nix") {inherit ix;};
     # XDG hygiene: point tool state/caches/config (cargo, go, npm/pnpm,
     # python, docker, aws, psql/sqlite histories, wget/less) at the XDG
     # base directories instead of $HOME. Import it and set
@@ -158,14 +167,14 @@ in {
     # cli-baseline, mux, xdg-tidy, and zsh-vi-cursor modules above; the
     # source repo's secrets/theme machinery is deliberately absent. See
     # users/harivansh-afk/home.nix.
-    harivansh-afk = import (paths.users + "/harivansh-afk/home.nix") {inherit ix;};
+    harivansh-afk = importApply (paths.users + "/harivansh-afk/home.nix") {inherit ix;};
     # Reusable workstation module: draw one Minecraft boss bar per in-flight
     # GitHub Actions run across a set of repos (green = running, filled by
     # elapsed / average duration; purple = queued/unpicked). Import it and set
     # `services.ciBars = { enable = true; repos = [ ... ]; }`. Closed over the
     # per-system packages so it resolves the `bossbar` CLI for the host. See
     # packages/minecraft/bossbar-overlay/ci-bars-home-module.nix.
-    ci-bars = import (paths.packagesRoot + "/minecraft/bossbar-overlay/ci-bars-home-module.nix") {
+    ci-bars = importApply (paths.packagesRoot + "/minecraft/bossbar-overlay/ci-bars-home-module.nix") {
       inherit indexPackages ix;
       portableServicesModule = ix.portableServices.homeModule;
     };
@@ -174,7 +183,7 @@ in {
     # Mixedbread, as a portable timer service. Closed over the per-system
     # packages so it resolves the `indexer` for the host. See
     # packages/search/indexer/home-module.nix.
-    indexer = import (paths.packagesRoot + "/search/indexer/home-module.nix") {
+    indexer = importApply (paths.packagesRoot + "/search/indexer/home-module.nix") {
       inherit indexPackages;
       portableServicesModule = ix.portableServices.homeModule;
     };

--- a/lib/profiles.nix
+++ b/lib/profiles.nix
@@ -9,6 +9,10 @@
   indexPackages,
   home-manager,
   nixpkgs,
+  # Wraps `import <path> args` with the path as `_file` so consumers'
+  # `definitionsWithLocations` attribute definitions to the module's own
+  # source file (#3938). Shared from lib/home-modules.nix.
+  importApply,
   claudeCodeModule,
   codexModule,
   mutableFilesModule,
@@ -18,18 +22,18 @@
   personalRoot = paths.users + "/andrewgazelka";
   configRoot = personalRoot + "/config";
   optionsModule = personalRoot + "/options.nix";
-  personalServicesModule = import (personalRoot + "/home.nix") {
+  personalServicesModule = importApply (personalRoot + "/home.nix") {
     inherit indexPackages ix claudeCodeModule;
     portableServicesModule = ix.portableServices.homeModule;
   };
   portableModule = personalRoot + "/profiles/portable.nix";
-  developmentModule = import (personalRoot + "/profiles/development.nix") {
+  developmentModule = importApply (personalRoot + "/profiles/development.nix") {
     agentLua = paths.modules + "/profiles/base/nvim/agent.lua";
     inherit configRoot;
   };
 in {
   inherit personalServicesModule portableModule developmentModule;
-  workstationModule = import (personalRoot + "/profiles/workstation.nix") {
+  workstationModule = importApply (personalRoot + "/profiles/workstation.nix") {
     inherit
       indexPackages
       personalServicesModule
@@ -44,7 +48,7 @@ in {
     tmuxModule = paths.modules + "/home/tmux.nix";
     activationTimingModule = paths.modules + "/home/activation-timing.nix";
   };
-  darwinHomeModule = import (personalRoot + "/profiles/darwin-home.nix") {
+  darwinHomeModule = importApply (personalRoot + "/profiles/darwin-home.nix") {
     inherit
       indexPackages
       ix
@@ -54,7 +58,7 @@ in {
     ghosttyModule = configRoot + "/home/ghostty.nix";
     raycastModule = paths.modules + "/home/raycast.nix";
     inherit macosGuestsModule;
-    guestsModule = import (personalRoot + "/guests") {inherit indexPackages;};
+    guestsModule = importApply (personalRoot + "/guests/default.nix") {inherit indexPackages;};
   };
   # The dependency-light personal profile pair (portable + development),
   # composed as a real homeManagerConfiguration so `checks` can force its

--- a/lib/services/mutable-json.nix
+++ b/lib/services/mutable-json.nix
@@ -127,6 +127,10 @@ in {
   # imports `homeModules.mutable-json`: the module system deduplicates by key,
   # so the option is declared once.
   homeModule = {
+    # Real source path, not just the key: without `_file` a consumer's
+    # `definitionsWithLocations` attributes this module's definitions to the
+    # importing file (#3938).
+    _file = ./mutable-json.nix;
     key = "index/lib/services/mutable-json.nix";
     imports = [moduleBody];
   };

--- a/packages/site/src/lib/updates/homemodules-file-attribution.svx
+++ b/packages/site/src/lib/updates/homemodules-file-attribution.svx
@@ -1,0 +1,29 @@
+---
+id: homemodules-file-attribution
+postedAt: 2026-07-21T12:00:00-07:00
+title: "Exported homeModules now carry their own file attribution"
+tags: [nix, modules]
+links:
+  - label: issue 3938
+    href: https://github.com/indexable-inc/index/issues/3938
+---
+
+Most of the flake's `homeModules` and `darwinModules` are built by
+applying a module file to its wiring args (`import ./mod.nix {...}`),
+which hands the consumer a plain attrset. The module system records no
+source file for a plain value, so it falls back to the file that
+imported it: in a consuming flake,
+`options.home.packages.definitionsWithLocations` blamed every
+definition from `homeModules.andrewgazelka-workstation` on the
+consumer's own `home/common.nix` instead of
+`users/andrewgazelka/profiles/workstation.nix`.
+
+The composition in `lib/home-modules.nix` and `lib/profiles.nix` now
+routes every applied-value export through one `importApply` helper that
+wraps the module as `{ _file = <path>; imports = [...]; }`, the same
+shape `lib.setDefaultModuleLocation` produces. `homeModules.mutable-json`
+gains a real `_file` next to its dedup `key` for the same reason.
+Definitions now resolve to the module's own source file, so
+location-driven tooling (`definitionsWithLocations`, provenance, error
+messages) points at the line that actually defined the value. Instance
+dedup is unchanged: the inner modules keep their explicit `key`s.


### PR DESCRIPTION
Fixes #3938.

Most flake-exported `homeModules` / `darwinModules` are applied values (`import ./mod.nix {...}`), which hand the consumer a plain attrset with no source file for the module system to record. A consuming flake's `options.<name>.definitionsWithLocations` therefore attributed every definition from `homeModules.andrewgazelka-workstation` to its own importing file (`home/common.nix`) instead of `users/andrewgazelka/profiles/workstation.nix`.

Changes:
- `lib/home-modules.nix`: one `importApply` helper (`file: args: { _file = file; imports = [(import file args)]; }`, the shape `lib.setDefaultModuleLocation` produces) applied to every applied-value export: the shared instances (provenance, mutable-files, macos-guests, claude-code, codex), the darwinModules (provenance, mutable-files, ray), and homeModules mux, harivansh-afk, ci-bars, indexer.
- `lib/profiles.nix`: takes `importApply` as an arg (single implementation) and uses it for the personal surfaces (home.nix, development, workstation, darwin-home, guests).
- `lib/services/mutable-json.nix`: `homeModule` gains `_file = ./mutable-json.nix;` next to its dedup `key`, matching the portable-services pattern.
- Site updates entry: `packages/site/src/lib/updates/homemodules-file-attribution.svx`.

Path exports are untouched (the module system already records paths), and instance dedup is unchanged (inner modules keep their explicit `key`s).

Verified locally on aarch64-darwin:
- `nix run .#lint`: 13/13.
- `nix eval .#homeModules` / `.#darwinModules` mapped over `_file`: every applied-value export now names its own source file.
- `nix eval .#checks.aarch64-darwin.personal-light-profile.drvPath`: evaluates.
- End-to-end from the consuming config (andrewgazelka/.config-nix) with `--override-input index <this branch>`:

  ```
  nix eval '.#homeConfigurations."andrewgazelka@hydra".options.home.packages.definitionsWithLocations' \
    --apply 'defs: map (d: d.file) (builtins.filter (d: builtins.any (p: (p.pname or "") == "agent-browser") d.value) defs)' --json
  # ["/nix/store/...-source/users/andrewgazelka/profiles/workstation.nix"]   (was .../home/common.nix)
  ```

(sent by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wrap exported `homeModules` and `darwinModules` with `_file` for source attribution
> Adds source attribution to all exported NixOS/home-manager modules by introducing an `importApply` helper in [lib/home-modules.nix](https://github.com/indexable-inc/index/pull/3944/files#diff-9cd8075c806ac51279850918b0d923d2e2fb376acc2b712ffa5a201a978a6217) that wraps applied modules in `{ _file = <path>; imports = [<module>]; }`. This makes error messages and module tracing point to the correct source file rather than the call site.
>
> - All bindings in [lib/home-modules.nix](https://github.com/indexable-inc/index/pull/3944/files#diff-9cd8075c806ac51279850918b0d923d2e2fb376acc2b712ffa5a201a978a6217) and [lib/profiles.nix](https://github.com/indexable-inc/index/pull/3944/files#diff-aa89d58be89e21d2931a3bc78f74c221bccd4adeab8b9ebd4b28d8cf3948981c) are updated to use `importApply` instead of bare `import`.
> - [lib/services/mutable-json.nix](https://github.com/indexable-inc/index/pull/3944/files#diff-0ad5a38350ef3522ce52573ca874e3a9f75008792927235c3c3ed8c2ef7e9d53) adds `_file = ./mutable-json.nix` directly to its `homeModule` attrset.
> - An update post is added to the site documenting the change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a7344f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->