### PR TITLE
ci: clear the site-test and clone-detect reds keeping main's flake-check dead

### DIFF
--- a/packages/code/clone-detect/detect/tests/no_self_overlap.rs
+++ b/packages/code/clone-detect/detect/tests/no_self_overlap.rs
@@ -34,9 +34,13 @@ fn process(values: &[i32]) -> i32 {
 }
 "#;
 
+/// One detection mode: fixture code, the config that enables the detector,
+/// and the selector for the pair kind it reports.
+type Case = (&'static str, DetectConfig, fn(&Kind) -> bool);
+
 #[test]
 fn detectors_never_compare_overlapping_regions_of_one_file() {
-    let cases: [(&str, DetectConfig, fn(&Kind) -> bool); 2] = [
+    let cases: [Case; 2] = [
         (
             TYPE3_FIXTURE,
             DetectConfig {

--- a/packages/site/package-lock.json
+++ b/packages/site/package-lock.json
@@ -22,7 +22,7 @@
         "eslint": "^10.4.0",
         "eslint-plugin-svelte": "^3.17.1",
         "globals": "^17.6.0",
-        "playwright": "^1.59.1",
+        "playwright": "^1.61.1",
         "svelte": "^5.55.9",
         "svelte-check": "^4.4.8",
         "typescript": "^6.0.3",
@@ -3096,13 +3096,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3115,9 +3115,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -22,7 +22,7 @@
     "eslint": "^10.4.0",
     "eslint-plugin-svelte": "^3.17.1",
     "globals": "^17.6.0",
-    "playwright": "^1.59.1",
+    "playwright": "^1.61.1",
     "svelte": "^5.55.9",
     "svelte-check": "^4.4.8",
     "typescript": "^6.0.3",

--- a/packages/unibind/conformance-ex/mix/test/unibind_conformance_test.exs
+++ b/packages/unibind/conformance-ex/mix/test/unibind_conformance_test.exs
@@ -127,7 +127,10 @@ defmodule UnibindConformanceTest do
       assert_receive :started, 1_000
       Process.exit(pid, :kill)
 
-      assert eventually(fn -> Conf.cancelled_count() >= baseline + 1 end),
+      # 15s, not the 2s default: this ran on CI hosts saturated by parallel
+      # nix builds, where caller-exit cancellation took over 2s to surface
+      # (main run 29889948013 missed the window by a hair).
+      assert eventually(fn -> Conf.cancelled_count() >= baseline + 1 end, 15_000),
              "cancelled_count never reached baseline + 1"
     end
 


### PR DESCRIPTION
## Root cause

Main's `flake-check` has been red since 2026-07-19 (last green: run 29669505406), so `closure-gate` refuses every run and nothing merges on its own verdict; red-on-red merges then stacked more breakage on top.

The brief for this work suspected the ci-budget worker's validation clock. It is innocent, and no budget change ships here. Measured against the last three failing main runs: the budgeted gate step dies ~140-270s in, well inside even the 300s routine window, and main pushes get the 10800s extended tier anyway (`force-big-change: github.event_name != 'pull_request'` in check.yml). A clock kill would end the step with exit 124 and no nix error; the actual logs end with `error: Cannot build ... Reason: builder failed with exit code 1` - real build failures. The "log cut mid-derivation" read was an artifact of nix-fast-build's interleaved output flushing at abort time.

What actually broke, lane by lane (all landed while main was already red, so their own failures were masked):

1. `clone_hash-clippy` - three real pedantic/anonymous-tuple violations from the #3878 canonicalizer commits (588e5d20..d08d1419). Fixed upstream by #3936/#3935 (I reproduced the identical fix independently before finding theirs merged).
2. `rust-mcp.serverTools` - #3503 dropped the `read` tool but the check's expected set kept it; the stale drv passed from cache until #3913 changed the package inputs (third recorded instance of this drift pattern). Fixed upstream by #3935.
3. `site-test` (ix-site-vitest) - the direct-to-main flake.lock bump 93ba5476 ("z", 2026-07-19, hours after the last green run) moved nixpkgs' `playwright-driver` to 1.61.1 while `packages/site` pins npm playwright 1.60.0, so vitest browser mode looks for `chromium_headless_shell-1223` in a browsers bundle that no longer ships it. **Fixed here**: bump `playwright` to 1.61.1 to match the driver.
4. `rust-clone-detect.clippy` - `no_self_overlap.rs`'s case-table annotation trips `type_complexity`. **Fixed here**: named `Case` alias.
5. unibind conformance (ex) - the caller-exit cancellation assertion missed its 2s grace window in run 29889948013 (failed at exactly 2020ms) and passed in run 29890368148: load flake on a saturated builder. **Hardened here**: that one poll gets 15s.

## Measurement

The freshest main run before this PR (29890368148, tree 8434d3ed) reports `BUILD: 215 successes, 2 failures - Failed attributes: site-test, rust-clone-detect.clippy`. Those two are exactly what this PR fixes, so main should go green when this lands.

## Merge mechanics / possible admin merge

The feared deadlock (a budget-clock fix being killed by the budget clock) does not apply: the clock never fires, and this PR's own flake-check builds the PR tree, which contains the fixes - it can go green on its own. Two caveats:

- Required checks are non-strict and merges have been landing on red main directly; if another red lane merges to main while this PR is in flight, the green here stays valid but main needs that new lane fixed too.
- If reviewers want this in before the (long, cold-cache) PR run completes, an admin merge is safe: every change is lane-local (one npm pin, one type alias, one test timeout).

Validation done locally: `cargo test -p clone-detect --test no_self_overlap` passes, the Elixir suite file parses, the lockfile pins playwright/playwright-core 1.61.1, `cargo fmt --check` clean on touched files.

(authored by Claude Code, model Fable 5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI failures in site-test, clone-detect, and flake-check on main
> - Bumps `playwright` dev dependency from `^1.59.1` to `^1.61.1` in [package.json](https://github.com/indexable-inc/index/pull/3945/files#diff-3b55589ea59f951fd193d8b8eb42fbb41c3fc340850f68b32ea24080ad9a0a1a) to clear site-test failures.
> - Introduces a `Case` type alias in [no_self_overlap.rs](https://github.com/indexable-inc/index/pull/3945/files#diff-95ddd127dd35924c854fb044a949d658aeac675e4d4b9d114c908a21c939d72b) to fix a type annotation issue in the clone-detect test.
> - Extends the `eventually(...)` timeout to 15,000ms in [unibind_conformance_test.exs](https://github.com/indexable-inc/index/pull/3945/files#diff-8347c2d522a5d56a0891faac50d486abbd029781bdb13611e530db0cfcf2778e) for a cancellation assertion that was timing out under the default window.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f5b402.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->