### PR TITLE
agent: attach agent-browser to the user's CDP Chrome by default

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -268,9 +268,13 @@
       text = ''
         Browser and web-app work goes through `agent-browser` (vercel-labs):
         take a `snapshot` and act on its `@eN` refs, not screenshots or DOM
-        dumps. Read `agent-browser skills get core` before the first
-        command; the CLI serves guides matched to its own version
-        (`skills list` for electron, slack, dogfood and friends).
+        dumps. Attach before launching: the user runs Chrome with
+        `--remote-debugging-port=9222`, so try `--auto-connect` (or
+        `connect 9222`) first and act in their session; launch a fresh
+        browser only when no CDP Chrome answers. Read
+        `agent-browser skills get core` before the first command; the CLI
+        serves guides matched to its own version (`skills list` for
+        electron, slack, dogfood and friends).
       '';
       reason = ''
         agent-browser ships in every dev environment (lib/dev/base) and the


### PR DESCRIPTION
Closes #3943. agent-browser launches a fresh Chromium unless told to attach; the user runs Chrome with --remote-debugging-port=9222. The browser rule now says attach first (--auto-connect / connect 9222) and launch only when no CDP Chrome answers. (sent by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Instruct agent to connect to existing CDP Chrome before launching a new browser
> Updates the agent prompt rules in [rules.nix](https://github.com/indexable-inc/index/pull/3946/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to guide the agent to try `--auto-connect` (or `connect 9222`) against a user's existing Chrome instance (started with `--remote-debugging-port=9222`) before launching a fresh browser. A new browser is only started when no CDP Chrome responds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1946026.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->