### PR TITLE
mcp-ex: generalize issue pickup into a Requests work bus (#3883)

### DIFF
--- a/packages/mcp-ex/README.md
+++ b/packages/mcp-ex/README.md
@@ -70,6 +70,7 @@ list):
 | `Ix.restart()` | cancel jobs (sparing the calling cell), restart the workspace, restore bindings |
 | `PrWatch.start(pr, cwd, interval \\ 15, timeout \\ 3600)` | watch a PR via `gh`, notify on merge/close/timeout |
 | `Issues.pickup(3880)` | claim an issue atomically before working it (also `"owner/repo#n"`); a lost claim names the session that won |
+| `Requests.post("review PR #42", body)` | offer any unit of work to every agent on the host (#3883); `Requests.pickup(id)` claims it atomically, `Requests.done(id)` finishes it, `Requests.list()` shows the board, open first |
 | `Sessions.list()` | the session directory: every kernel instance on this host, with heartbeat liveness |
 | `Sessions.send(id_or_name, text)` | message another session (`Sessions.broadcast/1` for all); arrives as a `source="sessions"` channel event within seconds |
 | `Tui.act(uri, send_keys, peer \\ nil)` | drive a federated TUI resource via `ix-resource-cli` |
@@ -143,8 +144,8 @@ IxMcp.Supervisor (one_for_one)
 ├── IxMcp.Jobs.History     ordered record of every run
 ├── IxMcp.MCP.Notifier     server-initiated notification fan-out
 ├── IxMcp.PrWatch.Supervisor (Task.Supervisor) one task per PR watch
-├── IxMcp.IssueWatch       new-issue + pickup-claim channel feed (stdio-gated, `gh search issues`)
-├── IxMcp.SessionWatch     session heartbeat + cross-session message delivery (stdio-gated)
+├── IxMcp.IssueWatch       new-issue channel feed (stdio-gated, `gh search issues`)
+├── IxMcp.SessionWatch     session heartbeat + message and request-feed delivery (stdio-gated)
 └── IxMcp.MCP.Stdio        newline-delimited JSON-RPC on stdin/stdout
 ```
 

--- a/packages/mcp-ex/lib/ix_mcp/action_log.ex
+++ b/packages/mcp-ex/lib/ix_mcp/action_log.ex
@@ -92,14 +92,33 @@ defmodule IxMcp.ActionLog do
   CREATE TABLE outbox (id INTEGER PRIMARY KEY, job_id TEXT, intent TEXT, status TEXT NOT NULL, elapsed_ms INTEGER, result TEXT, created_at TEXT NOT NULL, acked INTEGER NOT NULL DEFAULT 0)
   """
 
-  # index#3880: the arbiter for issue pickup. Every kernel instance on a host
-  # shares this database, so the UNIQUE(repo, number) constraint IS the
-  # atomic claim: the winning INSERT gets the row, every later attempt reads
-  # the winner back. Known limit, by design: the database is per host, so
-  # cross-machine claims race; the GitHub assignee mirror in `IxMcp.Issues`
-  # is not compare-and-set, so it stays a mirror, not the arbiter.
-  @create_issue_claims """
+  # The v6 shape of the issue-claim arbiter (#3880), frozen for the 5 -> 6
+  # migration step: #3883 generalized it into `requests` (v7 -> 8 migrates
+  # the rows across and drops this table), so history stays history.
+  @create_issue_claims_v6 """
   CREATE TABLE issue_claims (id INTEGER PRIMARY KEY, repo TEXT NOT NULL, number INTEGER NOT NULL, session_id INTEGER REFERENCES sessions(id), claimed_at TEXT NOT NULL, UNIQUE(repo, number))
+  """
+
+  # index#3883: the request bus, generalizing issue pickup (#3880) to any
+  # unit of work an agent can offer ("review this diff", "run this eval").
+  # kind is 'issue' (ref = "owner/repo#n") or 'adhoc' (ref NULL); status
+  # walks open -> claimed -> done. Claiming is a single UPDATE guarded on
+  # status = 'open' -- the row count decides the race -- and the UNIQUE ref
+  # makes ensuring an issue-kind row idempotent (SQLite unique treats NULLs
+  # as distinct, so adhoc rows never collide). Known limit, by design: the
+  # database is per host, so cross-machine claims race; the GitHub assignee
+  # mirror in `IxMcp.Issues` is not compare-and-set, so it stays a mirror,
+  # not the arbiter.
+  @create_requests """
+  CREATE TABLE requests (id INTEGER PRIMARY KEY, kind TEXT NOT NULL, ref TEXT UNIQUE, title TEXT NOT NULL, body TEXT, posted_by INTEGER REFERENCES sessions(id), status TEXT NOT NULL DEFAULT 'open', claimed_by INTEGER REFERENCES sessions(id), posted_at TEXT NOT NULL, claimed_at TEXT, done_at TEXT)
+  """
+
+  # Append-only companion to `requests` (#3883): one row per mutation
+  # (posted/claimed/done), written in the same transaction, so the feed each
+  # instance sweeps (`IxMcp.SessionWatch`) can never see a state the table
+  # does not hold. The requests row is current state; this is its history.
+  @create_request_events """
+  CREATE TABLE request_events (id INTEGER PRIMARY KEY, request_id INTEGER NOT NULL REFERENCES requests(id), event TEXT NOT NULL, session_id INTEGER REFERENCES sessions(id), at TEXT NOT NULL)
   """
 
   # index#3881: the per-host bus between kernel instances. A NULL to_session
@@ -123,8 +142,9 @@ defmodule IxMcp.ActionLog do
   # flat #3512 log, 2 = the #3532 normalization, 3 = the #3536 live rows,
   # 4 = the #3546 live cell line, 5 = the #3839 durable job ledger,
   # 6 = the #3880 issue-claim arbiter, 7 = the #3881 session heartbeat and
-  # message bus.
-  @user_version 7
+  # message bus, 8 = the #3883 request bus (issue_claims folded in and
+  # dropped).
+  @user_version 8
 
   # How long a statement waits for a sibling instance's write lock before
   # step!/fetch/execute! give up and crash with a diagnosis (#3890). A
@@ -239,7 +259,7 @@ defmodule IxMcp.ActionLog do
 
   # A v5 database predates the issue-claim arbiter (#3880): the table is
   # simply created empty.
-  @migrate_v5_to_v6 [@create_issue_claims]
+  @migrate_v5_to_v6 [@create_issue_claims_v6]
 
   # A v6 database predates the session heartbeat and message bus (#3881):
   # existing sessions gain a NULL last_seen_at (they never heartbeat), and
@@ -247,6 +267,23 @@ defmodule IxMcp.ActionLog do
   @migrate_v6_to_v7 [
     "ALTER TABLE sessions ADD COLUMN last_seen_at TEXT",
     @create_session_messages
+  ]
+
+  # A v7 database holds its issue claims in the #3880 table; the request bus
+  # (#3883) subsumes them, so each claim becomes a claimed request of kind
+  # 'issue' (ref doubles as the title -- the claim never carried one) and
+  # the old table drops. No request_events rows are synthesized: the feed
+  # announces news, and a migrated claim is history every instance already
+  # heard as event="picked_up".
+  @migrate_v7_to_v8 [
+    @create_requests,
+    @create_request_events,
+    """
+    INSERT INTO requests (kind, ref, title, posted_by, status, claimed_by, posted_at, claimed_at)
+    SELECT 'issue', repo || '#' || number, repo || '#' || number, NULL, 'claimed', session_id, claimed_at, claimed_at
+    FROM issue_claims ORDER BY id
+    """,
+    "DROP TABLE issue_claims"
   ]
 
   # Ordered migrations keyed by the user_version each upgrades FROM. Every
@@ -259,7 +296,8 @@ defmodule IxMcp.ActionLog do
     {3, @migrate_v3_to_v4},
     {4, @migrate_v4_to_v5},
     {5, @migrate_v5_to_v6},
-    {6, @migrate_v6_to_v7}
+    {6, @migrate_v6_to_v7},
+    {7, @migrate_v7_to_v8}
   ]
 
   @insert """
@@ -291,10 +329,18 @@ defmodule IxMcp.ActionLog do
   FROM jobs
   """
 
-  @select_issue_claim """
-  SELECT c.id, c.repo, c.number, c.session_id, s.name, c.claimed_at
-  FROM issue_claims c
-  LEFT JOIN sessions s ON s.id = c.session_id
+  @select_request """
+  SELECT r.id, r.kind, r.ref, r.title, r.body, r.posted_by, p.name, r.status, r.claimed_by, c.name, r.posted_at, r.claimed_at, r.done_at
+  FROM requests r
+  LEFT JOIN sessions p ON p.id = r.posted_by
+  LEFT JOIN sessions c ON c.id = r.claimed_by
+  """
+
+  @select_request_event """
+  SELECT e.id, e.request_id, e.event, e.session_id, s.name, e.at, r.kind, r.ref, r.title, r.body
+  FROM request_events e
+  JOIN requests r ON r.id = e.request_id
+  LEFT JOIN sessions s ON s.id = e.session_id
   """
 
   @select_session_message """
@@ -357,16 +403,42 @@ defmodule IxMcp.ActionLog do
         }
 
   @typedoc """
-  A recorded issue claim (#3880): `session` is the claiming sessions row's
-  name (nil when that session never named itself).
+  A request on the per-host work bus (#3883): `poster`/`claimer` are the
+  posting/claiming sessions rows' names (nil when unnamed or, for `poster`,
+  when the row was migrated from an issue claim, which nobody posted).
   """
-  @type issue_claim :: %{
+  @type request :: %{
           id: integer(),
-          repo: String.t(),
-          number: integer(),
+          kind: :issue | :adhoc,
+          ref: String.t() | nil,
+          title: String.t(),
+          body: String.t() | nil,
+          posted_by: integer() | nil,
+          poster: String.t() | nil,
+          status: :open | :claimed | :done,
+          claimed_by: integer() | nil,
+          claimer: String.t() | nil,
+          posted_at: String.t(),
+          claimed_at: String.t() | nil,
+          done_at: String.t() | nil
+        }
+
+  @typedoc """
+  A request mutation (#3883), joined with its request's identity so the feed
+  can announce without a second read: `session` is the acting sessions row's
+  name.
+  """
+  @type request_event :: %{
+          id: integer(),
+          request_id: integer(),
+          event: :posted | :claimed | :done,
           session_id: integer() | nil,
           session: String.t() | nil,
-          claimed_at: String.t()
+          at: String.t(),
+          kind: :issue | :adhoc,
+          ref: String.t() | nil,
+          title: String.t(),
+          body: String.t() | nil
         }
 
   @typedoc """
@@ -532,41 +604,107 @@ defmodule IxMcp.ActionLog do
     call(server, {:recent_jobs, session_id, n})
   end
 
-  # -- issue-claim arbiter (#3880) --------------------------------------------
+  # -- request bus (#3883) -----------------------------------------------------
 
   @doc """
-  Atomically claim `repo#number` for `session_id`. The shared database's
-  UNIQUE(repo, number) is the arbiter: the winning insert returns
-  `{:ok, claim}`, a conflict returns `{:error, winner}` with the standing
-  claim (including the winning session's name) so the loser can say who got
-  there first. Idempotent per session: re-claiming an issue this session
-  already holds is `{:ok, claim}`, which is what makes the call safe for
-  the client seam to retry across a server restart (#3903). `:disabled`
-  when the log is degraded (#3539) -- with no arbiter there is no claim to
-  win.
+  Record a request offering `title` to every agent on the host. `kind:
+  :adhoc` (ref nil) always inserts a fresh open row; `kind: :issue` requires
+  `ref` (`"owner/repo#n"`) and is an idempotent ensure -- the UNIQUE ref
+  makes a re-post read the standing row back, whatever its status. A
+  `posted` event lands in the same transaction only when the row is new: the
+  feed announces offers, and an existing row was already offered. Returns
+  `{:ok, request}`; `:disabled` when the log is degraded (#3539) -- with no
+  shared database there is no bus to post on.
+
+  Plain GenServer.call, not the retrying seam (#3874): an adhoc post is not
+  idempotent, so a retry across a server restart could offer the same work
+  twice (the same reason `send_session_message/4` does not retry).
+  """
+  @spec post_request(
+          :issue | :adhoc,
+          String.t() | nil,
+          String.t(),
+          String.t() | nil,
+          integer() | nil,
+          GenServer.server()
+        ) :: {:ok, request()} | :disabled
+  def post_request(kind, ref, title, body, session_id, server \\ __MODULE__)
+      when is_binary(title) and
+             ((kind == :adhoc and is_nil(ref)) or (kind == :issue and is_binary(ref))) do
+    GenServer.call(
+      server,
+      {:post_request, Atom.to_string(kind), ref, title, body, session_id, now()}
+    )
+  end
+
+  @doc """
+  Atomically claim request `id` for `session_id`: one UPDATE guarded on
+  `status = 'open'`, the row count deciding the race (#3883). The winner
+  gets `{:ok, request}` and a `claimed` event in the same transaction; a
+  loser reads the standing row back as `{:error, request}` (status and
+  claimer included) so it can say who got there first. Idempotent per
+  session: re-claiming a request this session already holds is
+  `{:ok, request}`, which is what makes the call safe for the client seam
+  to retry across a server restart (#3903). `{:error, :not_found}` when no
+  such request exists; `:disabled` when the log is degraded (#3539) -- with
+  no arbiter there is no claim to win.
+  """
+  @spec claim_request(integer(), integer() | nil, GenServer.server()) ::
+          {:ok, request()} | {:error, request()} | {:error, :not_found} | :disabled
+  def claim_request(id, session_id, server \\ __MODULE__) when is_integer(id) do
+    call(server, {:claim_request, id, session_id, now()})
+  end
+
+  @doc """
+  Mark claimed request `id` done: the same guarded-UPDATE shape as
+  `claim_request/3`, on `status = 'claimed'`, with a `done` event in the
+  same transaction. Finishing an already-done request is `{:ok, request}`
+  (idempotent, so the client seam can retry, #3903); a still-open one is
+  `{:error, request}` -- claim what you work, then finish it.
+  """
+  @spec finish_request(integer(), integer() | nil, GenServer.server()) ::
+          {:ok, request()} | {:error, request()} | {:error, :not_found} | :disabled
+  def finish_request(id, session_id, server \\ __MODULE__) when is_integer(id) do
+    call(server, {:finish_request, id, session_id, now()})
+  end
+
+  @doc """
+  Atomically claim the issue-kind request for `repo#number`, ensuring its
+  row first (`IxMcp.Issues.pickup/1`'s arbiter, #3880 generalized by
+  #3883): ensure + claim run in one transaction, and a row born here is
+  claimed at birth with only a `claimed` event -- it was never on offer, so
+  a `posted` announcement would offer work that is already taken. Same
+  returns and per-session idempotency as `claim_request/3`.
   """
   @spec claim_issue(String.t(), integer(), integer() | nil, GenServer.server()) ::
-          {:ok, issue_claim()} | {:error, issue_claim()} | :disabled
+          {:ok, request()} | {:error, request()} | :disabled
   def claim_issue(repo, number, session_id, server \\ __MODULE__)
       when is_binary(repo) and is_integer(number) do
     call(server, {:claim_issue, repo, number, session_id, now()})
   end
 
-  @doc """
-  Claims with id greater than `id`, oldest first. The cursor is the caller's
-  own watermark, per instance on purpose: several kernel instances share this
-  database and each must announce every claim to its own client, so a shared
-  announced flag (first sweeper wins) would silence all but one (#3880).
-  """
-  @spec issue_claims_after(integer(), GenServer.server()) :: [issue_claim()]
-  def issue_claims_after(id, server \\ __MODULE__) do
-    call(server, {:issue_claims_after, id})
+  @doc "Every request, open first (then claimed, then done), newest first within a status."
+  @spec list_requests(GenServer.server()) :: [request()]
+  def list_requests(server \\ __MODULE__) do
+    call(server, :list_requests)
   end
 
-  @doc "The highest issue-claim id (0 when none): a fresh watermark for `issue_claims_after/2`."
-  @spec last_issue_claim_id(GenServer.server()) :: integer()
-  def last_issue_claim_id(server \\ __MODULE__) do
-    call(server, :last_issue_claim_id)
+  @doc """
+  Request events with id greater than `id`, oldest first. The cursor is the
+  caller's own watermark, per instance on purpose: several kernel instances
+  share this database and each must announce every event to its own client,
+  so a shared announced flag (first sweeper wins) would silence all but one
+  (#3880).
+  """
+  @spec request_events_after(integer(), GenServer.server()) :: [request_event()]
+  def request_events_after(id, server \\ __MODULE__) do
+    call(server, {:request_events_after, id})
+  end
+
+  @doc "The highest request-event id (0 when none): a fresh watermark for `request_events_after/2`."
+  @spec last_request_event_id(GenServer.server()) :: integer()
+  def last_request_event_id(server \\ __MODULE__) do
+    call(server, :last_request_event_id)
   end
 
   # -- session directory + message bus (#3881) --------------------------------
@@ -605,7 +743,7 @@ defmodule IxMcp.ActionLog do
   @doc """
   Messages for `session_id` past the `id` watermark, oldest first: rows
   addressed to it plus broadcasts, never its own sends. The cursor is per
-  instance for the same reason as `issue_claims_after/2`: every instance
+  instance for the same reason as `request_events_after/2`: every instance
   must deliver to its own client (#3880).
   """
   @spec session_messages_after(integer(), integer(), GenServer.server()) :: [session_message()]
@@ -960,41 +1098,125 @@ defmodule IxMcp.ActionLog do
     {:reply, Enum.map(rows, &job_row_to_map/1), state}
   end
 
-  # The INSERT OR IGNORE plus the changes count is the whole race (#3880):
-  # a unique-constraint winner changes one row, every loser changes zero and
-  # reads the winner back. The single-writer GenServer serializes claims from
-  # this instance; claims from sibling instances serialize on SQLite itself.
-  def handle_call({:claim_issue, repo, number, session_id, at}, _from, %{db: db} = state) do
+  # The INSERT OR IGNORE plus the changes count is the ensure (#3883): the
+  # UNIQUE ref makes re-posting an issue-kind request read the standing row
+  # back, while an adhoc post (NULL ref, never unique-conflicting) always
+  # inserts. Only a fresh row gets a posted event, in the same transaction:
+  # the feed announces offers, and an existing row was already offered. The
+  # single-writer GenServer serializes posts from this instance; posts from
+  # sibling instances serialize on SQLite itself.
+  def handle_call(
+        {:post_request, kind, ref, title, body, session_id, at},
+        _from,
+        %{db: db} = state
+      ) do
+    :ok = execute!(db, "BEGIN IMMEDIATE")
+
     run(
       db,
-      "INSERT OR IGNORE INTO issue_claims (repo, number, session_id, claimed_at) VALUES (?, ?, ?, ?)",
-      [repo, number, session_id, at]
+      "INSERT OR IGNORE INTO requests (kind, ref, title, body, posted_by, status, posted_at) VALUES (?, ?, ?, ?, ?, 'open', ?)",
+      [kind, ref, title, body, session_id, at]
     )
 
     {:ok, changes} = Sqlite3.changes(db.conn)
 
-    [row] =
-      fetch(db, @select_issue_claim <> " WHERE c.repo = ? AND c.number = ?", [repo, number])
+    id =
+      if changes == 1 do
+        {:ok, id} = Sqlite3.last_insert_rowid(db.conn)
+        insert_request_event(db, id, "posted", session_id, at)
+        id
+      else
+        [[id]] = fetch(db, "SELECT id FROM requests WHERE ref = ?", [ref])
+        id
+      end
 
-    claim = issue_claim_row_to_map(row)
-
-    # A standing claim by the caller's own session is a win, not a loss:
-    # the client seam retries a claim whose server died after committing
-    # (#3903), and that retry must read back as the victory it already is,
-    # or the sole claimant would report losing the issue to itself. Only a
-    # real session id gets this: nil belongs to every anonymous caller at
-    # once, so it can never prove the standing claim is the caller's own.
-    won = changes == 1 or (session_id != nil and claim.session_id == session_id)
-    {:reply, if(won, do: {:ok, claim}, else: {:error, claim}), state}
+    :ok = execute!(db, "COMMIT")
+    {:reply, {:ok, fetch_request(db, id)}, state}
   end
 
-  def handle_call({:issue_claims_after, id}, _from, %{db: db} = state) do
-    rows = fetch(db, @select_issue_claim <> " WHERE c.id > ? ORDER BY c.id", [id])
-    {:reply, Enum.map(rows, &issue_claim_row_to_map/1), state}
+  # The guarded UPDATE plus the changes count is the whole race (#3883): the
+  # winner flips the one still-open row, every loser flips zero and reads
+  # the standing row back. The single-writer GenServer serializes claims
+  # from this instance; claims from sibling instances serialize on SQLite
+  # itself (BEGIN IMMEDIATE takes the write lock before the UPDATE looks).
+  def handle_call({:claim_request, id, session_id, at}, _from, %{db: db} = state) do
+    :ok = execute!(db, "BEGIN IMMEDIATE")
+    won = claim_request_row(db, id, session_id, at)
+    :ok = execute!(db, "COMMIT")
+    {:reply, claim_reply(db, id, session_id, won), state}
   end
 
-  def handle_call(:last_issue_claim_id, _from, %{db: db} = state) do
-    [[id]] = fetch(db, "SELECT COALESCE(MAX(id), 0) FROM issue_claims", [])
+  def handle_call({:finish_request, id, session_id, at}, _from, %{db: db} = state) do
+    :ok = execute!(db, "BEGIN IMMEDIATE")
+
+    run(
+      db,
+      "UPDATE requests SET status = 'done', done_at = ? WHERE id = ? AND status = 'claimed'",
+      [at, id]
+    )
+
+    {:ok, changes} = Sqlite3.changes(db.conn)
+    if changes == 1, do: insert_request_event(db, id, "done", session_id, at)
+    :ok = execute!(db, "COMMIT")
+
+    reply =
+      case fetch_request(db, id) do
+        nil ->
+          {:error, :not_found}
+
+        # Re-finishing a done request reads back as the finish it already
+        # is (the client seam retries across a restart, #3903); a still-open
+        # row was never claimed, and finishing unclaimed work stays an error.
+        %{status: :done} = request ->
+          {:ok, request}
+
+        request ->
+          {:error, request}
+      end
+
+    {:reply, reply, state}
+  end
+
+  # Issue pickup (#3880) as one transaction on the request bus: ensure the
+  # kind='issue' row, then claim it. A row born here is claimed at birth and
+  # writes only the claimed event -- it was never on offer, so a posted
+  # announcement would offer work that is already taken.
+  def handle_call({:claim_issue, repo, number, session_id, at}, _from, %{db: db} = state) do
+    ref = "#{repo}##{number}"
+    :ok = execute!(db, "BEGIN IMMEDIATE")
+
+    run(
+      db,
+      "INSERT OR IGNORE INTO requests (kind, ref, title, posted_by, status, posted_at) VALUES ('issue', ?, ?, ?, 'open', ?)",
+      [ref, ref, session_id, at]
+    )
+
+    [[id]] = fetch(db, "SELECT id FROM requests WHERE ref = ?", [ref])
+    won = claim_request_row(db, id, session_id, at)
+    :ok = execute!(db, "COMMIT")
+
+    {:reply, claim_reply(db, id, session_id, won), state}
+  end
+
+  def handle_call(:list_requests, _from, %{db: db} = state) do
+    rows =
+      fetch(
+        db,
+        @select_request <>
+          " ORDER BY CASE r.status WHEN 'open' THEN 0 WHEN 'claimed' THEN 1 ELSE 2 END, r.id DESC",
+        []
+      )
+
+    {:reply, Enum.map(rows, &request_row_to_map/1), state}
+  end
+
+  def handle_call({:request_events_after, id}, _from, %{db: db} = state) do
+    rows = fetch(db, @select_request_event <> " WHERE e.id > ? ORDER BY e.id", [id])
+    {:reply, Enum.map(rows, &request_event_row_to_map/1), state}
+  end
+
+  def handle_call(:last_request_event_id, _from, %{db: db} = state) do
+    [[id]] = fetch(db, "SELECT COALESCE(MAX(id), 0) FROM request_events", [])
     {:reply, id, state}
   end
 
@@ -1121,9 +1343,12 @@ defmodule IxMcp.ActionLog do
       "status" not in columns -> 2
       "line" not in columns -> 3
       not table_exists?(db, "jobs") -> 4
+      # v8 dropped issue_claims (#3883), so its presence must be judged
+      # after the requests table names the file current.
+      table_exists?(db, "requests") -> @user_version
       not table_exists?(db, "issue_claims") -> 5
       not table_exists?(db, "session_messages") -> 6
-      true -> @user_version
+      true -> 7
     end
   end
 
@@ -1142,7 +1367,8 @@ defmodule IxMcp.ActionLog do
         @create_jobs,
         @create_job_output,
         @create_outbox,
-        @create_issue_claims,
+        @create_requests,
+        @create_request_events,
         @create_session_messages,
         stamp(),
         "COMMIT"
@@ -1167,9 +1393,16 @@ defmodule IxMcp.ActionLog do
   defp disabled_reply({:create_topic, _session_id, _name, _at}), do: 0
   defp disabled_reply({:start_action, _action}), do: 0
   defp disabled_reply({:finish_job, _id, _status, _result, _at}), do: :already_final
+
+  defp disabled_reply({:post_request, _kind, _ref, _title, _body, _session_id, _at}),
+    do: :disabled
+
+  defp disabled_reply({:claim_request, _id, _session_id, _at}), do: :disabled
+  defp disabled_reply({:finish_request, _id, _session_id, _at}), do: :disabled
   defp disabled_reply({:claim_issue, _repo, _number, _session_id, _at}), do: :disabled
-  defp disabled_reply({:issue_claims_after, _id}), do: []
-  defp disabled_reply(:last_issue_claim_id), do: 0
+  defp disabled_reply(:list_requests), do: []
+  defp disabled_reply({:request_events_after, _id}), do: []
+  defp disabled_reply(:last_request_event_id), do: 0
   defp disabled_reply({:heartbeat_session, _session_id, _at}), do: :ok
   defp disabled_reply(:session_directory), do: []
   defp disabled_reply({:send_session_message, _from, _to, _body, _at}), do: :disabled
@@ -1350,14 +1583,124 @@ defmodule IxMcp.ActionLog do
     }
   end
 
-  defp issue_claim_row_to_map([id, repo, number, session_id, session, claimed_at]) do
+  # The claim step shared by claim_request and claim_issue (#3883): the
+  # guarded UPDATE, its row count, and the claimed event, inside the
+  # caller's open transaction. True means this call flipped the row.
+  defp claim_request_row(db, id, session_id, at) do
+    run(
+      db,
+      "UPDATE requests SET status = 'claimed', claimed_by = ?, claimed_at = ? WHERE id = ? AND status = 'open'",
+      [session_id, at, id]
+    )
+
+    {:ok, changes} = Sqlite3.changes(db.conn)
+    if changes == 1, do: insert_request_event(db, id, "claimed", session_id, at)
+    changes == 1
+  end
+
+  # A standing claim by the caller's own session is a win, not a loss: the
+  # client seam retries a claim whose server died after committing (#3903),
+  # and that retry must read back as the victory it already is, or the sole
+  # claimant would report losing the request to itself. Only a real session
+  # id gets this: nil belongs to every anonymous caller at once, so it can
+  # never prove the standing claim is the caller's own.
+  defp claim_reply(db, id, session_id, won) do
+    case fetch_request(db, id) do
+      nil ->
+        {:error, :not_found}
+
+      request ->
+        if won or
+             (session_id != nil and request.status == :claimed and
+                request.claimed_by == session_id) do
+          {:ok, request}
+        else
+          {:error, request}
+        end
+    end
+  end
+
+  defp insert_request_event(db, request_id, event, session_id, at) do
+    run(
+      db,
+      "INSERT INTO request_events (request_id, event, session_id, at) VALUES (?, ?, ?, ?)",
+      [request_id, event, session_id, at]
+    )
+  end
+
+  defp fetch_request(db, id) do
+    case fetch(db, @select_request <> " WHERE r.id = ?", [id]) do
+      [] -> nil
+      [row] -> request_row_to_map(row)
+    end
+  end
+
+  defp request_kind_atom("issue"), do: :issue
+  defp request_kind_atom("adhoc"), do: :adhoc
+
+  defp request_status_atom("open"), do: :open
+  defp request_status_atom("claimed"), do: :claimed
+  defp request_status_atom("done"), do: :done
+
+  defp request_event_atom("posted"), do: :posted
+  defp request_event_atom("claimed"), do: :claimed
+  defp request_event_atom("done"), do: :done
+
+  defp request_row_to_map([
+         id,
+         kind,
+         ref,
+         title,
+         body,
+         posted_by,
+         poster,
+         status,
+         claimed_by,
+         claimer,
+         posted_at,
+         claimed_at,
+         done_at
+       ]) do
     %{
       id: id,
-      repo: repo,
-      number: number,
+      kind: request_kind_atom(kind),
+      ref: ref,
+      title: title,
+      body: body,
+      posted_by: posted_by,
+      poster: poster,
+      status: request_status_atom(status),
+      claimed_by: claimed_by,
+      claimer: claimer,
+      posted_at: posted_at,
+      claimed_at: claimed_at,
+      done_at: done_at
+    }
+  end
+
+  defp request_event_row_to_map([
+         id,
+         request_id,
+         event,
+         session_id,
+         session,
+         at,
+         kind,
+         ref,
+         title,
+         body
+       ]) do
+    %{
+      id: id,
+      request_id: request_id,
+      event: request_event_atom(event),
       session_id: session_id,
       session: session,
-      claimed_at: claimed_at
+      at: at,
+      kind: request_kind_atom(kind),
+      ref: ref,
+      title: title,
+      body: body
     }
   end
 

--- a/packages/mcp-ex/lib/ix_mcp/application.ex
+++ b/packages/mcp-ex/lib/ix_mcp/application.ex
@@ -15,7 +15,7 @@ defmodule IxMcp.Application do
       │   └── IxMcp.Jobs.Job*   runs one evaluation in a monitored process
       ├── IxMcp.PrWatch.Supervisor (Task.Supervisor)  one task per PR watch
       ├── IxMcp.IssueWatch      (only when IX_MCP_STDIO=1) new-issue channel feed
-      ├── IxMcp.SessionWatch    (only when IX_MCP_STDIO=1) heartbeat + cross-session message delivery
+      ├── IxMcp.SessionWatch    (only when IX_MCP_STDIO=1) heartbeat + message/request-feed delivery
       ├── IxMcp.Agents.Harness     (AgentHarness) depth-1 subagent processes (#3700)
       ├── IxMcp.Agents.Events      subagent ledger: events, finals, graph, notifications
       └── IxMcp.MCP.Stdio       (only when IX_MCP_STDIO=1) the stdio transport

--- a/packages/mcp-ex/lib/ix_mcp/issue_watch.ex
+++ b/packages/mcp-ex/lib/ix_mcp/issue_watch.ex
@@ -12,18 +12,15 @@ defmodule IxMcp.IssueWatch do
   starts only alongside the stdio transport (`IxMcp.Application`), so
   `mix test` and IEx sessions never poll GitHub.
 
-  The same sweep also announces issue pickups (#3880): claims sessions win
-  through `IxMcp.Issues.pickup/1` land in the shared actions.db, and each
-  sweep pushes the ones this instance has not yet announced as
-  `event="picked_up"` notifications. The cursor is a per-instance claim-id
-  watermark (starting at the newest claim on boot), NOT a shared announced
-  flag: every instance on the host must tell its own client, and a shared
-  flag would let the first sweeper silence all the others.
+  Pickups no longer announce from here: an issue claim is a request on the
+  work bus (#3883), so `IxMcp.SessionWatch` delivers it with the rest of the
+  `source="requests"` feed -- that loop's cadence is seconds because it
+  talks only to the local SQLite, while this one's is set by GitHub polling
+  politeness.
   """
 
   use GenServer
 
-  alias IxMcp.ActionLog
   alias IxMcp.Cmd
   alias IxMcp.MCP.Notifier
 
@@ -54,18 +51,12 @@ defmodule IxMcp.IssueWatch do
         :ignore
 
       true ->
-        action_log = Keyword.get(opts, :action_log, ActionLog)
-
         state = %{
           gh: gh,
           owners: owners,
           interval_ms: Keyword.get(opts, :interval_ms, @interval_ms),
           since: DateTime.utc_now(:second),
-          seen: MapSet.new(),
-          action_log: action_log,
-          # Claims standing before this instance booted are old news; only
-          # pickups from here on announce (the filed-issue feed's since: now).
-          claims_since: ActionLog.last_issue_claim_id(action_log)
+          seen: MapSet.new()
         }
 
         {:ok, schedule(state)}
@@ -74,7 +65,7 @@ defmodule IxMcp.IssueWatch do
 
   @impl true
   def handle_info(:poll, state) do
-    {:noreply, state |> sweep() |> sweep_claims() |> schedule()}
+    {:noreply, state |> sweep() |> schedule()}
   end
 
   defp schedule(state) do
@@ -119,37 +110,6 @@ defmodule IxMcp.IssueWatch do
       {out, _nonzero} ->
         {:error, String.slice(out, 0, 400)}
     end
-  end
-
-  # Pickup fan-out (#3880): read past the watermark, announce, advance. The
-  # claim rows come from the shared database, so this hears every session on
-  # the host, including this instance's own pickups (harmless: the picker
-  # already knows, and one notification tells its transcript too).
-  defp sweep_claims(state) do
-    case ActionLog.issue_claims_after(state.claims_since, state.action_log) do
-      [] ->
-        state
-
-      claims ->
-        Enum.each(claims, &announce_claim/1)
-        %{state | claims_since: claims |> Enum.map(& &1.id) |> Enum.max()}
-    end
-  end
-
-  defp announce_claim(claim) do
-    ref = "#{claim.repo}##{claim.number}"
-    label = claim.session || "##{claim.session_id || "?"}"
-
-    Notifier.channel(
-      "issue picked up: #{ref} by session #{label} at #{claim.claimed_at}",
-      %{
-        "source" => "issues",
-        "event" => "picked_up",
-        "issue" => ref,
-        "session" => label,
-        "level" => "info"
-      }
-    )
   end
 
   defp announce(issue) do

--- a/packages/mcp-ex/lib/ix_mcp/issues.ex
+++ b/packages/mcp-ex/lib/ix_mcp/issues.ex
@@ -2,14 +2,15 @@ defmodule IxMcp.Issues do
   @moduledoc """
   Atomic issue pickup (#3880): `Issues.pickup/1` from any cell claims a
   GitHub issue before a session starts working it, so two agents hearing the
-  same `source="issues"` announcement (#3877) cannot both take it. The
-  arbiter is the shared actions.db every kernel instance on a host already
-  opens (`IxMcp.ActionLog`): a UNIQUE(repo, number) insert either wins the
-  claim or reads back who beat this session to it. A won claim mirrors
-  itself to GitHub with `gh issue edit --add-assignee @me`, best effort --
-  visibility off-host, never arbitration -- and `IxMcp.IssueWatch` announces
-  it to every session on the host as an `event="picked_up"` channel
-  notification.
+  same `source="issues"` announcement (#3877) cannot both take it. A veneer
+  over the request bus (#3883): the claim is a `requests` row of kind
+  `:issue` in the shared actions.db every kernel instance on a host already
+  opens (`IxMcp.ActionLog`), ensured and claimed in one transaction -- the
+  guarded UPDATE's row count either wins the claim or reads back who beat
+  this session to it. A won claim mirrors itself to GitHub with `gh issue
+  edit --add-assignee @me`, best effort -- visibility off-host, never
+  arbitration -- and `IxMcp.SessionWatch` announces it to every session on
+  the host as a `source="requests"` `event="claimed"` channel notification.
 
   Known limit, by design: actions.db is per host, so claims race across
   machines, and GitHub assignment is not compare-and-set, so it stays a
@@ -60,8 +61,11 @@ defmodule IxMcp.Issues do
     session_id = Keyword.get_lazy(opts, :session_id, fn -> Session.ids().session_id end)
 
     case ActionLog.claim_issue(repo, number, session_id, log) do
-      {:ok, claim} ->
-        {:ok, "claimed #{repo}##{number} at #{claim.claimed_at}#{assign(repo, number, opts)}"}
+      {:ok, request} ->
+        {:ok, "claimed #{repo}##{number} at #{request.claimed_at}#{assign(repo, number, opts)}"}
+
+      {:error, %{status: :done} = winner} ->
+        {:error, "already done at #{winner.done_at} (claimed by session #{label(winner)})"}
 
       {:error, winner} ->
         {:error, "claimed by session #{label(winner)} at #{winner.claimed_at}"}
@@ -91,8 +95,8 @@ defmodule IxMcp.Issues do
     end
   end
 
-  defp label(%{session: nil, session_id: id}), do: "##{id || "?"}"
-  defp label(%{session: name}), do: name
+  defp label(%{claimer: nil, claimed_by: id}), do: "##{id || "?"}"
+  defp label(%{claimer: name}), do: name
 
   defp default_gh do
     System.get_env("IX_MCP_GH") || System.find_executable("gh")

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -63,9 +63,17 @@ defmodule IxMcp.MCP.Tools do
       Issues.pickup(3880)                   claim an issue atomically BEFORE working
                                             it (also "owner/repo#n"); won claims
                                             assign @me on GitHub and announce as
-                                            event="picked_up"; a lost claim returns
+                                            source="requests"; a lost claim returns
                                             {:error, "claimed by session ..."} --
                                             pick a different issue
+      Requests.post("review PR #42", body)  offer any unit of work to every agent
+                                            on this host; it announces as a
+                                            source="requests" channel event.
+                                            Requests.pickup(id) claims one
+                                            atomically BEFORE working it,
+                                            Requests.done(id) when finished,
+                                            Requests.list() shows the board
+                                            (open first)
       Sessions.list()                       the session directory: every kernel
                                             instance on this host with its name,
                                             topic, and heartbeat liveness -- check

--- a/packages/mcp-ex/lib/ix_mcp/requests.ex
+++ b/packages/mcp-ex/lib/ix_mcp/requests.ex
@@ -1,0 +1,155 @@
+defmodule IxMcp.Requests do
+  @moduledoc """
+  The per-host work bus (#3883), generalizing issue pickup (#3880): any unit
+  of work -- "review this diff", "run this eval", "take over this PR" -- can
+  be posted from any cell, and any agent on the host can claim it
+  atomically. `post/3` offers work (a `requests` row in the shared
+  actions.db, announced to every session as a `source="requests"` channel
+  event); `pickup/2` claims one before working it, a single guarded UPDATE
+  in the single-writer `IxMcp.ActionLog` whose row count decides the race;
+  `done/2` finishes it; `list/1` shows the board, open first.
+  `IxMcp.Issues.pickup/1` is a veneer over this bus: an issue claim is a
+  request of kind `:issue` whose ref is the `"owner/repo#n"`.
+
+  Same scope limit as the rest of the shared database: the bus is per host.
+  Cross-host requests would ride the fleet, out of scope here (#3883).
+  """
+
+  alias IxMcp.ActionLog
+  alias IxMcp.Session
+
+  @doc """
+  Offer work to every agent on the host: inserts an open request and
+  announces it (every instance's `IxMcp.SessionWatch` delivers a
+  `source="requests"` `event="posted"` channel notification within
+  seconds). `kind: :issue` with `ref: "owner/repo#n"` posts a GitHub-backed
+  request instead of the default `:adhoc`; posting a ref that already has a
+  row reads the standing row back (idempotent ensure) and says so.
+
+  Options exist for tests: `:action_log` (the shared log), `:session_id`
+  (the posting sessions row).
+  """
+  @spec post(String.t(), String.t() | nil, keyword()) :: {:ok, String.t()} | {:error, String.t()}
+  def post(title, body \\ nil, opts \\ []) when is_binary(title) do
+    log = Keyword.get(opts, :action_log, ActionLog)
+    session_id = Keyword.get_lazy(opts, :session_id, fn -> Session.ids().session_id end)
+
+    with {:ok, kind, ref} <- kind_and_ref(opts) do
+      case ActionLog.post_request(kind, ref, title, body, session_id, log) do
+        # An adhoc post always inserts; an issue-kind post is an ensure, so
+        # the row may predate this call -- report its standing state rather
+        # than claim a fresh offer.
+        {:ok, %{kind: :adhoc} = request} ->
+          {:ok,
+           "posted request ##{request.id}: #{request.title}; " <>
+             "every session on the host hears it"}
+
+        {:ok, request} ->
+          {:ok, "request ##{request.id} for #{ref}: #{describe(request)}"}
+
+        :disabled ->
+          {:error, "action log disabled (#3539); no shared database to post on"}
+      end
+    end
+  end
+
+  @doc """
+  Claim request `id` atomically BEFORE working it. `{:ok, detail}` means
+  this session won -- do the work, then `done/2` it. A lost claim returns
+  `{:error, "claimed by session <label> ..."}`: pick different work.
+  Re-picking a request this session already holds is a win, not a loss
+  (#3903). Same test options as `post/3`.
+  """
+  @spec pickup(integer(), keyword()) :: {:ok, String.t()} | {:error, String.t()}
+  def pickup(id, opts \\ []) when is_integer(id) do
+    log = Keyword.get(opts, :action_log, ActionLog)
+    session_id = Keyword.get_lazy(opts, :session_id, fn -> Session.ids().session_id end)
+
+    case ActionLog.claim_request(id, session_id, log) do
+      {:ok, request} ->
+        {:ok, "claimed request ##{request.id} (#{request.title}) at #{request.claimed_at}"}
+
+      {:error, :not_found} ->
+        {:error, "no request ##{id}; Requests.list() shows the board"}
+
+      {:error, request} ->
+        {:error, describe(request)}
+
+      :disabled ->
+        # No arbiter, no claim: pretending to win here is exactly the double
+        # pickup this module exists to prevent.
+        {:error, "action log disabled (#3539); no arbiter to claim through"}
+    end
+  end
+
+  @doc """
+  Mark claimed request `id` done, announcing `event="done"` to the host.
+  Finishing an already-done request is idempotent; a still-open one is an
+  error -- claim what you work. Same test options as `post/3`.
+  """
+  @spec done(integer(), keyword()) :: {:ok, String.t()} | {:error, String.t()}
+  def done(id, opts \\ []) when is_integer(id) do
+    log = Keyword.get(opts, :action_log, ActionLog)
+    session_id = Keyword.get_lazy(opts, :session_id, fn -> Session.ids().session_id end)
+
+    case ActionLog.finish_request(id, session_id, log) do
+      {:ok, request} ->
+        {:ok, "request ##{request.id} (#{request.title}) done at #{request.done_at}"}
+
+      {:error, :not_found} ->
+        {:error, "no request ##{id}; Requests.list() shows the board"}
+
+      {:error, request} ->
+        {:error, "request ##{request.id} is still open; pickup before finishing it"}
+
+      :disabled ->
+        {:error, "action log disabled (#3539); no shared database to record it"}
+    end
+  end
+
+  @doc """
+  The request board: every request as a map, open first (then claimed, then
+  done), newest first within a status. Same test options as `post/3`.
+  """
+  @spec list(keyword()) :: [ActionLog.request()]
+  def list(opts \\ []) do
+    ActionLog.list_requests(Keyword.get(opts, :action_log, ActionLog))
+  end
+
+  defp kind_and_ref(opts) do
+    case {Keyword.get(opts, :kind, :adhoc), Keyword.get(opts, :ref)} do
+      {:adhoc, nil} ->
+        {:ok, :adhoc, nil}
+
+      {:adhoc, ref} ->
+        {:error, "ref #{inspect(ref)} needs kind: :issue; an adhoc request has no ref"}
+
+      {:issue, ref} when is_binary(ref) ->
+        if Regex.match?(~r{\A[\w.-]+/[\w.-]+#\d+\z}, ref) do
+          {:ok, :issue, ref}
+        else
+          {:error, "unrecognized issue ref #{inspect(ref)}; pass \"owner/repo#n\""}
+        end
+
+      {:issue, nil} ->
+        {:error, "kind: :issue needs ref: \"owner/repo#n\""}
+
+      {kind, _ref} ->
+        {:error, "unknown kind #{inspect(kind)}; post :adhoc (default) or :issue"}
+    end
+  end
+
+  defp describe(%{status: :open} = request), do: "open, posted by session #{poster(request)}"
+
+  defp describe(%{status: :claimed} = request),
+    do: "claimed by session #{claimer(request)} at #{request.claimed_at}"
+
+  defp describe(%{status: :done} = request),
+    do: "done at #{request.done_at} (claimed by session #{claimer(request)})"
+
+  defp poster(%{poster: nil, posted_by: id}), do: "##{id || "?"}"
+  defp poster(%{poster: name}), do: name
+
+  defp claimer(%{claimer: nil, claimed_by: id}), do: "##{id || "?"}"
+  defp claimer(%{claimer: name}), do: name
+end

--- a/packages/mcp-ex/lib/ix_mcp/session_watch.ex
+++ b/packages/mcp-ex/lib/ix_mcp/session_watch.ex
@@ -1,11 +1,15 @@
 defmodule IxMcp.SessionWatch do
   @moduledoc """
-  This instance's liveness heartbeat and message delivery loop (#3881).
+  This instance's liveness heartbeat and shared-bus delivery loop (#3881).
   Every tick -- seconds, because messaging is a conversation -- it stamps
-  the session's `last_seen_at` in the shared actions.db and sweeps
-  `session_messages` past a per-instance watermark, pushing each row
-  addressed to this session (or broadcast) into the agent's context as a
-  `source="sessions"` channel notification naming the sender.
+  the session's `last_seen_at` in the shared actions.db and sweeps two
+  per-instance watermarks: `session_messages` rows addressed to this
+  session (or broadcast) arrive as `source="sessions"` channel
+  notifications naming the sender, and `request_events` (#3883) as
+  `source="requests"` notifications with `event` posted/claimed/done -- the
+  request feed hears every session on the host, this instance's own moves
+  included (harmless: the actor already knows, and one notification tells
+  its transcript too).
 
   Deliberately its own GenServer rather than a bolt-on to `IxMcp.IssueWatch`:
   that loop's 60s cadence is set by GitHub polling politeness, while this
@@ -13,11 +17,13 @@ defmodule IxMcp.SessionWatch do
   only alongside the stdio transport (`IxMcp.Application`), so `mix test`
   and IEx sessions neither heartbeat nor deliver.
 
-  The watermark starts at the newest message on boot. That skips only
-  broadcasts from before this instance existed -- old news, the claim
+  Both watermarks start at the newest row on boot. For messages that skips
+  only broadcasts from before this instance existed -- old news, the claim
   feed's exact call (#3880) -- because addressed mail cannot predate its
   address: sessions rows are per instance and never reused, so a message to
-  this session's id can only be written after this instance created the row.
+  this session's id can only be written after this instance created the
+  row. For requests it skips pre-boot events the same way the claim feed
+  did, while `Requests.list()` still shows any standing open work.
   """
 
   use GenServer
@@ -48,7 +54,8 @@ defmodule IxMcp.SessionWatch do
       action_log: action_log,
       session_id: session_id,
       interval_ms: Keyword.get(opts, :interval_ms, @interval_ms),
-      cursor: ActionLog.last_session_message_id(action_log)
+      messages_cursor: ActionLog.last_session_message_id(action_log),
+      requests_cursor: ActionLog.last_request_event_id(action_log)
     }
 
     # Stamp now, not one tick from now: the instance is live from boot.
@@ -67,15 +74,66 @@ defmodule IxMcp.SessionWatch do
     state
   end
 
-  # Deliver everything past the watermark and advance it as one fold: the
-  # cursor stays monotone with no empty-sweep special case.
+  # Deliver everything past each watermark and advance it as one fold: the
+  # cursor stays monotone with no empty-sweep special case. One sweep shape
+  # for both feeds -- the fetch and the announcement differ, the cursor
+  # discipline must not.
   defp sweep(state) do
-    state.cursor
-    |> ActionLog.session_messages_after(state.session_id, state.action_log)
-    |> Enum.reduce(state, fn message, acc ->
-      announce(message)
-      %{acc | cursor: max(acc.cursor, message.id)}
+    state
+    |> sweep_feed(
+      :messages_cursor,
+      &ActionLog.session_messages_after(&1, state.session_id, state.action_log),
+      &announce/1
+    )
+    |> sweep_feed(
+      :requests_cursor,
+      &ActionLog.request_events_after(&1, state.action_log),
+      &announce_request/1
+    )
+  end
+
+  defp sweep_feed(state, cursor_key, fetch, announce) do
+    state
+    |> Map.fetch!(cursor_key)
+    |> fetch.()
+    |> Enum.reduce(state, fn row, acc ->
+      announce.(row)
+      Map.update!(acc, cursor_key, &max(&1, row.id))
     end)
+  end
+
+  defp announce_request(event) do
+    label = event.session || "##{event.session_id || "?"}"
+
+    # Issue rows ensured by a pickup use the ref as their title; only name
+    # the ref separately when a poster gave the request a real one.
+    what =
+      if event.ref && event.ref != event.title,
+        do: "#{event.title} (#{event.ref})",
+        else: event.title
+
+    detail =
+      case event.event do
+        :posted ->
+          body = if event.body, do: "\n#{String.slice(event.body, 0, @max_body_bytes)}", else: ""
+          "#{body}\npickup: Requests.pickup(#{event.request_id})"
+
+        _claimed_or_done ->
+          ""
+      end
+
+    Notifier.channel(
+      "request #{event.event}: ##{event.request_id} #{what} by session #{label}#{detail}",
+      %{
+        "source" => "requests",
+        "event" => Atom.to_string(event.event),
+        "request" => event.request_id,
+        "kind" => Atom.to_string(event.kind),
+        "ref" => event.ref,
+        "session" => label,
+        "level" => "info"
+      }
+    )
   end
 
   defp announce(message) do

--- a/packages/mcp-ex/lib/ix_mcp/workspace.ex
+++ b/packages/mcp-ex/lib/ix_mcp/workspace.ex
@@ -18,7 +18,8 @@ defmodule IxMcp.Workspace do
              "alias IxMcp.Read; alias IxMcp.Edit; alias IxMcp.PrWatch; alias IxMcp.Tui; " <>
              "alias IxMcp.TuiLocal; alias IxMcp.Gmail; alias IxMcp.Imsg; alias IxMcp.Contacts; " <>
              "alias IxMcp.Kernel, as: Ix; alias IxMcp.Agents; alias IxMcp.Memory; " <>
-             "alias IxMcp.Ask; alias IxMcp.Cmd; alias IxMcp.Issues; alias IxMcp.Sessions"
+             "alias IxMcp.Ask; alias IxMcp.Cmd; alias IxMcp.Issues; alias IxMcp.Sessions; " <>
+             "alias IxMcp.Requests"
 
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do

--- a/packages/mcp-ex/test/action_log_test.exs
+++ b/packages/mcp-ex/test/action_log_test.exs
@@ -319,8 +319,8 @@ defmodule IxMcp.ActionLogTest do
     :ok = ActionLog.finish_action(action_id, "done", false, 3, log)
     assert [%{status: "done", stack: nil, line: nil} | _] = ActionLog.recent(10, log)
 
-    # The 2 -> ... -> 7 steps stamped the file on their way through (index#3539).
-    assert user_version(path) == 7
+    # The 2 -> ... -> 8 steps stamped the file on their way through (index#3539).
+    assert user_version(path) == 8
   end
 
   test "a v1 database migrates losslessly to the normalized schema, once" do
@@ -403,8 +403,8 @@ defmodule IxMcp.ActionLogTest do
 
     stop_supervised!(:migrate)
 
-    # The ladder ran 1 -> 2 -> ... -> 7 and left the stamp behind (index#3539).
-    assert user_version(path) == 7
+    # The ladder ran 1 -> 2 -> ... -> 8 and left the stamp behind (index#3539).
+    assert user_version(path) == 8
 
     # The migrated file is the v2 shape on disk: normalized columns, no v1
     # leftovers, and a reopen (no-op detection) does not duplicate rows.
@@ -442,10 +442,11 @@ defmodule IxMcp.ActionLogTest do
     assert tables ==
              [
                ["actions"],
-               ["issue_claims"],
                ["job_output"],
                ["jobs"],
                ["outbox"],
+               ["request_events"],
+               ["requests"],
                ["session_messages"],
                ["sessions"],
                ["topics"]
@@ -472,7 +473,7 @@ defmodule IxMcp.ActionLogTest do
   test "a fresh database is created stamped with the current schema version" do
     path = tmp_db()
     start_supervised!({ActionLog, path: path, name: :action_log_fresh_stamp})
-    assert user_version(path) == 7
+    assert user_version(path) == 8
   end
 
   test "an unstamped file already at the current schema is stamped, not rewritten" do
@@ -497,7 +498,7 @@ defmodule IxMcp.ActionLogTest do
 
     reopened = start_supervised!({ActionLog, path: path, name: :action_log_stamp_b})
     assert [%{intent: "keep"}] = ActionLog.recent(10, reopened)
-    assert user_version(path) == 7
+    assert user_version(path) == 8
   end
 
   test "an unstamped pre-line file (the #3536 shape) sniffs as v3 and gains the line column" do
@@ -522,19 +523,26 @@ defmodule IxMcp.ActionLogTest do
     log = start_supervised!({ActionLog, path: path, name: :action_log_pre_line})
 
     assert [%{intent: "pre-line row", status: "done", line: nil}] = ActionLog.recent(10, log)
-    assert user_version(path) == 7
+    assert user_version(path) == 8
   end
 
-  test "the unique constraint arbitrates issue claims (#3880)" do
+  test "the guarded update arbitrates issue claims on the request bus (#3880, #3883)" do
     log = start_supervised!({ActionLog, path: ":memory:", name: :action_log_claims})
 
     winner = ActionLog.create_session("winner", log)
     loser = ActionLog.create_session(nil, log)
 
-    assert ActionLog.last_issue_claim_id(log) == 0
+    assert ActionLog.last_request_event_id(log) == 0
 
     assert {:ok, claim} = ActionLog.claim_issue("indexable-inc/index", 3880, winner, log)
-    assert %{repo: "indexable-inc/index", number: 3880, session: "winner"} = claim
+
+    assert %{
+             kind: :issue,
+             ref: "indexable-inc/index#3880",
+             status: :claimed,
+             claimer: "winner"
+           } = claim
+
     assert {:ok, %DateTime{}, 0} = DateTime.from_iso8601(claim.claimed_at)
 
     # The holder re-claiming its own issue reads back as the win it already
@@ -546,23 +554,28 @@ defmodule IxMcp.ActionLogTest do
     # The loser reads the standing claim back, name included.
     assert {:error, standing} = ActionLog.claim_issue("indexable-inc/index", 3880, loser, log)
     assert standing.id == claim.id
-    assert standing.session == "winner"
+    assert standing.claimer == "winner"
 
     # Same number on another repo is a different claim.
     assert {:ok, other} = ActionLog.claim_issue("indexable-inc/ix", 3880, loser, log)
-    assert other.session == nil
+    assert other.claimer == nil
 
-    # The watermark cursor sees exactly the claims past it, oldest first.
-    assert [%{number: 3880}, %{repo: "indexable-inc/ix"}] = ActionLog.issue_claims_after(0, log)
-    assert [%{repo: "indexable-inc/ix"}] = ActionLog.issue_claims_after(claim.id, log)
-    assert ActionLog.last_issue_claim_id(log) == other.id
+    # A pickup-born row was never on offer, so each claim wrote exactly one
+    # claimed event (no posted), and the watermark cursor sees exactly the
+    # events past it, oldest first -- the idempotent re-claim added nothing.
+    assert [first, second] = ActionLog.request_events_after(0, log)
+    assert %{event: :claimed, request_id: claimed_id, ref: "indexable-inc/index#3880"} = first
+    assert claimed_id == claim.id
+    assert %{event: :claimed, ref: "indexable-inc/ix#3880"} = second
+    assert [^second] = ActionLog.request_events_after(first.id, log)
+    assert ActionLog.last_request_event_id(log) == second.id
   end
 
   test "a nil-session re-claim is a loss, never a win (#3903)" do
     log = start_supervised!({ActionLog, path: ":memory:", name: :action_log_nil_claims})
 
     assert {:ok, claim} = ActionLog.claim_issue("indexable-inc/index", 3903, nil, log)
-    assert claim.session_id == nil
+    assert claim.claimed_by == nil
 
     # nil is every anonymous caller at once, so it can never prove the
     # standing claim is the caller's own: the retry-across-restart carve-out
@@ -570,6 +583,174 @@ defmodule IxMcp.ActionLogTest do
     # anonymous sessions would both walk away believing they won.
     assert {:error, standing} = ActionLog.claim_issue("indexable-inc/index", 3903, nil, log)
     assert standing.id == claim.id
+  end
+
+  test "a request walks post -> claim -> done, events in the same transactions (#3883)" do
+    log = start_supervised!({ActionLog, path: ":memory:", name: :action_log_requests})
+
+    poster = ActionLog.create_session("poster", log)
+    worker = ActionLog.create_session("worker", log)
+    rival = ActionLog.create_session("rival", log)
+
+    assert {:ok, request} =
+             ActionLog.post_request(:adhoc, nil, "review the diff", "the body", poster, log)
+
+    assert %{
+             kind: :adhoc,
+             ref: nil,
+             title: "review the diff",
+             body: "the body",
+             status: :open,
+             poster: "poster",
+             claimed_by: nil
+           } = request
+
+    # Two adhoc posts with the same title are two offers: NULL refs never
+    # unique-conflict.
+    assert {:ok, twin} = ActionLog.post_request(:adhoc, nil, "review the diff", nil, poster, log)
+    assert twin.id != request.id
+
+    # The guarded UPDATE's row count decides the race: the winner flips the
+    # row, the loser reads the standing claim back, and the holder's own
+    # re-claim stays a win (#3903).
+    assert {:ok, claimed} = ActionLog.claim_request(request.id, worker, log)
+    assert %{status: :claimed, claimer: "worker"} = claimed
+    assert {:ok, ^claimed} = ActionLog.claim_request(request.id, worker, log)
+    assert {:error, standing} = ActionLog.claim_request(request.id, rival, log)
+    assert standing.claimer == "worker"
+    assert {:error, :not_found} = ActionLog.claim_request(999_999, rival, log)
+
+    # Done requires claimed: finishing open work is refused, finishing done
+    # work is idempotent.
+    assert {:error, %{status: :open}} = ActionLog.finish_request(twin.id, worker, log)
+    assert {:ok, done} = ActionLog.finish_request(request.id, worker, log)
+    assert %{status: :done} = done
+    assert {:ok, %DateTime{}, 0} = DateTime.from_iso8601(done.done_at)
+    assert {:ok, ^done} = ActionLog.finish_request(request.id, worker, log)
+    assert {:error, :not_found} = ActionLog.finish_request(999_999, worker, log)
+
+    # Exactly one event per mutation, oldest first: two posts, one claim,
+    # one done -- the losses and idempotent retries added nothing.
+    assert [
+             %{
+               event: :posted,
+               request_id: posted_id,
+               session: "poster",
+               title: "review the diff"
+             },
+             %{event: :posted, request_id: twin_id},
+             %{event: :claimed, session: "worker"},
+             %{event: :done, session: "worker"}
+           ] = ActionLog.request_events_after(0, log)
+
+    assert posted_id == request.id
+    assert twin_id == twin.id
+
+    # The board lists open first, then claimed, then done.
+    assert [%{id: open_id, status: :open}, %{status: :done}] = ActionLog.list_requests(log)
+    assert open_id == twin.id
+  end
+
+  test "an issue-kind post is an idempotent ensure on the unique ref (#3883)" do
+    log = start_supervised!({ActionLog, path: ":memory:", name: :action_log_request_ensure})
+
+    poster = ActionLog.create_session("poster", log)
+    worker = ActionLog.create_session("worker", log)
+
+    assert {:ok, request} =
+             ActionLog.post_request(
+               :issue,
+               "indexable-inc/index#3883",
+               "generalize pickup",
+               nil,
+               poster,
+               log
+             )
+
+    assert %{kind: :issue, ref: "indexable-inc/index#3883", status: :open} = request
+
+    # Re-posting the ref reads the standing row back, whatever its status,
+    # and announces nothing new.
+    assert {:ok, ^request} =
+             ActionLog.post_request(
+               :issue,
+               "indexable-inc/index#3883",
+               "another title",
+               nil,
+               worker,
+               log
+             )
+
+    # A pickup of the posted issue claims the SAME row: the veneer and the
+    # board are one table.
+    assert {:ok, claimed} = ActionLog.claim_issue("indexable-inc/index", 3883, worker, log)
+    assert claimed.id == request.id
+    assert claimed.title == "generalize pickup"
+
+    assert [%{event: :posted}, %{event: :claimed}] = ActionLog.request_events_after(0, log)
+  end
+
+  test "a v7 database folds its issue claims into requests and drops the table (#3883)" do
+    path = tmp_db()
+
+    # The exact v7 shape (#3881) with a standing claim, as a pre-#3883
+    # binary leaves it on disk.
+    {:ok, conn} = Sqlite3.open(path)
+
+    for statement <- [
+          "CREATE TABLE sessions (id INTEGER PRIMARY KEY, name TEXT, started_at TEXT NOT NULL, last_seen_at TEXT)",
+          "CREATE TABLE topics (id INTEGER PRIMARY KEY, session_id INTEGER NOT NULL REFERENCES sessions(id), name TEXT NOT NULL, started_at TEXT NOT NULL)",
+          "CREATE TABLE actions (id INTEGER PRIMARY KEY, at TEXT NOT NULL, session_id INTEGER NOT NULL REFERENCES sessions(id), topic_id INTEGER REFERENCES topics(id), tool TEXT NOT NULL, intent TEXT, arguments TEXT NOT NULL, is_error INTEGER NOT NULL, elapsed_ms INTEGER NOT NULL, status TEXT NOT NULL DEFAULT 'done', stack TEXT, stack_at TEXT, line INTEGER)",
+          "CREATE TABLE jobs (id TEXT PRIMARY KEY, session_id INTEGER REFERENCES sessions(id), action_id INTEGER REFERENCES actions(id), intent TEXT, session_name TEXT, topic_name TEXT, code TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'running', watch INTEGER NOT NULL DEFAULT 0, result TEXT, output_bytes INTEGER NOT NULL DEFAULT 0, output_dropped INTEGER NOT NULL DEFAULT 0, started_at TEXT NOT NULL, finished_at TEXT, elapsed_ms INTEGER)",
+          "CREATE TABLE job_output (job_id TEXT NOT NULL REFERENCES jobs(id), seq INTEGER NOT NULL, chunk TEXT NOT NULL, PRIMARY KEY (job_id, seq))",
+          "CREATE TABLE outbox (id INTEGER PRIMARY KEY, job_id TEXT, intent TEXT, status TEXT NOT NULL, elapsed_ms INTEGER, result TEXT, created_at TEXT NOT NULL, acked INTEGER NOT NULL DEFAULT 0)",
+          "CREATE TABLE issue_claims (id INTEGER PRIMARY KEY, repo TEXT NOT NULL, number INTEGER NOT NULL, session_id INTEGER REFERENCES sessions(id), claimed_at TEXT NOT NULL, UNIQUE(repo, number))",
+          "CREATE TABLE session_messages (id INTEGER PRIMARY KEY, from_session INTEGER NOT NULL REFERENCES sessions(id), to_session INTEGER REFERENCES sessions(id), body TEXT NOT NULL, created_at TEXT NOT NULL)",
+          "INSERT INTO sessions (id, name, started_at, last_seen_at) VALUES (1, 'claimant', '2026-07-20T10:00:00Z', NULL)",
+          "INSERT INTO issue_claims (repo, number, session_id, claimed_at) VALUES ('indexable-inc/index', 3880, 1, '2026-07-20T10:00:01Z')",
+          "PRAGMA user_version = 7"
+        ] do
+      :ok = Sqlite3.execute(conn, statement)
+    end
+
+    :ok = Sqlite3.close(conn)
+
+    log = start_supervised!({ActionLog, path: path, name: :action_log_v7_to_v8})
+
+    # The claim crossed over as a claimed issue-kind request (the ref doubles
+    # as the title -- the claim never carried one, and nobody posted it)...
+    assert [request] = ActionLog.list_requests(log)
+
+    assert %{
+             kind: :issue,
+             ref: "indexable-inc/index#3880",
+             title: "indexable-inc/index#3880",
+             status: :claimed,
+             posted_by: nil,
+             claimed_by: 1,
+             claimer: "claimant",
+             claimed_at: "2026-07-20T10:00:01Z"
+           } = request
+
+    # ...still held against a rival claim, with no synthesized events (the
+    # feed announces news; a migrated claim was already heard).
+    assert {:error, %{claimer: "claimant"}} =
+             ActionLog.claim_issue("indexable-inc/index", 3880, nil, log)
+
+    assert ActionLog.request_events_after(0, log) == []
+
+    # The old table is gone and the stamp moved.
+    assert user_version(path) == 8
+
+    {:ok, conn} = Sqlite3.open(path)
+
+    {:ok, statement} =
+      Sqlite3.prepare(conn, "SELECT name FROM sqlite_master WHERE name = 'issue_claims'")
+
+    {:ok, leftovers} = Sqlite3.fetch_all(conn, statement)
+    :ok = Sqlite3.release(conn, statement)
+    :ok = Sqlite3.close(conn)
+    assert leftovers == []
   end
 
   test "the message cursor delivers addressed mail and broadcasts, never own sends (#3881)" do
@@ -633,7 +814,7 @@ defmodule IxMcp.ActionLogTest do
 
     # The refusal names both versions, so the operator knows which side moves.
     assert output =~ "user_version 9000"
-    assert output =~ "supported 7"
+    assert output =~ "supported 8"
     assert output =~ "index#3539"
 
     # The server stays useful: writes are absorbed, reads answer empty.
@@ -652,10 +833,14 @@ defmodule IxMcp.ActionLogTest do
     assert ActionLog.sessions(log) == []
     assert ActionLog.topics(log) == []
 
-    # With no arbiter there is no claim to win (#3880).
+    # With no arbiter there is no claim to win, and no bus to post on (#3883).
     assert ActionLog.claim_issue("indexable-inc/index", 1, session_id, log) == :disabled
-    assert ActionLog.issue_claims_after(0, log) == []
-    assert ActionLog.last_issue_claim_id(log) == 0
+    assert ActionLog.post_request(:adhoc, nil, "t", nil, session_id, log) == :disabled
+    assert ActionLog.claim_request(1, session_id, log) == :disabled
+    assert ActionLog.finish_request(1, session_id, log) == :disabled
+    assert ActionLog.list_requests(log) == []
+    assert ActionLog.request_events_after(0, log) == []
+    assert ActionLog.last_request_event_id(log) == 0
 
     # And no bus to carry a message (#3881).
     assert ActionLog.heartbeat_session(session_id, log) == :ok

--- a/packages/mcp-ex/test/ix_mcp/issue_watch_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/issue_watch_test.exs
@@ -1,7 +1,6 @@
 defmodule IxMcp.IssueWatchTest do
   use ExUnit.Case, async: false
 
-  alias IxMcp.ActionLog
   alias IxMcp.IssueWatch
   alias IxMcp.MCP.Notifier
 
@@ -71,58 +70,6 @@ defmodule IxMcp.IssueWatchTest do
     # the unchanged search result instead of re-announcing it.
     refute_receive {:mcp_send,
                     %{"params" => %{"meta" => %{"issue" => "indexable-inc/index#3877"}}}},
-                   200
-  end
-
-  test "announces a pickup claim once, skipping claims that predate boot", %{tmp_dir: dir} do
-    # Own ActionLog instance: the sweep must be driven by this test's claims
-    # alone, not whatever the globally running log accumulates.
-    log = :"issue_watch_claims_log_#{System.unique_integer([:positive])}"
-    start_supervised!({ActionLog, path: ":memory:", name: log})
-
-    # gh answers every issue search empty; only the claims sweep speaks.
-    gh = Path.join(dir, "gh")
-    File.write!(gh, "#!/bin/sh\necho '[]'\n")
-    File.chmod!(gh, 0o755)
-
-    stale = ActionLog.create_session("stale", log)
-    {:ok, _claim} = ActionLog.claim_issue("indexable-inc/index", 4200, stale, log)
-
-    Notifier.register(self())
-    _ = :sys.get_state(Notifier)
-
-    start_supervised!(
-      {IssueWatch,
-       gh: gh,
-       owners: ["indexable-inc"],
-       interval_ms: 25,
-       name: :issue_watch_claims_under_test,
-       action_log: log}
-    )
-
-    claimer = ActionLog.create_session("claimer", log)
-    {:ok, _claim} = ActionLog.claim_issue("indexable-inc/index", 4201, claimer, log)
-
-    assert_receive {:mcp_send,
-                    %{
-                      "method" => "notifications/claude/channel",
-                      "params" =>
-                        %{
-                          "meta" => %{
-                            "source" => "issues",
-                            "event" => "picked_up",
-                            "issue" => "indexable-inc/index#4201"
-                          }
-                        } = params
-                    }},
-                   5_000
-
-    assert params["meta"]["session"] == "claimer"
-    assert params["content"] =~ "issue picked up: indexable-inc/index#4201"
-
-    # The watermark must swallow both the already-announced claim and the
-    # one standing before this watcher booted.
-    refute_receive {:mcp_send, %{"params" => %{"meta" => %{"event" => "picked_up"}}}},
                    200
   end
 end

--- a/packages/mcp-ex/test/ix_mcp/issues_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/issues_test.exs
@@ -62,7 +62,8 @@ defmodule IxMcp.IssuesTest do
     assert detail =~ "claimed indexable-inc/index#4003"
     assert detail =~ "not mirrored"
 
-    assert [%{repo: "indexable-inc/index", number: 4003}] = ActionLog.issue_claims_after(0, log)
+    assert [%{kind: :issue, ref: "indexable-inc/index#4003", status: :claimed}] =
+             ActionLog.list_requests(log)
   end
 
   test "a failed GitHub mirror does not lose a won claim", %{tmp_dir: dir, log: log} do
@@ -92,6 +93,6 @@ defmodule IxMcp.IssuesTest do
   test "a malformed ref is rejected without touching the arbiter", %{log: log} do
     assert {:error, message} = Issues.pickup("not-a-ref", action_log: log, gh: nil)
     assert message =~ ~s(pass an integer or "owner/repo#n")
-    assert [] = ActionLog.issue_claims_after(0, log)
+    assert [] = ActionLog.list_requests(log)
   end
 end

--- a/packages/mcp-ex/test/ix_mcp/requests_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/requests_test.exs
@@ -1,0 +1,103 @@
+defmodule IxMcp.RequestsTest do
+  use ExUnit.Case, async: false
+
+  alias IxMcp.ActionLog
+  alias IxMcp.Requests
+
+  # Own ActionLog instance (in-memory, own name): requests must never land
+  # in the globally running log, where a leaked IX_MCP_STDIO=1 application
+  # boot has a real SessionWatch sweeping (see issue_watch_test.exs).
+  setup do
+    name = :"requests_test_log_#{System.unique_integer([:positive])}"
+    start_supervised!({ActionLog, path: ":memory:", name: name})
+    %{log: name}
+  end
+
+  test "post, pickup, done walk the lifecycle; the board lists open first", %{log: log} do
+    poster = ActionLog.create_session("poster", log)
+    worker = ActionLog.create_session("worker", log)
+
+    assert {:ok, detail} =
+             Requests.post("review the diff", "the body", action_log: log, session_id: poster)
+
+    assert detail =~ "posted request #"
+
+    assert [%{id: id, title: "review the diff", body: "the body", status: :open}] =
+             Requests.list(action_log: log)
+
+    assert {:ok, detail} = Requests.pickup(id, action_log: log, session_id: worker)
+    assert detail =~ "claimed request ##{id} (review the diff) at "
+
+    # The board sorts the still-open offer ahead of the claimed one.
+    assert {:ok, _detail} =
+             Requests.post("second offer", nil, action_log: log, session_id: poster)
+
+    assert [%{title: "second offer", status: :open}, %{id: ^id, status: :claimed}] =
+             Requests.list(action_log: log)
+
+    assert {:ok, detail} = Requests.done(id, action_log: log, session_id: worker)
+    assert detail =~ "request ##{id} (review the diff) done at "
+  end
+
+  test "a lost pickup names the winner; finishing open work is refused", %{log: log} do
+    poster = ActionLog.create_session("poster", log)
+    winner = ActionLog.create_session("winner", log)
+    loser = ActionLog.create_session("loser", log)
+
+    {:ok, _detail} = Requests.post("contended", nil, action_log: log, session_id: poster)
+    [%{id: id}] = Requests.list(action_log: log)
+
+    assert {:ok, _detail} = Requests.pickup(id, action_log: log, session_id: winner)
+    assert {:error, message} = Requests.pickup(id, action_log: log, session_id: loser)
+    assert message =~ "claimed by session winner at "
+
+    {:ok, _detail} = Requests.post("untouched", nil, action_log: log, session_id: poster)
+    [%{id: open_id, status: :open} | _rest] = Requests.list(action_log: log)
+
+    assert {:error, message} = Requests.done(open_id, action_log: log, session_id: winner)
+    assert message =~ "still open"
+
+    assert {:error, message} = Requests.pickup(999_999, action_log: log, session_id: loser)
+    assert message =~ "no request #999999"
+  end
+
+  test "an issue-kind post needs a well-formed ref and ensures idempotently", %{log: log} do
+    poster = ActionLog.create_session("poster", log)
+
+    assert {:error, message} = Requests.post("t", nil, kind: :issue, action_log: log)
+    assert message =~ ~s(needs ref: "owner/repo#n")
+
+    assert {:error, message} =
+             Requests.post("t", nil, kind: :issue, ref: "not-a-ref", action_log: log)
+
+    assert message =~ "unrecognized issue ref"
+
+    assert {:error, message} = Requests.post("t", nil, ref: "owner/repo#1", action_log: log)
+    assert message =~ "needs kind: :issue"
+
+    # An issue-kind post is an ensure, so its detail reports standing state
+    # rather than claiming a fresh offer.
+    assert {:ok, detail} =
+             Requests.post("take over the PR", nil,
+               kind: :issue,
+               ref: "indexable-inc/index#3883",
+               action_log: log,
+               session_id: poster
+             )
+
+    assert detail =~ "for indexable-inc/index#3883: open, posted by session poster"
+
+    # Re-posting the same ref reads the standing row back instead of
+    # offering the work twice.
+    assert {:ok, detail} =
+             Requests.post("another title", nil,
+               kind: :issue,
+               ref: "indexable-inc/index#3883",
+               action_log: log,
+               session_id: poster
+             )
+
+    assert detail =~ "open, posted by session poster"
+    assert [%{title: "take over the PR"}] = Requests.list(action_log: log)
+  end
+end

--- a/packages/mcp-ex/test/ix_mcp/session_watch_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/session_watch_test.exs
@@ -85,6 +85,78 @@ defmodule IxMcp.SessionWatchTest do
                    200
   end
 
+  test "delivers the request feed once, skipping pre-boot events (#3883)", %{log: log} do
+    me = ActionLog.create_session("request-watcher", log)
+    poster = ActionLog.create_session("request-poster", log)
+    worker = ActionLog.create_session("request-worker", log)
+
+    # An event standing before the watch boots is old news: the watermark
+    # must swallow it (the claim feed's exact call, #3880).
+    {:ok, _pre} = ActionLog.post_request(:adhoc, nil, "pre-boot offer", nil, poster, log)
+
+    Notifier.register(self())
+    _ = :sys.get_state(Notifier)
+
+    start_supervised!(
+      {SessionWatch,
+       action_log: log, session_id: me, interval_ms: 25, name: :session_watch_requests}
+    )
+
+    {:ok, request} =
+      ActionLog.post_request(:adhoc, nil, "argazelka-fixture offer", "the body", poster, log)
+
+    rid = request.id
+
+    assert_receive {:mcp_send,
+                    %{
+                      "method" => "notifications/claude/channel",
+                      "params" =>
+                        %{
+                          "meta" => %{
+                            "source" => "requests",
+                            "event" => "posted",
+                            "request" => ^rid
+                          }
+                        } = posted_params
+                    }},
+                   5_000
+
+    assert posted_params["meta"]["session"] == "request-poster"
+    assert posted_params["meta"]["kind"] == "adhoc"
+    assert posted_params["content"] =~ "request posted: ##{request.id} argazelka-fixture offer"
+    assert posted_params["content"] =~ "the body"
+    assert posted_params["content"] =~ "pickup: Requests.pickup(#{request.id})"
+
+    # The claim and the finish follow on the same feed, actor named.
+    {:ok, _claimed} = ActionLog.claim_request(request.id, worker, log)
+    {:ok, _done} = ActionLog.finish_request(request.id, worker, log)
+
+    assert_receive {:mcp_send,
+                    %{
+                      "params" =>
+                        %{"meta" => %{"event" => "claimed", "request" => ^rid}} =
+                          claimed_params
+                    }},
+                   5_000
+
+    assert claimed_params["meta"]["session"] == "request-worker"
+    assert claimed_params["content"] =~ "request claimed: ##{request.id}"
+
+    assert_receive {:mcp_send,
+                    %{"params" => %{"meta" => %{"event" => "done", "request" => ^rid}}}},
+                   5_000
+
+    # Several more sweeps run inside this window; the watermark must swallow
+    # the delivered events and the pre-boot one instead of re-announcing.
+    refute_receive {:mcp_send,
+                    %{
+                      "params" => %{
+                        "meta" => %{"source" => "requests", "session" => "request-poster"}
+                      }
+                    }},
+                   200
+  end
+
   test "stamps the heartbeat at boot and keeps stamping on ticks", %{log: log} do
     me = ActionLog.create_session("beater", log)
 


### PR DESCRIPTION
Closes #3883.

An agent can now post any unit of work -- "review this diff", "run this eval", "take over this PR" -- and any agent on the host can claim it atomically. Issue pickup (#3880) becomes one shape of that instead of its own table:

- Schema v8: a `requests` table (kind `issue`|`adhoc`, `ref` `"owner/repo#n"` and UNIQUE for issue-kind idempotent ensure / NULL for adhoc, title/body, poster, status open -> claimed -> done, claimer, timestamps) plus an append-only `request_events` table, one row per mutation written in the same transaction, so the feed can never see a state the table does not hold. The v7 -> v8 step folds `issue_claims` rows in as claimed issue-kind requests (ref doubles as title; nobody posted them) and drops the table -- pre-v1, no shim, every call site re-pointed.
- Claiming is a single UPDATE guarded on `status = 'open'`; the row count decides the race (single-writer GenServer per instance, `BEGIN IMMEDIATE` across siblings). The #3903 carve-out carries over: the holder's own re-claim reads back as the win it already is, a nil session never wins a standing claim.
- `Requests.post/pickup/done/list` in the workspace prelude; instructions and README tell agents to post work meant for anyone, pickup before working, done when finished.
- `Issues.pickup/1` is now a veneer: ensure + claim in one `ActionLog.claim_issue/4` transaction. A row born from a pickup writes only a `claimed` event -- it was never on offer, so a `posted` announcement would offer work that is already taken.
- Feed: `IssueWatch` loses its claim sweep (the `source="issues"` new-issue feed is untouched); `SessionWatch`'s tick now sweeps two watermarks through one factored `sweep_feed/4` shape, delivering `source="requests"` posted/claimed/done alongside `source="sessions"` mail -- same cadence rationale, both feeds are local SQLite.

Checks: `mix test` 154 tests 0 failures (148 on main), `mix format --check-formatted` clean, `MIX_ENV=test mix credo --strict` at the 6 pre-existing findings (none in touched files).

Heads-up: main's Check is currently red on `flake-check`/`closure-gate` from tonight's unrelated waves (#3932 and friends); this diff touches only packages/mcp-ex Elixir, docs, and tests.

(sent by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace issue-claims table with a generalized Requests work bus in `mcp-ex`
> - Introduces a new `requests`/`request_events` schema (v8) replacing `issue_claims`, with a full post→claim→done lifecycle and an append-only event feed.
> - Adds [`IxMcp.Requests`](https://github.com/indexable-inc/index/pull/3948/files#diff-fa38f7d2b645e283bd7d58c22c8e45dbb652c5991434152762305d3a965b8bc2) as the public API for agents to post, claim, complete, and list work requests; `Requests.*` is aliased in the workspace prelude by default.
> - Issue claiming in [`IxMcp.Issues`](https://github.com/indexable-inc/index/pull/3948/files#diff-5141a79ca689b5f18c29ac8e21a0bdcb737fd0c32da6388338959ad139e26b7e) now routes through the request bus; `IssueWatch` no longer emits pickup notifications.
> - [`SessionWatch`](https://github.com/indexable-inc/index/pull/3948/files#diff-afe8d016f51838ed696a6c2372973ebf69f0703df04a4e289b83640b3a2922bc) now sweeps a `request_events` feed and delivers posted/claimed/done notifications on a `requests` channel, skipping pre-boot events.
> - Risk: v7 databases are migrated automatically — existing `issue_claims` rows are folded into `requests` with no synthesized events, and the `issue_claims` table is dropped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b875c2b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->