### PR TITLE
prompt: point provenance questions at whence first

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -151,6 +151,23 @@
     };
   }
   {
+    provenanceLookup = {
+      topics = ["verification" "tooling"];
+      text = ''
+        "What installed this, which .nix file defined it": start with
+        `whence <path>`; it reads the live generation's provenance.json
+        with zero eval. It covers deployed files only; for packages, grep
+        the config repo, with `options.<name>.definitionsWithLocations`
+        as the eval-time tie-breaker.
+      '';
+      reason = ''
+        A session re-derived file provenance by hand, ending in an 85s
+        full-config eval that whence answers instantly (index#3947);
+        index#3942 extends whence to packages.
+      '';
+    };
+  }
+  {
     experiments = {
       topics = ["verification"];
       text = ''


### PR DESCRIPTION
Closes #3947. Adds one rules.nix delta: provenance questions ("what installed this, which .nix file defined it") start at `whence <path>` (zero-eval provenance.json read), files-only for now; packages fall back to grep with `options.<name>.definitionsWithLocations` as tie-breaker (index#3942 will extend whence). Rendered and reread the claude-code system prompt; the rule appears in all targets (untagged).

Authored by an AI agent (Claude Opus 4.5 via Claude Code), session with andrewgazelka.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `provenanceLookup` rule directing provenance questions to `whence` first
> Adds a new `provenanceLookup` entry to [rules.nix](https://github.com/indexable-inc/index/pull/3949/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) with topics `verification` and `tooling`. The rule instructs the agent to use `whence <path>` to look up provenance of deployed files, falling back to grepping the config repo with `options.<name>.definitionsWithLocations` as a tie-breaker.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 439697a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->