### PR TITLE
site: give five updates entries the label/href link shape (last red flake-check lane)

### DIFF
--- a/packages/site/src/lib/updates/cache-plane-cutover-ci-reliability.svx
+++ b/packages/site/src/lib/updates/cache-plane-cutover-ci-reliability.svx
@@ -3,12 +3,18 @@ id: cache-plane-cutover-ci-reliability
 postedAt: 2026-07-21
 title: "Cache plane on hil-stor-2 + three CI livelocks fixed: hot narinfo at 1ms, queues at zero"
 links:
-  - https://github.com/indexable-inc/ix/pull/8026
-  - https://github.com/indexable-inc/ix/pull/8018
-  - https://github.com/indexable-inc/ix/pull/8032
-  - https://github.com/indexable-inc/ix/pull/8037
-  - https://github.com/indexable-inc/ix/issues/8031
-  - https://github.com/indexable-inc/ix/issues/8033
+  - label: "ix#8026"
+    href: https://github.com/indexable-inc/ix/pull/8026
+  - label: "ix#8018"
+    href: https://github.com/indexable-inc/ix/pull/8018
+  - label: "ix#8032"
+    href: https://github.com/indexable-inc/ix/pull/8032
+  - label: "ix#8037"
+    href: https://github.com/indexable-inc/ix/pull/8037
+  - label: "ix#8031"
+    href: https://github.com/indexable-inc/ix/issues/8031
+  - label: "ix#8033"
+    href: https://github.com/indexable-inc/ix/issues/8033
 tags: [fleet, ci, cache, incident]
 ---
 

--- a/packages/site/src/lib/updates/fleet-nix-data-array.svx
+++ b/packages/site/src/lib/updates/fleet-nix-data-array.svx
@@ -3,9 +3,12 @@ id: fleet-nix-data-array
 postedAt: 2026-07-21T22:10:00Z
 title: "Compute fleet: /nix moved to the RAID10 data arrays, root arrays freed"
 links:
-  - https://github.com/indexable-inc/ix/issues/8035
-  - https://github.com/indexable-inc/ix/pull/8036
-  - https://github.com/indexable-inc/index/pull/3850
+  - label: "ix#8035"
+    href: https://github.com/indexable-inc/ix/issues/8035
+  - label: "ix#8036"
+    href: https://github.com/indexable-inc/ix/pull/8036
+  - label: "index#3850"
+    href: https://github.com/indexable-inc/index/pull/3850
 tags: [fleet, storage, incident-prevention]
 ---
 

--- a/packages/site/src/lib/updates/ix-fleet-sdk-apply-vm-groups.svx
+++ b/packages/site/src/lib/updates/ix-fleet-sdk-apply-vm-groups.svx
@@ -3,7 +3,8 @@ id: ix-fleet-sdk-apply-vm-groups
 postedAt: 2026-07-22T00:40:00Z
 title: "ix-fleet builds again: SDK wheel pins bumped for apply_vm_groups"
 links:
-  - https://github.com/indexable-inc/index/issues/3889
+  - label: "index#3889"
+    href: https://github.com/indexable-inc/index/issues/3889
 tags: [fleet, sdk, fix]
 ---
 

--- a/packages/site/src/lib/updates/unibind-ex-shared-eventually.svx
+++ b/packages/site/src/lib/updates/unibind-ex-shared-eventually.svx
@@ -4,7 +4,8 @@ postedAt: 2026-07-21
 title: unibind ex suites share one staged eventually helper
 tags: [elixir, unibind, clone-detect]
 links:
-  - https://github.com/indexable-inc/index/issues/3901
+  - label: "index#3901"
+    href: https://github.com/indexable-inc/index/issues/3901
 ---
 
 The three unibind Elixir binding suites (plumb, tui, the conformance crate)

--- a/packages/site/src/lib/updates/zellij-config-bind-fix.svx
+++ b/packages/site/src/lib/updates/zellij-config-bind-fix.svx
@@ -3,7 +3,8 @@ id: zellij-config-bind-fix
 postedAt: "2026-07-22"
 title: zellij-config check green again after backslash keybind fix
 links:
-  - https://github.com/indexable-inc/index/issues/3927
+  - label: "index#3927"
+    href: https://github.com/indexable-inc/index/issues/3927
 tags:
   - checks
   - dotfiles


### PR DESCRIPTION
Follow-up to #3945 (admin-merged red at 04:24Z), finishing the last red lane of the flake-check outage running since 2026-07-19.

## Root cause

Once #3945's playwright 1.61.1 pin let vitest browser mode launch again, its PR run (29890705824) showed the one remaining failure: `updates.test.ts > link hrefs are absolute https URLs` dies with `link.href` undefined. Five updates entries merged during the red window list bare URLs under `links:` instead of the `label`/`href` map shape every other entry (and the test contract) uses:

- `unibind-ex-shared-eventually.svx`
- `cache-plane-cutover-ci-reliability.svx` (6 links)
- `fleet-nix-data-array.svx` (3 links)
- `ix-fleet-sdk-apply-vm-groups.svx`
- `zellij-config-bind-fix.svx`

## Fix

Convert each bare URL to `label`/`href`; labels use the `repo#number` style. A sweep over every entry at tip finds no other offenders.

## Measurement

PR run 29890705824 (tree with the playwright pin): `Failed attributes: site-test` only, vitest `Tests 1 failed | 45 passed (46)`, and the single failure is this contract. With #3945 now on main plus this change, no known red lane remains.

## Merge mechanics

Same non-deadlock as #3945: this PR's own flake-check builds the fixed tree and can go green on its own. If it does, merge normally; an admin merge is only warranted if yet another red lane lands on main first (direct pushes and red merges were still happening as of 04:3xZ).

(authored by Claude Code, model Fable 5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Convert site update entry `links` frontmatter from plain strings to label/href objects
> Five `.svx` update entries in `packages/site/src/lib/updates/` had their `links` frontmatter fields converted from bare URL strings to objects with explicit `label` and `href` fields, matching the shape expected by a flake-check lint rule. No content or URLs were changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fbe3fbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->