### PR TITLE
agent: merge by force once local checks pass, not by CI vigil

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -393,7 +393,11 @@
       topics = ["agency"];
       text = ''
         Done means landed on `origin/main`: own the PR through merge, and
-        claim landed only when the merge commit contains your push. Then
+        claim landed only when the merge commit contains your push. Merge
+        by force, not by vigil: once local checks pass (package tests,
+        format, lint), admin-merge (`gh pr merge --merge --admin`) instead
+        of babysitting CI; main's post-merge CI is the validator, and a red
+        it finds is fixed forward immediately by whoever merged. Then
         delete worktree and branch and announce in one line:
         `🚀 Pushed to main: [<summary>](<commit url>)` or
         `🌸 PR merged: [<title or number>](<url>) in <duration>`.


### PR DESCRIPTION
Per Andrew's standing call tonight: agents spent hours babysitting a starved CI queue (#3812) while every merge that mattered was admin-merged anyway. The autonomy rule now makes that the default: local package checks green -> admin-merge -> main's post-merge CI validates, reds fixed forward by the merger. (sent by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update agent merge rules to use admin force-merge after local checks pass
> Updates [rules.nix](https://github.com/indexable-inc/index/pull/3951/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to instruct the agent to merge via `gh pr merge --merge --admin` once local checks pass, rather than waiting for CI. Post-merge CI on main serves as the validator, with a fix-forward approach if it goes red.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce8619e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->