### PR TITLE
update-flake-lock: drop checkout submodules option in submodule mode

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -83,10 +83,10 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # Submodule mode edits pins in the caller's tree; flake mode needs no
-          # submodules (and index itself has none).
-          submodules: ${{ inputs.submodule-paths != '' }}
+        # Never checkout's `submodules:` option: on ix runners the
+        # dispatcher's per-job GIT_CONFIG_GLOBAL defeats checkout's
+        # temp-HOME token plumbing (ix#8123). The bump step below runs its
+        # own anonymous `git submodule update --init`.
 
       # Fully qualified, not `./.github/actions/install-nix`: this workflow is
       # reusable (`workflow_call`), and for a cross-repo caller (ix) the


### PR DESCRIPTION
Follow-up to #3940 (issue #3937): checkout's `submodules:` option cannot work on ix runners because the dispatcher exports a per-job `GIT_CONFIG_GLOBAL` that defeats checkout's temp-HOME token-placeholder plumbing (indexable-inc/ix#8123). The bump step already runs `git submodule update --init` itself; the checkout knob was redundant and fatal.

(authored by an AI agent via Claude Code, Claude)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop `submodules` option from `actions/checkout` in update-flake-lock workflow
> The `actions/checkout` step in [update-flake-lock.yml](.github/workflows/update-flake-lock.yml) no longer passes the `submodules` option when submodule paths are set. A later step already runs `git submodule update --init` directly, making the checkout option redundant.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f14ee56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->