### PR TITLE
site: kernel agent coordination bus update

### DIFF
--- a/packages/site/src/lib/updates/kernel-agent-work-bus.svx
+++ b/packages/site/src/lib/updates/kernel-agent-work-bus.svx
@@ -1,0 +1,45 @@
+---
+id: kernel-agent-work-bus
+postedAt: 2026-07-22T04:30:00-07:00
+title: "The kernel grew an agent coordination bus: issue feed, atomic pickup, session messaging, Requests"
+tags: [kernel, mcp-ex, agents]
+links:
+  - label: issue feed (PR 3879)
+    href: https://github.com/indexable-inc/index/pull/3879
+  - label: atomic pickup (PR 3882)
+    href: https://github.com/indexable-inc/index/pull/3882
+  - label: session messaging (PR 3891)
+    href: https://github.com/indexable-inc/index/pull/3891
+  - label: Requests bus (PR 3948)
+    href: https://github.com/indexable-inc/index/pull/3948
+---
+
+Four stacked changes turned the mcp-ex kernel from a per-session tool server
+into a coordination bus for every agent on a host, using the SQLite database
+they already share as the arbiter and feed.
+
+**Issues announce themselves.** An always-on `IssueWatch` polls
+`gh search issues` and pushes every newly filed issue into connected sessions
+as a `source="issues"` channel event. Background agents file issues nobody
+watches; now the filing itself is the notification.
+
+**Pickup is atomic.** `Issues.pickup(n)` claims an issue before work starts.
+The claim is a `UNIQUE`-constrained insert in the shared database: one winner,
+losers read back who got there first, and the claim mirrors to GitHub as an
+assignee. No two agents build the same fix again.
+
+**Sessions can see and message each other.** `Sessions.list()` shows every
+kernel session on the host with heartbeat liveness; `Sessions.send(id, text)`
+delivers into the target session as a channel event within seconds
+(`NULL` target broadcasts). The delivery sweep is a per-instance cursor over a
+shared table, so every session hears every message exactly once.
+
+**Requests generalize all of it.** `Requests.post/pickup/done` puts any unit
+of work on offer: a review, an eval run, a PR to babysit. Issue pickup is now
+just a Request of kind `issue`; an append-only `request_events` table drives a
+posted/claimed/done feed on the same 3-second tick as messaging. Schema landed
+at v8 with the old claims table migrated in and dropped, no compatibility
+shims.
+
+Scope, stated plainly: the bus is per host, because the shared SQLite is the
+transport. Cross-host coordination stays with the fleet layer.


### PR DESCRIPTION
Update entry for tonight's kernel work: issue feed (#3879), atomic pickup (#3882), session messaging (#3891), Requests bus (#3948). (sent by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add site update post for kernel agent coordination bus
> Adds a new update entry in [kernel-agent-work-bus.svx](https://github.com/indexable-inc/index/pull/3953/files#diff-3264f992f9d70c6a25e5593c3516c8263912a3ff885909a8e6aa6386d8ea9145) describing the kernel agent coordination bus features, including issue feed via IssueWatch, atomic pickup with UNIQUE-constrained DB claims and GitHub assignee mirroring, session listing and inter-session messaging, and a generalized Requests bus with `request_events`. The post is tagged and linked with relevant metadata and will appear wherever site updates are rendered. Schema is noted at v8.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df01b6a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->