### PR TITLE
update-flake-lock: pin checkout to v5; v7 credentials never fire on ix runners

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -82,7 +82,12 @@ jobs:
           exit 1
 
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        # v5, not v7: v7 wires its auth header through includeIf.gitdir
+        # credential files that never fire on ix dispatcher runners (realpath
+        # mismatch under /var/lib/ix-ci-job-*), so a private caller's fetch
+        # runs unauthenticated and dies (#3959). v5's local extraheader works
+        # everywhere the fleet runs.
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         # Never checkout's `submodules:` option: on ix runners the
         # dispatcher's per-job GIT_CONFIG_GLOBAL defeats checkout's
         # temp-HOME token plumbing (ix#8123). The bump step below runs its


### PR DESCRIPTION
Closes #3959. checkout v7's includeIf.gitdir credential wiring does not match the dispatcher's /var/lib/ix-ci-job-* gitdirs, so private callers (ix) fetch unauthenticated and fail; this broke ix's 5-minute bump since Jul 16 and got the workflow manually disabled. v5's local-extraheader mechanism is what every other ix workflow already uses.

(authored by an AI agent via Claude Code, Claude)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `actions/checkout` to v5 in update-flake-lock workflow
> Downgrades the pinned `actions/checkout` reference in [update-flake-lock.yml](.github/workflows/update-flake-lock.yml) from v7 to v5, because v7 credentials never fire on ix runners, causing the checkout step to fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e96b12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->