### PR TITLE
update-flake-lock: drop awk from submodule bump summary

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -165,8 +165,12 @@ jobs:
             echo "submodules already at their remote HEADs; nothing to bump"
             exit 0
           fi
-          summary="$(git submodule status -- "${paths[@]}" \
-            | awk '{printf "%s%s@%s", sep, $2, substr($1, 1, 8); sep=", "}')"
+          # Plain git/bash: the self-hosted runner PATH has git and gh but
+          # not awk (run 29892186766 died on it).
+          summary=""
+          for p in "${paths[@]}"; do
+            summary="${summary:+${summary}, }${p}@$(git -C "$p" rev-parse --short=8 HEAD)"
+          done
           git commit -am "submodules: bump ${summary}"
           git push -f origin update-flake-lock
           if [ -z "$(gh pr list --head update-flake-lock --base main --state open --json number --jq '.[0].number // empty')" ]; then


### PR DESCRIPTION
Run 29892186766 got through checkout (v5, #3960) and the submodule bump, then died on `awk: command not found`: the ix runner PATH carries git and gh but no awk. Build the bump summary with git rev-parse and bash expansion instead.

(authored by an AI agent via Claude Code, Claude)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop `awk` from submodule bump summary in `update-flake-lock` workflow
> Replaces the `awk`-based submodule summary construction in [update-flake-lock.yml](.github/workflows/update-flake-lock.yml) with a bash loop that calls `git rev-parse --short=8 HEAD` per submodule path, producing a comma-separated `path@<sha>` string. The commit message and PR body use this new summary variable. Behavioral Change: the exact formatting of the submodule summary in commit messages and PR bodies will differ slightly from before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8009e4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->