### PR TITLE
update-flake-lock: provision gh/jq/curl on minimal runner PATHs

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -142,6 +142,20 @@ jobs:
       # rolling branch the flake bump uses, so the escalate watcher below works
       # identically in both modes. Manual branch/commit/PR because the DS
       # action can only write flake.lock.
+      # ix's self-hosted runner jobs expose a minimal PATH (git + nix, no gh,
+      # jq, curl, awk; see indexable-inc/ix run 29892367191). Extend PATH from
+      # nixpkgs via the preinstalled nix only for what is missing, so hosted
+      # runners (ubuntu-latest, everything native) skip the builds.
+      - name: Provision missing CLI tools
+        run: |
+          set -euo pipefail
+          ensure() {
+            command -v "$1" >/dev/null 2>&1 && return
+            local out
+            out="$(nix build "nixpkgs#$1" --no-link --print-out-paths)"
+            echo "${out}/bin" >> "$GITHUB_PATH"
+          }
+          ensure gh
       - name: Bump submodules
         if: ${{ inputs.submodule-paths != '' }}
         env:
@@ -241,6 +255,20 @@ jobs:
       SLACK_CHANNEL: ${{ inputs.slack-channel || 'C0A4TD9G7HR' }}
       SLACK_BOT_TOKEN: ${{ secrets.slack-bot-token }}
     steps:
+      # Same minimal-PATH provisioning as the update job above; the escalate
+      # script needs gh, jq, and curl.
+      - name: Provision missing CLI tools
+        run: |
+          set -euo pipefail
+          ensure() {
+            command -v "$1" >/dev/null 2>&1 && return
+            local out
+            out="$(nix build "nixpkgs#$1" --no-link --print-out-paths)"
+            echo "${out}/bin" >> "$GITHUB_PATH"
+          }
+          ensure gh
+          ensure jq
+          ensure curl
       - name: Escalate a stuck flake bump
         run: |
           set -euo pipefail


### PR DESCRIPTION
Round 3 of making the submodule bump loop run on ix runners (#3937): checkout fixed by #3960, awk dropped by #3961, and now gh (bump step) plus gh/jq/curl (escalate job, broken there since the runner-label switch) get provisioned from nixpkgs via the preinstalled nix when absent. Pure bash otherwise; hosted runners no-op.

(authored by an AI agent via Claude Code, Claude)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Provision `gh`, `jq`, and `curl` from nixpkgs on minimal runner PATHs in update-flake-lock workflow
> Adds a 'Provision missing CLI tools' step to both the `update-flake-lock` and `escalate` jobs in [update-flake-lock.yml](.github/workflows/update-flake-lock.yml). Each step defines an `ensure` shell function that checks whether a tool is on PATH and, if missing, builds it from nixpkgs via `nix build nixpkgs#<tool>` and appends the resulting bin directory to `GITHUB_PATH`. The `update-flake-lock` job provisions `gh`; the `escalate` job provisions `gh`, `jq`, and `curl`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c48afa7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->