### PR TITLE
google: fold run_logout and event-time parsing into shared crates (#3957)

### DIFF
--- a/packages/google/auth/src/lib.rs
+++ b/packages/google/auth/src/lib.rs
@@ -493,6 +493,20 @@ pub fn logout_message(removed: &[PathBuf], json: bool) -> String {
     message
 }
 
+/// Delete this machine's stored Google grant and print the shared logout
+/// confirmation ([`logout_message`]). Idempotent: signing out when already
+/// signed out is a no-op, not an error. The `gmail` and `gcal` CLIs both
+/// call this so their `logout` subcommands cannot drift.
+///
+/// # Errors
+/// Returns an error if the platform exposes no config directory, or if a
+/// token file exists but cannot be removed.
+pub fn run_logout(json: bool) -> Result<()> {
+    let removed = TokenStore::new()?.remove()?;
+    println!("{}", logout_message(&removed, json));
+    Ok(())
+}
+
 pub struct Authenticator {
     token: TokenClient,
     store: TokenStore,

--- a/packages/google/calendar/cli/src/main.rs
+++ b/packages/google/calendar/cli/src/main.rs
@@ -221,7 +221,7 @@ impl From<Notify> for SendUpdates {
 async fn main() -> anyhow::Result<()> {
     match Cli::parse().command {
         Command::Auth(args) => run_auth(args).await,
-        Command::Logout(args) => run_logout(args.json),
+        Command::Logout(args) => google_auth::run_logout(args.json).map_err(Into::into),
         Command::PrintAccessToken(args) => run_print_access_token(args).await,
         Command::List(args) => run_list(args).await,
         Command::Show(args) => run_show(args).await,
@@ -281,14 +281,6 @@ async fn run_auth(args: AuthArgs) -> anyhow::Result<()> {
     client.list_events(PRIMARY_CALENDAR, &probe).await?;
 
     consent.report_verified("Calendar");
-    Ok(())
-}
-
-/// Delete the stored grant. Idempotent: signing out when already signed out
-/// is a no-op, not an error.
-fn run_logout(json: bool) -> anyhow::Result<()> {
-    let removed = TokenStore::new()?.remove()?;
-    println!("{}", google_auth::logout_message(&removed, json));
     Ok(())
 }
 

--- a/packages/google/calendar/src/lib.rs
+++ b/packages/google/calendar/src/lib.rs
@@ -10,6 +10,7 @@
 
 mod error;
 mod model;
+mod parse;
 
 pub use error::{Error, Result};
 pub use google_auth::scopes::{ALL_KNOWN as ALL_KNOWN_SCOPES, CALENDAR_EVENTS as EVENTS_SCOPE};
@@ -20,6 +21,7 @@ pub use model::{
     Attendee, AttendeeDraft, Event, EventDraft, EventQuery, EventTime, InvalidSendUpdates, Person,
     SendUpdates,
 };
+pub use parse::{ParseEventTimeError, parse_event_end, parse_event_time};
 
 use google_auth::api_message;
 use serde::Deserialize;

--- a/packages/google/calendar/src/parse.rs
+++ b/packages/google/calendar/src/parse.rs
@@ -1,0 +1,185 @@
+//! Parse `--start`/`--end` boundary strings into wire [`EventTime`]s.
+//!
+//! The Rust MCP server (`packages/google/mcp`) and the PyO3 bindings
+//! (`packages/google/py`) both take an event boundary as a string plus an
+//! `all_day` flag, and both must agree on how it parses and on the
+//! inclusive-to-exclusive all-day end conversion. One parser here keeps the
+//! tool surface and the Python surface from drifting (RFC 0003); each
+//! surface maps [`ParseEventTimeError`] onto its own error type.
+
+use chrono::{DateTime, NaiveDate};
+use snafu::{OptionExt as _, Snafu};
+
+use crate::model::EventTime;
+
+/// Failure parsing an event start or end boundary.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub enum ParseEventTimeError {
+    /// All-day input was not a `YYYY-MM-DD` date. `reason` is a plain field
+    /// rather than a snafu `source`: `chrono::ParseError` only implements
+    /// `std::error::Error` under chrono's `std` feature, which this crate
+    /// deliberately leaves off (default-features = false, `alloc` only).
+    #[snafu(display("{field}: could not parse {input:?} as YYYY-MM-DD: {reason}"))]
+    Date {
+        /// Which boundary (`start` or `end`).
+        field: &'static str,
+        /// The rejected input.
+        input: String,
+        /// Underlying parse failure.
+        reason: chrono::ParseError,
+    },
+
+    /// Timed input was not an RFC 3339 instant.
+    #[snafu(display("{field}: could not parse {input:?} as RFC 3339: {reason}"))]
+    Rfc3339 {
+        /// Which boundary (`start` or `end`).
+        field: &'static str,
+        /// The rejected input.
+        input: String,
+        /// Underlying parse failure.
+        reason: chrono::ParseError,
+    },
+
+    /// The inclusive last day is the last representable date, so there is no
+    /// day after it to use as Google's exclusive all-day `end.date`.
+    #[snafu(display("end: no day follows {last}"))]
+    NoDayFollows {
+        /// The inclusive last day with no successor.
+        last: NaiveDate,
+    },
+}
+
+/// Parse one event boundary: an all-day `YYYY-MM-DD` date when `all_day`,
+/// otherwise an RFC 3339 instant with offset. `field` names the boundary
+/// (`start` or `end`) for the error message.
+///
+/// # Errors
+/// Returns [`ParseEventTimeError`] if the input does not match the expected
+/// shape for `all_day`.
+pub fn parse_event_time(
+    input: &str,
+    all_day: bool,
+    field: &'static str,
+) -> Result<EventTime, ParseEventTimeError> {
+    if all_day {
+        let date = input.parse().map_err(|reason| {
+            DateSnafu {
+                field,
+                input: input.to_owned(),
+                reason,
+            }
+            .build()
+        })?;
+        Ok(EventTime::AllDay { date })
+    } else {
+        let date_time = DateTime::parse_from_rfc3339(input).map_err(|reason| {
+            Rfc3339Snafu {
+                field,
+                input: input.to_owned(),
+                reason,
+            }
+            .build()
+        })?;
+        Ok(EventTime::Timed {
+            date_time,
+            time_zone: None,
+        })
+    }
+}
+
+/// Parse the `end` of an event. All-day input is the inclusive last day (how
+/// the CLI, tools, and bindings document it); Google's all-day `end.date` is
+/// exclusive, so convert at this boundary.
+///
+/// # Errors
+/// Returns [`ParseEventTimeError`] if the input does not parse, or if an
+/// all-day last day has no representable successor.
+pub fn parse_event_end(input: &str, all_day: bool) -> Result<EventTime, ParseEventTimeError> {
+    match parse_event_time(input, all_day, "end")? {
+        EventTime::AllDay { date } => {
+            EventTime::all_day_end_from_inclusive(date).context(NoDayFollowsSnafu { last: date })
+        }
+        timed @ EventTime::Timed { .. } => Ok(timed),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+
+    use super::{ParseEventTimeError, parse_event_end, parse_event_time};
+    use crate::model::EventTime;
+
+    #[test]
+    fn all_day_end_is_inclusive_at_the_surface_and_exclusive_on_the_wire() {
+        let end = parse_event_end("2026-06-12", true).expect("parses");
+        assert_eq!(
+            end,
+            EventTime::AllDay {
+                date: "2026-06-13".parse().expect("date"),
+            }
+        );
+    }
+
+    #[test]
+    fn timed_end_passes_through_unchanged() {
+        let end = parse_event_end("2026-06-05T10:00:00-07:00", false).expect("parses");
+        assert_eq!(
+            end,
+            EventTime::Timed {
+                date_time: "2026-06-05T10:00:00-07:00".parse().expect("instant"),
+                time_zone: None,
+            }
+        );
+    }
+
+    #[test]
+    fn all_day_start_parses_the_bare_date() {
+        let start = parse_event_time("2026-06-05", true, "start").expect("parses");
+        assert_eq!(
+            start,
+            EventTime::AllDay {
+                date: "2026-06-05".parse().expect("date"),
+            }
+        );
+    }
+
+    #[test]
+    fn bad_all_day_date_names_the_field_and_input() {
+        let err = parse_event_time("not-a-date", true, "start").expect_err("rejects");
+        assert!(
+            matches!(err, ParseEventTimeError::Date { .. }),
+            "got {err:?}"
+        );
+        let message = err.to_string();
+        assert!(
+            message.contains("start"),
+            "message names the field: {message}"
+        );
+        assert!(
+            message.contains("YYYY-MM-DD"),
+            "message names the shape: {message}"
+        );
+    }
+
+    #[test]
+    fn bad_timed_input_names_rfc_3339() {
+        let err = parse_event_time("2026-06-05 09:30", false, "end").expect_err("rejects");
+        assert!(
+            matches!(err, ParseEventTimeError::Rfc3339 { .. }),
+            "got {err:?}"
+        );
+        assert!(err.to_string().contains("RFC 3339"), "got: {err}");
+    }
+
+    #[test]
+    fn no_day_follows_the_last_representable_date() {
+        let last = NaiveDate::MAX;
+        let err = parse_event_end(&last.to_string(), true).expect_err("no successor");
+        assert!(
+            matches!(err, ParseEventTimeError::NoDayFollows { .. }),
+            "got {err:?}"
+        );
+    }
+}

--- a/packages/google/calendar/src/parse.rs
+++ b/packages/google/calendar/src/parse.rs
@@ -16,27 +16,22 @@ use crate::model::EventTime;
 #[derive(Debug, Snafu)]
 #[non_exhaustive]
 pub enum ParseEventTimeError {
-    /// All-day input was not a `YYYY-MM-DD` date. `reason` is a plain field
-    /// rather than a snafu `source`: `chrono::ParseError` only implements
-    /// `std::error::Error` under chrono's `std` feature, which this crate
-    /// deliberately leaves off (default-features = false, `alloc` only).
-    #[snafu(display("{field}: could not parse {input:?} as YYYY-MM-DD: {reason}"))]
-    Date {
+    /// The boundary string did not match the shape required for its kind: a
+    /// `YYYY-MM-DD` date for an all-day boundary, an RFC 3339 instant for a
+    /// timed one.
+    ///
+    /// `reason` is a plain field rather than a snafu `source` because
+    /// `chrono::ParseError` only implements `std::error::Error` under
+    /// chrono's `std` feature, which this crate deliberately leaves off
+    /// (default-features = false, `alloc` only).
+    #[snafu(display("{field}: could not parse {input:?} as {expected}: {reason}"))]
+    Parse {
         /// Which boundary (`start` or `end`).
         field: &'static str,
         /// The rejected input.
         input: String,
-        /// Underlying parse failure.
-        reason: chrono::ParseError,
-    },
-
-    /// Timed input was not an RFC 3339 instant.
-    #[snafu(display("{field}: could not parse {input:?} as RFC 3339: {reason}"))]
-    Rfc3339 {
-        /// Which boundary (`start` or `end`).
-        field: &'static str,
-        /// The rejected input.
-        input: String,
+        /// The shape the parser expected (`YYYY-MM-DD` or `RFC 3339`).
+        expected: &'static str,
         /// Underlying parse failure.
         reason: chrono::ParseError,
     },
@@ -48,6 +43,26 @@ pub enum ParseEventTimeError {
         /// The inclusive last day with no successor.
         last: NaiveDate,
     },
+}
+
+/// The `map_err` for a boundary parse: names the field, the rejected input,
+/// and the shape that was expected. One constructor keeps the all-day and
+/// timed branches from each spelling out the same closure.
+fn parse_failure(
+    field: &'static str,
+    input: &str,
+    expected: &'static str,
+) -> impl FnOnce(chrono::ParseError) -> ParseEventTimeError {
+    let input = input.to_owned();
+    move |reason| {
+        ParseSnafu {
+            field,
+            input,
+            expected,
+            reason,
+        }
+        .build()
+    }
 }
 
 /// Parse one event boundary: an all-day `YYYY-MM-DD` date when `all_day`,
@@ -63,24 +78,13 @@ pub fn parse_event_time(
     field: &'static str,
 ) -> Result<EventTime, ParseEventTimeError> {
     if all_day {
-        let date = input.parse().map_err(|reason| {
-            DateSnafu {
-                field,
-                input: input.to_owned(),
-                reason,
-            }
-            .build()
-        })?;
+        let date = input
+            .parse()
+            .map_err(parse_failure(field, input, "YYYY-MM-DD"))?;
         Ok(EventTime::AllDay { date })
     } else {
-        let date_time = DateTime::parse_from_rfc3339(input).map_err(|reason| {
-            Rfc3339Snafu {
-                field,
-                input: input.to_owned(),
-                reason,
-            }
-            .build()
-        })?;
+        let date_time =
+            DateTime::parse_from_rfc3339(input).map_err(parse_failure(field, input, "RFC 3339"))?;
         Ok(EventTime::Timed {
             date_time,
             time_zone: None,
@@ -146,28 +150,22 @@ mod tests {
     }
 
     #[test]
-    fn bad_all_day_date_names_the_field_and_input() {
+    fn bad_all_day_date_names_the_field_and_the_expected_shape() {
         let err = parse_event_time("not-a-date", true, "start").expect_err("rejects");
         assert!(
-            matches!(err, ParseEventTimeError::Date { .. }),
+            matches!(err, ParseEventTimeError::Parse { .. }),
             "got {err:?}"
         );
         let message = err.to_string();
-        assert!(
-            message.contains("start"),
-            "message names the field: {message}"
-        );
-        assert!(
-            message.contains("YYYY-MM-DD"),
-            "message names the shape: {message}"
-        );
+        assert!(message.contains("start"), "names the field: {message}");
+        assert!(message.contains("YYYY-MM-DD"), "names the shape: {message}");
     }
 
     #[test]
     fn bad_timed_input_names_rfc_3339() {
         let err = parse_event_time("2026-06-05 09:30", false, "end").expect_err("rejects");
         assert!(
-            matches!(err, ParseEventTimeError::Rfc3339 { .. }),
+            matches!(err, ParseEventTimeError::Parse { .. }),
             "got {err:?}"
         );
         assert!(err.to_string().contains("RFC 3339"), "got: {err}");

--- a/packages/google/gmail/cli/src/main.rs
+++ b/packages/google/gmail/cli/src/main.rs
@@ -315,7 +315,7 @@ struct SingleIdArgs {
 async fn main() -> anyhow::Result<()> {
     match Cli::parse().command {
         Command::Auth(args) => run_auth(args).await,
-        Command::Logout(args) => run_logout(args.json),
+        Command::Logout(args) => google_auth::run_logout(args.json).map_err(Into::into),
         Command::List(args) => run_list(args).await,
         Command::Show(args) => run_show(args).await,
         Command::Search(args) => run_search(args).await,
@@ -354,14 +354,6 @@ async fn run_auth(args: AuthArgs) -> anyhow::Result<()> {
     )?)?;
     client.list_labels().await?;
     consent.report_verified("Gmail");
-    Ok(())
-}
-
-/// Delete the stored grant. Idempotent: signing out when already signed out
-/// is a no-op, not an error.
-fn run_logout(json: bool) -> anyhow::Result<()> {
-    let removed = TokenStore::new()?.remove()?;
-    println!("{}", google_auth::logout_message(&removed, json));
     Ok(())
 }
 

--- a/packages/google/mcp/src/tools.rs
+++ b/packages/google/mcp/src/tools.rs
@@ -19,7 +19,8 @@ use serde::Deserialize;
 use serde_json::json;
 
 use google_calendar::{
-    AttendeeDraft, EventDraft, EventQuery, EventTime, PRIMARY_CALENDAR, SendUpdates,
+    AttendeeDraft, EventDraft, EventQuery, PRIMARY_CALENDAR, SendUpdates, parse_event_end,
+    parse_event_time,
 };
 use google_gmail::{Attachment, MessageFormat, MessageQuery, OutgoingMessage};
 
@@ -150,8 +151,8 @@ impl GoogleMcp {
         &self,
         Parameters(args): Parameters<CalendarEventCreateArgs>,
     ) -> Result<String, ErrorData> {
-        let start = parse_event_time(&args.start, args.all_day, "start")?;
-        let end = parse_event_end(&args.end, args.all_day)?;
+        let start = parse_event_time(&args.start, args.all_day, "start").map_err(invalid_params)?;
+        let end = parse_event_end(&args.end, args.all_day).map_err(invalid_params)?;
         let draft = EventDraft {
             summary: args.summary,
             description: args.description,
@@ -716,51 +717,11 @@ fn into_tool_error<E: std::fmt::Display>(err: E) -> ErrorData {
     ErrorData::new(ErrorCode::INTERNAL_ERROR, err.to_string(), None)
 }
 
-fn parse_event_time(
-    input: &str,
-    all_day: bool,
-    field: &'static str,
-) -> Result<EventTime, ErrorData> {
-    if all_day {
-        let date = input.parse().map_err(|err| {
-            ErrorData::new(
-                ErrorCode::INVALID_PARAMS,
-                format!("{field}: could not parse {input:?} as YYYY-MM-DD: {err}"),
-                None,
-            )
-        })?;
-        Ok(EventTime::AllDay { date })
-    } else {
-        let date_time = DateTime::parse_from_rfc3339(input).map_err(|err| {
-            ErrorData::new(
-                ErrorCode::INVALID_PARAMS,
-                format!("{field}: could not parse {input:?} as RFC 3339: {err}"),
-                None,
-            )
-        })?;
-        Ok(EventTime::Timed {
-            date_time,
-            time_zone: None,
-        })
-    }
-}
-
-/// Parse the `end` of an event. All-day input is the inclusive last day
-/// (how the tools document it); Google's all-day `end.date` is exclusive,
-/// so convert at this boundary.
-fn parse_event_end(input: &str, all_day: bool) -> Result<EventTime, ErrorData> {
-    match parse_event_time(input, all_day, "end")? {
-        EventTime::AllDay { date } => {
-            EventTime::all_day_end_from_inclusive(date).ok_or_else(|| {
-                ErrorData::new(
-                    ErrorCode::INVALID_PARAMS,
-                    format!("end: no day follows {date}"),
-                    None,
-                )
-            })
-        }
-        timed @ EventTime::Timed { .. } => Ok(timed),
-    }
+/// Map a bad-input failure onto an `INVALID_PARAMS` tool error (the client
+/// sent something malformed), distinct from [`into_tool_error`]'s
+/// `INTERNAL_ERROR` for failures on our side.
+fn invalid_params<E: std::fmt::Display>(err: E) -> ErrorData {
+    ErrorData::new(ErrorCode::INVALID_PARAMS, err.to_string(), None)
 }
 
 /// `notify` defaults to `All` only when absent; an unrecognized value is
@@ -826,22 +787,11 @@ fn build_outgoing(args: MailComposeArgs) -> Result<OutgoingMessage, ErrorData> {
 
 #[cfg(test)]
 mod tests {
-    use google_calendar::{EventTime, SendUpdates};
+    use google_calendar::SendUpdates;
     use google_gmail::MessageFormat;
     use rmcp::model::ErrorCode;
 
-    use super::{message_format, parse_event_end, send_updates};
-
-    #[test]
-    fn all_day_end_is_inclusive_at_the_tool_and_exclusive_on_the_wire() {
-        let end = parse_event_end("2026-06-12", true).expect("parses");
-        assert_eq!(
-            end,
-            EventTime::AllDay {
-                date: "2026-06-13".parse().expect("date"),
-            }
-        );
-    }
+    use super::{message_format, send_updates};
 
     #[test]
     fn absent_notify_and_format_keep_their_documented_defaults() {

--- a/packages/google/py/src/lib.rs
+++ b/packages/google/py/src/lib.rs
@@ -17,7 +17,9 @@ use std::sync::Arc;
 
 use google_auth::scopes::{CALENDAR_EVENTS, GMAIL_MODIFY, GMAIL_SEND};
 use google_auth::{Authenticator, ClientSecrets, TokenStore};
-use google_calendar::{AttendeeDraft, EventDraft, EventQuery, EventTime, SendUpdates};
+use google_calendar::{
+    AttendeeDraft, EventDraft, EventQuery, SendUpdates, parse_event_end, parse_event_time,
+};
 use google_gmail::{Attachment, MessageFormat, MessageQuery, OutgoingMessage};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -121,32 +123,6 @@ fn parse_send_updates(name: Option<&str>) -> PyResult<SendUpdates> {
             .parse()
             .map_err(|err| PyValueError::new_err(format!("notify: {err}")))
     })
-}
-
-fn parse_event_time(input: &str, all_day: bool, field: &'static str) -> PyResult<EventTime> {
-    if all_day {
-        let date = input
-            .parse()
-            .map_err(|err| PyValueError::new_err(format!("{field}: not a date: {err}")))?;
-        Ok(EventTime::AllDay { date })
-    } else {
-        let date_time = chrono::DateTime::parse_from_rfc3339(input)
-            .map_err(|err| PyValueError::new_err(format!("{field}: not RFC 3339: {err}")))?;
-        Ok(EventTime::Timed {
-            date_time,
-            time_zone: None,
-        })
-    }
-}
-
-/// Parse the `end` of an event. All-day input is the inclusive last day;
-/// Google's all-day `end.date` is exclusive, so convert at this boundary.
-fn parse_event_end(input: &str, all_day: bool) -> PyResult<EventTime> {
-    match parse_event_time(input, all_day, "end")? {
-        EventTime::AllDay { date } => EventTime::all_day_end_from_inclusive(date)
-            .ok_or_else(|| PyValueError::new_err(format!("end: no day follows {date}"))),
-        timed @ EventTime::Timed { .. } => Ok(timed),
-    }
 }
 
 // ---------------------------------------------------------------------
@@ -634,8 +610,8 @@ impl CalendarClient {
         calendar_id: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = Arc::clone(&self.inner);
-        let start_time = parse_event_time(&start, all_day, "start")?;
-        let end_time = parse_event_end(&end, all_day)?;
+        let start_time = parse_event_time(&start, all_day, "start").map_err(into_py_value_error)?;
+        let end_time = parse_event_end(&end, all_day).map_err(into_py_value_error)?;
         let draft = EventDraft {
             summary,
             description,


### PR DESCRIPTION
Mechanical dedup of the google package twins from the embedding dupe finder (#3957). Two folds landed; two are left in place with reasons below.

## Folds

**run_logout (gmail/cli vs gcal/cli).** The two CLIs had byte-identical logout functions that both built the default TokenStore, removed it, and printed google_auth::logout_message. Moved to `google_auth::run_logout(json)`, sitting next to the logout_message it already shared. Both CLIs now dispatch straight to it, so the two logout subcommands cannot drift.

**parse_event_end plus its parse_event_time dependency (mcp/tools.rs vs py/lib.rs).** The MCP server and the PyO3 bindings each carried their own copy of the event-boundary parser and the inclusive-to-exclusive all-day end conversion. Moved both into a new `google_calendar::parse` module (both crates already depend on google_calendar, where EventTime and all_day_end_from_inclusive already live). The shared parser returns a typed `ParseEventTimeError`; each surface maps it onto its own error type (INVALID_PARAMS for the tool, PyValueError for Python). The canonical test moved to the parser; the MCP copy that restated it was deleted.

Note: ParseEventTimeError keeps the chrono parse failure as a plain field rather than a snafu source, because google_calendar builds chrono with default-features off (alloc only) and chrono::ParseError only implements std::error::Error under the std feature. Feature unification hid this in a combined build; the standalone crate build is now clean.

## Skips (would need a new abstraction, not a mechanical fold)

**into_query (same file, mcp/tools.rs).** The substantive conversion already lives in the shared `message_query` free function; both MailSearchArgs::into_query and MailListMessagesArgs::into_query are one-argument-different adapters that already delegate to it. The only remaining fold is to merge the two argument structs, but they back two intentionally distinct MCP tool schemas (mail_search requires a query, mail_list_messages makes it optional), so merging them would change the LLM-facing tool surface. Left as is.

**build.rs (gmail/ex vs py).** The four-line macOS `-undefined dynamic_lookup` snippet is a deliberate per-crate convention mirrored across 13 crates repo-wide (search-py, tui-py, unibind conformance, and more). A cargo build script cannot share code without a new shared build-helper crate, and introducing one for only the two google crates would be inconsistent with the fleet-wide mirror. Left as is.

## Validation

nix run .#lint passes (all 13 tasks, including the clone detector). cargo fmt --check clean on touched files. Tests pass for google-auth, google-calendar, google-gmail, google-mcp, ix-google-py, google-gmail-cli, google-calendar-cli.

(authored by Claude Code, model Opus)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Centralize Google logout and calendar event-time parsing into shared crates
> - Moves `run_logout` into `google_auth` and replaces duplicate implementations in the Gmail and Calendar CLIs with calls to the shared function.
> - Extracts `parse_event_time`, `parse_event_end`, and `ParseEventTimeError` into a new `parse` module in `google_calendar`, re-exporting them publicly.
> - Updates the MCP tools handler and Python bindings to use the shared parsers, replacing bespoke error construction with standardized `INVALID_PARAMS` and `PyValueError` messages.
> - All-day end dates are treated as inclusive at the surface and converted to Google's exclusive wire format; overflow on `NaiveDate::MAX` surfaces as a dedicated error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d24a60a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->