### PR TITLE
search: fold duplicated helpers across the search crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11481,6 +11481,7 @@ dependencies = [
  "object_store",
  "parquet 59.1.0",
  "serde_json",
+ "sink-parquet",
  "snafu",
  "source-meta",
  "tokio",

--- a/packages/search/search-core/src/search.rs
+++ b/packages/search/search-core/src/search.rs
@@ -44,6 +44,15 @@ pub enum RenderMode {
     Compact,
 }
 
+impl RenderMode {
+    /// The projection mode for a caller-facing `compact` flag (the CLI's
+    /// `--compact`, the Python binding's `compact=`).
+    #[must_use]
+    pub const fn from_compact(compact: bool) -> Self {
+        if compact { Self::Compact } else { Self::Full }
+    }
+}
+
 /// A search result projected for display.
 ///
 /// Serializes to the stable `search --json` object. `label` is renamed to `path`

--- a/packages/search/search-py/src/lib.rs
+++ b/packages/search/search-py/src/lib.rs
@@ -49,15 +49,6 @@ fn resolve_time(value: Option<TimeSpec>) -> PyResult<Option<i64>> {
     }
 }
 
-/// The projection mode for a `compact=` flag.
-const fn render_mode(compact: bool) -> RenderMode {
-    if compact {
-        RenderMode::Compact
-    } else {
-        RenderMode::Full
-    }
-}
-
 /// Run a natural-language semantic search over the shared corpus store.
 ///
 /// Returns an awaitable resolving to a list of dicts, one per hit, each with
@@ -158,7 +149,7 @@ fn semantic(
         include_web: web,
         options,
         filter,
-        mode: render_mode(compact),
+        mode: RenderMode::from_compact(compact),
     };
     hits_future(py, run_search(args))
 }
@@ -220,7 +211,7 @@ fn grep(
         base,
         options,
         filter,
-        mode: render_mode(compact),
+        mode: RenderMode::from_compact(compact),
     };
     hits_future(py, run_grep(args))
 }
@@ -274,7 +265,7 @@ fn recent(
     let store_name = store.unwrap_or_else(|| DEFAULT_STORE.to_owned());
     let base = base_url.unwrap_or_else(|| mixedbread::DEFAULT_BASE_URL.to_owned());
     let filter = scope_filter(source, not_source, repo, user, host, project, since, until)?;
-    let mode = render_mode(compact);
+    let mode = RenderMode::from_compact(compact);
     hits_future(py, async move {
         async {
             let store = MixedbreadStore::from_login(base).await?;

--- a/packages/search/search/src/main.rs
+++ b/packages/search/search/src/main.rs
@@ -513,15 +513,6 @@ fn print_answer(
     }
 }
 
-/// The projection mode for a `--compact` flag.
-const fn render_mode(compact: bool) -> RenderMode {
-    if compact {
-        RenderMode::Compact
-    } else {
-        RenderMode::Full
-    }
-}
-
 async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
     let pattern = require_pattern(&cli);
 
@@ -594,7 +585,7 @@ async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
             top_k,
             filter.as_ref(),
             &sort,
-            render_mode(cli.compact),
+            RenderMode::from_compact(cli.compact),
         )
         .await;
         finish(bar);
@@ -633,7 +624,7 @@ async fn run(cli: SemanticArgs) -> anyhow::Result<()> {
             cli.web,
             filter.as_ref(),
             CodeScope::ServerFiltered,
-            render_mode(cli.compact),
+            RenderMode::from_compact(cli.compact),
         )
         .await;
         finish(bar);
@@ -664,7 +655,7 @@ async fn run_recent(cli: RecentArgs) -> anyhow::Result<()> {
         &store_name,
         cli.max_count.max(1),
         filter.as_ref(),
-        render_mode(cli.compact),
+        RenderMode::from_compact(cli.compact),
     )
     .await;
     finish(bar);
@@ -1036,7 +1027,7 @@ async fn run_grep(cli: GrepArgs) -> anyhow::Result<()> {
         grep_options,
         filter.as_ref(),
         CodeScope::ServerFiltered,
-        render_mode(cli.compact),
+        RenderMode::from_compact(cli.compact),
     )
     .await;
     finish(bar);

--- a/packages/search/sink/parquet/src/lib.rs
+++ b/packages/search/sink/parquet/src/lib.rs
@@ -32,7 +32,11 @@ use sha2::{Digest as _, Sha256};
 use snafu::{IntoError as _, ResultExt as _, Snafu};
 use source_meta::{Document, Reconciler, Source, keys};
 
-/// Connection and layout for the S3/R2 parquet sink.
+/// Connection and layout for the S3/R2 parquet corpus log.
+///
+/// Shared by both halves of the log: this crate writes it, and `source-parquet`
+/// re-exports this type to read it back with the same bucket, endpoint, region,
+/// and prefix.
 #[derive(Debug, Clone)]
 pub struct Config {
     /// Target bucket name.
@@ -133,9 +137,30 @@ impl Config {
     /// environment.
     pub fn connect(&self) -> Result<ParquetReconciler> {
         Ok(ParquetReconciler {
-            store: build_store(self)?,
+            store: self.build_store().context(BuildStoreSnafu {
+                bucket: self.bucket.clone(),
+            })?,
             prefix: self.prefix.clone(),
         })
+    }
+
+    /// Build the raw S3 client for this config. Credentials come from the
+    /// environment (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`).
+    ///
+    /// Shared with `source-parquet`, the consumer half of the corpus log, so
+    /// both halves connect to the store the same way.
+    ///
+    /// # Errors
+    /// Returns the underlying `object_store` error when the client cannot be
+    /// built from the config and environment; callers add their own context.
+    pub fn build_store(&self) -> Result<AmazonS3, object_store::Error> {
+        let mut builder = AmazonS3Builder::from_env()
+            .with_bucket_name(&self.bucket)
+            .with_region(&self.region);
+        if let Some(endpoint) = &self.endpoint {
+            builder = builder.with_endpoint(endpoint);
+        }
+        builder.build()
     }
 }
 
@@ -193,20 +218,6 @@ impl<S: ObjectStore> Reconciler for ParquetReconciler<S> {
             skipped: false,
         })
     }
-}
-
-/// Build the S3 client. Credentials come from the environment
-/// (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`).
-fn build_store(config: &Config) -> Result<AmazonS3> {
-    let mut builder = AmazonS3Builder::from_env()
-        .with_bucket_name(&config.bucket)
-        .with_region(&config.region);
-    if let Some(endpoint) = &config.endpoint {
-        builder = builder.with_endpoint(endpoint);
-    }
-    builder.build().context(BuildStoreSnafu {
-        bucket: config.bucket.clone(),
-    })
 }
 
 /// The flat corpus schema: identity, the common header fields, the embedded

--- a/packages/search/source/atuin/src/record.rs
+++ b/packages/search/source/atuin/src/record.rs
@@ -2,7 +2,7 @@
 
 use serde_json::{Map, Value, json};
 use snafu::ResultExt as _;
-use source_meta::{Document, keys};
+use source_meta::{Document, insert_some, keys};
 
 use crate::SOURCE_TAG;
 use crate::error::{MetadataSnafu, Result};
@@ -73,14 +73,6 @@ impl Entry {
             meta_json,
             content_hash,
         })
-    }
-}
-
-/// Insert `key` only when a value is present, keeping absent tags off the record
-/// rather than serializing nulls.
-fn insert_some(meta: &mut Map<String, Value>, key: &str, value: Option<Value>) {
-    if let Some(value) = value {
-        meta.insert(key.to_owned(), value);
     }
 }
 

--- a/packages/search/source/claude/src/record.rs
+++ b/packages/search/source/claude/src/record.rs
@@ -2,7 +2,7 @@
 
 use serde_json::{Map, Value, json};
 use snafu::ResultExt as _;
-use source_meta::{Document, keys};
+use source_meta::{Document, insert_some, keys};
 
 use crate::error::{MetadataSnafu, Result};
 
@@ -128,14 +128,6 @@ impl Message {
             meta_json,
             content_hash,
         })
-    }
-}
-
-/// Insert `key` only when a value is present, keeping absent tags off the record
-/// rather than serializing nulls.
-fn insert_some(meta: &mut Map<String, Value>, key: &str, value: Option<Value>) {
-    if let Some(value) = value {
-        meta.insert(key.to_owned(), value);
     }
 }
 

--- a/packages/search/source/codex/src/record.rs
+++ b/packages/search/source/codex/src/record.rs
@@ -3,7 +3,7 @@
 
 use serde_json::{Map, Value, json};
 use snafu::ResultExt as _;
-use source_meta::{Document, keys};
+use source_meta::{Document, insert_some, keys};
 
 use crate::SOURCE_TAG;
 use crate::error::{MetadataSnafu, Result};
@@ -175,14 +175,6 @@ impl RolloutItem {
             meta_json,
             content_hash,
         })
-    }
-}
-
-/// Insert `key` only when a value is present, keeping absent tags off the
-/// record rather than serializing nulls.
-fn insert_some(meta: &mut Map<String, Value>, key: &str, value: Option<Value>) {
-    if let Some(value) = value {
-        meta.insert(key.to_owned(), value);
     }
 }
 

--- a/packages/search/source/debug/src/record.rs
+++ b/packages/search/source/debug/src/record.rs
@@ -2,7 +2,7 @@
 
 use serde_json::{Map, Value, json};
 use snafu::ResultExt as _;
-use source_meta::{Document, keys};
+use source_meta::{Document, insert_some, keys};
 
 use crate::SOURCE_TAG;
 use crate::error::{MetadataSnafu, Result};
@@ -68,13 +68,5 @@ impl Entry {
             meta_json,
             content_hash,
         })
-    }
-}
-
-/// Insert `key` only when a value is present, keeping absent tags off the record
-/// rather than serializing nulls.
-fn insert_some(meta: &mut Map<String, Value>, key: &str, value: Option<Value>) {
-    if let Some(value) = value {
-        meta.insert(key.to_owned(), value);
     }
 }

--- a/packages/search/source/github/src/lib.rs
+++ b/packages/search/source/github/src/lib.rs
@@ -326,6 +326,32 @@ struct CiJob {
 // Projection: item -> Document.
 // ---------------------------------------------------------------------------
 
+/// The common metadata envelope every `github` grain shares: source tag,
+/// identity, content hash, title, url, and timestamp when known.
+///
+/// Each grain's `build_meta` layers its extras on top.
+fn common_envelope(
+    external_id: &str,
+    content_hash: &str,
+    title: &str,
+    url: &str,
+    timestamp: Option<i64>,
+) -> Map<String, Value> {
+    let mut meta = Map::new();
+    meta.insert(
+        keys::SOURCE.to_owned(),
+        json!(Source::new("github").as_str()),
+    );
+    meta.insert(keys::EXTERNAL_ID.to_owned(), json!(external_id));
+    meta.insert(keys::CONTENT_HASH.to_owned(), json!(content_hash));
+    meta.insert(keys::TITLE.to_owned(), json!(title));
+    meta.insert(keys::URL.to_owned(), json!(url));
+    if let Some(ts) = timestamp {
+        meta.insert(keys::TIMESTAMP.to_owned(), json!(ts));
+    }
+    meta
+}
+
 impl Item {
     /// Render this item into a [`Document`]: build the body, the flat metadata,
     /// validate the metadata against the store limits, then assemble.
@@ -367,20 +393,7 @@ impl Item {
         title: &str,
         timestamp: Option<i64>,
     ) -> Value {
-        let mut meta = Map::new();
-
-        // Common envelope.
-        meta.insert(
-            keys::SOURCE.to_owned(),
-            json!(Source::new("github").as_str()),
-        );
-        meta.insert("external_id".to_owned(), json!(external_id));
-        meta.insert(keys::CONTENT_HASH.to_owned(), json!(content_hash));
-        meta.insert(keys::TITLE.to_owned(), json!(title));
-        meta.insert("url".to_owned(), json!(self.url));
-        if let Some(ts) = timestamp {
-            meta.insert(keys::TIMESTAMP.to_owned(), json!(ts));
-        }
+        let mut meta = common_envelope(external_id, content_hash, title, &self.url, timestamp);
 
         // GitHub extras.
         meta.insert(keys::REPO.to_owned(), json!(self.repo));
@@ -580,20 +593,7 @@ impl CiRun {
         title: &str,
         timestamp: Option<i64>,
     ) -> Value {
-        let mut meta = Map::new();
-
-        // Common envelope.
-        meta.insert(
-            keys::SOURCE.to_owned(),
-            json!(Source::new("github").as_str()),
-        );
-        meta.insert(keys::EXTERNAL_ID.to_owned(), json!(external_id));
-        meta.insert(keys::CONTENT_HASH.to_owned(), json!(content_hash));
-        meta.insert(keys::TITLE.to_owned(), json!(title));
-        meta.insert(keys::URL.to_owned(), json!(self.url));
-        if let Some(ts) = timestamp {
-            meta.insert(keys::TIMESTAMP.to_owned(), json!(ts));
-        }
+        let mut meta = common_envelope(external_id, content_hash, title, &self.url, timestamp);
 
         // CI-run extras. `kind` separates this grain from issues/PRs within the
         // shared `github` source.

--- a/packages/search/source/github/tests/fixture.rs
+++ b/packages/search/source/github/tests/fixture.rs
@@ -310,11 +310,5 @@ fn export_without_ci_runs_file_still_opens() {
 /// Re-running the adapter over the same export yields identical content hashes.
 #[test]
 fn content_hash_is_deterministic() {
-    let first = collect_docs();
-    let second = collect_docs();
-    assert_eq!(first.len(), second.len());
-    for (a, b) in first.iter().zip(second.iter()) {
-        assert_eq!(a.external_id, b.external_id);
-        assert_eq!(a.content_hash, b.content_hash, "stable hash across runs");
-    }
+    source_meta::testing::assert_deterministic_hashes(&collect_docs(), &collect_docs());
 }

--- a/packages/search/source/linear/tests/fixture.rs
+++ b/packages/search/source/linear/tests/fixture.rs
@@ -178,11 +178,5 @@ fn null_description_uses_placeholder() {
 /// Re-running the adapter over the same export yields identical content hashes.
 #[test]
 fn content_hash_is_deterministic() {
-    let first = collect_docs();
-    let second = collect_docs();
-    assert_eq!(first.len(), second.len());
-    for (a, b) in first.iter().zip(second.iter()) {
-        assert_eq!(a.external_id, b.external_id);
-        assert_eq!(a.content_hash, b.content_hash, "stable hash across runs");
-    }
+    source_meta::testing::assert_deterministic_hashes(&collect_docs(), &collect_docs());
 }

--- a/packages/search/source/meta/src/lib.rs
+++ b/packages/search/source/meta/src/lib.rs
@@ -25,6 +25,7 @@
 pub mod files;
 pub mod keys;
 pub mod sanitize;
+pub mod testing;
 
 use std::fmt;
 use std::future::Future;
@@ -372,6 +373,20 @@ pub fn check_metadata(
         }
     );
     Ok(bytes)
+}
+
+/// Insert `key` only when a value is present, keeping absent tags off the
+/// record rather than serializing nulls.
+///
+/// A JSON `null` would become a bogus filter value in the store.
+pub fn insert_some(
+    meta: &mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    value: Option<serde_json::Value>,
+) {
+    if let Some(value) = value {
+        meta.insert(key.to_owned(), value);
+    }
 }
 
 #[cfg(test)]

--- a/packages/search/source/meta/src/testing.rs
+++ b/packages/search/source/meta/src/testing.rs
@@ -1,0 +1,23 @@
+//! Assertions shared by adapter test suites.
+//!
+//! Lives in the production crate because every adapter already depends on
+//! `source-meta` and Cargo exposes regular dependencies to `tests/` targets;
+//! the module is plain assertion code with no test-framework dependency.
+
+use crate::Document;
+
+/// Assert two runs of an adapter over the same corpus yielded the same records
+/// with identical content hashes.
+///
+/// The hash is the change-detection key, so a nondeterministic one would
+/// re-embed an unchanged corpus every ingest.
+///
+/// # Panics
+/// Panics when the runs differ in length, identity, or hash.
+pub fn assert_deterministic_hashes(first: &[Document], second: &[Document]) {
+    assert_eq!(first.len(), second.len());
+    for (a, b) in first.iter().zip(second) {
+        assert_eq!(a.external_id, b.external_id);
+        assert_eq!(a.content_hash, b.content_hash, "stable hash across runs");
+    }
+}

--- a/packages/search/source/parquet/Cargo.toml
+++ b/packages/search/source/parquet/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 source-meta.workspace = true
+sink-parquet.workspace = true
 object_store = { workspace = true, features = ["aws"] }
 futures.workspace = true
 serde_json.workspace = true

--- a/packages/search/source/parquet/src/lib.rs
+++ b/packages/search/source/parquet/src/lib.rs
@@ -29,7 +29,6 @@
 use arrow::array::{Array as _, StringArray};
 use arrow::record_batch::RecordBatch;
 use futures::stream::StreamExt as _;
-use object_store::aws::{AmazonS3, AmazonS3Builder};
 use object_store::path::Path as ObjectPath;
 use object_store::{ObjectStore, ObjectStoreExt as _};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -49,18 +48,9 @@ const COL_CONTENT_HASH: &str = "content_hash";
 const COL_BODY: &str = "body";
 const COL_META_JSON: &str = "meta_json";
 
-/// Connection and layout for reading the parquet corpus log.
-#[derive(Debug, Clone)]
-pub struct Config {
-    /// Bucket the parquet sink writes to.
-    pub bucket: String,
-    /// S3 endpoint URL. `None` uses AWS S3; for a self-hosted store pass its endpoint.
-    pub endpoint: Option<String>,
-    /// Region (`auto` for non-AWS stores).
-    pub region: String,
-    /// Key prefix under the bucket to read parquet objects from.
-    pub prefix: String,
-}
+/// Connection and layout for reading the parquet corpus log: the same `Config`
+/// (bucket, endpoint, region, prefix) the sink wrote it with.
+pub use sink_parquet::Config;
 
 /// Failures from the parquet reader.
 #[derive(Debug, Snafu)]
@@ -154,7 +144,9 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Returns an error if the client cannot be built, the prefix cannot be listed,
 /// or any object cannot be read, decoded, or reconstructed.
 pub async fn read_documents(config: &Config) -> Result<Vec<Document>> {
-    let store = build_store(config)?;
+    let store = config.build_store().context(BuildStoreSnafu {
+        bucket: config.bucket.clone(),
+    })?;
     read_from_store(&store, &config.prefix).await
 }
 
@@ -251,7 +243,9 @@ fn parse_slice_key(key: &str) -> Option<SliceId> {
 /// Returns an error if the client cannot be built, the prefix cannot be listed,
 /// or any object cannot be read or decoded.
 pub async fn read_slices(config: &Config) -> Result<Vec<Slice>> {
-    let store = build_store(config)?;
+    let store = config.build_store().context(BuildStoreSnafu {
+        bucket: config.bucket.clone(),
+    })?;
     read_slices_from_store(&store, &config.prefix).await
 }
 
@@ -292,20 +286,6 @@ pub async fn read_slices_from_store(store: &dyn ObjectStore, prefix: &str) -> Re
         });
     }
     Ok(slices)
-}
-
-/// Build the S3 client. Credentials come from the environment
-/// (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`).
-fn build_store(config: &Config) -> Result<AmazonS3> {
-    let mut builder = AmazonS3Builder::from_env()
-        .with_bucket_name(&config.bucket)
-        .with_region(&config.region);
-    if let Some(endpoint) = &config.endpoint {
-        builder = builder.with_endpoint(endpoint);
-    }
-    builder.build().context(BuildStoreSnafu {
-        bucket: config.bucket.clone(),
-    })
 }
 
 /// Parse one parquet object's record batches into documents, appending to `out`.


### PR DESCRIPTION
Folds the duplicated helpers the embedding dupe finder flagged in #3956 (the #3905 campaign, wave 2). Each pair judged on its own; one skip, with the reason below. Verified locally: cargo check, cargo nextest (158 tests across the affected crates), cargo fmt --check on the touched crates, and nix run .#lint all pass.

## Folds

**build_store + Config (sink/parquet vs source/parquet, 0.993)**
The reader is the consumer half of the corpus log the sink writes, and the indexer already builds both configs from the same flags. sink-parquet now exposes `Config::build_store()` (returning the raw `object_store::Error` so each side keeps its own snafu context), and source-parquet re-exports `sink_parquet::Config` instead of carrying an identical struct plus an identical builder. Both halves now connect to the store the same way by construction.

**insert_some (source/{codex,claude,atuin} plus source/debug, 0.98+)**
The issue listed three copies; there were four (source/debug too). One copy now lives in source-meta, the pure shared adapter crate every source already depends on, and all four adapters import it.

**render_mode (search-py vs search CLI, 0.989)**
Became `RenderMode::from_compact(bool)` in search-core, next to the enum it constructs; both the CLI's `--compact` and the binding's `compact=` call it.

**content_hash_is_deterministic test twin (source/{linear,github})**
The shared body moved to `source_meta::testing::assert_deterministic_hashes`; each fixture keeps its own one-line test over its own `collect_docs()`. Cargo exposes regular dependencies to `tests/` targets, so no dev-dependency plumbing was needed.

**build_meta twin inside source/github**
The issue/PR grain and the CI-run grain now share a `common_envelope` helper for the source/identity/hash/title/url/timestamp header; each `build_meta` layers only its grain-specific extras on top. The Item grain used literal `"external_id"`/`"url"` keys where the CI grain used `keys::` constants; the constants are the same strings, so behavior is unchanged.

## Skip

**_read_lines (search-eval data.py vs system-prompt-eval data.py, 0.981)**
Skipped. The two are separately locked uv applications in different subsystems (packages/search vs packages/agent), and sharing code between them requires a real shared package: `ix.buildUvApplication` documents support for registry distributions only, no repo pyproject uses a path or workspace source today, and the default source fileset only includes the project's own pyproject.toml, src/, and uv.lock. Creating and wiring a new library package (plus lockfile and Nix plumbing in both apps) is more machinery than the 12 duplicated, fully typed lines it would remove. If a third eval harness appears, that is the moment to mint the shared package.

Fixes #3956

(authored by Claude Code, model Fable 5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fold duplicated helpers across search crates into shared utilities
> - Moves the repeated `render_mode(bool) -> RenderMode` helper into `RenderMode::from_compact` in [search-core](https://github.com/indexable-inc/index/pull/3964/files#diff-2be005094e7c16023346bb0c835f8bdb7a9d4cc816523842c75b8dff4b666dbb), replacing local copies in the CLI and Python bindings.
> - Adds `insert_some` to [source-meta](https://github.com/indexable-inc/index/pull/3964/files#diff-6a1d730d64bd6cab56305cbd41f53467f002125e856bec69b496c20696da7586) and removes identical local copies from the atuin, claude, codex, and debug source crates.
> - Adds `assert_deterministic_hashes` to a new `source_meta::testing` module, replacing manual assertion loops in the GitHub and Linear fixture tests.
> - Consolidates S3 client construction into `Config::build_store` on the shared [sink-parquet](https://github.com/indexable-inc/index/pull/3964/files#diff-f117ec50b730790c77e172732875daf6b9d26f2e2fd4740821211d09b0e76460) `Config`, which is now re-exported by [source-parquet](https://github.com/indexable-inc/index/pull/3964/files#diff-f0df900ec1070849ecbc3507c3ff1c0be80797b754b11f9ecdfa21d1ad3829ef) instead of defining its own.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7da8c3b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->