### PR TITLE
update-flake-lock: handle multi-output packages in CLI provisioning

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -151,9 +151,11 @@ jobs:
           set -euo pipefail
           ensure() {
             command -v "$1" >/dev/null 2>&1 && return
-            local out
-            out="$(nix build "nixpkgs#$1" --no-link --print-out-paths)"
-            echo "${out}/bin" >> "$GITHUB_PATH"
+            # --print-out-paths prints one line per output (jq: bin + man);
+            # add /bin per path, not to the joined string.
+            while IFS= read -r p; do
+              echo "${p}/bin" >> "$GITHUB_PATH"
+            done < <(nix build "nixpkgs#$1" --no-link --print-out-paths)
           }
           ensure gh
       - name: Bump submodules
@@ -262,9 +264,11 @@ jobs:
           set -euo pipefail
           ensure() {
             command -v "$1" >/dev/null 2>&1 && return
-            local out
-            out="$(nix build "nixpkgs#$1" --no-link --print-out-paths)"
-            echo "${out}/bin" >> "$GITHUB_PATH"
+            # --print-out-paths prints one line per output (jq: bin + man);
+            # add /bin per path, not to the joined string.
+            while IFS= read -r p; do
+              echo "${p}/bin" >> "$GITHUB_PATH"
+            done < <(nix build "nixpkgs#$1" --no-link --print-out-paths)
           }
           ensure gh
           ensure jq


### PR DESCRIPTION
nixpkgs#jq builds bin+man outputs; --print-out-paths is one line each, and the previous code appended /bin to the joined string, leaving jq off PATH (run 29892512641: update job green, escalate still 127). Append /bin per line. Verified on vin-compute-1 that jq prints exactly two paths.

(authored by an AI agent via Claude Code, Claude)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix multi-output package PATH provisioning in `update-flake-lock` workflow
> The `ensure()` function in the 'Provision missing CLI tools' step previously captured all output paths from `nix build --print-out-paths` into a single variable and added one `$out/bin` entry to `$GITHUB_PATH`. For packages with multiple outputs (e.g., `jq` produces both `bin` and `man`), this caused binaries to be undiscoverable. The fix replaces the single assignment with a loop that appends a `/bin` entry for each output path individually, applied to both the update and escalation jobs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b3912c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->