### PR TITLE
ghostty: declare the 0004 lib-vt sandbox patch intent

### DIFF
--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -330,6 +330,11 @@
           reason = "The render-state C API exposes only a per-cell has-hyperlink bool (the row flag may false-positive), so a libghostty-vt embedder cannot learn a cell's OSC 8 link target; the URI must be duplicated out of page memory during update() like graphemes and styles already are.";
           prExtra = "Motivating embedder: ix-term (indexable-inc/ix#8008), which renders the terminal grid in a browser and needs real anchors for OSC 8 hyperlinks.";
         };
+        "0004-build-keep-Demit-lib-vt-buildable-without-Apple-abso.patch" = {
+          upstream = "attempt";
+          reason = "A -Demit-lib-vt build cannot exec hardcoded /bin/cp and /usr/bin/ranlib in a hermetic (Nix darwin sandbox) build, and hanging the vt xcframework off install forces xcodebuild on every darwin build; resolving the tools from PATH and gating the xcframework on emit-xcframework (already default-false under emit-lib-vt) matches how the app xcframework is gated and changes nothing for developer Macs.";
+          prExtra = "Motivating embedder: ix-vt (indexable-inc/ix#8117), which builds the VT-only subtree fully sandboxed; lib/build/libghostty-vt.nix documents the boundary.";
+        };
       };
     }
     {


### PR DESCRIPTION
Main red on patch-dag-ghostty since the ix#8117 vt work: commit 5211bdc2 added packages/ghostty/patches/0004 without declaring its intent in lib/fork-packages.nix, and the dag check refuses undeclared patches. Adds the entry (upstream attempt: PATH-resolved tools and emit-xcframework gating are correct on developer Macs too). Verified locally: checks.aarch64-darwin.patch-dag-ghostty builds green with this change, and nix run .#lint passes.

(authored by Claude Code, model Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Declare intent for `0004-build-keep-Demit-lib-vt-buildable-without-Apple-abso.patch` in ghostty fork packages
> Adds metadata for the `0004` lib-vt sandbox patch to [lib/fork-packages.nix](https://github.com/indexable-inc/index/pull/3967/files#diff-35e5ff5b02c2dcd32c93fd770ad2194f9fcbfc9f35fdcbd56821891b6e7452f4), including upstream status (`attempt`), reason, and extra PR context. This registers the patch in the metadata set so build logic can select and apply it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72ea5e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->