### PR TITLE
misc: dedup sigchld helper, bossbar open_url, mcp test helpers (#3958)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9034,12 +9034,12 @@ dependencies = [
 name = "plumb-ex"
 version = "0.1.0"
 dependencies = [
- "libc",
  "plumb-core",
  "rustler",
  "serde",
  "serde_json",
  "unibind",
+ "unibind-ex-runtime",
 ]
 
 [[package]]
@@ -13181,10 +13181,10 @@ dependencies = [
 name = "tui-ex"
 version = "0.1.0"
 dependencies = [
- "libc",
  "rustler",
  "tui",
  "unibind",
+ "unibind-ex-runtime",
 ]
 
 [[package]]
@@ -13444,6 +13444,7 @@ name = "unibind-ex-runtime"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "libc",
  "rustler",
  "tokio",
  "unibind-runtime",

--- a/packages/mcp/src/fabric/module.nix
+++ b/packages/mcp/src/fabric/module.nix
@@ -67,6 +67,9 @@
   # no other derivation runs them. The file is weave's, riding its module drv
   # as passthru (src/weave/module.nix).
   weaveTestSource = weaveModule.ixTestSource;
+  # Shared spool-teardown fixture, copied in as conftest.py so both
+  # test_fabric.py and test_weave.py pick it up (src/weave/conftest.py).
+  weaveConftestSource = weaveModule.ixConftestSource;
   fabricTests =
     pkgs.runCommand "ix-mcp-fabric-tests"
     {
@@ -82,6 +85,7 @@
       mkdir -p "$HOME"
       cp ${fabricTestSource} "$TMPDIR/test_fabric.py"
       cp ${weaveTestSource} "$TMPDIR/test_weave.py"
+      cp ${weaveConftestSource} "$TMPDIR/conftest.py"
       ${lib.getExe fabricTestPython} -m pytest "$TMPDIR/test_fabric.py" "$TMPDIR/test_weave.py" -q -p no:cacheprovider >stdout 2>stderr || {
         echo "ix-mcp fabric tests failed:" >&2
         cat stdout stderr >&2

--- a/packages/mcp/src/fabric/test_fabric.py
+++ b/packages/mcp/src/fabric/test_fabric.py
@@ -6,7 +6,7 @@ import json
 import re
 import sys
 import threading
-from collections.abc import AsyncIterator, Coroutine, Iterator
+from collections.abc import AsyncIterator, Coroutine
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, TypeVar
@@ -31,19 +31,6 @@ _HEX64 = re.compile(r"^[0-9a-f]{64}$")
 
 def run(coro: Coroutine[Any, Any, _T]) -> _T:
     return asyncio.run(coro)
-
-
-@pytest.fixture(autouse=True)
-def _spool_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
-    """weave.record spools under the test's tmp dir; teardown joins flusher
-    threads BEFORE monkeypatched transports revert (a live flusher must never
-    fall back to a real URL)."""
-    from weave import spool as weave_spool
-
-    monkeypatch.setenv("WEAVE_SPOOL", str(tmp_path / "weave-spool"))
-    yield tmp_path / "weave-spool"
-    weave_spool.close_all()
-    weave_spool._down_urls.clear()
 
 
 def drain() -> None:

--- a/packages/mcp/src/iphone/module.nix
+++ b/packages/mcp/src/iphone/module.nix
@@ -42,6 +42,10 @@
     name = "ix-mcp-iphone-test";
     path = testsRoot + "/test_iphone.py";
   };
+  typeHintSupport = builtins.path {
+    name = "ix-mcp-iphone-type-hint-support";
+    path = testsRoot + "/type_hint_support.py";
+  };
   iphoneTests =
     pkgs.runCommand "ix-mcp-iphone-tests"
     {
@@ -52,6 +56,7 @@
       export HOME=$TMPDIR/home
       mkdir -p "$HOME"
       cp ${iphoneTestSource} "$TMPDIR/test_iphone.py"
+      cp ${typeHintSupport} "$TMPDIR/type_hint_support.py"
       ${lib.getExe iphoneTestPython} -m pytest "$TMPDIR/test_iphone.py" -q -p no:cacheprovider >stdout 2>stderr || {
         echo "ix-mcp iphone tests failed:" >&2
         cat stdout stderr >&2

--- a/packages/mcp/src/notion/module.nix
+++ b/packages/mcp/src/notion/module.nix
@@ -37,6 +37,10 @@
     name = "ix-mcp-notion-test";
     path = testsRoot + "/test_notion.py";
   };
+  typeHintSupport = builtins.path {
+    name = "ix-mcp-notion-type-hint-support";
+    path = testsRoot + "/type_hint_support.py";
+  };
   notionTests =
     pkgs.runCommand "ix-mcp-notion-tests"
     {
@@ -47,6 +51,7 @@
       export HOME=$TMPDIR/home
       mkdir -p "$HOME"
       cp ${notionTestSource} "$TMPDIR/test_notion.py"
+      cp ${typeHintSupport} "$TMPDIR/type_hint_support.py"
       ${lib.getExe notionTestPython} -m pytest "$TMPDIR/test_notion.py" -q -p no:cacheprovider >stdout 2>stderr || {
         echo "ix-mcp notion tests failed:" >&2
         cat stdout stderr >&2

--- a/packages/mcp/src/slack/module.nix
+++ b/packages/mcp/src/slack/module.nix
@@ -94,6 +94,10 @@
     name = "ix-mcp-slack-test";
     path = testsRoot + "/test_slack.py";
   };
+  typeHintSupport = builtins.path {
+    name = "ix-mcp-slack-type-hint-support";
+    path = testsRoot + "/type_hint_support.py";
+  };
   slackTests =
     pkgs.runCommand "ix-mcp-slack-tests"
     {
@@ -104,6 +108,7 @@
       export HOME=$TMPDIR/home
       mkdir -p "$HOME"
       cp ${slackTestSource} "$TMPDIR/test_slack.py"
+      cp ${typeHintSupport} "$TMPDIR/type_hint_support.py"
       ${lib.getExe slackTestPython} -m pytest "$TMPDIR/test_slack.py" -q -p no:cacheprovider >stdout 2>stderr || {
         echo "ix-mcp slack tests failed:" >&2
         cat stdout stderr >&2

--- a/packages/mcp/src/weave/conftest.py
+++ b/packages/mcp/src/weave/conftest.py
@@ -1,0 +1,25 @@
+"""Shared pytest fixtures for the weave client tests and the fabric tests
+that exercise it. Both files run together in the fabric test derivation
+(src/fabric/module.nix), which copies this file in as conftest.py, so the
+spool-teardown fixture lives here once instead of in each test module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _spool_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Every test spools under its own tmp dir; teardown joins flusher
+    threads BEFORE monkeypatched transports revert (a live flusher must
+    never fall back to a real URL)."""
+    from weave import spool as weave_spool
+
+    monkeypatch.setenv("WEAVE_SPOOL", str(tmp_path / "weave-spool"))
+    yield tmp_path / "weave-spool"
+    weave_spool.close_all()
+    weave_spool._down_urls.clear()

--- a/packages/mcp/src/weave/module.nix
+++ b/packages/mcp/src/weave/module.nix
@@ -20,6 +20,12 @@
         name = "ix-mcp-weave-test";
         path = ./test_weave.py;
       };
+      # Shared pytest fixtures for test_weave.py and the fabric tests that run
+      # it; fabricTests copies this in as conftest.py (src/fabric/module.nix).
+      passthru.ixConftestSource = builtins.path {
+        name = "ix-mcp-weave-conftest";
+        path = ./conftest.py;
+      };
       meta.description = "Weave 2 async client bundled into the ix-mcp interpreter";
     }
     ''

--- a/packages/mcp/src/weave/test_weave.py
+++ b/packages/mcp/src/weave/test_weave.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import re
 import sys
-from collections.abc import Callable, Coroutine, Iterator
+from collections.abc import Callable, Coroutine
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -185,20 +185,6 @@ def test_result_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 # --- record / spool (durable-local-first, index#3418) ---------------------------
-
-
-from weave import spool as weave_spool
-
-
-@pytest.fixture(autouse=True)
-def _spool_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
-    """Every test spools under its own tmp dir; teardown joins flusher
-    threads BEFORE monkeypatched transports revert (a live flusher must
-    never fall back to a real URL)."""
-    monkeypatch.setenv("WEAVE_SPOOL", str(tmp_path / "spool"))
-    yield tmp_path / "spool"
-    weave_spool.close_all()
-    weave_spool._down_urls.clear()
 
 
 def _journal_transport(monkeypatch: pytest.MonkeyPatch, *, down: dict[str, bool]) -> tuple[list[tuple[str, str, Any]], dict[str, bytes]]:

--- a/packages/mcp/tests/test_iphone.py
+++ b/packages/mcp/tests/test_iphone.py
@@ -20,6 +20,7 @@ if IPHONE_SRC.is_dir() and str(IPHONE_SRC) not in sys.path:
     sys.path.insert(0, str(IPHONE_SRC))
 
 import iphone
+from type_hint_support import assert_type_hints_explicit
 
 # Public callables = everything exported except the error class.
 _PUBLIC_FUNCS = [
@@ -44,17 +45,7 @@ def test_public_funcs_are_async() -> None:
 
 
 def test_type_hints_explicit() -> None:
-    # Mirrors the ruff ANN gate: every public function fully annotates its params
-    # and return type.
-    for func in _PUBLIC_FUNCS:
-        sig = inspect.signature(func)
-        assert sig.return_annotation is not inspect.Signature.empty, (
-            f"{func.__name__} missing return annotation"
-        )
-        for param in sig.parameters.values():
-            assert param.annotation is not inspect.Parameter.empty, (
-                f"{func.__name__}({param.name}) missing annotation"
-            )
+    assert_type_hints_explicit(_PUBLIC_FUNCS)
 
 
 def test_pmd3_argv_resolves() -> None:

--- a/packages/mcp/tests/test_notion.py
+++ b/packages/mcp/tests/test_notion.py
@@ -10,7 +10,6 @@ to NotionError mapping.
 from __future__ import annotations
 
 import asyncio
-import inspect
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -25,6 +24,7 @@ if NOTION_SRC.is_dir() and str(NOTION_SRC) not in sys.path:
     sys.path.insert(0, str(NOTION_SRC))
 
 import notion
+from type_hint_support import assert_type_hints_explicit
 
 # Public callables = everything exported except the error class and the model.
 _NON_CALLABLE = {"NotionError", "Page"}
@@ -46,17 +46,7 @@ def test_public_funcs_are_async() -> None:
 
 
 def test_type_hints_explicit() -> None:
-    # Mirrors the ruff ANN gate: every public function fully annotates its params
-    # and return type.
-    for func in _PUBLIC_FUNCS:
-        sig = inspect.signature(func)
-        assert sig.return_annotation is not inspect.Signature.empty, (
-            f"{func.__name__} missing return annotation"
-        )
-        for pname, param in sig.parameters.items():
-            assert param.annotation is not inspect.Parameter.empty, (
-                f"{func.__name__}({pname}) missing annotation"
-            )
+    assert_type_hints_explicit(_PUBLIC_FUNCS)
 
 
 def _install_handler(

--- a/packages/mcp/tests/test_slack.py
+++ b/packages/mcp/tests/test_slack.py
@@ -9,7 +9,6 @@ posts vs. in-thread replies, by stubbing the one network primitive
 from __future__ import annotations
 
 import asyncio
-import inspect
 import sys
 from pathlib import Path
 from typing import Any
@@ -22,6 +21,7 @@ if SLACK_SRC.is_dir() and str(SLACK_SRC) not in sys.path:
     sys.path.insert(0, str(SLACK_SRC))
 
 import slack
+from type_hint_support import assert_type_hints_explicit
 
 # Public callables = everything exported except the error classes.
 _PUBLIC_FUNCS = [
@@ -45,17 +45,7 @@ def test_error_type() -> None:
 
 
 def test_type_hints_explicit() -> None:
-    # Mirrors the ruff ANN gate: every public function fully annotates its params
-    # and return type.
-    for func in _PUBLIC_FUNCS:
-        sig = inspect.signature(func)
-        assert sig.return_annotation is not inspect.Signature.empty, (
-            f"{func.__name__} missing return annotation"
-        )
-        for pname, param in sig.parameters.items():
-            assert param.annotation is not inspect.Parameter.empty, (
-                f"{func.__name__}({pname}) missing annotation"
-            )
+    assert_type_hints_explicit(_PUBLIC_FUNCS)
 
 
 @pytest.fixture

--- a/packages/mcp/tests/type_hint_support.py
+++ b/packages/mcp/tests/type_hint_support.py
@@ -1,0 +1,22 @@
+"""Shared test helper mirroring the ruff ANN gate: assert every public
+function fully annotates its parameters and return type. Copied next to the
+per-module tests that use it (see each module's module.nix).
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable, Iterable
+from typing import Any
+
+
+def assert_type_hints_explicit(funcs: Iterable[Callable[..., Any]]) -> None:
+    for func in funcs:
+        sig = inspect.signature(func)
+        assert sig.return_annotation is not inspect.Signature.empty, (
+            f"{func.__name__} missing return annotation"
+        )
+        for pname, param in sig.parameters.items():
+            assert param.annotation is not inspect.Parameter.empty, (
+                f"{func.__name__}({pname}) missing annotation"
+            )

--- a/packages/minecraft/bossbar-overlay/app/crates/bossbar/src/layer_shell.rs
+++ b/packages/minecraft/bossbar-overlay/app/crates/bossbar/src/layer_shell.rs
@@ -121,12 +121,6 @@ fn now_unix() -> i64 {
         .unwrap_or(0)
 }
 
-fn open_url(url: &str) {
-    if let Err(e) = std::process::Command::new("xdg-open").arg(url).spawn() {
-        eprintln!("bossbar-overlay: failed to open {url}: {e}");
-    }
-}
-
 fn shell_margin(pos: Pos, positioned: bool) -> (i32, i32, i32, i32) {
     let top = pos.y.max(0.0).round() as i32;
     let left = if positioned {
@@ -963,7 +957,7 @@ impl App {
                             win.press_pos = None;
                         }
                         if let Some(url) = click_url {
-                            open_url(&url);
+                            overlay_core::open_url("bossbar-overlay", &url);
                         }
                         if let Some(pos) = drag_to {
                             self.move_bar(ev, bar_id, pos, true);

--- a/packages/minecraft/bossbar-overlay/app/crates/bossbar/src/overlay.rs
+++ b/packages/minecraft/bossbar-overlay/app/crates/bossbar/src/overlay.rs
@@ -83,20 +83,6 @@ fn now_unix() -> i64 {
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0)
 }
-/// Open a bar's click URL with the platform's opener (a URL, file, or any URI it
-/// accepts), detached so the overlay never blocks on the browser launch. A spawn
-/// failure is reported but not fatal: a bad URL should not take down the HUD.
-fn open_url(url: &str) {
-    let opener = if cfg!(target_os = "macos") {
-        "open"
-    } else {
-        "xdg-open"
-    };
-    if let Err(e) = std::process::Command::new(opener).arg(url).spawn() {
-        eprintln!("bossbar-overlay: failed to open {url}: {e}");
-    }
-}
-
 /// One bar's window and its surface.
 struct BarWin {
     window: Arc<Window>,
@@ -663,7 +649,7 @@ impl ApplicationHandler<Vec<BossBar>> for App {
                     (clicked && !win.bar.url.trim().is_empty()).then(|| win.bar.url.clone())
                 });
                 if let Some(url) = url {
-                    open_url(&url);
+                    overlay_core::open_url("bossbar-overlay", &url);
                 }
             }
             WindowEvent::MouseInput {

--- a/packages/minecraft/bossbar-overlay/app/crates/orb/src/overlay.rs
+++ b/packages/minecraft/bossbar-overlay/app/crates/orb/src/overlay.rs
@@ -52,19 +52,6 @@ const SHIMMER_PERIOD: Duration = Duration::from_millis(2000);
 /// lock into one motion.
 const BOB_PERIOD: Duration = Duration::from_millis(2600);
 
-/// Open the orb's click URL with the platform opener, detached so the overlay
-/// never blocks on the launch. A spawn failure is reported but not fatal.
-fn open_url(url: &str) {
-    let opener = if cfg!(target_os = "macos") {
-        "open"
-    } else {
-        "xdg-open"
-    };
-    if let Err(e) = std::process::Command::new(opener).arg(url).spawn() {
-        eprintln!("xp-orb-overlay: failed to open {url}: {e}");
-    }
-}
-
 struct WinState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
@@ -335,7 +322,7 @@ impl ApplicationHandler<Orb> for App {
                     false
                 };
                 if clicked && !self.orb.url.trim().is_empty() {
-                    open_url(&self.orb.url);
+                    overlay_core::open_url("xp-orb-overlay", &self.orb.url);
                 }
             }
             WindowEvent::MouseInput {

--- a/packages/minecraft/bossbar-overlay/app/crates/overlay-core/src/lib.rs
+++ b/packages/minecraft/bossbar-overlay/app/crates/overlay-core/src/lib.rs
@@ -58,3 +58,18 @@ pub fn resolve_data_path(env_var: &str, app_dir: &str, file_name: &str) -> std::
         .join(app_dir)
         .join(file_name)
 }
+
+/// Open `url` with the platform's opener (`open` on macOS, `xdg-open`
+/// elsewhere), detached so the overlay never blocks on the launch. A spawn
+/// failure is logged under `app` but is not fatal: a bad URL should not take
+/// down the HUD.
+pub fn open_url(app: &str, url: &str) {
+    let opener = if cfg!(target_os = "macos") {
+        "open"
+    } else {
+        "xdg-open"
+    };
+    if let Err(e) = std::process::Command::new(opener).arg(url).spawn() {
+        eprintln!("{app}: failed to open {url}: {e}");
+    }
+}

--- a/packages/plumb/ex/Cargo.toml
+++ b/packages/plumb/ex/Cargo.toml
@@ -13,9 +13,9 @@ crate-type = ["cdylib"]
 workspace = true
 
 [dependencies]
-libc.workspace = true
 plumb-core.workspace = true
 serde.workspace = true
 rustler.workspace = true
 serde_json.workspace = true
 unibind = { workspace = true, features = ["ex"] }
+unibind-ex-runtime.workspace = true

--- a/packages/plumb/ex/src/lib.rs
+++ b/packages/plumb/ex/src/lib.rs
@@ -54,23 +54,6 @@ mod _plumb {
 
     impl std::error::Error for PlumbError {}
 
-    /// The BEAM's main VM process ignores SIGCHLD (ports fork from
-    /// erl_child_setup, so the VM expects to own no children), and SIG_IGN
-    /// auto-reaps our pipeline children before waitpid can collect their
-    /// exit statuses (ECHILD). Restore the default disposition once: with
-    /// erl_child_setup in the picture the VM process has no other children
-    /// to reap.
-    fn ensure_sigchld_default() {
-        static ONCE: std::sync::Once = std::sync::Once::new();
-        ONCE.call_once(|| {
-            // SAFETY: signal(2) with a standard disposition; no handler
-            // code runs.
-            unsafe {
-                libc::signal(libc::SIGCHLD, libc::SIG_DFL);
-            }
-        });
-    }
-
     fn convert(error: plumb_core::Error) -> PlumbError {
         use plumb_core::Error;
         let message = error.to_string();
@@ -105,7 +88,7 @@ mod _plumb {
         /// Open a shell (process env, process cwd, output captured only).
         #[unibind(constructor)]
         pub fn new() -> Result<Self, PlumbError> {
-            ensure_sigchld_default();
+            unibind_ex_runtime::ensure_sigchld_default();
             plumb_core::Shell::new(plumb_core::Config::default())
                 .map(|inner| Self { inner })
                 .map_err(convert)

--- a/packages/tui/ex/Cargo.toml
+++ b/packages/tui/ex/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 workspace = true
 
 [dependencies]
-libc.workspace = true
 rustler.workspace = true
 tui.workspace = true
 unibind = { workspace = true, features = ["ex"] }
+unibind-ex-runtime.workspace = true

--- a/packages/tui/ex/src/lib.rs
+++ b/packages/tui/ex/src/lib.rs
@@ -67,28 +67,12 @@ mod _tui_ex {
 
     impl std::error::Error for TuiError {}
 
-    /// The BEAM's main VM process ignores SIGCHLD (ports fork from
-    /// erl_child_setup, so the VM expects to own no children), and SIG_IGN
-    /// auto-reaps our PTY children before the manager's reaper can collect
-    /// their exit statuses. Restore the default disposition once, before
-    /// the first spawn; mirrors packages/plumb/ex.
-    fn ensure_sigchld_default() {
-        static ONCE: std::sync::Once = std::sync::Once::new();
-        ONCE.call_once(|| {
-            // SAFETY: signal(2) with a standard disposition; no handler
-            // code runs.
-            unsafe {
-                libc::signal(libc::SIGCHLD, libc::SIG_DFL);
-            }
-        });
-    }
-
     /// One manager (and one tokio runtime) per BEAM node, alive for the
     /// process lifetime, exactly like tui-py's `global_manager`.
     fn manager() -> &'static tui::TuiManager {
         static MANAGER: OnceLock<tui::TuiManager> = OnceLock::new();
         MANAGER.get_or_init(|| {
-            ensure_sigchld_default();
+            unibind_ex_runtime::ensure_sigchld_default();
             tui::TuiManager::new()
         })
     }

--- a/packages/unibind/ex-runtime/Cargo.toml
+++ b/packages/unibind/ex-runtime/Cargo.toml
@@ -9,6 +9,7 @@ description = "BEAM-side support for unibind's rustler backend: the shared tokio
 workspace = true
 
 [dependencies]
+libc.workspace = true
 rustler.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time"] }
 unibind-runtime.workspace = true

--- a/packages/unibind/ex-runtime/src/lib.rs
+++ b/packages/unibind/ex-runtime/src/lib.rs
@@ -5,9 +5,11 @@
 //! by every unibind NIF library in the node, the [`spawn_reply`] plumbing
 //! that runs an `async fn` and messages the calling process, and the
 //! [`spawn_stream`] plumbing that drives a [`unibind_runtime::UniStream`]
-//! under consumer demand. User crates never name this crate in their own
-//! code (streams are `UniStream<T>` from `unibind-runtime`, shared with
-//! every backend); everything here is called by generated code.
+//! under consumer demand. Aside from [`ensure_sigchld_default`], which a NIF
+//! that spawns OS child processes calls by hand before its first spawn, user
+//! crates never name this crate in their own code (streams are `UniStream<T>`
+//! from `unibind-runtime`, shared with every backend); the rest is called by
+//! generated code.
 //!
 //! # Wire protocol
 //!
@@ -32,3 +34,21 @@ mod stream;
 pub use reply::{InFlight, Never, spawn_reply};
 pub use runtime::runtime;
 pub use stream::{StreamHandle, grant, spawn_stream};
+
+/// Restore `SIGCHLD` to its default disposition, once per process.
+///
+/// The BEAM's main VM process ignores `SIGCHLD` (its ports fork from
+/// `erl_child_setup`, so the VM expects to own no children), and `SIG_IGN`
+/// auto-reaps a NIF's own child processes before it can `waitpid` their exit
+/// statuses (`ECHILD`). A NIF that spawns OS child processes and reaps them
+/// itself calls this before its first spawn: with `erl_child_setup` in the
+/// picture the VM process has no other children to reap.
+pub fn ensure_sigchld_default() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        // SAFETY: signal(2) with a standard disposition; no handler code runs.
+        unsafe {
+            libc::signal(libc::SIGCHLD, libc::SIG_DFL);
+        }
+    });
+}


### PR DESCRIPTION
Mechanical dedup of the twins the embedding dupe finder flagged in #3958.

## Folds

- **ensure_sigchld_default** (plumb/ex, tui/ex): the byte-identical BEAM SIGCHLD reset moved into `unibind-ex-runtime`, the crate that already holds BEAM-side rustler runtime support, exported as `unibind_ex_runtime::ensure_sigchld_default`. Both NIF crates call it and drop their local copy plus their now-unused direct `libc` dependency. (`unibind` itself is a proc-macro crate and cannot host a plain fn, so ex-runtime is the correct seam; both crates already pull it in transitively via the `ex` backend.)
- **open_url** (bossbar overlays): moved into `overlay-core`, the crate both overlays already depend on, as `overlay_core::open_url(app, url)`. Folded all three copies: `orb/overlay.rs`, `bossbar/overlay.rs`, and a third copy inside `bossbar/layer_shell.rs`. The `app` tag preserves each binary's distinct log prefix.
- **_spool_home** (mcp): the weave spool teardown fixture now lives once in `packages/mcp/src/weave/conftest.py`, copied into the fabric test derivation (where `test_fabric.py` and `test_weave.py` already run together) via a weave `passthru`, and removed from both test files.
- **test_type_hints_explicit** (mcp): extracted into `packages/mcp/tests/type_hint_support.py`, mirroring the existing `linear_test_support.py` shared-helper pattern, and wired into the notion, iphone, and slack test derivations. Folded all three copies.

## Skips (no coupling invented)

- **tui/ex/build.rs vs tui/tui-py/build.rs**: the identical `fn main()` emitting the macOS `-undefined dynamic_lookup` link flag is a workspace-wide convention with about 14 copies, each carrying a backend-specific rationale (NIF `enif_*` vs PyO3), and `nix-cargo-unit` already centralizes link-flag handling at the build-graph layer. A shared build-dependency crate for only the tui pair would be inconsistent 2-of-14 coupling, so it is left as is.
- **minecraft/protocol py vs jvm parse_address/classify**: both files already carry a `clone:ignore-file` marker documenting that each backend's boundary must live inside its own `#[unibind::export]` module in its own crate. The helpers produce per-backend unibind record/error types (`ServerAddress`, `SlpError`) that cannot be extracted until unibind can export one module to several backends. Folding would require inventing an intermediate type, so it is left as the maintainers intend.

The issue's NOT-bugs (astlog lint-test inputs, cargo-unit fixture trees, tui slice tests) were left untouched.

## Verification

`nix run .#lint` passes; `cargo fmt --check` (pinned toolchain) is clean on the touched Rust; `Cargo.lock` regenerated for the new dependency edges. Crate builds and mcp test derivations run in CI.

(authored by Claude Code, model Opus)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate `ensure_sigchld_default`, `open_url`, and MCP test helpers into shared utilities
> - Moves `ensure_sigchld_default` (SIGCHLD reset via `libc::signal`) into `unibind-ex-runtime` and removes duplicate implementations from `plumb/ex` and `tui/ex`.
> - Moves `open_url` (platform-aware URL opener) into `overlay-core` and removes duplicate implementations from `bossbar` and `orb` overlays.
> - Extracts a shared `assert_type_hints_explicit` helper into [type_hint_support.py](https://github.com/indexable-inc/index/pull/3968/files#diff-00fbc63c0e320fbccec4eb1aef6c919b58d93d8f636a85194fdd80b895504ad9) and replaces inline inspection logic in iphone, notion, and slack tests.
> - Moves the autouse `_spool_home` pytest fixture into a shared [conftest.py](https://github.com/indexable-inc/index/pull/3968/files#diff-9cc87e78198953397f32c7bda11785cd4e4a23763919f9a1a72381bcf7cbf051) and removes duplicate fixture definitions from `test_fabric.py` and `test_weave.py`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a02ae19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->