### PR TITLE
rust: clear the five red lanes the wave-2 force merges stacked on main

### DIFF
--- a/packages/google/auth/src/lib.rs
+++ b/packages/google/auth/src/lib.rs
@@ -494,9 +494,11 @@ pub fn logout_message(removed: &[PathBuf], json: bool) -> String {
 }
 
 /// Delete this machine's stored Google grant and print the shared logout
-/// confirmation ([`logout_message`]). Idempotent: signing out when already
-/// signed out is a no-op, not an error. The `gmail` and `gcal` CLIs both
-/// call this so their `logout` subcommands cannot drift.
+/// confirmation ([`logout_message`]).
+///
+/// Idempotent: signing out when already signed out is a no-op, not an
+/// error. The `gmail` and `gcal` CLIs both call this so their `logout`
+/// subcommands cannot drift.
 ///
 /// # Errors
 /// Returns an error if the platform exposes no config directory, or if a

--- a/packages/google/calendar/src/parse.rs
+++ b/packages/google/calendar/src/parse.rs
@@ -1,6 +1,6 @@
 //! Parse `--start`/`--end` boundary strings into wire [`EventTime`]s.
 //!
-//! The Rust MCP server (`packages/google/mcp`) and the PyO3 bindings
+//! The Rust MCP server (`packages/google/mcp`) and the `PyO3` bindings
 //! (`packages/google/py`) both take an event boundary as a string plus an
 //! `all_day` flag, and both must agree on how it parses and on the
 //! inclusive-to-exclusive all-day end conversion. One parser here keeps the
@@ -48,6 +48,9 @@ pub enum ParseEventTimeError {
 /// The `map_err` for a boundary parse: names the field, the rejected input,
 /// and the shape that was expected. One constructor keeps the all-day and
 /// timed branches from each spelling out the same closure.
+// The fork's anonymous_tuple_return_type lint misreads FnOnce(A) -> B sugar
+// as a tuple return (index#3970); remove this allow when the lint is fixed.
+#[allow(clippy::anonymous_tuple_return_type)]
 fn parse_failure(
     field: &'static str,
     input: &str,

--- a/packages/mcp/src/fabric/test_fabric.py
+++ b/packages/mcp/src/fabric/test_fabric.py
@@ -836,7 +836,7 @@ def test_reconcile_weave_unreachable_raises_fabric_error(monkeypatch: pytest.Mon
 
 
 def test_run_spawn_survives_unreachable_weave(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, _spool_home: Path
 ) -> None:
     """The other half of the boundary (index#3419): spawn-path recording rides
     the durable local spool, so an unreachable server never fails or blocks
@@ -851,7 +851,7 @@ def test_run_spawn_survives_unreachable_weave(
         return await handle.wait()
 
     assert run(main()) == 5
-    segments = list((tmp_path / "weave-spool").glob("w-*.jsonl"))
+    segments = list(_spool_home.glob("w-*.jsonl"))
     assert segments, "intent must be durable on disk while undelivered"
 
 
@@ -859,7 +859,7 @@ def test_run_spawn_survives_unreachable_weave(
 
 
 def test_session_spawns_and_records_while_weave_down(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, _spool_home: Path
 ) -> None:
     """index#3418 invariant: with weave unreachable, the submitted intent is
     fsync'd to the local spool BEFORE the SDK subprocess spawns, the session
@@ -896,7 +896,7 @@ def test_session_spawns_and_records_while_weave_down(
     # append order, prompt payload included.
     assert fake.queries == ["do it"]
     assert journal.facts == []
-    segments = list((tmp_path / "weave-spool").glob("w-*.jsonl"))
+    segments = list(_spool_home.glob("w-*.jsonl"))
     assert len(segments) == 1
     lines = [json.loads(line) for line in segments[0].read_text().splitlines() if line]
     attrs = [item["fact"]["attr"] for item in lines if "fact" in item]

--- a/packages/mcp/src/weave/test_weave.py
+++ b/packages/mcp/src/weave/test_weave.py
@@ -214,7 +214,7 @@ def _journal_transport(monkeypatch: pytest.MonkeyPatch, *, down: dict[str, bool]
 
 
 def test_record_is_durable_before_delivery_and_drains_in_order(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    _spool_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     down = {"is": True}
     facts, blobs = _journal_transport(monkeypatch, down=down)
@@ -223,7 +223,7 @@ def test_record_is_durable_before_delivery_and_drains_in_order(
     run(weave.record([("task:1", "state", "running")]))
 
     # Durable on disk while the server is unreachable; nothing delivered.
-    segments = list((tmp_path / "spool").glob("*.jsonl"))
+    segments = list(_spool_home.glob("*.jsonl"))
     assert len(segments) == 1
     lines = [weave.json.loads(line) for line in segments[0].read_text().splitlines()]
     assert [item.get("fact", {}).get("attr", "blob") for item in lines] == ["state", "blob", "state"]
@@ -259,11 +259,11 @@ def test_spool_transition_prints_exactly_one_loud_line(
     assert err.count("reachable again") == 1
 
 
-def test_spool_orphan_segment_adopted_and_drained(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_spool_orphan_segment_adopted_and_drained(_spool_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     down = {"is": False}
     facts, _blobs = _journal_transport(monkeypatch, down=down)
-    orphan = tmp_path / "spool"
-    orphan.mkdir(parents=True)
+    orphan = _spool_home
+    orphan.mkdir(parents=True, exist_ok=True)
     # A crashed writer's segment: two committed lines plus one torn append
     # (never fsync-completed, so never intent) - no live flock holder.
     (orphan / "w-999-dead.jsonl").write_text(

--- a/packages/tui/vt/ix-vt/src/lib.rs
+++ b/packages/tui/vt/ix-vt/src/lib.rs
@@ -115,15 +115,15 @@ impl StyleColor {
     /// which holds for any value libghostty-vt writes into a `GhosttyStyle`.
     unsafe fn from_raw(color: sys::GhosttyStyleColor) -> Self {
         match color.tag {
-            sys::GhosttyStyleColorTag::GHOSTTY_STYLE_COLOR_NONE => Self::None,
+            // The MAX_VALUE arm is an ABI-width sentinel; never a real tag.
+            sys::GhosttyStyleColorTag::GHOSTTY_STYLE_COLOR_NONE
+            | sys::GhosttyStyleColorTag::GHOSTTY_STYLE_COLOR_TAG_MAX_VALUE => Self::None,
             sys::GhosttyStyleColorTag::GHOSTTY_STYLE_COLOR_PALETTE => {
                 Self::Palette(unsafe { color.value.palette })
             }
             sys::GhosttyStyleColorTag::GHOSTTY_STYLE_COLOR_RGB => {
                 Self::Rgb(unsafe { color.value.rgb }.into())
             }
-            // ABI-width sentinel; never a real tag.
-            sys::GhosttyStyleColorTag::GHOSTTY_STYLE_COLOR_TAG_MAX_VALUE => Self::None,
         }
     }
 }
@@ -233,11 +233,11 @@ impl From<sys::GhosttyRenderStateCursorVisualStyle> for CursorVisualStyle {
         use sys::GhosttyRenderStateCursorVisualStyle as Raw;
         match s {
             Raw::GHOSTTY_RENDER_STATE_CURSOR_VISUAL_STYLE_BAR => Self::Bar,
-            Raw::GHOSTTY_RENDER_STATE_CURSOR_VISUAL_STYLE_BLOCK => Self::Block,
+            // The MAX_VALUE arm is an ABI-width sentinel; never a real style.
+            Raw::GHOSTTY_RENDER_STATE_CURSOR_VISUAL_STYLE_BLOCK
+            | Raw::GHOSTTY_RENDER_STATE_CURSOR_VISUAL_STYLE_MAX_VALUE => Self::Block,
             Raw::GHOSTTY_RENDER_STATE_CURSOR_VISUAL_STYLE_UNDERLINE => Self::Underline,
             Raw::GHOSTTY_RENDER_STATE_CURSOR_VISUAL_STYLE_BLOCK_HOLLOW => Self::BlockHollow,
-            // ABI-width sentinel; never a real style.
-            Raw::GHOSTTY_RENDER_STATE_CURSOR_VISUAL_STYLE_MAX_VALUE => Self::Block,
         }
     }
 }
@@ -555,7 +555,12 @@ impl Terminal {
             sys::ghostty_terminal_set(
                 terminal.raw,
                 sys::GhosttyTerminalOption::GHOSTTY_TERMINAL_OPT_USERDATA,
-                terminal.responses.as_ref().get().cast::<c_void>().cast_const(),
+                terminal
+                    .responses
+                    .as_ref()
+                    .get()
+                    .cast::<c_void>()
+                    .cast_const(),
             )
         })?;
         let write_pty: unsafe extern "C" fn(sys::GhosttyTerminal, *mut c_void, *const u8, usize) =

--- a/packages/unibind/backend-py/src/stream.rs
+++ b/packages/unibind/backend-py/src/stream.rs
@@ -27,6 +27,7 @@ pub struct StreamExport<'a> {
 
 /// Every stream-returning export in the interface, in render order (free
 /// functions first, then each object's methods).
+#[must_use]
 pub fn collect(interface: &ir::Interface) -> Vec<StreamExport<'_>> {
     let free = interface
         .functions
@@ -56,10 +57,12 @@ fn stream_export<'a>(
 }
 
 impl StreamExport<'_> {
+    #[must_use]
     pub fn class_ident(&self) -> Ident {
         class_ident(self.owner, &self.function.name)
     }
 
+    #[must_use]
     pub fn render(&self, ctx: &Ctx<'_>) -> TokenStream {
         let ident = self.class_ident();
         let py_name = class_name(self.owner, &self.function.name);
@@ -110,11 +113,13 @@ impl StreamExport<'_> {
     }
 }
 
-/// The Rust identifier of a stream class. Export names are unique per
-/// scope (Rust enforces it), so classes cannot collide within a scope; a
-/// free function named exactly like an object+method concatenation would
-/// collide across scopes, and fails loudly as a duplicate item in the glue
-/// module rather than silently misbinding.
+/// The Rust identifier of a stream class.
+///
+/// Export names are unique per scope (Rust enforces it), so classes cannot
+/// collide within a scope; a free function named exactly like an
+/// object+method concatenation would collide across scopes, and fails loudly
+/// as a duplicate item in the glue module rather than silently misbinding.
+#[must_use]
 pub fn class_ident(owner: Option<&str>, export: &str) -> Ident {
     let export = pascal_case(export);
     owner.map_or_else(


### PR DESCRIPTION
Main is red again after the wave-2 force merges (#3963/#3966/#3968) plus the earlier ix#8117 vt commit. Freshest main run (29893604492): rust-mcp.fabricTests, rust-ix-vt.clippy, rust-google-auth.clippy, rust-google-calendar.clippy; the prior run also had rust-unibind-backend-py.clippy. All five reproduced locally against the exact CI lane derivations and fixed:

- fabricTests: #3968 folded two _spool_home fixtures that differed in spool path (weave: tmp_path/spool, fabric: tmp_path/weave-spool) and kept fabric's; two weave tests hardcoding the old path failed. Tests now take the fixture's yielded path, removing the hidden coupling. Lane rebuilt green locally.
- ix-vt.clippy: match_same_arms on two ABI-sentinel arms; merged the patterns.
- unibind-backend-py.clippy: 4x must_use_candidate + 1 too_long_first_doc_paragraph in the stream module #3966 moved.
- google-auth.clippy: too_long_first_doc_paragraph on run_logout.
- google-calendar.clippy: doc-markdown (PyO3) plus the fork anonymous_tuple_return_type misfiring on impl FnOnce(A) -> B sugar; targeted allow citing index#3970 (fork lint fix is the root fix).

(authored by Claude Code, model Fable 5)
