### PR TITLE
chromium-cookies: macOS Chromium cookie extractor for VM cookie sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1338,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,6 +1605,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1701,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "chromium-cookies"
+version = "0.1.0"
+dependencies = [
+ "aes",
+ "anyhow",
+ "cbc",
+ "clap",
+ "pbkdf2",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,6 +1774,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
 ]
 
 [[package]]
@@ -5543,6 +5597,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8762,6 +8826,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "packages/audio/net",
   "packages/audio/score",
   "packages/blast-radius",
+  "packages/chromium-cookies",
   "packages/code/ast-merge/ast",
   "packages/code/ast-merge/cli",
   "packages/code/ast-merge/diff",
@@ -187,6 +188,7 @@ anonymous_tuple_return_type = "deny"
 fallible_int_fallback = "deny"
 
 [workspace.dependencies]
+aes = "0.8"
 anstream = "1"
 anstyle = "1"
 anyhow = "1"
@@ -207,6 +209,7 @@ astlog-core = { path = "packages/code/astlog/core" }
 axum = "0.8"
 base64 = "0.22"
 bytes = "1"
+cbc = "0.1"
 # Pure-Rust bzip2 (the 0.6 default backend is libbz2-rs-sys), used to read
 # Nix's build logs, which are bzip2-compressed on disk while being written.
 bzip2 = "0.6"
@@ -312,6 +315,7 @@ panes-protocol = { path = "packages/vm/panes/protocol" }
 panes-guest-transport = { path = "packages/vm/panes/guest-transport" }
 parking_lot = "0.12"
 parquet = { version = "59", features = ["arrow"] }
+pbkdf2 = { version = "0.12", default-features = false }
 percent-encoding = "2"
 # Apple property lists for index-delta's logical-diff engines: macOS `defaults`
 # domains and LaunchAgents are plists (XML and binary), so drift in them must be
@@ -353,6 +357,7 @@ source-meta = { path = "packages/search/source/meta" }
 serde = "1"
 serde_json = "1"
 serde_norway = "0.9"
+sha1 = "0.10"
 sha2 = "0.11"
 shlex = "1"
 similar = "3"

--- a/packages/chromium-cookies/Cargo.toml
+++ b/packages/chromium-cookies/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "chromium-cookies"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Extract and decrypt cookies from macOS Chromium apps for VM cookie sync"
+license = "MIT"
+
+[lints]
+workspace = true
+
+[dependencies]
+aes = { workspace = true }
+anyhow = { workspace = true }
+cbc = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+pbkdf2 = { workspace = true, features = ["hmac"] }
+rusqlite = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+sha1 = { workspace = true }

--- a/packages/chromium-cookies/README.md
+++ b/packages/chromium-cookies/README.md
@@ -1,0 +1,35 @@
+# chromium-cookies
+
+Extract and decrypt cookies from any macOS Chromium app (Chrome, Arc, Dia,
+Brave, Edge, and Electron apps like Slack) so a local browser session can be
+synced onto a remote ix VM.
+
+Chromium apps share one SQLite `Cookies` schema but namespace the AES key per
+app (a separate `<App> Safe Storage` Keychain entry each), so cookies cannot be
+copied raw across apps or machines. This tool decrypts with the source app's key
+so the result is replantable elsewhere.
+
+```sh
+chromium-cookies list                              # apps with a cookie store
+chromium-cookies extract dia                       # decrypted, as JSON
+chromium-cookies extract Slack --domain slack.com  # filter by host
+chromium-cookies extract chrome --format netscape > cookies.txt
+```
+
+`--format netscape` writes a curl-importable `cookies.txt`, the shape a VM
+wants. The first read of another app's secret pops the macOS Keychain dialog
+once; choose "Always Allow" to silence it.
+
+## Layers
+
+| module     | job                                                             |
+|------------|-----------------------------------------------------------------|
+| `browser`  | find the `Cookies` DB (flat or `User Data/` layout), name the secret |
+| `keychain` | read `<App> Safe Storage` via `/usr/bin/security`               |
+| `crypto`   | PBKDF2 the key, AES-128-CBC decrypt the `v10`/`v11` blob         |
+| `store`    | open the DB read-only + `immutable`, decrypt each row            |
+
+## Scope
+
+macOS only. Windows (DPAPI) and Linux (libsecret) use different key management;
+add them as sibling `keychain`/`crypto` backends when needed.

--- a/packages/chromium-cookies/default.nix
+++ b/packages/chromium-cookies/default.nix
@@ -1,0 +1,14 @@
+{
+  ix,
+  lib,
+  ...
+}:
+ix.cargoUnit.selectBinaryWithTests ix.rustWorkspace.units {
+  binary = "chromium-cookies";
+  meta = {
+    description = "Extract and decrypt cookies from macOS Chromium apps for VM cookie sync";
+    license = lib.licenses.mit;
+    mainProgram = "chromium-cookies";
+    platforms = lib.platforms.darwin;
+  };
+}

--- a/packages/chromium-cookies/package.nix
+++ b/packages/chromium-cookies/package.nix
@@ -1,0 +1,10 @@
+{
+  id = "chromium-cookies";
+  packageSet = true;
+  flake = true;
+  # A local operator CLI for syncing browser sessions onto a VM; nothing
+  # consumes it as `pkgs.chromium-cookies` from modules.
+  overlay = false;
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/chromium-cookies/src/browser.rs
+++ b/packages/chromium-cookies/src/browser.rs
@@ -1,0 +1,118 @@
+//! Where a Chromium app keeps its cookies and what its Keychain secret is called.
+//!
+//! Every Chromium app follows the same shape, so resolution is a search, not a
+//! hardcoded table. A name is either a display name we know an alias for, or the
+//! literal `Application Support` subdirectory of the app.
+
+use anyhow::{Result, anyhow, bail};
+use std::path::{Path, PathBuf};
+
+/// A resolved app: the cookie DB to open and the Keychain secret to unlock it.
+#[derive(Debug, Clone)]
+pub struct Target {
+    pub name: String,
+    pub cookie_db: PathBuf,
+    pub keychain_service: String,
+}
+
+/// Display-name aliases whose `Application Support` dir differs from the name.
+fn alias(name: &str) -> &'static str {
+    match name.to_ascii_lowercase().as_str() {
+        "chrome" | "google chrome" => "Google/Chrome",
+        "chrome beta" => "Google/Chrome Beta",
+        "chromium" => "Chromium",
+        "edge" => "Microsoft Edge",
+        "brave" => "BraveSoftware/Brave-Browser",
+        "arc" => "Arc",
+        "dia" => "Dia",
+        _ => "",
+    }
+}
+
+/// The Keychain secret is `<DisplayName> Safe Storage`; recover the display name.
+fn keychain_service_for(name: &str) -> String {
+    let display = match name.to_ascii_lowercase().as_str() {
+        "chrome" | "google chrome" => "Chrome",
+        "chromium" => "Chromium",
+        "edge" => "Microsoft Edge",
+        "brave" => "Brave",
+        "arc" => "Arc",
+        "dia" => "Dia",
+        _ => name,
+    };
+    format!("{display} Safe Storage")
+}
+
+fn app_support() -> Result<PathBuf> {
+    let home = std::env::var_os("HOME").ok_or_else(|| anyhow!("HOME is unset"))?;
+    Ok(Path::new(&home).join("Library/Application Support"))
+}
+
+/// Candidate cookie-DB locations under an app dir, most specific first. Chrome
+/// uses a flat profile; Arc and Dia nest it under `User Data`.
+fn cookie_db_candidates(dir: &Path) -> Vec<PathBuf> {
+    [
+        "User Data/Default/Network/Cookies",
+        "User Data/Default/Cookies",
+        "Default/Network/Cookies",
+        "Default/Cookies",
+        "Network/Cookies",
+        "Cookies",
+    ]
+    .iter()
+    .map(|leaf| dir.join(leaf))
+    .collect()
+}
+
+/// Resolve a name to a concrete, existing cookie store plus its Keychain secret.
+pub fn resolve(name: &str) -> Result<Target> {
+    let base = app_support()?;
+    let subdir = match alias(name) {
+        "" => name,
+        mapped => mapped,
+    };
+    let dir = base.join(subdir);
+    let cookie_db = cookie_db_candidates(&dir)
+        .into_iter()
+        .find(|p| p.exists())
+        .ok_or_else(|| {
+            anyhow!(
+                "no cookie DB under {} (looked for a Chromium profile, e.g. User Data/Default/Cookies)",
+                dir.display()
+            )
+        })?;
+
+    Ok(Target {
+        name: name.to_owned(),
+        cookie_db,
+        keychain_service: keychain_service_for(name),
+    })
+}
+
+/// Every Chromium app on this machine that has a cookie DB, by subdir name.
+pub fn discover() -> Result<Vec<Target>> {
+    let base = app_support()?;
+    let entries = std::fs::read_dir(&base).map_err(|e| anyhow!("reading {}: {e}", base.display()))?;
+
+    let mut out: Vec<Target> = entries
+        .flatten()
+        .filter(|entry| entry.path().is_dir())
+        .filter_map(|entry| {
+            let db = cookie_db_candidates(&entry.path())
+                .into_iter()
+                .find(|p| p.exists())?;
+            let name = entry.file_name().to_string_lossy().into_owned();
+            Some(Target {
+                keychain_service: keychain_service_for(&name),
+                name,
+                cookie_db: db,
+            })
+        })
+        .collect();
+
+    if out.is_empty() {
+        bail!("no Chromium cookie stores found under {}", base.display());
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
+}

--- a/packages/chromium-cookies/src/crypto.rs
+++ b/packages/chromium-cookies/src/crypto.rs
@@ -1,0 +1,68 @@
+//! Turn a `Safe Storage` password into an AES key and decrypt a cookie blob.
+//!
+//! macOS Chromium uses `AES-128-CBC` with a key of
+//! `PBKDF2-HMAC-SHA1(password, "saltysalt", 1003, 16)` and a fixed 16-space IV.
+//! Encrypted values carry a 3-byte `v10`/`v11` version tag. Recent Chromium also
+//! prepends a 32-byte `SHA-256` domain hash to the plaintext, which
+//! [`decode_value`] strips when present.
+
+use aes::cipher::{BlockDecryptMut, KeyIvInit, block_padding::Pkcs7};
+use anyhow::{Result, anyhow, bail};
+
+const SALT: &[u8] = b"saltysalt";
+const ITERATIONS: u32 = 1003;
+const KEY_LEN: usize = 16;
+const IV: [u8; 16] = [b' '; 16];
+const HASH_PREFIX_LEN: usize = 32;
+
+type Aes128CbcDec = cbc::Decryptor<aes::Aes128>;
+
+/// Derive the 16-byte AES key from a `Safe Storage` password.
+#[must_use]
+pub fn derive_key(password: &[u8]) -> [u8; KEY_LEN] {
+    let mut key = [0u8; KEY_LEN];
+    pbkdf2::pbkdf2_hmac::<sha1::Sha1>(password, SALT, ITERATIONS, &mut key);
+    key
+}
+
+/// Decrypt one `encrypted_value` blob to raw plaintext (hash prefix intact).
+///
+/// # Errors
+/// Fails when the blob lacks a known version tag, has a non-block-aligned body,
+/// or the `AES`/`PKCS7` decrypt does not validate.
+pub fn decrypt(blob: &[u8], key: &[u8; KEY_LEN]) -> Result<Vec<u8>> {
+    let body = match blob.get(..3) {
+        Some(b"v10" | b"v11") => &blob[3..],
+        _ => bail!("unrecognized cookie encryption (want a v10/v11 prefix)"),
+    };
+    if body.is_empty() || body.len() % 16 != 0 {
+        let len = body.len();
+        bail!("ciphertext length {len} is not a block multiple");
+    }
+
+    let mut buf = body.to_vec();
+    let pt = Aes128CbcDec::new(key.into(), &IV.into())
+        .decrypt_padded_mut::<Pkcs7>(&mut buf)
+        .map_err(|e| anyhow!("AES/PKCS7 decrypt failed: {e}"))?;
+    Ok(pt.to_vec())
+}
+
+/// Decode plaintext to a cookie string, stripping the 32-byte domain-hash prefix
+/// newer Chromium prepends. Printable UTF-8 as-is wins; otherwise the tail after
+/// the prefix is tried.
+#[must_use]
+pub fn decode_value(plaintext: &[u8]) -> String {
+    fn printable(bytes: &[u8]) -> Option<String> {
+        std::str::from_utf8(bytes)
+            .ok()
+            .filter(|s| s.chars().all(|c| !c.is_control() || c == '\t'))
+            .map(str::to_owned)
+    }
+
+    printable(plaintext)
+        .or_else(|| plaintext.get(HASH_PREFIX_LEN..).and_then(printable))
+        .unwrap_or_else(|| {
+            let len = plaintext.len();
+            format!("<{len} binary bytes>")
+        })
+}

--- a/packages/chromium-cookies/src/keychain.rs
+++ b/packages/chromium-cookies/src/keychain.rs
@@ -1,0 +1,33 @@
+//! Read a Chromium app's `Safe Storage` secret from the macOS login Keychain.
+//!
+//! There is no stable one-shot C API for a generic-password read that respects
+//! the access-control prompt, so we shell out to `/usr/bin/security`, the path
+//! Chrome itself documents. The first read of another app's secret pops the
+//! standard Keychain dialog; `Always Allow` makes it silent thereafter.
+
+use anyhow::{Result, bail};
+use std::process::Command;
+
+/// Fetch the cleartext password for the generic-password service `service`
+/// (e.g. `"Dia Safe Storage"`), the raw bytes Chromium feeds to `PBKDF2`.
+pub fn safe_storage_password(service: &str) -> Result<Vec<u8>> {
+    let out = Command::new("/usr/bin/security")
+        .args(["find-generic-password", "-w", "-s", service])
+        .output()?;
+
+    if !out.status.success() {
+        let status = out.status;
+        let msg = String::from_utf8_lossy(&out.stderr);
+        bail!("security exited {status}: {}", msg.trim());
+    }
+
+    // `-w` prints the password followed by a trailing newline.
+    let mut pw = out.stdout;
+    if pw.last() == Some(&b'\n') {
+        pw.pop();
+    }
+    if pw.is_empty() {
+        bail!("empty password for Keychain service {service:?}");
+    }
+    Ok(pw)
+}

--- a/packages/chromium-cookies/src/main.rs
+++ b/packages/chromium-cookies/src/main.rs
@@ -1,0 +1,108 @@
+//! `chromium-cookies` - pull decrypted cookies out of any macOS Chromium app.
+//!
+//! Built to sync a local browser session onto a remote ix VM: extract here as
+//! JSON or a Netscape `cookies.txt`, ship the file over, and replant it in the
+//! VM's browser or an HTTP client. `list` discovers installed apps.
+
+mod browser;
+mod crypto;
+mod keychain;
+mod store;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand, ValueEnum};
+use std::fmt::Write as _;
+use store::Cookie;
+
+/// Seconds between the Chromium epoch (1601-01-01) and the Unix epoch.
+const CHROMIUM_TO_UNIX_SECS: i64 = 11_644_473_600;
+
+#[derive(Parser)]
+#[command(about, version)]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// List Chromium apps on this machine that have a cookie store.
+    List,
+    /// Extract and decrypt cookies for one app (e.g. `dia`, `chrome`, `Slack`).
+    Extract {
+        /// App display name or `Application Support` subdirectory.
+        app: String,
+        /// Output format.
+        #[arg(long, value_enum, default_value_t = Format::Json)]
+        format: Format,
+        /// Keep only cookies whose host contains this substring.
+        #[arg(long)]
+        domain: Option<String>,
+    },
+}
+
+#[derive(Copy, Clone, ValueEnum)]
+enum Format {
+    Json,
+    Netscape,
+}
+
+fn main() -> Result<()> {
+    match Cli::parse().cmd {
+        Cmd::List => list(),
+        Cmd::Extract {
+            app,
+            format,
+            domain,
+        } => extract(&app, format, domain.as_deref()),
+    }
+}
+
+fn list() -> Result<()> {
+    for t in browser::discover()? {
+        println!("{:<24} {}", t.name, t.cookie_db.display());
+    }
+    Ok(())
+}
+
+fn extract(app: &str, format: Format, domain: Option<&str>) -> Result<()> {
+    let target = browser::resolve(app)?;
+    let password = keychain::safe_storage_password(&target.keychain_service)
+        .with_context(|| format!("reading Keychain secret {:?}", target.keychain_service))?;
+    let key = crypto::derive_key(&password);
+
+    let mut cookies =
+        store::read(&target.cookie_db, &key).with_context(|| format!("reading {}", target.cookie_db.display()))?;
+    if let Some(d) = domain {
+        cookies.retain(|c| c.host.contains(d));
+    }
+
+    match format {
+        Format::Json => println!("{}", serde_json::to_string_pretty(&cookies)?),
+        Format::Netscape => print!("{}", netscape(&cookies)),
+    }
+    eprintln!("{} cookies", cookies.len());
+    Ok(())
+}
+
+/// Render cookies as a Netscape `cookies.txt`, the format curl and browsers
+/// import. Chromium expiry (microseconds since 1601) becomes Unix seconds.
+fn netscape(cookies: &[Cookie]) -> String {
+    let mut out = String::from("# Netscape HTTP Cookie File\n");
+    for c in cookies {
+        let expires = if c.expires_utc == 0 {
+            0
+        } else {
+            c.expires_utc / 1_000_000 - CHROMIUM_TO_UNIX_SECS
+        };
+        let subdomains = if c.host.starts_with('.') { "TRUE" } else { "FALSE" };
+        let secure = if c.secure { "TRUE" } else { "FALSE" };
+        // Infallible: writing to a String never errors.
+        let _ = writeln!(
+            out,
+            "{}\t{subdomains}\t{}\t{secure}\t{expires}\t{}\t{}",
+            c.host, c.path, c.name, c.value
+        );
+    }
+    out
+}

--- a/packages/chromium-cookies/src/store.rs
+++ b/packages/chromium-cookies/src/store.rs
@@ -1,0 +1,80 @@
+//! Read and decrypt rows from a Chromium `Cookies` `SQLite` database.
+//!
+//! The DB is opened read-only and `immutable=1` so a running browser holding a
+//! write-ahead-log lock does not block us. Each row's `encrypted_value` is
+//! decrypted with the caller's key; a row that fails to decrypt surfaces the
+//! error in its value rather than being dropped.
+
+use crate::crypto;
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OpenFlags};
+use serde::Serialize;
+use std::path::Path;
+
+/// One decrypted cookie, with the fields a sync target needs to replant it.
+#[derive(Debug, Clone, Serialize)]
+pub struct Cookie {
+    pub host: String,
+    pub name: String,
+    pub value: String,
+    pub path: String,
+    pub secure: bool,
+    pub http_only: bool,
+    pub same_site: i64,
+    /// Chromium epoch: microseconds since 1601-01-01 UTC. 0 means a session cookie.
+    pub expires_utc: i64,
+}
+
+/// Read every cookie from `db`, decrypting values with `key`.
+///
+/// # Errors
+/// Fails when the database cannot be opened read-only or a row cannot be read.
+pub fn read(db: &Path, key: &[u8; 16]) -> Result<Vec<Cookie>> {
+    let uri = format!("file:{}?immutable=1", db.display());
+    let conn = Connection::open_with_flags(
+        uri,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+    )
+    .with_context(|| format!("opening {}", db.display()))?;
+
+    let mut stmt = conn.prepare(
+        "SELECT host_key, name, value, encrypted_value, path, \
+                is_secure, is_httponly, samesite, expires_utc \
+         FROM cookies",
+    )?;
+
+    let rows = stmt.query_map([], |r| {
+        let plain: String = r.get(2)?;
+        let enc: Vec<u8> = r.get(3)?;
+        let value = decrypt_field(&plain, &enc, key);
+
+        Ok(Cookie {
+            host: r.get(0)?,
+            name: r.get(1)?,
+            value,
+            path: r.get(4)?,
+            secure: r.get::<_, i64>(5)? != 0,
+            http_only: r.get::<_, i64>(6)? != 0,
+            same_site: r.get(7)?,
+            expires_utc: r.get(8)?,
+        })
+    })?;
+
+    rows.collect::<rusqlite::Result<Vec<Cookie>>>()
+        .context("reading cookie rows")
+}
+
+/// Prefer a plaintext `value`; otherwise decrypt `encrypted_value`, reporting a
+/// failure inline so one bad row never sinks the whole export.
+fn decrypt_field(plain: &str, enc: &[u8], key: &[u8; 16]) -> String {
+    if !plain.is_empty() {
+        return plain.to_owned();
+    }
+    if enc.is_empty() {
+        return String::new();
+    }
+    match crypto::decrypt(enc, key) {
+        Ok(pt) => crypto::decode_value(&pt),
+        Err(e) => format!("<decrypt failed: {e}>"),
+    }
+}


### PR DESCRIPTION
New macOS CLI crate that decrypts cookies from any Chromium app (Chrome, Arc, Dia, Brave, Edge, Electron apps) so a local browser session can be synced onto a remote ix VM.

Chromium namespaces its AES cookie key per app in the Keychain, so raw copies are useless off-machine. This decrypts with the source app's key and emits JSON or a curl-importable Netscape `cookies.txt`.

Modules: `browser` (locate the profile Cookies DB; handles Chrome's flat layout and Arc/Dia's `User Data/` layout), `keychain` (read `<App> Safe Storage` via `/usr/bin/security`), `crypto` (PBKDF2-HMAC-SHA1 key, AES-128-CBC decrypt of `v10`/`v11` blobs, strip the 32-byte domain-hash prefix), `store` (open read-only + `immutable`, decrypt each row).

Verified locally: decrypts real Slack and Dia sessions. macOS only (compiles everywhere; Keychain/paths are darwin).

Closes #3972.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `chromium-cookies` CLI tool to extract and decrypt macOS Chromium browser cookies
> - Adds a new `chromium-cookies` binary crate that reads cookies from Chromium-based browsers (Chrome, Edge, Brave, Arc, Dia) on macOS and decrypts them using the macOS Keychain Safe Storage password.
> - Implements AES-128-CBC decryption via PBKDF2-HMAC-SHA1 key derivation in [crypto.rs](https://github.com/indexable-inc/index/pull/3973/files#diff-83fed5acf07892fe3db903a193f07f64c9bdaf0b28ccbcf500dfc5ca18086831), using the fixed salt `saltysalt` and 1003 iterations matching Chromium's scheme.
> - Provides `list` and `extract` subcommands: `list` enumerates detected Chromium cookie stores; `extract` decrypts and outputs cookies as JSON or Netscape `cookies.txt` format with optional domain filtering.
> - Opens the SQLite cookies DB in read-only/immutable mode to avoid locking a running browser; single-row decryption failures produce an inline error string rather than aborting the export.
> - Packaged as a Darwin-only Nix derivation in [default.nix](https://github.com/indexable-inc/index/pull/3973/files#diff-f7fd1a4bf19b6e601ceefd96ac9f4e7544e3816ae47705a39e27e23ef9460b81).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22c2420.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->