### PR TITLE
unibind: kill the conformance caller only after slow/1 has started

### DIFF
--- a/packages/unibind/conformance-ex/mix/test/unibind_conformance_test.exs
+++ b/packages/unibind/conformance-ex/mix/test/unibind_conformance_test.exs
@@ -111,6 +111,7 @@ defmodule UnibindConformanceTest do
   describe "caller-exit cancellation" do
     test "a caller exiting mid-call drops the in-flight future (cancelled_count)" do
       baseline = Conf.cancelled_count()
+      started = Conf.started_count()
       parent = self()
 
       pid =
@@ -125,6 +126,15 @@ defmodule UnibindConformanceTest do
         end)
 
       assert_receive :started, 1_000
+
+      # Kill only once slow's body is running: the NIF returning proves the
+      # future was spawned, not polled, and an abort that lands before the
+      # first poll drops it with the cancel guard never armed, so
+      # cancelled_count would stay flat forever (index#3974; main runs
+      # 29893447304 and 29895946094 lost that race under CI load).
+      assert eventually(fn -> Conf.started_count() >= started + 1 end, 15_000),
+             "slow/1 never started executing"
+
       Process.exit(pid, :kill)
 
       # 15s, not the 2s default: this ran on CI hosts saturated by parallel

--- a/packages/unibind/conformance-ex/src/lib.rs
+++ b/packages/unibind/conformance-ex/src/lib.rs
@@ -161,6 +161,7 @@ mod _unibind_conformance {
     }
 
     static CANCELLED: AtomicU64 = AtomicU64::new(0);
+    static STARTED: AtomicU64 = AtomicU64::new(0);
 
     /// Cancellation probe: dropped while still armed (the only way the
     /// future can end other than running to completion), it bumps
@@ -182,8 +183,14 @@ mod _unibind_conformance {
 
     /// Sleep `ms` on the runtime holding a `CancelGuard` across the await,
     /// then resolve to `ms`. Cancelled, the guard drops armed.
+    ///
+    /// Bumps `STARTED` on entry: an async body only runs at first poll, so
+    /// an abort that lands earlier drops the future with the guard never
+    /// armed. Callers that want to observe cancellation wait for
+    /// `started_count` to move before killing the caller.
     pub async fn slow(ms: u64) -> u64 {
         let mut guard = CancelGuard { armed: true };
+        STARTED.fetch_add(1, Ordering::SeqCst);
         tokio::time::sleep(Duration::from_millis(ms)).await;
         guard.armed = false;
         ms
@@ -192,6 +199,12 @@ mod _unibind_conformance {
     /// Calls of `slow` cancelled so far (armed guard drops).
     pub fn cancelled_count() -> u64 {
         CANCELLED.load(Ordering::SeqCst)
+    }
+
+    /// Calls of `slow` whose body has begun executing (first poll reached;
+    /// the cancel guard is armed from this point on).
+    pub fn started_count() -> u64 {
+        STARTED.load(Ordering::SeqCst)
     }
 
     static DROPPED_SESSIONS: AtomicU64 = AtomicU64::new(0);


### PR DESCRIPTION
Fixes #3974.

Main flake-check went red on `unibind-conformance-ex-run` in runs [29893447304](https://github.com/indexable-inc/index/actions/runs/29893447304) and [29895946094](https://github.com/indexable-inc/index/actions/runs/29895946094):

```
1) test caller-exit cancellation a caller exiting mid-call drops the in-flight future (cancelled_count)
   cancelled_count never reached baseline + 1
```

The test killed the caller microseconds after `Native.slow` returned. `spawn_reply` schedules the future on tokio, but the async body -- which arms the `CancelGuard` -- only runs at first poll. When the BEAM monitor's `down` -> `abort()` beats the first poll (easy on a loaded CI host), tokio drops the future without running it: the guard is never armed and `cancelled_count` can never move, so the 15s `eventually` window is useless. The same drv passed on a quiet retry in run 29896520979, and the failing run's sibling tests with 100-200ms timing all passed, which rules out plain slowness.

Fix: `slow` bumps a `STARTED` counter at body entry (new `started_count` export) and the test gates the `Process.exit` on `started_count` moving, so the kill only ever lands mid-call -- the property the test was written to defend. The zlib.h noise in the logs is unrelated (libz-sys pkg-config probe before its vendored fallback; that drv succeeds).

Verified: `nix build .#checks.x86_64-linux.unibind-conformance-ex-run` (the exact CI attr, built on the vc1-nix builder) is green with 26 tests, 0 failures; the fixed test now completes in 41ms. `nix run .#lint` passes.

(authored by Claude Code, model Fable 5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix race condition in unibind conformance caller-exit cancellation test
> - Adds a `started_count()` function (backed by an `AtomicU64` static `STARTED`) to [lib.rs](https://github.com/indexable-inc/index/pull/3980/files#diff-f5cd2e315048c8c9d445a89fb2d7cc5f700b3a58b0b9f2e7df72ba34bfdd6849) that tracks how many `slow()` invocations have reached their first poll.
> - Updates the [conformance test](https://github.com/indexable-inc/index/pull/3980/files#diff-8347c2d522a5d56a0891faac50d486abbd029781bdb13611e530db0cfcf2778e) to wait (up to 15s) for `started_count` to increment before killing the caller process, ensuring `slow/1`'s async body has begun executing.
> - Risk: the 15s timeout is a hard ceiling; on very slow CI machines the check could still time out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4384142.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->