### PR TITLE
site: point every indexable-inc.github.io link at the live ix.dev origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 index is a Nix monorepo in the spirit of [nixpkgs](https://github.com/NixOS/nixpkgs) and [Raycast extensions](https://github.com/raycast/extensions): one shared definition of the software everyone here runs. Inside: [packages](packages/), patched toolchains ([Nix](packages/nix/nix/), [Clippy](packages/llm-clippy/)), [NixOS and Home Manager modules](modules/), [VM images](images/), and [CI](.github/workflows/). It is also the default world an [ix.dev](https://ix.dev) VM boots: ix is the runtime, index is what runs on it.
 
-It exists because agents now write patches faster than upstream review can absorb them. A fix that takes an agent minutes can wait months in a review queue, and some projects refuse AI-written patches outright. Here the same change lands on main today, and upstream can adopt it whenever it wants. The [philosophy](https://indexable-inc.github.io/index/philosophy/) page has the full argument.
+It exists because agents now write patches faster than upstream review can absorb them. A fix that takes an agent minutes can wait months in a review queue, and some projects refuse AI-written patches outright. Here the same change lands on main today, and upstream can adopt it whenever it wants. The [philosophy](https://ix.dev/philosophy) page has the full argument.
 
 ## Why
 
@@ -79,9 +79,9 @@ You download binaries instead of compiling them. CI builds on the [ix.dev](https
 
 The fastest way to get what this repo is for: short case examples, each a two-minute read with a diagram.
 
-1. [Your whole team's Claude, from one flake](https://indexable-inc.github.io/index/stories/manage-claude-with-nix/): the agent binary, prompt, tools, permissions, and MCP servers, pinned in code.
-2. [Add a tool once, everyone gets it](https://indexable-inc.github.io/index/stories/add-a-tool-once/): a small utility stops dying on the laptop it was born on.
-3. [Your Mac never compiles](https://indexable-inc.github.io/index/stories/mac-never-compiles/): the Linux fleet cross-compiles macOS binaries your laptop just downloads.
-4. [Every session becomes searchable memory](https://indexable-inc.github.io/index/stories/searchable-history/): shell and agent history from every machine, one semantic index.
-5. [CI builds each crate exactly once](https://indexable-inc.github.io/index/stories/build-each-crate-once/): the Rust workspace as a per-crate build DAG.
-6. [A thousand agents, one Elixir kernel](https://indexable-inc.github.io/index/stories/elixir-agent-kernel/): agents work through supervised, fleet-federated workspaces on a runtime built for that shape.
+1. [Your whole team's Claude, from one flake](https://ix.dev/stories/manage-claude-with-nix): the agent binary, prompt, tools, permissions, and MCP servers, pinned in code.
+2. [Add a tool once, everyone gets it](https://ix.dev/stories/add-a-tool-once): a small utility stops dying on the laptop it was born on.
+3. [Your Mac never compiles](https://ix.dev/stories/mac-never-compiles): the Linux fleet cross-compiles macOS binaries your laptop just downloads.
+4. [Every session becomes searchable memory](https://ix.dev/stories/searchable-history): shell and agent history from every machine, one semantic index.
+5. [CI builds each crate exactly once](https://ix.dev/stories/build-each-crate-once): the Rust workspace as a per-crate build DAG.
+6. [A thousand agents, one Elixir kernel](https://ix.dev/stories/elixir-agent-kernel): agents work through supervised, fleet-federated workspaces on a runtime built for that shape.

--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -635,7 +635,7 @@
         Publish substantial work as a site update:
         `packages/site/src/lib/updates/<slug>.svx`, frontmatter `id`,
         `postedAt`, `title`, `links`, `tags`; mdsvex, so fence `{` and
-        `<...>`. It renders at `https://indexable-inc.github.io/index/<slug>`;
+        `<...>`. It renders at `https://ix.dev/updates/<slug>`;
         post that link to Slack `#general` with AI attribution.
       '';
       reason = ''

--- a/packages/site/default.nix
+++ b/packages/site/default.nix
@@ -5,7 +5,6 @@
   siteBuild = ix.buildSvelteSite pkgs {
     sourceRoot = ix.paths.packagesRoot + "/site";
     distDir = "build";
-    serve.routePrefix = "/index";
   };
 in
   siteBuild.overrideAttrs (old: {

--- a/packages/site/src/lib/components.ts
+++ b/packages/site/src/lib/components.ts
@@ -1,7 +1,7 @@
 // Page-level components of the index site, exported for consumers of the
 // raw-source package (`@indexable/site/components`). The index app's own
 // routes import the same files through `$lib`, which aliases this package
-// source dir, so one implementation serves github.io and ix.dev.
+// source dir, so one implementation serves ix.dev and local previews.
 export { default as BenchCompareTable } from './BenchCompareTable.svelte';
 export { default as Dag } from './Dag.svelte';
 export { default as FilterBar } from './FilterBar.svelte';

--- a/packages/site/src/lib/feed.ts
+++ b/packages/site/src/lib/feed.ts
@@ -10,8 +10,9 @@ import {
 
 // RSS 2.0 builder for the updates feed. Lives in the library (not the
 // feed.xml route) so ix.dev renders the same feed from the same
-// implementation; the defaults reproduce the github.io output byte for
-// byte, and a consumer overrides `siteUrl` to emit its own permalinks.
+// implementation; the defaults reproduce the live ix.dev output, and a
+// consumer serving the content elsewhere overrides `siteUrl` to emit its
+// own permalinks.
 export type FeedOptions = {
   // Absolute site root with a trailing slash; entry permalinks append ids.
   siteUrl?: string;

--- a/packages/site/src/lib/plans/0006-hosted-tool-credentials.svx
+++ b/packages/site/src/lib/plans/0006-hosted-tool-credentials.svx
@@ -91,7 +91,7 @@ The requirements surface is the seam that makes this incremental: a hosted crede
 
 ### Relationship to Plan 0002
 
-[Plan 0002](https://indexable-inc.github.io/index/plans/0002-third-party-integrations) designs partner-mediated integrations for ix *VMs*: per-VM scoped credentials, host-attested identity, fleet-time binding, boot-time materialization. This proposal is the user-identity sibling for tooling that runs anywhere (a laptop running `ix-mcp`, not a fleet VM), and inherits 0002's invariants where they apply: no secrets in the Nix store or evaluated configuration; scoped, revocable credentials per principal; billing truth from gateway or provider-side records, never from counters the client can forge; typed, fail-closed failures. The identity primitive differs (user login instead of VM attestation); when both exist, the gateway and provisioner should be one service with two principal types.
+[Plan 0002](https://ix.dev/plans/0002-third-party-integrations) designs partner-mediated integrations for ix *VMs*: per-VM scoped credentials, host-attested identity, fleet-time binding, boot-time materialization. This proposal is the user-identity sibling for tooling that runs anywhere (a laptop running `ix-mcp`, not a fleet VM), and inherits 0002's invariants where they apply: no secrets in the Nix store or evaluated configuration; scoped, revocable credentials per principal; billing truth from gateway or provider-side records, never from counters the client can forge; typed, fail-closed failures. The identity primitive differs (user login instead of VM attestation); when both exist, the gateway and provisioner should be one service with two principal types.
 
 ### Implementation shape and sequencing
 

--- a/packages/site/src/lib/stories/build-each-crate-once.svx
+++ b/packages/site/src/lib/stories/build-each-crate-once.svx
@@ -36,4 +36,5 @@ The same per-unit seam is where repo-wide lint policy attaches: the patched
 Clippy with house lints runs per crate and caches per crate. The machinery
 is [`lib/`'s `cargo-unit`](https://github.com/indexable-inc/index/tree/main/packages/nix/nix-cargo-unit),
 proposed to go further in
-[Plan 0005](https://indexable-inc.github.io/index/plans/0005-cargo-drv/).
+[Plan 0005](https://github.com/indexable-inc/index/blob/c570253deb255ed30380fbd6d43f2efcf85535eb/packages/site/src/lib/plans/0005-cargo-drv.svx)
+(since retired from the live plans set).

--- a/packages/site/src/lib/stories/mac-never-compiles.svx
+++ b/packages/site/src/lib/stories/mac-never-compiles.svx
@@ -34,5 +34,5 @@ happened.
 </svg>
 
 The design and its tradeoffs are written up in
-[Plan 0009](https://indexable-inc.github.io/index/plans/0009-cross-compiled-darwin-packages/),
+[Plan 0009](https://ix.dev/plans/0009-cross-compiled-darwin-packages),
 which the fleet has since made load-bearing.

--- a/packages/site/src/lib/styles/tokens.css
+++ b/packages/site/src/lib/styles/tokens.css
@@ -7,7 +7,7 @@
 
    Berkeley Mono is commercially licensed, so the woff2 files live in the
    ix repo only; this public repo ships the stack and falls back to
-   ui-monospace on github.io. Single source of truth: app.css imports this
+   ui-monospace elsewhere. Single source of truth: app.css imports this
    file, and consumers import `@indexable/site/styles/tokens.css`. */
 
 :root {

--- a/packages/site/src/lib/updates.ts
+++ b/packages/site/src/lib/updates.ts
@@ -58,7 +58,7 @@ export const siteUpdates: SiteUpdate[] = Object.entries(modules)
   })
   .sort((a, b) => Date.parse(b.postedAt) - Date.parse(a.postedAt));
 
-export const siteUrl = 'https://indexable-inc.github.io/index/';
+export const siteUrl = 'https://ix.dev/';
 export const siteFeedUrl = `${siteUrl}feed.xml`;
 export const siteIntro =
   'Agents made writing code cheap; waiting on review queues and upstreams is now the expensive part. index is one open monorepo where every change lands now and reaches everyone: packages, NixOS modules, VM images, patched toolchains, and the agent infrastructure that ties them together.';

--- a/packages/site/src/lib/updates/agent-memory-weave-store.svx
+++ b/packages/site/src/lib/updates/agent-memory-weave-store.svx
@@ -9,7 +9,7 @@ links:
   - label: PR #3851 (seam + helper)
     href: https://github.com/indexable-inc/index/pull/3851
   - label: weave agent memory at scale
-    href: https://indexable-inc.github.io/index/weave-agent-memory-executed
+    href: https://ix.dev/updates/weave-agent-memory-executed
 ---
 
 The markdown auto-memory flow (a MEMORY.md flat index plus one file per fact, maintained by prompt rules) is retired on the first workstation and replaced by a weave store: an append-only fact journal with Datalog-derived views, committed to the operator's private config repo. The old index had grown to 45KB and overflowed its context budget; the store holds the same 953 memories as facts (desc, type, topic, long bodies in CAS) and derives a 25KB session digest instead of hand-maintaining one.

--- a/packages/site/src/lib/updates/ix-term-v2-native.svx
+++ b/packages/site/src/lib/updates/ix-term-v2-native.svx
@@ -15,12 +15,12 @@ links:
   - label: index removal (3811)
     href: https://github.com/indexable-inc/index/pull/3811
   - label: v1 update
-    href: https://indexable-inc.github.io/index/ix-term-web-terminal
+    href: https://ix.dev/updates/ix-term-web-terminal
 ---
 
 term.ix.dev now scrolls, renders in Berkeley Mono, answers the operator's
 Ghostty keybinds byte for byte, and runs as a real NixOS service. This is
-the sequel to [the v1 post](https://indexable-inc.github.io/index/ix-term-web-terminal):
+the sequel to [the v1 post](https://ix.dev/updates/ix-term-web-terminal):
 development moved to the private ix repo ([index#3810](https://github.com/indexable-inc/index/issues/3810)
 removed the index packages), and v2 landed there as
 [ix#7991](https://github.com/indexable-inc/ix/pull/7991) with follow-ups

--- a/packages/site/svelte.config.js
+++ b/packages/site/svelte.config.js
@@ -18,11 +18,12 @@ const config = {
       precompress: false,
       strict: true
     }),
-    // Site is served at https://indexable-inc.github.io/index/, so every
-    // emitted URL needs the `/index` prefix. Override with BASE_PATH="" for
-    // user.github.io-style deployments or a custom domain.
+    // No deployment serves this app under a path prefix: GitHub Pages (the
+    // only consumer of the old `/index` base) is gone (#3975, #3978), and
+    // ix.dev serves this package's content at the domain root via the web
+    // app in the ix repo. Override with BASE_PATH for a prefixed deployment.
     paths: {
-      base: process.env.BASE_PATH ?? '/index'
+      base: process.env.BASE_PATH ?? ''
     }
   }
 };


### PR DESCRIPTION
Fixes #3978.

Pages is disabled and pages.yml removed (#3975); every `indexable-inc.github.io/index` URL 404s. This repoints the repo at the live site.

## What changed

- **`packages/site/src/lib/updates.ts`**: `siteUrl = 'https://ix.dev/'`. This constant is already the single source of truth (`siteFeedUrl` and `updateUrl` derive from it, `feed.ts` imports it). Evidence it matches the live deployment exactly: the live `https://ix.dev/feed.xml` has channel `<link>https://ix.dev/</link>` and bare-slug item permalinks (`https://ix.dev/<slug>`, which 301 to `/updates/<slug>`).
- **`packages/site/svelte.config.js`**: base default `'/index'` -> `''`. Evidence, not guesswork: `https://ix.dev/index/` returns 404; ix.dev is not built from this app at all -- it is served by the ix repo's `packages/web` SvelteKit app (routes `(index)/updates/[id]`, `(index)/plans/[id]`, ...) which consumes this package's content at the domain root. The only deployment that ever needed `/index` was github.io, which is gone. `BASE_PATH` override kept for prefixed deployments.
- **`packages/site/default.nix`**: dropped `serve.routePrefix = "/index"` so `nix run .#site` previews the same root layout the build now emits (`buildSvelteSite` treats absent prefix as root).
- **`packages/agent/prompt/rules.nix:638`**: site-updates rule now says updates render at `https://ix.dev/updates/<slug>` (edited only rules.nix; rendered copies are overwritten per the file's own instruction).
- **Content hrefs** rewritten to live equivalents, each curl-verified 200:
  - `updates/agent-memory-weave-store.svx` -> `https://ix.dev/updates/weave-agent-memory-executed`
  - `updates/ix-term-v2-native.svx` (x2) -> `https://ix.dev/updates/ix-term-web-terminal`
  - `stories/mac-never-compiles.svx` -> `https://ix.dev/plans/0009-cross-compiled-darwin-packages`
  - `plans/0006-hosted-tool-credentials.svx` -> `https://ix.dev/plans/0002-third-party-integrations`
  - `stories/build-each-crate-once.svx`: Plan 0005 has **no live equivalent** -- `0005-cargo-drv.svx` was deleted from the plans set in 3274159a ("removed redundant RFCs") and `https://ix.dev/plans/0005-cargo-drv` 404s. The link now pins to the last rev carrying the plan (`blob/c570253d.../0005-cargo-drv.svx`, 200) and the prose notes it was retired.
- **Beyond the issue's list, same class of bug**: `README.md` had 7 more dead github.io links (philosophy + 6 stories), now `https://ix.dev/philosophy` and `https://ix.dev/stories/<slug>`; stale github.io comments in `feed.ts`, `components.ts`, `tokens.css` reworded.

`rg indexable-inc.github.io` over the tree is now empty.

## Verification

- All 14 rewritten URLs curl 200 (listed above plus `https://ix.dev/` and `https://ix.dev/feed.xml` for the derived constants).
- `packages/site`: `npm run build` (svelte-check + eslint + vite build) green; `npm run test` 46/46; built `build/index.html` emits relative `./_app` paths, no `/index` prefix.
- `nix build .#site --dry-run` evals; `nix run .#lint` exit 0.

Authored by Claude Code (AI agent).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Point all site URLs from indexable-inc.github.io to ix.dev
> - Changes `siteUrl` in [updates.ts](https://github.com/indexable-inc/index/pull/3983/files#diff-8385bcb03c190b4f8f3e68a626fc11b628e55aab40b9ef3c903649633de16ff6) from `https://indexable-inc.github.io/index/` to `https://ix.dev/`, updating all derived feed and permalink URLs.
> - Removes the `/index` route prefix from [svelte.config.js](https://github.com/indexable-inc/index/pull/3983/files#diff-8ed9bf89ee197b1e1e366425229801c5fb7c2cb758205e54ec4f5902bc89e99a) and the site build config, so assets and routes are served from the domain root by default.
> - Updates remaining `indexable-inc.github.io` links across docs, stories, and agent prompt rules to their `ix.dev` equivalents.
> - Behavioral Change: the built site no longer emits `/index`-prefixed paths unless `BASE_PATH` is explicitly set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a839940.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->