### PR TITLE
image: compute registry narHash when self is a path-locked input

### DIFF
--- a/lib/image/default.nix
+++ b/lib/image/default.nix
@@ -142,10 +142,22 @@
           # context, so it roots into the image closure once (no duplicate
           # copy — the #1748 trap). `self.narHash` locks the pin. Only this
           # flake scope sees `self`, so it is plumbed down from `flake.nix`.
+          # `self.narHash` is absent when index is consumed as a path-locked
+          # flake input (ix's ./index submodule seam, ix#8142): path-type lock
+          # nodes carry no narHash, so nix hands the input through without
+          # one. Recompute it from the already-ingested source in that case;
+          # fetchTree on a store path is pure and yields the same NAR hash
+          # a git consumption would have carried (index#3981).
           nix.registry.index.to = {
             type = "path";
             path = self.outPath;
-            inherit (self) narHash;
+            narHash =
+              self.narHash
+                or (builtins.fetchTree {
+                type = "path";
+                path = self.outPath;
+              })
+                .narHash;
           };
         }
         ++ [


### PR DESCRIPTION
Closes #3981.

ix consumes index as the ./index submodule (path:./index input). Path-type lock nodes carry no narHash, so once ix#8142 made the lock consistent, `inherit (self) narHash` in lib/image failed eval and every ix main ci run went red on the seam checks (e.g. run 29897475367; also ix#8147). Before the sync, the stale lock forced an in-memory relock that recomputed narHash, masking this.

Fall back to `builtins.fetchTree { type = "path"; path = self.outPath; }` (pure for store paths, same NAR hash a git consumption carries).

Verified: `checks.x86_64-linux.seam-activation-job-timeouts` in ix evals to a drvPath with this index (was: attribute narHash missing); fetchTree narHash confirmed on a store path.

Authored with Claude Code (Anthropic Fable).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Compute `narHash` from `self.outPath` when self is a path-locked flake input
> Path-locked flake inputs do not carry a `narHash` on `self`, which caused the registry entry to be missing it. [default.nix](https://github.com/indexable-inc/index/pull/3984/files#diff-3883253618b080892e770f4ceb96188ed814f4f588df529f7a82d338874c14bd) now falls back to computing the hash via `builtins.fetchTree { type = "path"; path = self.outPath; }.narHash` when `self.narHash` is absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e634656.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->