### PR TITLE
kernel: raise on a missing Cmd cd: target instead of returning {"", 2} (#3979)

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/cmd.ex
+++ b/packages/mcp-ex/lib/ix_mcp/cmd.ex
@@ -17,6 +17,12 @@ defmodule IxMcp.Cmd do
   `cd:` is the cwd captured once at application boot (`capture_launch_cwd/0`,
   called before any cell can run), immutable for the life of the instance.
   Working anywhere else takes an explicit `cd:` (or `git -C`).
+
+  A `cd:` directory that does not exist raises before the spawn. Erlang's
+  child setup reports a failed `chdir` by exiting with the raw errno --
+  `{"", 2}` for ENOENT, `{"", 20}` for ENOTDIR -- indistinguishable from
+  the command's own exit status, so a session whose launch dir was deleted
+  mid-session saw every command "fail" with empty exit-2 output (#3979).
   """
 
   @launch_cwd_key {__MODULE__, :launch_cwd}
@@ -48,12 +54,11 @@ defmodule IxMcp.Cmd do
   """
   @spec run(binary(), [binary()], keyword()) :: {Collectable.t(), non_neg_integer()}
   def run(cmd, args \\ [], opts \\ []) do
+    opts = validate_cd!(opts)
+
     # `$0` is `cmd` and `$@` the args, so no shell parsing touches them.
-    System.cmd(
-      "/bin/sh",
-      ["-c", ~S(exec "$0" "$@" </dev/null), cmd | args],
-      Keyword.put_new(opts, :cd, launch_cwd())
-    )
+    System.cmd("/bin/sh", ["-c", ~S(exec "$0" "$@" </dev/null), cmd | args], opts)
+    |> guard_cd_race(opts[:cd])
   end
 
   @doc """
@@ -64,10 +69,50 @@ defmodule IxMcp.Cmd do
   """
   @spec sh(binary(), keyword()) :: {Collectable.t(), non_neg_integer()}
   def sh(script, opts \\ []) do
-    System.cmd(
-      "/bin/sh",
-      ["-c", "exec </dev/null\n" <> script],
-      Keyword.put_new(opts, :cd, launch_cwd())
-    )
+    opts = validate_cd!(opts)
+
+    System.cmd("/bin/sh", ["-c", "exec </dev/null\n" <> script], opts)
+    |> guard_cd_race(opts[:cd])
+  end
+
+  # Default `cd:` to the launch dir and refuse to spawn into a directory
+  # that is not there: the port would otherwise report the child's failed
+  # `chdir` as `{"", errno}` with no diagnostic (#3979).
+  @spec validate_cd!(keyword()) :: keyword()
+  defp validate_cd!(opts) do
+    {cd, hint} =
+      case Keyword.fetch(opts, :cd) do
+        {:ok, cd} -> {cd, ""}
+        :error -> {launch_cwd(), " (session launch dir deleted?)"}
+      end
+
+    case File.stat(cd) do
+      {:ok, %File.Stat{type: :directory}} ->
+        Keyword.put(opts, :cd, cd)
+
+      {:ok, %File.Stat{type: other}} ->
+        raise ArgumentError, "cd target #{cd} is not a directory (#{other})"
+
+      {:error, :enoent} ->
+        raise ArgumentError, "cd target #{cd} does not exist#{hint}"
+
+      {:error, reason} ->
+        raise ArgumentError, "cd target #{cd} is not usable: #{:file.format_error(reason)}"
+    end
+  end
+
+  # The validate/spawn gap (TOCTOU): a `cd:` deleted after validation still
+  # produces the bare-errno exit. A zero status means `chdir` succeeded, so
+  # only a nonzero status with the directory now gone is ambiguous -- raise
+  # rather than hand back a status that may be errno, not the command's.
+  @spec guard_cd_race({Collectable.t(), non_neg_integer()}, binary()) ::
+          {Collectable.t(), non_neg_integer()}
+  defp guard_cd_race({_out, status} = result, cd) do
+    if status == 0 or File.dir?(cd) do
+      result
+    else
+      raise "cd target #{cd} no longer exists; exit #{status} may be the " <>
+              "raw chdir errno rather than the command's own status"
+    end
   end
 end

--- a/packages/mcp-ex/test/ix_mcp/cmd_cwd_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/cmd_cwd_test.exs
@@ -40,4 +40,34 @@ defmodule IxMcp.CmdCwdTest do
     # nothing in this suite has moved the OS cwd, so the two still agree.
     assert Cmd.launch_cwd() == File.cwd!()
   end
+
+  # The #3979 incident shape: a session launched from a directory that is
+  # later deleted (a cleaned-up git worktree) saw every pathless command
+  # return {"", 2} forever. The default-cd path must instead raise and
+  # point at the launch dir.
+  test "a deleted launch dir raises with the launch-dir hint (#3979)" do
+    doomed = Path.join(System.tmp_dir!(), "ix-cwd-doomed-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(doomed)
+
+    before = File.cwd!()
+    File.cd!(doomed)
+    Cmd.capture_launch_cwd()
+    File.cd!(before)
+    # File.cwd!() resolves symlinks (/tmp -> /private/tmp on macOS), so the
+    # captured path is the canonical spelling, not `doomed` verbatim.
+    captured = Cmd.launch_cwd()
+
+    try do
+      assert {_out, 0} = Cmd.run("pwd")
+
+      File.rm_rf!(doomed)
+      err = assert_raise(ArgumentError, fn -> Cmd.run("pwd") end)
+      assert err.message == "cd target #{captured} does not exist (session launch dir deleted?)"
+      assert_raise(ArgumentError, ~r/launch dir deleted/, fn -> Cmd.sh("pwd") end)
+    after
+      # Recapture the real launch dir so no later test inherits the stub.
+      Cmd.capture_launch_cwd()
+      File.rm_rf!(doomed)
+    end
+  end
 end

--- a/packages/mcp-ex/test/ix_mcp/cmd_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/cmd_test.exs
@@ -46,4 +46,45 @@ defmodule IxMcp.CmdTest do
     assert {out, 0} = await_5s(fn -> Cmd.sh("cat | wc -c") end)
     assert String.trim(out) == "0"
   end
+
+  # The #3979 incident: Erlang's child setup reports a failed chdir by
+  # exiting with the raw errno, so a missing cd: came back as {"", 2} --
+  # empty output, ENOENT dressed up as the command's own exit status.
+  describe "missing cd target (#3979)" do
+    test "run works while the cd exists and raises once it is deleted" do
+      dir = tmp_dir!()
+      assert {"a\n", 0} = Cmd.run("echo", ["a"], cd: dir)
+
+      File.rm_rf!(dir)
+      err = assert_raise(ArgumentError, fn -> Cmd.run("echo", ["a"], cd: dir) end)
+      assert err.message == "cd target #{dir} does not exist"
+    end
+
+    test "sh raises on a missing cd instead of returning {\"\", 2}" do
+      dir = tmp_dir!()
+      assert {"a\n", 0} = Cmd.sh("echo a", cd: dir)
+
+      File.rm_rf!(dir)
+      assert_raise(ArgumentError, ~r/does not exist/, fn -> Cmd.sh("echo a", cd: dir) end)
+    end
+
+    test "a cd that is a file, not a directory, raises (was {\"\", 20})" do
+      file = Path.join(tmp_dir!(), "plain-file")
+      File.write!(file, "")
+
+      assert_raise(ArgumentError, ~r/is not a directory/, fn ->
+        Cmd.run("echo", ["a"], cd: file)
+      end)
+    end
+
+    test "a cd deleted mid-command raises instead of returning an ambiguous status" do
+      dir = tmp_dir!()
+
+      # The command removes its own cwd and exits nonzero: the same
+      # after-the-spawn shape as a validate/spawn race, deterministically.
+      assert_raise(RuntimeError, ~r/no longer exists/, fn ->
+        Cmd.sh(~S(rmdir "$PWD" && exit 3), cd: dir)
+      end)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #3979.

## What broke

Erlang's child setup reports a failed `chdir` by exiting with the raw errno: `{"", 2}` (ENOENT) for a missing `cd:` directory, `{"", 20}` (ENOTDIR) for a non-directory -- empty output, no diagnostic, indistinguishable from the command's own exit. Since `Cmd` defaults `cd:` to the boot-captured launch dir (#3902), a session launched from a later-deleted directory (a cleaned-up git worktree) lost every subsequent `Cmd.run`/`Cmd.sh` exactly as the incident described: fine for 40 minutes, then permanent silent exit-2.

## Fix

- `run/3` and `sh/2` validate the resolved `cd:` before spawning: missing dir raises `ArgumentError` naming the path; the default-launch-dir case adds the `(session launch dir deleted?)` hint; a non-directory target raises too.
- TOCTOU: a `cd:` deleted between validation and spawn still yields the bare-errno exit, so a nonzero status with the directory now gone raises instead of returning the ambiguous status. A zero status means `chdir` succeeded, so successful runs are never second-guessed.
- Regression tests: the deterministic repro from the issue (pre-delete success, post-delete raise) for both `run` and `sh`, the ENOTDIR shape, the mid-command vanish, and the deleted-launch-dir hint.

## Audit

The `{"", 2}` was not fabricated by the wrapper -- it is OTP's `erl_child_setup` doing `_exit(errno)` on chdir failure (verified empirically: missing dir => 2/ENOENT, file-as-cd => 20/ENOTDIR). No other swallowed shape found in `Cmd`: a missing executable exits 127 and a non-executable 126 from `sh` itself (real statuses, documented), and a missing `/bin/sh` raises from `System.cmd`. Adjacent site `agents/cli_runner.ex` opens a Port with the same launch-dir default and would show the same errno-exit shape; left for a follow-up since it reports per-agent, not through this wrapper.

## Gates (local)

- `mix test`: 168 tests, 0 failures (5 new)
- nix sandbox check `.#mcp-ex.tests.elixir` + `.#mcp-ex.tests.smoke`: green (163/0, 2 env-excluded)
- `mix format --check-formatted`, `mix credo --strict` (shared `lib/elixir/credo.exs`): clean
- `nix run .#clone`: gate pass (0.313% vs 0.36% budget)

Authored by Claude Code (Fable 5), an AI agent, on andrew's behalf; admin-merge per standing instruction (andrewgazelka, 2026-07-21).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise on missing or invalid `cd:` target in `IxMcp.Cmd` instead of returning `{"" , 2}`
> - `run/3` and `sh/2` in [`cmd.ex`](https://github.com/indexable-inc/index/pull/3985/files#diff-b19457e1b4efbbfa827f50123aa2b3bcf7faa96953297c02aa1f57c2cef83453) now call `validate_cd!/1` before spawning, raising `ArgumentError` if `:cd` is missing, non-existent, or not a directory.
> - A new `guard_cd_race/2` helper checks the result of `System.cmd/3` after execution: if the directory disappeared and the exit status is nonzero, it raises `RuntimeError` to flag the ambiguous chdir errno instead of returning it silently.
> - Previously, a missing directory caused Erlang's child setup to report failure as `{"", 2}` (ENOENT) or `{"", 20}` (ENOTDIR), which was indistinguishable from a command that exited with those codes.
> - Behavioral Change: callers that previously received `{"", 2}` for a bad `:cd` path will now get an `ArgumentError` raised before spawn.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d49457e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->