### PR TITLE
kernel: raise a named error when Cmd's working directory is gone

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/cmd.ex
+++ b/packages/mcp-ex/lib/ix_mcp/cmd.ex
@@ -17,6 +17,12 @@ defmodule IxMcp.Cmd do
   `cd:` is the cwd captured once at application boot (`capture_launch_cwd/0`,
   called before any cell can run), immutable for the life of the instance.
   Working anywhere else takes an explicit `cd:` (or `git -C`).
+
+  A `cd:` that no longer exists -- the launch directory deleted mid-session,
+  or a caller naming a removed worktree -- raises `IxMcp.Cmd.DeadCwdError`
+  before the spawn. Left to `System.cmd/3`, the port child's failed `chdir`
+  exits 2 with nothing on stdout, so every command appears to fail as
+  `{"", 2}` with no diagnostics (#3979).
   """
 
   @launch_cwd_key {__MODULE__, :launch_cwd}
@@ -52,7 +58,7 @@ defmodule IxMcp.Cmd do
     System.cmd(
       "/bin/sh",
       ["-c", ~S(exec "$0" "$@" </dev/null), cmd | args],
-      Keyword.put_new(opts, :cd, launch_cwd())
+      put_live_cd!(opts)
     )
   end
 
@@ -67,7 +73,52 @@ defmodule IxMcp.Cmd do
     System.cmd(
       "/bin/sh",
       ["-c", "exec </dev/null\n" <> script],
-      Keyword.put_new(opts, :cd, launch_cwd())
+      put_live_cd!(opts)
     )
+  end
+
+  # `System.cmd/3` with a dead `cd:` does not raise: the port child's chdir
+  # fails after the fork, the child exits 2 with nothing on stdout, and the
+  # caller reads `{"", 2}` as if the command itself ran and failed. That is
+  # how a deleted launch directory silently broke every command mid-session
+  # while `:os.cmd/1` (no chdir) kept working (#3979). Checking here turns
+  # the dead directory into a named error; a concurrent delete can still
+  # race the spawn, but the window shrinks from "any time since boot" to
+  # one syscall.
+  defp put_live_cd!(opts) do
+    {cd, default?} =
+      case Keyword.fetch(opts, :cd) do
+        {:ok, cd} -> {cd, false}
+        :error -> {launch_cwd(), true}
+      end
+
+    if !File.dir?(cd) do
+      raise IxMcp.Cmd.DeadCwdError, path: cd, default?: default?
+    end
+
+    Keyword.put(opts, :cd, cd)
+  end
+end
+
+defmodule IxMcp.Cmd.DeadCwdError do
+  @moduledoc """
+  The directory a command would run in does not exist.
+
+  Raised by `IxMcp.Cmd.run/3` and `IxMcp.Cmd.sh/2` before the spawn, because
+  `System.cmd/3` reports a failed port-child `chdir` as `{"", 2}` --
+  indistinguishable from the command's own exit (#3979).
+  """
+  defexception [:path, :default?]
+
+  @impl true
+  def message(%{path: path, default?: true}) do
+    "launch directory #{path} no longer exists: it was deleted after the " <>
+      "kernel booted, so every pathless Cmd.run/Cmd.sh would spawn-fail as " <>
+      ~S({"", 2}) <> " (#3979); pass cd: naming a live directory"
+  end
+
+  def message(%{path: path, default?: false}) do
+    "cd: #{path} is not a directory, so the spawn would fail as " <>
+      ~S({"", 2}) <> " masquerading as the command's own exit (#3979)"
   end
 end

--- a/packages/mcp-ex/test/ix_mcp/cmd_cwd_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/cmd_cwd_test.exs
@@ -35,6 +35,38 @@ defmodule IxMcp.CmdCwdTest do
     end
   end
 
+  # The #3979 incident: the directory the kernel booted in was deleted
+  # mid-session, and from then on every Cmd.run/Cmd.sh -- `echo` included --
+  # returned {"", 2} in ~0s with no diagnostics, while :os.cmd/1 in the same
+  # cells kept working. The port child's failed chdir masquerades as the
+  # command's own exit code; the wrapper must name the dead layer instead.
+  test "a launch cwd deleted after boot raises a named error, not {\"\", 2} (#3979)" do
+    live = Cmd.launch_cwd()
+    before = File.cwd!()
+
+    doomed = Path.join(System.tmp_dir!(), "ix-dead-launch-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(doomed)
+    File.cd!(doomed)
+    Cmd.capture_launch_cwd()
+    File.cd!(before)
+
+    on_exit(fn ->
+      File.cd!(live)
+      Cmd.capture_launch_cwd()
+      File.cd!(before)
+    end)
+
+    File.rm_rf!(doomed)
+
+    assert_raise Cmd.DeadCwdError, ~r/launch directory .* no longer exists/, fn ->
+      Cmd.run("echo", ["hi"])
+    end
+
+    assert_raise Cmd.DeadCwdError, ~r/launch directory .* no longer exists/, fn ->
+      Cmd.sh("echo hi")
+    end
+  end
+
   test "the launch cwd is captured at boot, before any cell can move it" do
     # Application.start/2 captured File.cwd!() before the supervision tree;
     # nothing in this suite has moved the OS cwd, so the two still agree.

--- a/packages/mcp-ex/test/ix_mcp/cmd_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/cmd_test.exs
@@ -46,4 +46,12 @@ defmodule IxMcp.CmdTest do
     assert {out, 0} = await_5s(fn -> Cmd.sh("cat | wc -c") end)
     assert String.trim(out) == "0"
   end
+
+  test "an explicit cd: naming a missing directory raises, not {\"\", 2} (#3979)" do
+    gone = Path.join(System.tmp_dir!(), "ix-cmd-gone-#{System.unique_integer([:positive])}")
+
+    assert_raise Cmd.DeadCwdError, ~r/is not a directory/, fn ->
+      Cmd.run("echo", ["hi"], cd: gone)
+    end
+  end
 end

--- a/packages/site/src/lib/updates/cmd-dead-launch-cwd.svx
+++ b/packages/site/src/lib/updates/cmd-dead-launch-cwd.svx
@@ -1,0 +1,26 @@
+---
+id: cmd-dead-launch-cwd
+postedAt: 2026-07-21T12:00:00-07:00
+title: Kernel commands name a deleted working directory instead of failing as exit 2
+tags: [kernel, mcp, reliability]
+links:
+  - label: issue #3979
+    href: https://github.com/indexable-inc/index/issues/3979
+  - label: Cmd
+    href: https://github.com/indexable-inc/index/blob/main/packages/mcp-ex/lib/ix_mcp/cmd.ex
+---
+
+Kernel commands default to the directory captured at boot, so pathless
+`Cmd.run` and `Cmd.sh` always resolve against the launch checkout. When that
+directory was deleted mid-session -- a removed worktree, a recreated config
+repo -- every command from then on returned `{"", 2}` in about zero seconds,
+`echo` included, while `:os.cmd/1` and the File helpers kept working. The
+port child's failed `chdir` exits 2 with nothing on stdout, indistinguishable
+from the command itself failing, so nothing pointed at the real culprit.
+
+Both entry points now check the effective `cd:` before spawning and raise
+`IxMcp.Cmd.DeadCwdError`, whose message says which layer died: the boot-time
+launch directory that no longer exists (and to pass an explicit `cd:`), or a
+caller-supplied `cd:` that names a missing directory. The silent failure mode
+is gone; a vanished directory is one loud error naming its path, not a
+session's worth of empty exit-2s.


### PR DESCRIPTION
## Root cause

`System.cmd/3` reports a failed port-child `chdir` as `{"", 2}`: the child exits 2 with nothing on stdout before `exec`, indistinguishable from the command's own exit. `Cmd.run/3` and `Cmd.sh/2` default `cd:` to the launch directory captured at boot, so deleting that directory mid-session (a removed worktree, a recreated checkout) silently broke every subsequent command -- `echo` included -- while `:os.cmd/1` (no chdir) and the File/Edit helpers kept working. Exactly the #3979 signature: empty output, exit 2, ~0s elapsed.

Reproduced live: the kernel this fix was authored in had itself booted in `/Users/andrewgazelka/.config/nix/index`, since deleted. In that session `Cmd.run("echo", ["hello"])` returned `{"", 2}` while `System.cmd("/bin/sh", ["-c", "echo hi"])` with no `cd:` returned `{"hi\n", 0}`, and `File.exists?(Cmd.launch_cwd())` was `false`. The originally hypothesized spawner-process death was not the cause.

## Change

- `put_live_cd!/1` checks the effective `cd:` before every spawn and raises `IxMcp.Cmd.DeadCwdError`, whose message names the dead layer: the boot-time launch directory that no longer exists (with the hint to pass an explicit `cd:`), or a caller-supplied `cd:` naming a missing directory.
- Regression tests: launch cwd deleted after boot raises for both `run/3` and `sh/2` (public API only: re-capture in a doomed temp dir, delete it); explicit dead `cd:` raises.
- Site updates page `packages/site/src/lib/updates/cmd-dead-launch-cwd.svx`.

## Gates

- `mix test` in `packages/mcp-ex`: 165 tests, 0 failures.
- `nix run .#lint`: failure set byte-identical to pristine `origin/main` (4 pre-existing ruff PT019 errors in `packages/mcp/src/weave/test_weave.py`, untouched here); every other check succeeds.

Fixes #3979

Authored by Claude Code (Fable 5) for andrew


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise `IxMcp.Cmd.DeadCwdError` when a command's working directory does not exist
> Previously, `IxMcp.Cmd.run/3` and `IxMcp.Cmd.sh/2` would silently return `{"" , 2}` when the working directory (explicit or defaulted to the launch CWD) was missing. Now a named `IxMcp.Cmd.DeadCwdError` exception is raised before spawning, with a message that distinguishes between a deleted launch directory and an explicitly provided bad path.
>
> - A new private helper `put_live_cd!/1` validates the effective `:cd` option via `File.dir?/1` and raises `DeadCwdError` with `:path` and `:default?` fields if the directory is absent.
> - Two error message clauses differentiate the cause: one advises passing `cd:` explicitly when the launch directory is gone, the other flags an explicit `cd:` that is not a directory.
> - Behavioral Change: callers that previously handled `{"" , 2}` must now rescue `IxMcp.Cmd.DeadCwdError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e4edbe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->