### PR TITLE
site: add updates entry for the Cmd missing-cwd fix (#3979)

### DIFF
--- a/packages/site/src/lib/updates/cmd-dead-launch-cwd.svx
+++ b/packages/site/src/lib/updates/cmd-dead-launch-cwd.svx
@@ -1,0 +1,29 @@
+---
+id: cmd-dead-launch-cwd
+postedAt: 2026-07-22T00:30:00-07:00
+title: Kernel commands name a missing working directory instead of failing as exit 2
+tags: [kernel, mcp, reliability]
+links:
+  - label: issue #3979
+    href: https://github.com/indexable-inc/index/issues/3979
+  - label: PR #3985
+    href: https://github.com/indexable-inc/index/pull/3985
+---
+
+Kernel commands default to the directory captured at boot, so pathless
+`Cmd.run` and `Cmd.sh` always resolve against the launch checkout. When that
+directory was deleted mid-session -- a cleaned-up worktree, a recreated
+checkout -- every command from then on returned `{"", 2}` in about zero
+seconds, `echo` included, while `:os.cmd/1` and the File helpers kept
+working. The port child reports a failed `chdir` by exiting with the raw
+errno and nothing on stdout, indistinguishable from the command itself
+failing, so nothing pointed at the real culprit.
+
+Both entry points now validate the effective `cd:` before spawning and raise
+an error naming the target: a missing directory (with a hint when it is the
+boot-time launch dir that vanished), a path that is not a directory, or an
+otherwise unusable one. A directory deleted between the check and the spawn
+is caught after the fact too -- a nonzero exit with the directory now gone
+raises instead of handing back a status that may be errno rather than the
+command's own. The silent failure mode is gone; a vanished directory is one
+loud error naming its path, not a session's worth of empty exit-2s.


### PR DESCRIPTION
Follow-up to #3985, which landed the kernel Cmd fail-loud fix for #3979 without a site updates entry. This adds the operator-facing page describing the silent `{"", 2}` failure mode and the raise that replaced it. Lint: site-ids succeeded; only the pre-existing ruff PT019 failures from main remain.

Authored by Claude Code (Fable 5) for andrew

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add site update entry documenting `Cmd` missing working directory fix
> Adds a new update post at [cmd-dead-launch-cwd.svx](https://github.com/indexable-inc/index/pull/3987/files#diff-4a4c779cdfe4dadad8d90960f918c0a906150757ad67a66fe2809f41e3a58612) describing the fix for kernel command behavior when the working directory is missing, including validation and error messaging changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2eb7511.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->