### PR TITLE
image: pin registry without narHash on the path-locked seam

### DIFF
--- a/lib/image/default.nix
+++ b/lib/image/default.nix
@@ -144,21 +144,18 @@
           # flake scope sees `self`, so it is plumbed down from `flake.nix`.
           # `self.narHash` is absent when index is consumed as a path-locked
           # flake input (ix's ./index submodule seam, ix#8142): path-type lock
-          # nodes carry no narHash, so nix hands the input through without
-          # one. Recompute it from the already-ingested source in that case;
-          # fetchTree on a store path is pure and yields the same NAR hash
-          # a git consumption would have carried (index#3981).
-          nix.registry.index.to = {
-            type = "path";
-            path = self.outPath;
-            narHash =
-              self.narHash
-                or (builtins.fetchTree {
-                type = "path";
-                path = self.outPath;
-              })
-                .narHash;
-          };
+          # nodes carry no narHash, and recomputing via fetchTree is rejected
+          # in pure eval (the source is a lazy-tree subpath, index#3981). Pin
+          # without narHash on that seam: in-guest `nix run index#...` then
+          # re-ingests the baked source once (the #1748-era cost) instead of
+          # failing every consumer eval. Images published by index's own CI
+          # consume self via git and keep the locked, narHash-matched pin.
+          nix.registry.index.to =
+            {
+              type = "path";
+              path = self.outPath;
+            }
+            // lib.optionalAttrs (self ? narHash) {inherit (self) narHash;};
         }
         ++ [
           ./platform.nix


### PR DESCRIPTION
Follow-up to #3984 (issue #3981). The fetchTree fallback is rejected in pure eval when self is a lazy-tree subpath, which is exactly what the ix submodule seam produces, so ix evals still failed (verified on seam-privileged-bind-policy). Include narHash only when the input carries it. Cost disclosed: on the submodule seam, in-guest `nix run index#...` re-ingests the baked source once instead of resolving instantly; index-published images keep the locked pin.

Verified: seam-privileged-bind-policy, seam-activation-job-timeouts, cross-artifact-* eval to drvPaths from an ix tree pinned at this commit (validation running for the full set).

Authored with Claude Code (Anthropic Fable).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Omit `narHash` from registry path entry in `nix.registry.index.to` when absent
> Updates [lib/image/default.nix](https://github.com/indexable-inc/index/pull/3988/files#diff-3883253618b080892e770f4ceb96188ed814f4f588df529f7a82d338874c14bd) to conditionally include `narHash` in the registry entry only when `self.narHash` exists, using `lib.optionalAttrs`. Previously, the code always set `narHash` by falling back to `builtins.fetchTree` on `self.outPath` when `self.narHash` was absent. The registry entry no longer invokes `builtins.fetchTree` as a fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc78bfa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->