### PR TITLE
image: registry pin tolerates a self without narHash (ix#8147)

### DIFF
--- a/lib/image/default.nix
+++ b/lib/image/default.nix
@@ -142,11 +142,20 @@
           # context, so it roots into the image closure once (no duplicate
           # copy — the #1748 trap). `self.narHash` locks the pin. Only this
           # flake scope sees `self`, so it is plumbed down from `flake.nix`.
-          nix.registry.index.to = {
-            type = "path";
-            path = self.outPath;
-            inherit (self) narHash;
-          };
+          #
+          # `narHash` is conditional: when index is consumed as a relative
+          # `path:./index` input (ix vendors it as a git submodule, ix#8119),
+          # nix resolves the input as a subpath of the parent flake's source
+          # and its `self` carries no `narHash` — the parent's own rev locks
+          # the submodule content transitively. Emitting the pin unlocked
+          # there (first in-guest eval re-hashes the tree once) beats failing
+          # the whole eval on `attribute 'narHash' missing` (ix#8147).
+          nix.registry.index.to =
+            {
+              type = "path";
+              path = self.outPath;
+            }
+            // lib.optionalAttrs (self ? narHash) {inherit (self) narHash;};
         }
         ++ [
           ./platform.nix


### PR DESCRIPTION
When index is consumed as a relative `path:./index` flake input (ix vendors it as a git submodule, indexable-inc/ix#8119), nix resolves the input as a subpath of the parent flake's source, and that `self` carries no `narHash` — the parent flake's rev locks the submodule content transitively. The `nix.registry.index.to` image pin then failed pure eval with `attribute 'narHash' missing`, which is what turned every ix `cas-image-*` / `seam-*` check red (indexable-inc/ix#8147).

This makes the pin's `narHash` conditional: locked when `self` has one (index's own flake, unchanged behavior), unlocked path pin otherwise. The unlocked pin costs one in-guest re-hash on first eval; failing the whole consumer eval costs everything.

Verified from ix: `nix eval .#checks.x86_64-linux.cas-image-shadow.drvPath` (and digest/cache-root, seam-*) goes from `attribute 'narHash' missing` to a clean drvPath with the submodule at this commit.

Authored by Claude Code (Fable 5) for andrew


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix registry pin to tolerate `self` without `narHash` in `nix.registry.index.to`
> The registry entry for `index` previously always included `narHash`, causing an evaluation error when `self` did not provide it. The fix uses `optionalAttrs` to merge `narHash` into the path-type attrset only when it exists on `self`. Behavior is unchanged when `narHash` is present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9d78bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->