### PR TITLE
mcp: rename spool_home fixture to satisfy ruff PT019

### DIFF
--- a/packages/mcp/src/fabric/test_fabric.py
+++ b/packages/mcp/src/fabric/test_fabric.py
@@ -836,7 +836,7 @@ def test_reconcile_weave_unreachable_raises_fabric_error(monkeypatch: pytest.Mon
 
 
 def test_run_spawn_survives_unreachable_weave(
-    monkeypatch: pytest.MonkeyPatch, _spool_home: Path
+    monkeypatch: pytest.MonkeyPatch, spool_home: Path
 ) -> None:
     """The other half of the boundary (index#3419): spawn-path recording rides
     the durable local spool, so an unreachable server never fails or blocks
@@ -851,7 +851,7 @@ def test_run_spawn_survives_unreachable_weave(
         return await handle.wait()
 
     assert run(main()) == 5
-    segments = list(_spool_home.glob("w-*.jsonl"))
+    segments = list(spool_home.glob("w-*.jsonl"))
     assert segments, "intent must be durable on disk while undelivered"
 
 
@@ -859,7 +859,7 @@ def test_run_spawn_survives_unreachable_weave(
 
 
 def test_session_spawns_and_records_while_weave_down(
-    monkeypatch: pytest.MonkeyPatch, _spool_home: Path
+    monkeypatch: pytest.MonkeyPatch, spool_home: Path
 ) -> None:
     """index#3418 invariant: with weave unreachable, the submitted intent is
     fsync'd to the local spool BEFORE the SDK subprocess spawns, the session
@@ -896,7 +896,7 @@ def test_session_spawns_and_records_while_weave_down(
     # append order, prompt payload included.
     assert fake.queries == ["do it"]
     assert journal.facts == []
-    segments = list(_spool_home.glob("w-*.jsonl"))
+    segments = list(spool_home.glob("w-*.jsonl"))
     assert len(segments) == 1
     lines = [json.loads(line) for line in segments[0].read_text().splitlines() if line]
     attrs = [item["fact"]["attr"] for item in lines if "fact" in item]

--- a/packages/mcp/src/weave/conftest.py
+++ b/packages/mcp/src/weave/conftest.py
@@ -13,7 +13,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _spool_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+def spool_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
     """Every test spools under its own tmp dir; teardown joins flusher
     threads BEFORE monkeypatched transports revert (a live flusher must
     never fall back to a real URL)."""

--- a/packages/mcp/src/weave/test_weave.py
+++ b/packages/mcp/src/weave/test_weave.py
@@ -214,7 +214,7 @@ def _journal_transport(monkeypatch: pytest.MonkeyPatch, *, down: dict[str, bool]
 
 
 def test_record_is_durable_before_delivery_and_drains_in_order(
-    _spool_home: Path, monkeypatch: pytest.MonkeyPatch
+    spool_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     down = {"is": True}
     facts, blobs = _journal_transport(monkeypatch, down=down)
@@ -223,7 +223,7 @@ def test_record_is_durable_before_delivery_and_drains_in_order(
     run(weave.record([("task:1", "state", "running")]))
 
     # Durable on disk while the server is unreachable; nothing delivered.
-    segments = list(_spool_home.glob("*.jsonl"))
+    segments = list(spool_home.glob("*.jsonl"))
     assert len(segments) == 1
     lines = [weave.json.loads(line) for line in segments[0].read_text().splitlines()]
     assert [item.get("fact", {}).get("attr", "blob") for item in lines] == ["state", "blob", "state"]
@@ -259,10 +259,10 @@ def test_spool_transition_prints_exactly_one_loud_line(
     assert err.count("reachable again") == 1
 
 
-def test_spool_orphan_segment_adopted_and_drained(_spool_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_spool_orphan_segment_adopted_and_drained(spool_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     down = {"is": False}
     facts, _blobs = _journal_transport(monkeypatch, down=down)
-    orphan = _spool_home
+    orphan = spool_home
     orphan.mkdir(parents=True, exist_ok=True)
     # A crashed writer's segment: two committed lines plus one torn append
     # (never fsync-completed, so never intent) - no live flock holder.


### PR DESCRIPTION
Fixes #3991.

## What

`nix run .#lint` on pristine main fails 4 ruff PT019 errors (underscore-named fixture injected as a parameter): `packages/mcp/src/fabric/test_fabric.py:839,:862` and `packages/mcp/src/weave/test_weave.py:217,:262`, so every branch inherits a red lint gate.

The issue prescribed `@pytest.mark.usefixtures("_spool_home")`, but that drops the fixture value, and every flagged site uses it:

- test_fabric.py:854 and :899 — `spool_home.glob("w-*.jsonl")`
- test_weave.py:226 — `spool_home.glob("*.jsonl")`
- test_weave.py:265 — `orphan = spool_home`

So instead the fixture is renamed `_spool_home` -> `spool_home` at its single definition (`packages/mcp/src/weave/conftest.py`, copied into the fabric test derivation as conftest.py by `src/fabric/module.nix`) and at every consumer. Semantics identical; autouse unaffected.

## Evidence

- `nix run .#lint` on the branch: 13/13 stages green, including the previously-red `ruff` stage.
- `nix build .#mcp.tests.fabricTests`: 71 passed (runs test_fabric.py + test_weave.py with the shared conftest).
- `ruff check` on the three edited files: All checks passed.

Authored by Claude Code (Fable 5) for andrew


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `_spool_home` fixture to `spool_home` to satisfy ruff PT019
> Drops the leading underscore from the `spool_home` pytest fixture in [conftest.py](https://github.com/indexable-inc/index/pull/3993/files#diff-9cc87e78198953397f32c7bda11785cd4e4a23763919f9a1a72381bcf7cbf051) and updates all references in test files to match. The fixture behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 64fd04f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->