### PR TITLE
kernel: raise on a missing cli_runner cwd instead of the raw errno exit (#3989)

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/agents/cli_runner.ex
+++ b/packages/mcp-ex/lib/ix_mcp/agents/cli_runner.ex
@@ -40,13 +40,15 @@ defmodule IxMcp.Agents.CliRunner do
         |> Keyword.put(:prompt, instructions)
       )
 
-    port = open_port(spec, ctx)
+    cwd = validate_cwd!(ctx.opts)
+    port = open_port(spec, cwd)
     if spec.stdin == :stream, do: inject_user(port, instructions)
 
     loop(%{
       ctx: ctx,
       backend: backend,
       port: port,
+      cwd: cwd,
       stdin: spec.stdin,
       buf: "",
       final: nil,
@@ -56,12 +58,40 @@ defmodule IxMcp.Agents.CliRunner do
     })
   end
 
-  defp open_port(spec, ctx) do
-    # Never File.cwd!(): the OS cwd is BEAM-global and cell-movable, so a
-    # child spawned without :cwd would inherit wherever some other session
-    # last wandered (#3902). The boot-time capture is stable.
-    cwd = Keyword.get(ctx.opts, :cwd, IxMcp.Cmd.launch_cwd())
+  # Resolve the child's working directory and refuse to spawn into one
+  # that is not there: Erlang's child setup reports a failed `chdir` by
+  # exiting with the raw errno -- `{"", 2}` for ENOENT, `{"", 20}` for
+  # ENOTDIR -- indistinguishable from the CLI's own exit status, with no
+  # output to explain it (#3989; the Cmd shape fixed in #3985).
+  #
+  # The default is never File.cwd!(): the OS cwd is BEAM-global and
+  # cell-movable, so a child spawned without :cwd would inherit wherever
+  # some other session last wandered (#3902). The boot-time capture is
+  # stable.
+  @spec validate_cwd!(keyword()) :: binary()
+  defp validate_cwd!(opts) do
+    {cwd, hint} =
+      case Keyword.fetch(opts, :cwd) do
+        {:ok, cwd} -> {cwd, ""}
+        :error -> {IxMcp.Cmd.launch_cwd(), " (session launch dir deleted?)"}
+      end
 
+    case File.stat(cwd) do
+      {:ok, %File.Stat{type: :directory}} ->
+        cwd
+
+      {:ok, %File.Stat{type: other}} ->
+        raise ArgumentError, "cwd #{cwd} is not a directory (#{other})"
+
+      {:error, :enoent} ->
+        raise ArgumentError, "cwd #{cwd} does not exist#{hint}"
+
+      {:error, reason} ->
+        raise ArgumentError, "cwd #{cwd} is not usable: #{:file.format_error(reason)}"
+    end
+  end
+
+  defp open_port(spec, cwd) do
     {exe, args} =
       case spec.stdin do
         :stream ->
@@ -126,6 +156,20 @@ defmodule IxMcp.Agents.CliRunner do
   end
 
   defp continue_or_finish(state), do: loop(state)
+
+  # The validate/spawn gap (TOCTOU): a cwd deleted after validation still
+  # produces the bare-errno exit. A zero status means `chdir` succeeded,
+  # and a run that reached a final result speaks for itself, so only a
+  # nonzero exit with no final and the directory now gone is ambiguous --
+  # raise rather than report a status that may be errno, not the CLI's.
+  defp exit_result(%{final: nil, cwd: cwd}, code) when code != 0 do
+    if File.dir?(cwd) do
+      {:error, {:exit_status, code}}
+    else
+      raise "cwd #{cwd} no longer exists; exit #{code} may be the " <>
+              "raw chdir errno rather than the CLI's own status"
+    end
+  end
 
   defp exit_result(%{final: nil}, code), do: {:error, {:exit_status, code}}
   defp exit_result(%{final: final}, _code), do: final

--- a/packages/mcp-ex/test/ix_mcp/agents/cli_runner_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/agents/cli_runner_test.exs
@@ -43,4 +43,121 @@ defmodule IxMcp.Agents.CliRunnerTest do
     assert %{nodes: nodes, edges: _} = Agents.graph()
     assert Enum.any?(nodes, &(&1["id"] == "rt-codex" and &1["state"] == "blocked"))
   end
+
+  # The #3989 shape (Cmd's #3979, fixed in #3985): Erlang's child setup
+  # reports a failed chdir by exiting with the raw errno, so a missing
+  # cwd came back as {:exit_status, 2} -- no output, ENOENT dressed up as
+  # the CLI's own exit. The runner now raises before the spawn; the crash
+  # reaches the lead as a named error instead of a bare status.
+  describe "missing cwd (#3989)" do
+    # A stub that waits for the injected user line, removes its own cwd,
+    # and exits as told: the deterministic after-the-spawn (TOCTOU) shape.
+    defp rmdir_stub!(tmp, exit_code) do
+      path = Path.join(tmp, "stub-rmdir-#{exit_code}")
+      File.write!(path, "#!/bin/sh\nread _line\nrmdir \"$PWD\"\nexit #{exit_code}\n")
+      File.chmod!(path, 0o755)
+      path
+    end
+
+    defp workdir!(tmp) do
+      dir = Path.join(tmp, "workdir-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(dir)
+      dir
+    end
+
+    # Spawn, await, and delete: the live-subagent cap (max_concurrent)
+    # counts idle finished children, so each probe must free its slot.
+    defp run_child(brief, opts) do
+      {:ok, id} = Agents.spawn(brief, opts)
+      result = Agents.await(id, 10_000)
+      Agents.delete(id)
+      result
+    end
+
+    @tag :tmp_dir
+    @tag capture_log: true
+    test "spawn works while the cwd exists and raises once it is deleted", %{tmp_dir: tmp} do
+      bin = stub!(tmp, "claude-oneshot.ndjson")
+      dir = workdir!(tmp)
+
+      assert {:ok, "ok"} =
+               run_child("say ok", backend: :claude, bin: bin, cwd: dir, name: "rt-cwd-ok")
+
+      File.rm_rf!(dir)
+
+      assert {:error, message} =
+               run_child("say ok", backend: :claude, bin: bin, cwd: dir, name: "rt-cwd-gone")
+
+      assert message =~ "runner_crash"
+      assert message =~ "cwd #{dir} does not exist"
+    end
+
+    @tag :tmp_dir
+    @tag capture_log: true
+    test "a cwd that is a file, not a directory, raises (was errno 20)", %{tmp_dir: tmp} do
+      bin = stub!(tmp, "claude-oneshot.ndjson")
+      file = Path.join(tmp, "plain-file")
+      File.write!(file, "")
+
+      assert {:error, message} =
+               run_child("say ok", backend: :claude, bin: bin, cwd: file, name: "rt-cwd-file")
+
+      assert message =~ "cwd #{file} is not a directory"
+    end
+
+    @tag :tmp_dir
+    @tag capture_log: true
+    test "a cwd deleted mid-run with a nonzero exit raises instead of an ambiguous status",
+         %{tmp_dir: tmp} do
+      bin = rmdir_stub!(tmp, 3)
+      dir = workdir!(tmp)
+
+      assert {:error, message} =
+               run_child("go", backend: :claude, bin: bin, cwd: dir, name: "rt-cwd-race")
+
+      assert message =~ "cwd #{dir} no longer exists"
+      assert message =~ "raw chdir errno"
+    end
+
+    @tag :tmp_dir
+    test "exit 0 is never second-guessed, even with the cwd gone", %{tmp_dir: tmp} do
+      bin = rmdir_stub!(tmp, 0)
+      dir = workdir!(tmp)
+
+      assert {:error, message} =
+               run_child("go", backend: :claude, bin: bin, cwd: dir, name: "rt-cwd-clean")
+
+      assert message =~ "exit_status, 0"
+      refute message =~ "errno"
+    end
+
+    @tag :tmp_dir
+    @tag capture_log: true
+    test "a deleted launch dir raises with the launch-dir hint", %{tmp_dir: tmp} do
+      bin = stub!(tmp, "claude-oneshot.ndjson")
+
+      doomed = Path.join(System.tmp_dir!(), "ix-cli-doomed-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(doomed)
+      before = File.cwd!()
+      File.cd!(doomed)
+      IxMcp.Cmd.capture_launch_cwd()
+      File.cd!(before)
+      # File.cwd!() resolves symlinks (/tmp -> /private/tmp on macOS), so
+      # the captured path is the canonical spelling, not `doomed` verbatim.
+      captured = IxMcp.Cmd.launch_cwd()
+
+      try do
+        File.rm_rf!(doomed)
+
+        assert {:error, message} =
+                 run_child("say ok", backend: :claude, bin: bin, name: "rt-launch-gone")
+
+        assert message =~ "cwd #{captured} does not exist (session launch dir deleted?)"
+      after
+        # Recapture the real launch dir so no later test inherits the stub.
+        IxMcp.Cmd.capture_launch_cwd()
+        File.rm_rf!(doomed)
+      end
+    end
+  end
 end

--- a/packages/site/src/lib/updates/agents-cli-runner-cwd.svx
+++ b/packages/site/src/lib/updates/agents-cli-runner-cwd.svx
@@ -1,0 +1,25 @@
+---
+id: agents-cli-runner-cwd
+postedAt: 2026-07-22T09:30:00-07:00
+title: Child-agent spawns name a missing working directory instead of dying as exit 2
+tags: [kernel, mcp, agents, reliability]
+links:
+  - label: issue #3989
+    href: https://github.com/indexable-inc/index/issues/3989
+  - label: PR #3985
+    href: https://github.com/indexable-inc/index/pull/3985
+---
+
+The Cmd fix for the missing-working-directory failure left one sibling
+untouched: the agent CLI runner opens its child port the same way, so a
+child spawned into a deleted or bogus directory died as the raw `chdir`
+errno -- exit 2 for a missing path, exit 20 for a file -- with empty
+output, indistinguishable from the CLI failing on its own.
+
+The runner now validates the working directory before the spawn and raises
+an error naming the path (with the launch-dir hint when the boot-time
+default vanished), so the lead sees the real culprit instead of a bare
+exit status. A directory deleted after the check is caught too: a nonzero
+exit with the directory now gone raises with the errno caveat rather than
+reporting a status that may not be the CLI's own. Clean exits and runs
+that already produced a final result are never second-guessed.


### PR DESCRIPTION
Fixes #3989. The follow-up flagged in #3985.

## What broke

`IxMcp.Agents.CliRunner` opens its child port with the same launch-dir default `Cmd` had before #3985, and the same silent failure shape: Erlang's `erl_child_setup` reports a failed `chdir` by exiting with the raw errno, so a child spawned into a missing cwd died as `{:exit_status, 2}` (ENOENT) or `{:exit_status, 20}` (ENOTDIR) with empty output, indistinguishable from the agent CLI failing on its own.

## Fix (mirrors #3985)

- `validate_cwd!/1` checks the resolved `:cwd` before the spawn: a missing directory raises `ArgumentError` naming the path (`cwd <path> does not exist`), the boot-captured default adds the `(session launch dir deleted?)` hint, a non-directory target and an unusable one raise too. The raise surfaces to the lead as a named `runner_crash` error instead of a bare exit status.
- TOCTOU: a cwd deleted between validation and spawn still yields the bare-errno exit, so a nonzero exit with no final result and the directory now gone raises (`... may be the raw chdir errno rather than the CLI's own status`). Exit 0 and runs that already produced a final result are never second-guessed.
- Regression tests adapted from the #3985 set (5 new): pre-delete success / post-delete raise, the ENOTDIR shape, the mid-run vanish, never-second-guessing exit 0, and the deleted-launch-dir hint.
- Site updates entry: `packages/site/src/lib/updates/agents-cli-runner-cwd.svx`.

## Gates (local)

- `mix test`: 173 tests, 0 failures (was 168/0 on origin/main)
- `mix format --check-formatted`, `MIX_ENV=test mix credo --strict`: clean
- `nix run .#lint`: 13/13 tasks green

Authored by Claude Code (Fable 5), an AI agent, on andrew's behalf; admin-merge per standing instruction (andrewgazelka, 2026-07-21).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise on missing or invalid `cwd` in `CliRunner` instead of returning a raw errno exit code
> - Adds `validate_cwd!/1` in [`cli_runner.ex`](https://github.com/indexable-inc/index/pull/3994/files#diff-4a271ffe244b92f1169c881fbcdd949691cbadc7966e4d08210a883c2b7614a3) to check the working directory before spawning; raises `ArgumentError` with a descriptive message if the path is missing or not a directory.
> - Stores the resolved `cwd` in loop state so `exit_result/2` can check whether the directory was removed mid-run and raise instead of returning `{:error, {:exit_status, code}}`.
> - Behavioral Change: callers that previously received a raw errno exit code when `cwd` was missing or deleted will now get a raised exception instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 989f49a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->