### PR TITLE
tests: hold the index registry pin's two self shapes (#3981)

### DIFF
--- a/lib/image/default.nix
+++ b/lib/image/default.nix
@@ -15,6 +15,9 @@
   # flake; the pin is then omitted.
   self ? null,
 }: let
+  # The `nix.registry.index.to` construction, shared with the
+  # `image-registry-pin` check (tests/default.nix). See its doc comment.
+  registryPin = import ./registry-pin.nix {inherit lib;};
   /**
   One nixpkgs instance shared by every image evaluation. `lib.nixosSystem`
   otherwise instantiates a fresh nixpkgs PER node, and a consumer that
@@ -140,22 +143,12 @@
           #
           # `self.outPath` is the ORIGINAL `-source` path and carries string
           # context, so it roots into the image closure once (no duplicate
-          # copy — the #1748 trap). `self.narHash` locks the pin. Only this
-          # flake scope sees `self`, so it is plumbed down from `flake.nix`.
-          # `self.narHash` is absent when index is consumed as a path-locked
-          # flake input (ix's ./index submodule seam, ix#8142): path-type lock
-          # nodes carry no narHash, and recomputing via fetchTree is rejected
-          # in pure eval (the source is a lazy-tree subpath, index#3981). Pin
-          # without narHash on that seam: in-guest `nix run index#...` then
-          # re-ingests the baked source once (the #1748-era cost) instead of
-          # failing every consumer eval. Images published by index's own CI
-          # consume self via git and keep the locked, narHash-matched pin.
-          nix.registry.index.to =
-            {
-              type = "path";
-              path = self.outPath;
-            }
-            // lib.optionalAttrs (self ? narHash) {inherit (self) narHash;};
+          # copy — the #1748 trap). Only this flake scope sees `self`, so it
+          # is plumbed down from `flake.nix`. The pin's `narHash` is
+          # conditional — present locks the pin, absent tolerates the
+          # path-locked submodule seam (index#3981) — see ./registry-pin.nix;
+          # the `image-registry-pin` check holds both shapes.
+          nix.registry.index.to = registryPin self;
         }
         ++ [
           ./platform.nix

--- a/lib/image/registry-pin.nix
+++ b/lib/image/registry-pin.nix
@@ -1,0 +1,26 @@
+/**
+Build the `nix.registry.index.to` value for a flake `self`: a `path`-type
+pin on `self.outPath`, locked with `self.narHash` when `self` carries one.
+
+`narHash` is conditional because `self` arrives in two shapes (index#3981,
+shape landed in #3988):
+
+- index's own flake, and images published by its CI (consumed via git):
+  `self` carries `narHash` and the pin must keep it. An unlocked `path:` pin
+  makes nix treat the input as mutable and re-hash AND re-copy the whole
+  source tree on every in-guest eval (the #1748-era cost).
+- a path-locked flake input (ix's `./index` submodule seam, ix#8142):
+  path-type lock nodes carry no `narHash` — the parent flake's rev locks the
+  content transitively — so `inherit (self) narHash` fails eval, and
+  recomputing one via fetchTree is rejected in pure eval (the source is a
+  lazy-tree subpath). The pin must simply omit `narHash`.
+
+Extracted from `lib/image/default.nix` (its only production consumer) so the
+`image-registry-pin` check can exercise both shapes with mock selves.
+*/
+{lib}: self:
+{
+  type = "path";
+  path = self.outPath;
+}
+// lib.optionalAttrs (self ? narHash) {inherit (self) narHash;}

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1653,6 +1653,12 @@
             # `nix` command does not re-copy the tree through VCFS (ix
             # #1748/#1749/#1815). Its own check because it builds an image.
             base-image-nix-db = tests.baseImageNixDb;
+            # Holds the `nix.registry.index.to` construction against both
+            # shapes of `self` (narHash-bearing git consumption vs the
+            # path-locked submodule seam), the boundary that broke twice on
+            # 2026-07-22 (index#3981, fixed in #3988). Pure eval; its own
+            # check so a regression fails by name, not inside `eval`.
+            image-registry-pin = tests.imageRegistryPin;
             # The commented knob/env reference at the Home Manager consumption
             # site (index#3710) is asserted, at eval, against what the
             # claude-code wrapper actually accepts (functionArgs plus

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -2388,6 +2388,44 @@
   # once wrote the customisation blob as a symlink into /nix/store, so the
   # archive depended on out-of-tar store state and this check failed whenever
   # the referenced path was not visible at read time (index#2058).
+  # Both shapes of `self` the guest `index` registry pin must serve
+  # (lib/image/registry-pin.nix). The boundary broke twice on 2026-07-22:
+  # unconditional `inherit (self) narHash` failed eval on the narHash-less
+  # path-locked seam shape (index#3981), and the fetchTree fallback tried
+  # next (#3984) was rejected by pure eval on lazy-tree subpaths. #3988
+  # landed the conditional-omit shape; these assertions hold it. Mock selves
+  # because the real `self` only ever has one shape per evaluation.
+  imageRegistryPinAssertions = let
+    registryPin = import (paths.root + "/lib/image/registry-pin.nix") {inherit lib;};
+    # The construction never validates `narHash`, so a labeled mock keeps the
+    # fixture honest; a plausible SRI literal would read as a real pin.
+    mockNarHash = "sha256-mock+image-registry-pin";
+    mockPath = "/nix/store/mock-index-source";
+  in [
+    {
+      assertion =
+        registryPin {
+          outPath = mockPath;
+          narHash = mockNarHash;
+        }
+        == {
+          type = "path";
+          path = mockPath;
+          narHash = mockNarHash;
+        };
+      message = "a narHash-bearing self must keep narHash in the registry pin: an unlocked path pin re-hashes and re-copies the source tree on every in-guest eval (#1748)";
+    }
+    {
+      assertion =
+        registryPin {outPath = mockPath;}
+        == {
+          type = "path";
+          path = mockPath;
+        };
+      message = "a narHash-less self (path-locked seam input, index#3981) must yield a pin that omits narHash; the whole-attrset equality also proves the construction evaluates on that shape";
+    }
+  ];
+
   baseImageNixDb = let
     # Every `path`-type registry pin the image ships. Guard on the type so a
     # non-path entry (e.g. a default indirect/github registry row) can't break
@@ -6439,6 +6477,8 @@
   cargoUnitPrebuiltTest =
     mkTest "cargo-unit-prebuilt-library" cargoUnitPrebuiltAssertions
     cargoUnitPrebuiltScript;
+
+  imageRegistryPinTest = mkTest "image-registry-pin" imageRegistryPinAssertions "";
 in {
   inherit
     groupTests
@@ -6457,6 +6497,7 @@ in {
   minecraftBlocksVm = minecraftBlocksVmTest;
   minestomSpleefVm = minestomSpleefVmTest;
   inherit baseImageNixDb;
+  imageRegistryPin = imageRegistryPinTest;
 
   # Aggregate. Pulls every group test into one derivation so
   # `nix flake check` covers the whole suite.


### PR DESCRIPTION
Follow-up to #3981: #3988 landed the conditional-omit pin shape with no regression check, after the boundary broke twice in one day (unconditional `inherit (self) narHash` crashing on path-locked seam inputs, then the #3984 fetchTree fallback rejected by pure eval on lazy-tree subpaths).

This extracts the `nix.registry.index.to` construction into `lib/image/registry-pin.nix` — the inline expression closed over the flake's real `self` at import time, so a check could not reach both shapes without re-evaluating full images against stubbed lib/image internals — and adds an eval-first `checks.x86_64-linux.image-registry-pin` holding both mock selves:

- narHash-bearing `self` -> the pin must keep `narHash` (the locked-pin guarantee; an unlocked path pin re-hashes and re-copies the tree on every in-guest eval, #1748)
- narHash-less `self` (the path-locked submodule seam) -> the pin must omit `narHash` and the construction must evaluate

Validated locally: the check evals green on origin/main's shape; regressing the helper to unconditional `inherit` fails the seam assertion, and always-omitting fails the locked-pin assertion. Check attr names are unchanged apart from the addition; `nix run .#lint` is green.

Authored by Claude Code (Fable 5) for andrew


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests for both `self` shapes in the image registry pin
> - Extracts the inline registry pin construction from [lib/image/default.nix](https://github.com/indexable-inc/index/pull/3995/files#diff-3883253618b080892e770f4ceb96188ed814f4f588df529f7a82d338874c14bd) into a reusable helper at [lib/image/registry-pin.nix](https://github.com/indexable-inc/index/pull/3995/files#diff-d93f642a1edbc2b013de78fafbe6eef8a5f9d7d7c07b1fedc36b760a8d679936).
> - The helper returns a path-type registry pin pointing at `self.outPath`, conditionally including `narHash` via `lib.optionalAttrs` when present.
> - Adds `imageRegistryPin` tests in [tests/default.nix](https://github.com/indexable-inc/index/pull/3995/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) asserting correct behavior for both `self` shapes (with and without `narHash`), wired into [lib/per-system.nix](https://github.com/indexable-inc/index/pull/3995/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e88b3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->