### PR TITLE
rules: mandate recursive submodule init in fresh worktrees

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -91,9 +91,12 @@
       topics = ["workflow"];
       text = ''
         Never edit in a primary checkout: work on a dedicated `git worktree`
-        branch and verify root and branch before committing. Unmerged
-        branches are unfinished for reasons you may not see; check for open
-        PRs touching a file before nontrivial edits.
+        branch and verify root and branch before committing. Right after
+        `git worktree add`, run `git submodule update --init --recursive`:
+        a new worktree leaves submodules uninitialized even when the build
+        needs them. Unmerged branches are unfinished for reasons you may
+        not see; check for open PRs touching a file before nontrivial
+        edits.
       '';
       reason = ''
         Primary-checkout edits collided with concurrent work; parallel


### PR DESCRIPTION
Adds to the `worktree` rule: run `git submodule update --init --recursive` right after `git worktree add`, because a new worktree leaves submodules uninitialized by default even when the build needs them.

Force/admin merge is already covered by the `merged` rule ("Merge by force, not by vigil"), so no change there.

Closes #3999

(sent by an AI agent via Claude Code, Claude Sonnet 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mandate recursive submodule init after creating git worktrees in workflow rules
> Updates the workflow rule text in [rules.nix](https://github.com/indexable-inc/index/pull/4000/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to instruct the agent to run `git submodule update --init --recursive` immediately after creating a new git worktree.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 355c277.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->