### PR TITLE
rules: mandate recursive submodule init in new worktrees

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -91,7 +91,9 @@
       topics = ["workflow"];
       text = ''
         Never edit in a primary checkout: work on a dedicated `git worktree`
-        branch and verify root and branch before committing. Unmerged
+        branch and verify root and branch before committing. Run
+        `git submodule update --init --recursive` in each new worktree;
+        `git worktree add` leaves submodules uninitialized. Unmerged
         branches are unfinished for reasons you may not see; check for open
         PRs touching a file before nontrivial edits.
       '';


### PR DESCRIPTION
The worktree rule tells agents to work in a dedicated git worktree, but git worktree add leaves submodules uninitialized, so builds in a fresh worktree break when the repo vendors them (ix vendors index at ./index). This extends the rule with one sentence mandating git submodule update --init --recursive after creating a worktree. Fixes #3999

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mandate recursive submodule init in new git worktrees
> Adds an explicit instruction to [rules.nix](https://github.com/indexable-inc/index/pull/4003/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) clarifying that creating a worktree leaves submodules uninitialized and that `git submodule update --init --recursive` must be run afterward.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ece261.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->