### PR TITLE
agent rules: claim an issue before dispatching its fixer

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -205,6 +205,22 @@
     };
   }
   {
+    claimBeforeDispatch = {
+      topics = ["workflow"];
+      text = ''
+        A filed-issue notification reaches every session. Before dispatching
+        a fixer, check the issue for a claim (assignee or claim comment);
+        if none, post a claim comment naming your session, then dispatch.
+        An issue already claimed gets watched, not re-dispatched.
+      '';
+      reason = ''
+        Every listening session dispatched its own fixer: ix#8156 got two
+        full parallel implementations, ix#8155 two live branches, each
+        duplicate ~30 min of builds and ~140k tokens (index#4002).
+      '';
+    };
+  }
+  {
     preV1 = {
       topics = ["architecture"];
       text = ''


### PR DESCRIPTION
Issue-filed channel notifications fan out to every listening session, and each dispatched its own fixer: ix#8156 got two full parallel implementations today (one discarded unpushed), ix#8155 has two live branches, each duplicate roughly 30 min of builds and ~140k tokens.

Adds one rule, `claimBeforeDispatch`, next to `tieToIssue`:

> A filed-issue notification reaches every session. Before dispatching a fixer, check the issue for a claim (assignee or claim comment); if none, post a claim comment naming your session, then dispatch. An issue already claimed gets watched, not re-dispatched.

Verified: `nix run .#lint` green (13/13), rule renders in `nix eval --raw .#claude-code.systemPrompt`.

Closes #4002

Authored by an AI agent (Claude Code).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `claimBeforeDispatch` workflow rule to agent rules
> Adds a new rule in [rules.nix](https://github.com/indexable-inc/index/pull/4004/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) that instructs the agent to check and claim an issue before dispatching a fixer, and to monitor already-claimed issues. The rule includes a reason citing duplicate work and token/build costs as motivation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8d6381.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->