### PR TITLE
unibind: emit the async abort/stream scaffold once, not per binding (#3996)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13560,6 +13560,7 @@ name = "unibind-runtime"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "tokio",
 ]
 
 [[package]]

--- a/clone.toml
+++ b/clone.toml
@@ -55,7 +55,16 @@ ignore = [
 # type2 triple is gone (dead method deleted, pure field dumps now
 # dataclasses.asdict); measured 0.3593%. The 13-line _read_lines type1 twin
 # stays in the scan as a documented pair (see both data.py docstrings).
+#
+# 2026-07-22 (#3996): lowered 0.36 -> 0.30. The unibind ts/py emitters no
+# longer inline the async scaffold per binding: ts async exports share one
+# __unibind_with_abort per glue module, the ts stream handle guts moved to
+# unibind_runtime::PullStream, py __anext__ moved to
+# SharedStream::next_into_py, and the gen emitter tests share their fixture
+# builders and host-file walk through unibind-test-support; measured
+# 0.2941%. The residual per-export class shells (napi/pyo3 need concrete
+# classes) stay in the scan.
 [budget]
-global_pct = 0.36
+global_pct = 0.30
 diff_pct = 0.0
 diff_base = "origin/main"

--- a/packages/unibind/backend-py/src/stream.rs
+++ b/packages/unibind/backend-py/src/stream.rs
@@ -98,15 +98,7 @@ impl StreamExport<'_> {
                     &self,
                     py: ::pyo3::Python<'py>,
                 ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
-                    let next = self.stream.next();
-                    ::unibind_py_runtime::future_into_py(py, async move {
-                        match next.await {
-                            ::std::option::Option::Some(item) => ::pyo3::PyResult::Ok(item),
-                            ::std::option::Option::None => ::pyo3::PyResult::Err(
-                                ::pyo3::exceptions::PyStopAsyncIteration::new_err(()),
-                            ),
-                        }
-                    })
+                    self.stream.next_into_py(py)
                 }
             }
         }

--- a/packages/unibind/backend-py/tests/snapshots/sample.py.rs
+++ b/packages/unibind/backend-py/tests/snapshots/sample.py.rs
@@ -341,20 +341,7 @@ mod __unibind_py_sample {
             &self,
             py: ::pyo3::Python<'py>,
         ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
-            let next = self.stream.next();
-            ::unibind_py_runtime::future_into_py(
-                py,
-                async move {
-                    match next.await {
-                        ::std::option::Option::Some(item) => ::pyo3::PyResult::Ok(item),
-                        ::std::option::Option::None => {
-                            ::pyo3::PyResult::Err(
-                                ::pyo3::exceptions::PyStopAsyncIteration::new_err(()),
-                            )
-                        }
-                    }
-                },
-            )
+            self.stream.next_into_py(py)
         }
     }
     ///Async iterator produced by `follow`.
@@ -382,20 +369,7 @@ mod __unibind_py_sample {
             &self,
             py: ::pyo3::Python<'py>,
         ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
-            let next = self.stream.next();
-            ::unibind_py_runtime::future_into_py(
-                py,
-                async move {
-                    match next.await {
-                        ::std::option::Option::Some(item) => ::pyo3::PyResult::Ok(item),
-                        ::std::option::Option::None => {
-                            ::pyo3::PyResult::Err(
-                                ::pyo3::exceptions::PyStopAsyncIteration::new_err(()),
-                            )
-                        }
-                    }
-                },
-            )
+            self.stream.next_into_py(py)
         }
     }
     ///A sample boundary exercising the phase 0-2 surface.

--- a/packages/unibind/backend-ts/src/function.rs
+++ b/packages/unibind/backend-ts/src/function.rs
@@ -177,8 +177,9 @@ fn sync_body(shape: &CallShape<'_>, value: &TokenStream) -> BodyAndRet {
 }
 
 /// The async wrapper: convert arguments on the JavaScript thread, then
-/// `select!` the user future against the abort notification so an abort
-/// drops the future.
+/// race the user future against the abort notification through the
+/// module's shared `__unibind_with_abort` (see [`crate::module`]); only
+/// the settle conversion stays per binding.
 fn async_body(shape: &CallShape<'_>, value: &TokenStream) -> BodyAndRet {
     let CallShape {
         name,
@@ -210,25 +211,8 @@ fn async_body(shape: &CallShape<'_>, value: &TokenStream) -> BodyAndRet {
         },
         ret: quote!(::napi::Result<#ok_decl>),
         body: quote! {
-            let __unibind_future = #call;
-            match __unibind_signal {
-                ::std::option::Option::Some(__unibind_signal) => {
-                    if __unibind_signal.already_aborted {
-                        return ::std::result::Result::Err(__unibind_aborted());
-                    }
-                    ::tokio::select! {
-                        biased;
-                        () = __unibind_signal.notify.notified() => {
-                            ::std::result::Result::Err(__unibind_aborted())
-                        }
-                        value = __unibind_future => #settle,
-                    }
-                }
-                ::std::option::Option::None => {
-                    let value = __unibind_future.await;
-                    #settle
-                }
-            }
+            let value = __unibind_with_abort(__unibind_signal, #call).await?;
+            #settle
         },
     }
 }

--- a/packages/unibind/backend-ts/src/module.rs
+++ b/packages/unibind/backend-ts/src/module.rs
@@ -83,9 +83,10 @@ fn needs_signal(interface: &ir::Interface) -> bool {
 
 /// The bridge from a JavaScript `AbortSignal` onto the tokio side. napi's
 /// own `AbortSignal` type only cancels `AsyncTask` work queue entries, so
-/// the glue registers an `on_abort` callback that wakes a `Notify`; the
-/// wrapper `select!`s on it and dropping the user future is the
-/// cancellation.
+/// the glue registers an `on_abort` callback that wakes a `Notify`;
+/// `__unibind_with_abort` `select!`s on it and dropping the user future
+/// is the cancellation. Every async wrapper routes through that one
+/// helper rather than repeating the race per binding.
 fn abort_signal() -> TokenStream {
     quote! {
         /// One trailing optional argument on every async export; `undefined`
@@ -119,6 +120,31 @@ fn abort_signal() -> TokenStream {
 
         fn __unibind_aborted() -> ::napi::Error {
             ::napi::Error::new(::napi::Status::Cancelled, "__unibind__:aborted")
+        }
+
+        /// Race `future` against `signal`; the shared body of every async
+        /// export. The `biased` arm keeps an abort that raced completion
+        /// deterministic (the abort wins), and dropping the user future is
+        /// the cancellation.
+        async fn __unibind_with_abort<__UnibindOutput>(
+            signal: ::std::option::Option<__UnibindAbortSignal>,
+            future: impl ::std::future::Future<Output = __UnibindOutput>,
+        ) -> ::napi::Result<__UnibindOutput> {
+            match signal {
+                ::std::option::Option::Some(signal) => {
+                    if signal.already_aborted {
+                        return ::std::result::Result::Err(__unibind_aborted());
+                    }
+                    ::tokio::select! {
+                        biased;
+                        () = signal.notify.notified() => {
+                            ::std::result::Result::Err(__unibind_aborted())
+                        }
+                        value = future => ::std::result::Result::Ok(value),
+                    }
+                }
+                ::std::option::Option::None => ::std::result::Result::Ok(future.await),
+            }
         }
     }
 }

--- a/packages/unibind/backend-ts/src/stream.rs
+++ b/packages/unibind/backend-ts/src/stream.rs
@@ -2,12 +2,11 @@
 //!
 //! Pull semantics: JavaScript calls `next()` and gets a promise of the next
 //! element or `null` at the end, so nothing is produced faster than the
-//! consumer asks (backpressure falls out of the pull). `close()` is
-//! synchronous and race-free: a watch channel flips to closed, which both
-//! wakes a pull blocked inside `next()` (dropping the checked-out stream)
-//! and keeps later pulls from checking the stream back in. The generated
-//! `index.js` wraps the handle into a real `AsyncIterable`; the surface
-//! here stays minimal on purpose: `next` and `close`.
+//! consumer asks (backpressure falls out of the pull). The pull and close
+//! mechanics live in `unibind_runtime::PullStream`; the class here is the
+//! thin napi shell that names the element type. The generated `index.js`
+//! wraps the handle into a real `AsyncIterable`; the surface stays minimal
+//! on purpose: `next` and `close`.
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -69,8 +68,8 @@ pub fn render_stream_fn(
     })
 }
 
-/// The generated handle class: checked-out pull state, a pull gate, and a
-/// level-triggered closed flag.
+/// The generated handle class: a napi shell over
+/// `unibind_runtime::PullStream`, which owns the pull and close mechanics.
 fn stream_class(
     class: &proc_macro2::Ident,
     js_class: &str,
@@ -83,31 +82,14 @@ fn stream_class(
         #class_docs
         #[::napi_derive::napi(js_name = #js_class)]
         pub struct #class {
-            stream: ::std::sync::Mutex<
-                ::std::option::Option<::unibind_runtime::UniStream<#element_decl>>,
-            >,
-            pull: ::tokio::sync::Mutex<()>,
-            closed: ::tokio::sync::watch::Sender<bool>,
+            stream: ::unibind_runtime::PullStream<#element_decl>,
         }
 
         impl #class {
             fn __unibind_from(stream: ::unibind_runtime::UniStream<#element_decl>) -> Self {
                 Self {
-                    stream: ::std::sync::Mutex::new(::std::option::Option::Some(stream)),
-                    pull: ::tokio::sync::Mutex::new(()),
-                    closed: ::tokio::sync::watch::Sender::new(false),
+                    stream: ::unibind_runtime::PullStream::new(stream),
                 }
-            }
-
-            fn __unibind_slot(
-                &self,
-            ) -> ::std::sync::MutexGuard<
-                '_,
-                ::std::option::Option<::unibind_runtime::UniStream<#element_decl>>,
-            > {
-                self.stream
-                    .lock()
-                    .unwrap_or_else(::std::sync::PoisonError::into_inner)
             }
         }
 
@@ -118,18 +100,7 @@ fn stream_class(
             // `#[napi]` attribute, so the marker below is load-bearing.
             #[::napi_derive::napi]
             pub async fn next(&self) -> ::std::option::Option<#element_top> {
-                let _pull = self.pull.lock().await;
-                let mut stream = self.__unibind_slot().take()?;
-                let mut closed = self.closed.subscribe();
-                let item = ::tokio::select! {
-                    biased;
-                    _ = closed.wait_for(|closed| *closed) => ::std::option::Option::None,
-                    item = stream.next() => item,
-                };
-                if item.is_some() && !*self.closed.borrow() {
-                    self.__unibind_slot().replace(stream);
-                }
-                let value = item?;
+                let value = self.stream.next().await?;
                 ::std::option::Option::Some(#element_ret)
             }
 
@@ -137,8 +108,7 @@ fn stream_class(
             /// the producer sees its stream dropped.
             #[::napi_derive::napi]
             pub fn close(&self) {
-                let _ = self.closed.send(true);
-                self.__unibind_slot().take();
+                self.stream.close();
             }
         }
     }

--- a/packages/unibind/backend-ts/tests/snapshots/sample.ts.rs
+++ b/packages/unibind/backend-ts/tests/snapshots/sample.ts.rs
@@ -43,6 +43,28 @@ mod __unibind_ts_sample_ts {
     fn __unibind_aborted() -> ::napi::Error {
         ::napi::Error::new(::napi::Status::Cancelled, "__unibind__:aborted")
     }
+    /// Race `future` against `signal`; the shared body of every async
+    /// export. The `biased` arm keeps an abort that raced completion
+    /// deterministic (the abort wins), and dropping the user future is
+    /// the cancellation.
+    async fn __unibind_with_abort<__UnibindOutput>(
+        signal: ::std::option::Option<__UnibindAbortSignal>,
+        future: impl ::std::future::Future<Output = __UnibindOutput>,
+    ) -> ::napi::Result<__UnibindOutput> {
+        match signal {
+            ::std::option::Option::Some(signal) => {
+                if signal.already_aborted {
+                    return ::std::result::Result::Err(__unibind_aborted());
+                }
+                ::tokio::select! {
+                    biased; () = signal.notify.notified() => {
+                    ::std::result::Result::Err(__unibind_aborted()) } value = future =>
+                    ::std::result::Result::Ok(value),
+                }
+            }
+            ::std::option::Option::None => ::std::result::Result::Ok(future.await),
+        }
+    }
     ///Map `SampleError` onto a decodable napi rejection reason, message from `Display`.
     impl ::std::convert::From<super::sample_ts::SampleError> for ::napi::Error {
         fn from(error: super::sample_ts::SampleError) -> Self {
@@ -114,23 +136,12 @@ mod __unibind_ts_sample_ts {
         b: i64,
         __unibind_signal: ::std::option::Option<__UnibindAbortSignal>,
     ) -> ::napi::Result<i64> {
-        let __unibind_future = super::sample_ts::slow_add(a, b);
-        match __unibind_signal {
-            ::std::option::Option::Some(__unibind_signal) => {
-                if __unibind_signal.already_aborted {
-                    return ::std::result::Result::Err(__unibind_aborted());
-                }
-                ::tokio::select! {
-                    biased; () = __unibind_signal.notify.notified() => {
-                    ::std::result::Result::Err(__unibind_aborted()) } value =
-                    __unibind_future => ::std::result::Result::Ok(value),
-                }
-            }
-            ::std::option::Option::None => {
-                let value = __unibind_future.await;
-                ::std::result::Result::Ok(value)
-            }
-        }
+        let value = __unibind_with_abort(
+                __unibind_signal,
+                super::sample_ts::slow_add(a, b),
+            )
+            .await?;
+        ::std::result::Result::Ok(value)
     }
     ///Fetch one row.
     #[::napi_derive::napi]
@@ -138,28 +149,15 @@ mod __unibind_ts_sample_ts {
         store: ::std::string::String,
         __unibind_signal: ::std::option::Option<__UnibindAbortSignal>,
     ) -> ::napi::Result<super::sample_ts::Row> {
-        let __unibind_future = super::sample_ts::fetch(store);
-        match __unibind_signal {
-            ::std::option::Option::Some(__unibind_signal) => {
-                if __unibind_signal.already_aborted {
-                    return ::std::result::Result::Err(__unibind_aborted());
-                }
-                ::tokio::select! {
-                    biased; () = __unibind_signal.notify.notified() => {
-                    ::std::result::Result::Err(__unibind_aborted()) } value =
-                    __unibind_future => match value { ::std::result::Result::Ok(value) =>
-                    ::std::result::Result::Ok(value), ::std::result::Result::Err(error)
-                    => { ::std::result::Result::Err(::napi::Error::from(error)) } },
-                }
-            }
-            ::std::option::Option::None => {
-                let value = __unibind_future.await;
-                match value {
-                    ::std::result::Result::Ok(value) => ::std::result::Result::Ok(value),
-                    ::std::result::Result::Err(error) => {
-                        ::std::result::Result::Err(::napi::Error::from(error))
-                    }
-                }
+        let value = __unibind_with_abort(
+                __unibind_signal,
+                super::sample_ts::fetch(store),
+            )
+            .await?;
+        match value {
+            ::std::result::Result::Ok(value) => ::std::result::Result::Ok(value),
+            ::std::result::Result::Err(error) => {
+                ::std::result::Result::Err(::napi::Error::from(error))
             }
         }
     }
@@ -172,29 +170,15 @@ mod __unibind_ts_sample_ts {
     ///Pull handle over the stream returned by `tail`.
     #[::napi_derive::napi(js_name = "TailStream")]
     pub struct __UnibindStreamTail {
-        stream: ::std::sync::Mutex<
-            ::std::option::Option<::unibind_runtime::UniStream<super::sample_ts::Row>>,
-        >,
-        pull: ::tokio::sync::Mutex<()>,
-        closed: ::tokio::sync::watch::Sender<bool>,
+        stream: ::unibind_runtime::PullStream<super::sample_ts::Row>,
     }
     impl __UnibindStreamTail {
         fn __unibind_from(
             stream: ::unibind_runtime::UniStream<super::sample_ts::Row>,
         ) -> Self {
             Self {
-                stream: ::std::sync::Mutex::new(::std::option::Option::Some(stream)),
-                pull: ::tokio::sync::Mutex::new(()),
-                closed: ::tokio::sync::watch::Sender::new(false),
+                stream: ::unibind_runtime::PullStream::new(stream),
             }
-        }
-        fn __unibind_slot(
-            &self,
-        ) -> ::std::sync::MutexGuard<
-            '_,
-            ::std::option::Option<::unibind_runtime::UniStream<super::sample_ts::Row>>,
-        > {
-            self.stream.lock().unwrap_or_else(::std::sync::PoisonError::into_inner)
         }
     }
     #[::napi_derive::napi]
@@ -202,25 +186,14 @@ mod __unibind_ts_sample_ts {
         /// The next element, or `null` once the stream ends or closes.
         #[::napi_derive::napi]
         pub async fn next(&self) -> ::std::option::Option<super::sample_ts::Row> {
-            let _pull = self.pull.lock().await;
-            let mut stream = self.__unibind_slot().take()?;
-            let mut closed = self.closed.subscribe();
-            let item = ::tokio::select! {
-                biased; _ = closed.wait_for(| closed | * closed) =>
-                ::std::option::Option::None, item = stream.next() => item,
-            };
-            if item.is_some() && !*self.closed.borrow() {
-                self.__unibind_slot().replace(stream);
-            }
-            let value = item?;
+            let value = self.stream.next().await?;
             ::std::option::Option::Some(value)
         }
         /// Drop the stream early; a pull in flight resolves `null`, and
         /// the producer sees its stream dropped.
         #[::napi_derive::napi]
         pub fn close(&self) {
-            let _ = self.closed.send(true);
-            self.__unibind_slot().take();
+            self.stream.close();
         }
     }
     ///Tail rows once the store opens (an async stream function).
@@ -229,62 +202,34 @@ mod __unibind_ts_sample_ts {
         store: ::std::string::String,
         __unibind_signal: ::std::option::Option<__UnibindAbortSignal>,
     ) -> ::napi::Result<__UnibindStreamTailLater> {
-        let __unibind_future = super::sample_ts::tail_later(store);
-        match __unibind_signal {
-            ::std::option::Option::Some(__unibind_signal) => {
-                if __unibind_signal.already_aborted {
-                    return ::std::result::Result::Err(__unibind_aborted());
-                }
-                ::tokio::select! {
-                    biased; () = __unibind_signal.notify.notified() => {
-                    ::std::result::Result::Err(__unibind_aborted()) } value =
-                    __unibind_future => match value { ::std::result::Result::Ok(value) =>
-                    ::std::result::Result::Ok(__UnibindStreamTailLater::__unibind_from(value)),
-                    ::std::result::Result::Err(error) => {
-                    ::std::result::Result::Err(::napi::Error::from(error)) } },
-                }
+        let value = __unibind_with_abort(
+                __unibind_signal,
+                super::sample_ts::tail_later(store),
+            )
+            .await?;
+        match value {
+            ::std::result::Result::Ok(value) => {
+                ::std::result::Result::Ok(
+                    __UnibindStreamTailLater::__unibind_from(value),
+                )
             }
-            ::std::option::Option::None => {
-                let value = __unibind_future.await;
-                match value {
-                    ::std::result::Result::Ok(value) => {
-                        ::std::result::Result::Ok(
-                            __UnibindStreamTailLater::__unibind_from(value),
-                        )
-                    }
-                    ::std::result::Result::Err(error) => {
-                        ::std::result::Result::Err(::napi::Error::from(error))
-                    }
-                }
+            ::std::result::Result::Err(error) => {
+                ::std::result::Result::Err(::napi::Error::from(error))
             }
         }
     }
     ///Pull handle over the stream returned by `tail_later`.
     #[::napi_derive::napi(js_name = "TailLaterStream")]
     pub struct __UnibindStreamTailLater {
-        stream: ::std::sync::Mutex<
-            ::std::option::Option<::unibind_runtime::UniStream<super::sample_ts::Row>>,
-        >,
-        pull: ::tokio::sync::Mutex<()>,
-        closed: ::tokio::sync::watch::Sender<bool>,
+        stream: ::unibind_runtime::PullStream<super::sample_ts::Row>,
     }
     impl __UnibindStreamTailLater {
         fn __unibind_from(
             stream: ::unibind_runtime::UniStream<super::sample_ts::Row>,
         ) -> Self {
             Self {
-                stream: ::std::sync::Mutex::new(::std::option::Option::Some(stream)),
-                pull: ::tokio::sync::Mutex::new(()),
-                closed: ::tokio::sync::watch::Sender::new(false),
+                stream: ::unibind_runtime::PullStream::new(stream),
             }
-        }
-        fn __unibind_slot(
-            &self,
-        ) -> ::std::sync::MutexGuard<
-            '_,
-            ::std::option::Option<::unibind_runtime::UniStream<super::sample_ts::Row>>,
-        > {
-            self.stream.lock().unwrap_or_else(::std::sync::PoisonError::into_inner)
         }
     }
     #[::napi_derive::napi]
@@ -292,25 +237,14 @@ mod __unibind_ts_sample_ts {
         /// The next element, or `null` once the stream ends or closes.
         #[::napi_derive::napi]
         pub async fn next(&self) -> ::std::option::Option<super::sample_ts::Row> {
-            let _pull = self.pull.lock().await;
-            let mut stream = self.__unibind_slot().take()?;
-            let mut closed = self.closed.subscribe();
-            let item = ::tokio::select! {
-                biased; _ = closed.wait_for(| closed | * closed) =>
-                ::std::option::Option::None, item = stream.next() => item,
-            };
-            if item.is_some() && !*self.closed.borrow() {
-                self.__unibind_slot().replace(stream);
-            }
-            let value = item?;
+            let value = self.stream.next().await?;
             ::std::option::Option::Some(value)
         }
         /// Drop the stream early; a pull in flight resolves `null`, and
         /// the producer sees its stream dropped.
         #[::napi_derive::napi]
         pub fn close(&self) {
-            let _ = self.closed.send(true);
-            self.__unibind_slot().take();
+            self.stream.close();
         }
     }
     ///Open a counter from a free function (the non-constructor path).
@@ -360,35 +294,18 @@ mod __unibind_ts_sample_ts {
             amount: i64,
             __unibind_signal: ::std::option::Option<__UnibindAbortSignal>,
         ) -> ::napi::Result<i64> {
-            let __unibind_future = {
-                let __unibind_inner = ::std::sync::Arc::clone(&self.inner);
-                async move { __unibind_inner.add(amount).await }
-            };
-            match __unibind_signal {
-                ::std::option::Option::Some(__unibind_signal) => {
-                    if __unibind_signal.already_aborted {
-                        return ::std::result::Result::Err(__unibind_aborted());
-                    }
-                    ::tokio::select! {
-                        biased; () = __unibind_signal.notify.notified() => {
-                        ::std::result::Result::Err(__unibind_aborted()) } value =
-                        __unibind_future => match value {
-                        ::std::result::Result::Ok(value) =>
-                        ::std::result::Result::Ok(value),
-                        ::std::result::Result::Err(error) => {
-                        ::std::result::Result::Err(::napi::Error::from(error)) } },
-                    }
-                }
-                ::std::option::Option::None => {
-                    let value = __unibind_future.await;
-                    match value {
-                        ::std::result::Result::Ok(value) => {
-                            ::std::result::Result::Ok(value)
-                        }
-                        ::std::result::Result::Err(error) => {
-                            ::std::result::Result::Err(::napi::Error::from(error))
-                        }
-                    }
+            let value = __unibind_with_abort(
+                    __unibind_signal,
+                    {
+                        let __unibind_inner = ::std::sync::Arc::clone(&self.inner);
+                        async move { __unibind_inner.add(amount).await }
+                    },
+                )
+                .await?;
+            match value {
+                ::std::result::Result::Ok(value) => ::std::result::Result::Ok(value),
+                ::std::result::Result::Err(error) => {
+                    ::std::result::Result::Err(::napi::Error::from(error))
                 }
             }
         }
@@ -413,3 +330,4 @@ mod __unibind_ts_sample_ts {
         }
     }
 }
+

--- a/packages/unibind/gen/tests/ex.rs
+++ b/packages/unibind/gen/tests/ex.rs
@@ -8,7 +8,8 @@
 use unibind_core::ir;
 use unibind_gen::ex::ExEmitter;
 use unibind_gen::host::HostEmitter as _;
-use unibind_test_support::assert_snapshot;
+use unibind_test_support::assert_host_snapshots;
+use unibind_test_support::fixtures::{self, arg, docs};
 
 fn names(ex: Option<&str>) -> ir::Names {
     ir::Names {
@@ -17,30 +18,8 @@ fn names(ex: Option<&str>) -> ir::Names {
     }
 }
 
-fn docs(lines: &[&str]) -> Vec<String> {
-    lines.iter().map(|line| (*line).to_owned()).collect()
-}
-
-fn arg(name: &str, ty: ir::Type, default: Option<ir::Literal>) -> ir::Arg {
-    ir::Arg {
-        name: name.to_owned(),
-        names: names(None),
-        ty,
-        default,
-    }
-}
-
 fn function(name: &str, doc_lines: &[&str], args: Vec<ir::Arg>) -> ir::Function {
-    ir::Function {
-        name: name.to_owned(),
-        names: names(None),
-        docs: docs(doc_lines),
-        asyncness: ir::Asyncness::Sync,
-        blocking: false,
-        args,
-        ret: None,
-        throws: None,
-    }
+    fixtures::function(name, names(None), doc_lines, args)
 }
 
 const fn owned_string() -> ir::Type {
@@ -195,17 +174,22 @@ fn ex_host_files_snapshot() {
         nif_soname: "libsample.so".to_owned(),
     };
     let files = emitter.emit(&sample_interface()).expect("emits");
-    let paths: Vec<&str> = files.iter().map(|file| file.path.as_str()).collect();
-    assert_eq!(paths, ["lib/sample/native.ex", "lib/sample.ex"]);
-    assert_snapshot(
-        &files[0].contents,
-        include_str!("snapshots/sample.native.ex"),
-        "sample.native.ex",
-    );
-    assert_snapshot(
-        &files[1].contents,
-        include_str!("snapshots/sample.wrapper.ex"),
-        "sample.wrapper.ex",
+    assert_host_snapshots(
+        files
+            .iter()
+            .map(|file| (file.path.as_str(), file.contents.as_str())),
+        &[
+            (
+                "lib/sample/native.ex",
+                "sample.native.ex",
+                include_str!("snapshots/sample.native.ex"),
+            ),
+            (
+                "lib/sample.ex",
+                "sample.wrapper.ex",
+                include_str!("snapshots/sample.wrapper.ex"),
+            ),
+        ],
     );
 }
 

--- a/packages/unibind/gen/tests/jvm.rs
+++ b/packages/unibind/gen/tests/jvm.rs
@@ -8,7 +8,7 @@ use proc_macro2::TokenStream;
 use unibind_core::ir;
 use unibind_gen::host::HostEmitter as _;
 use unibind_gen::jvm::JvmEmitter;
-use unibind_test_support::assert_snapshot;
+use unibind_test_support::assert_host_snapshots;
 
 fn sample_interface() -> ir::Interface {
     let source = include_str!("../../backend-jvm/tests/fixtures/sample.rs");
@@ -25,12 +25,15 @@ fn jvm_host_file_lands_at_the_package_path() {
         package: Some("com.example.sample".to_owned()),
     };
     let files = emitter.emit(&sample_interface()).expect("emits");
-    let paths: Vec<&str> = files.iter().map(|file| file.path.as_str()).collect();
-    assert_eq!(paths, ["com/example/sample/Sample.java"]);
-    assert_snapshot(
-        &files[0].contents,
-        include_str!("../../backend-jvm/tests/snapshots/Sample.java"),
-        "Sample.java",
+    assert_host_snapshots(
+        files
+            .iter()
+            .map(|file| (file.path.as_str(), file.contents.as_str())),
+        &[(
+            "com/example/sample/Sample.java",
+            "Sample.java",
+            include_str!("../../backend-jvm/tests/snapshots/Sample.java"),
+        )],
     );
 }
 

--- a/packages/unibind/gen/tests/render.rs
+++ b/packages/unibind/gen/tests/render.rs
@@ -11,24 +11,12 @@ use unibind_gen::artifact::parse_ir_bytes;
 use unibind_gen::host::HostEmitter as _;
 use unibind_gen::py::PyEmitter;
 use unibind_test_support::assert_snapshot;
+use unibind_test_support::fixtures::{self, arg, docs};
 
 fn names(py: Option<&str>) -> ir::Names {
     ir::Names {
         py: py.map(str::to_owned),
         ..ir::Names::default()
-    }
-}
-
-fn docs(lines: &[&str]) -> Vec<String> {
-    lines.iter().map(|line| (*line).to_owned()).collect()
-}
-
-fn arg(name: &str, ty: ir::Type, default: Option<ir::Literal>) -> ir::Arg {
-    ir::Arg {
-        name: name.to_owned(),
-        names: names(None),
-        ty,
-        default,
     }
 }
 
@@ -46,16 +34,7 @@ const fn owned_string() -> ir::Type {
 }
 
 fn function(name: &str, py: Option<&str>, doc_lines: &[&str], args: Vec<ir::Arg>) -> ir::Function {
-    ir::Function {
-        name: name.to_owned(),
-        names: names(py),
-        docs: docs(doc_lines),
-        asyncness: ir::Asyncness::Sync,
-        blocking: false,
-        args,
-        ret: None,
-        throws: None,
-    }
+    fixtures::function(name, names(py), doc_lines, args)
 }
 
 fn sample_functions() -> Vec<ir::Function> {

--- a/packages/unibind/gen/tests/ts.rs
+++ b/packages/unibind/gen/tests/ts.rs
@@ -8,26 +8,14 @@
 use unibind_core::ir;
 use unibind_gen::host::HostEmitter as _;
 use unibind_gen::ts::TsEmitter;
-use unibind_test_support::assert_snapshot;
+use unibind_test_support::assert_host_snapshots;
+use unibind_test_support::fixtures::{self, arg, docs};
 
 fn names(py: Option<&str>, ts: Option<&str>) -> ir::Names {
     ir::Names {
         py: py.map(str::to_owned),
         ts: ts.map(str::to_owned),
         ..ir::Names::default()
-    }
-}
-
-fn docs(lines: &[&str]) -> Vec<String> {
-    lines.iter().map(|line| (*line).to_owned()).collect()
-}
-
-fn arg(name: &str, ty: ir::Type, default: Option<ir::Literal>) -> ir::Arg {
-    ir::Arg {
-        name: name.to_owned(),
-        names: names(None, None),
-        ty,
-        default,
     }
 }
 
@@ -41,16 +29,7 @@ fn field(name: &str, ts: Option<&str>, doc_lines: &[&str], ty: ir::Type) -> ir::
 }
 
 fn function(name: &str, ts: Option<&str>, doc_lines: &[&str], args: Vec<ir::Arg>) -> ir::Function {
-    ir::Function {
-        name: name.to_owned(),
-        names: names(None, ts),
-        docs: docs(doc_lines),
-        asyncness: ir::Asyncness::Sync,
-        blocking: false,
-        args,
-        ret: None,
-        throws: None,
-    }
+    fixtures::function(name, names(None, ts), doc_lines, args)
 }
 
 const fn owned_string() -> ir::Type {
@@ -280,17 +259,18 @@ fn ts_host_files_snapshot() {
         addon: "sample_ts".to_owned(),
     };
     let files = emitter.emit(&interface()).expect("emits");
-    let paths: Vec<&str> = files.iter().map(|file| file.path.as_str()).collect();
-    assert_eq!(paths, ["index.d.ts", "index.js"]);
-    assert_snapshot(
-        &files[0].contents,
-        include_str!("snapshots/sample.d.ts"),
-        "sample.d.ts",
-    );
-    assert_snapshot(
-        &files[1].contents,
-        include_str!("snapshots/sample.js"),
-        "sample.js",
+    assert_host_snapshots(
+        files
+            .iter()
+            .map(|file| (file.path.as_str(), file.contents.as_str())),
+        &[
+            (
+                "index.d.ts",
+                "sample.d.ts",
+                include_str!("snapshots/sample.d.ts"),
+            ),
+            ("index.js", "sample.js", include_str!("snapshots/sample.js")),
+        ],
     );
 }
 

--- a/packages/unibind/py-runtime/src/lib.rs
+++ b/packages/unibind/py-runtime/src/lib.rs
@@ -97,6 +97,28 @@ impl<T> SharedStream<T> {
         let inner = Arc::clone(&self.inner);
         async move { inner.lock().await.next().await }
     }
+
+    /// The body of every generated `__anext__`: the next item as an
+    /// awaitable Python object, with stream end mapped to
+    /// `StopAsyncIteration`. Lives here so the per-export iterator classes
+    /// stay one call deep instead of each repeating the bridge.
+    ///
+    /// # Errors
+    ///
+    /// Fails when no asyncio event loop can be resolved for the calling
+    /// context.
+    pub fn next_into_py<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>>
+    where
+        T: for<'a> pyo3::IntoPyObject<'a> + Send + 'static,
+    {
+        let next = self.next();
+        future_into_py(py, async move {
+            match next.await {
+                Some(item) => Ok(item),
+                None => Err(pyo3::exceptions::PyStopAsyncIteration::new_err(())),
+            }
+        })
+    }
 }
 
 impl<T> fmt::Debug for SharedStream<T> {

--- a/packages/unibind/runtime/Cargo.toml
+++ b/packages/unibind/runtime/Cargo.toml
@@ -3,10 +3,13 @@ name = "unibind-runtime"
 version.workspace = true
 edition.workspace = true
 publish.workspace = true
-description = "Language-free boundary types exported code references at runtime: UniStream"
+description = "Language-free boundary types exported code references at runtime: UniStream and its PullStream handle"
 
 [lints]
 workspace = true
 
 [dependencies]
 futures.workspace = true
+# `sync` for the pull gate and closed flag, `macros` for the `select!`
+# racing a pull against close.
+tokio = { workspace = true, features = ["macros", "sync"] }

--- a/packages/unibind/runtime/src/lib.rs
+++ b/packages/unibind/runtime/src/lib.rs
@@ -54,3 +54,66 @@ impl<T> fmt::Debug for UniStream<T> {
         formatter.debug_struct("UniStream").finish_non_exhaustive()
     }
 }
+
+/// One consumer's pull handle over a [`UniStream`]: checked-out pull
+/// state, a gate serializing concurrent pulls, and a level-triggered
+/// closed flag. The shared body of every generated handle class, so the
+/// per-export types stay thin shells.
+///
+/// `close` is synchronous and race-free: the watch channel flips to
+/// closed, which both wakes a pull blocked inside `next` (dropping the
+/// checked-out stream) and keeps later pulls from checking the stream
+/// back in.
+pub struct PullStream<T> {
+    stream: std::sync::Mutex<Option<UniStream<T>>>,
+    pull: tokio::sync::Mutex<()>,
+    closed: tokio::sync::watch::Sender<bool>,
+}
+
+impl<T> PullStream<T> {
+    /// Wrap `stream` for one consumer's serialized pulls.
+    #[must_use]
+    pub fn new(stream: UniStream<T>) -> Self {
+        Self {
+            stream: std::sync::Mutex::new(Some(stream)),
+            pull: tokio::sync::Mutex::new(()),
+            closed: tokio::sync::watch::Sender::new(false),
+        }
+    }
+
+    fn slot(&self) -> std::sync::MutexGuard<'_, Option<UniStream<T>>> {
+        self.stream
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// The next element, or `None` once the stream ends or closes.
+    pub async fn next(&self) -> Option<T> {
+        let _pull = self.pull.lock().await;
+        let mut stream = self.slot().take()?;
+        let mut closed = self.closed.subscribe();
+        let item = tokio::select! {
+            biased;
+            _ = closed.wait_for(|closed| *closed) => None,
+            item = stream.next() => item,
+        };
+        if item.is_some() && !*self.closed.borrow() {
+            self.slot().replace(stream);
+        }
+        item
+    }
+
+    /// Drop the stream early; a pull in flight resolves `None`, and the
+    /// producer sees its stream dropped.
+    pub fn close(&self) {
+        let _ = self.closed.send(true);
+        self.slot().take();
+    }
+}
+
+// Opaque like `UniStream`, and for the same reason.
+impl<T> fmt::Debug for PullStream<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("PullStream").finish_non_exhaustive()
+    }
+}

--- a/packages/unibind/test-support/src/fixtures.rs
+++ b/packages/unibind/test-support/src/fixtures.rs
@@ -1,0 +1,45 @@
+//! Literal-IR fixture builders shared by the emitter snapshot tests.
+//!
+//! Every backend's snapshot test builds the same shapes and differs only
+//! in which rename slot its `names` wrapper fills, so the constructors
+//! live here once and each test keeps only that wrapper.
+
+use unibind_core::ir;
+
+/// Docs lines as the IR stores them.
+#[must_use]
+pub fn docs(lines: &[&str]) -> Vec<String> {
+    lines.iter().map(|line| (*line).to_owned()).collect()
+}
+
+/// An argument with no rename in any language.
+#[must_use]
+pub fn arg(name: &str, ty: ir::Type, default: Option<ir::Literal>) -> ir::Arg {
+    ir::Arg {
+        name: name.to_owned(),
+        names: ir::Names::default(),
+        ty,
+        default,
+    }
+}
+
+/// A sync, non-throwing, returnless function; tests override the rest
+/// through struct update syntax.
+#[must_use]
+pub fn function(
+    name: &str,
+    names: ir::Names,
+    doc_lines: &[&str],
+    args: Vec<ir::Arg>,
+) -> ir::Function {
+    ir::Function {
+        name: name.to_owned(),
+        names,
+        docs: docs(doc_lines),
+        asyncness: ir::Asyncness::Sync,
+        blocking: false,
+        args,
+        ret: None,
+        throws: None,
+    }
+}

--- a/packages/unibind/test-support/src/lib.rs
+++ b/packages/unibind/test-support/src/lib.rs
@@ -1,5 +1,7 @@
 //! Shared assertions for Unibind integration and snapshot tests.
 
+pub mod fixtures;
+
 use std::fmt::Write as _;
 
 pub struct RecordAttributes<'a> {
@@ -71,6 +73,26 @@ pub fn assert_ir_json_snapshot(
 ) {
     let json = serde_json::to_string_pretty(interface).expect("serializes");
     assert_snapshot(&json, expected, name);
+}
+
+/// Assert emitted host files: the paths in emit order, then each file's
+/// contents against its committed snapshot. `expected` rows are
+/// `(path, snapshot name, snapshot contents)`; the emitter snapshot tests
+/// share this walk so the assertion flow lives once.
+///
+/// # Panics
+/// Panics when the path list differs or any snapshot drifted.
+pub fn assert_host_snapshots<'a>(
+    files: impl IntoIterator<Item = (&'a str, &'a str)>,
+    expected: &[(&'a str, &'a str, &'a str)],
+) {
+    let files: Vec<(&str, &str)> = files.into_iter().collect();
+    let paths: Vec<&str> = files.iter().map(|(path, _)| *path).collect();
+    let want: Vec<&str> = expected.iter().map(|(path, _, _)| *path).collect();
+    assert_eq!(paths, want);
+    for ((_, contents), (_, name, snapshot)) in files.iter().zip(expected) {
+        assert_snapshot(contents, snapshot, name);
+    }
 }
 
 /// Compare rendered output while printing a copy-ready replacement on drift.


### PR DESCRIPTION
Closes #3996.

The unibind emitters inlined the same async scaffold into every binding instead of sharing it. This PR emits each scaffold once:

- backend-ts: async exports now call a single `__unibind_with_abort` helper, emitted once per glue module next to `__UnibindAbortSignal`; only the per-binding settle conversion stays inline. The `biased` select and already-aborted early return are unchanged, just hoisted.
- backend-ts streams: the handle class guts (checked-out pull state, pull gate, level-triggered close) moved to `unibind_runtime::PullStream<T>`, which is napi-free; the generated class is now a thin shell naming the element type.
- backend-py streams: the `__anext__` body (next item, `StopAsyncIteration` on end) moved to `SharedStream::next_into_py` in `unibind-py-runtime`, next to the machinery it uses.
- gen tests: the fixture builders (`docs`/`arg`/`function`) and the emit-then-assert host-file walk now live in `unibind-test-support` (`fixtures` module, `assert_host_snapshots`); each backend test keeps only its `names` wrapper. Same shape as the #3901 staged-helper cleanup.

The ex backend already routes async through `unibind_ex_runtime::spawn_reply` and the jvm backend rejects async, so neither shared the pattern.

Snapshots regenerated (`sample.ts.rs`, `sample.py.rs`).

Verification:
- `cargo test` for all 12 non-conformance unibind crates: green, no snapshot drift.
- ts node conformance suite (local macOS assembly per the package's own recipe): 14/14, including abort mid-flight, already-aborted, stream backpressure, early close, and GC-driven drop.
- py conformance runner: 6/6, including cancel-mid-flight and stream backpressure.
- `nix run .#clone -- .`: duplication_pct 0.3125% -> 0.2941% (duplicated lines 1931 -> 1817). `clone.toml` ratchet lowered 0.36 -> 0.30 with a dated log entry.

Remaining unibind duplication is the per-export class shells (napi/pyo3 need concrete classes per element type) and the intentionally literal `ir::Interface` test fixtures; both stay in the scan as pressure.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Emit async abort/stream scaffold once per module instead of per binding in unibind
> - Extracts the inlined `tokio::select!` abort-racing logic from each generated TypeScript async function into a single module-level helper `__unibind_with_abort`, reducing per-binding code size.
> - Introduces `unibind_runtime::PullStream<T>` to hold serialized pull semantics and early-close state, replacing duplicated fields and logic in each generated stream handle class.
> - Adds `SharedStream::next_into_py` to the Python runtime, moving the inlined `future_into_py` async block out of each generated `__anext__` method.
> - Adds shared IR fixture builders and `assert_host_snapshots` to `test-support` to reduce boilerplate across backend test files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea703ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->