### PR TITLE
git: default maintenance.auto = false across rendered gitconfigs

### DIFF
--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -450,7 +450,14 @@ in {
               recurse = true;
               fetchJobs = 16;
             };
-            maintenance.auto = true;
+            # Never let ordinary git commands spawn background `git
+            # maintenance run --auto`: each auto run detaches an uncapped
+            # `git repack --cruft`, and at agent-fleet commit/fetch volume
+            # those stack without bound -- 1,033 of them piled up in ~12
+            # minutes and swapped a 128 GB workstation (ix#8161, #4001).
+            # Repos that want maintenance get scheduled runs via
+            # `git maintenance register` (maintenance.repo) instead.
+            maintenance.auto = false;
           };
         };
       };

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -1623,24 +1623,28 @@ in {
             update = "merge";
           };
         });
-        # Fetch-time background maintenance is for real project repos only.
-        # Nix-internal git cache repos (~/.cache/nix/tarball-cache-v2,
-        # ~/.cache/nix/gitv3/*) inherit this global file, and with
-        # maintenance.auto + gc.autodetach set every fetch spawned a
-        # detached `git maintenance run --auto` that SIGSEGVs on macOS
-        # (gettext locale init -> CFLocaleCopyPreferredLanguages -> NULL CF
-        # distributed-notification center), so the caches never got
-        # maintained (#3755). Scoping by gitdir keeps today's behavior for
-        # everything under ~/Projects/ (linked worktrees too: their gitdir
-        # resolves into the main checkout's .git) while ~/.cache repos fall
-        # back to git defaults.
-        "includeIf \"gitdir:~/Projects/\"".path = pkgs.writeText "projects-git-maintenance" (lib.generators.toGitINI {
-          gc.autodetach = true;
-          maintenance = {
-            auto = true;
+        # No fetch/commit-time auto maintenance anywhere, and explicitly so:
+        # git's own default for maintenance.auto is true, so this file must
+        # say `false` rather than stay silent. A ~/Projects/ includeIf used
+        # to turn it on for project repos (linked worktrees too: their
+        # gitdir resolves into the main checkout's .git), but at agent-fleet
+        # commit/fetch volume each auto run detaches an uncapped `git repack
+        # --cruft` and they stack without bound -- 1,033 of them piled up in
+        # ~12 minutes against the ix checkout and swapped this 128 GB
+        # machine (ix#8161, #4001). Off globally also keeps nix-internal
+        # cache repos (~/.cache/nix/tarball-cache-v2, ~/.cache/nix/gitv3/*)
+        # from spawning the detached runs that SIGSEGV on macOS (#3755).
+        maintenance =
+          {
+            auto = false;
+          }
+          # The registered maintenance repo lives on the workstation only:
+          # scheduled `git maintenance run` (launchd, incremental strategy)
+          # is the one maintenance path left for the ix checkout.
+          // lib.optionalAttrs pkgs.stdenv.isDarwin {
+            repo = cfg.paths.ixCheckout;
             strategy = "incremental";
           };
-        });
         push = {
           default = "simple";
           autoSetupRemote = true;
@@ -1677,14 +1681,6 @@ in {
         pager.log = true;
       }
       // gitCredentialHelpers
-      # Registered maintenance repo lives on the workstation only. The
-      # maintenance scheduling knobs (maintenance.auto/strategy,
-      # gc.autodetach) live in the ~/Projects/ includeIf above: they are
-      # for real project repos, not the git cache repos tools keep under
-      # ~/.cache (#3755).
-      // lib.optionalAttrs pkgs.stdenv.isDarwin {
-        maintenance.repo = cfg.paths.ixCheckout;
-      }
     );
 
   programs.ssh = let


### PR DESCRIPTION
Closes #4001

ix#8161: 1,033 concurrent `git maintenance run --auto` processes (each a detached, uncapped `git repack --cruft`) piled up in ~12 minutes of agent-fleet commit/fetch volume against the ix checkout and swapped a 128 GB workstation. The live machine was mitigated imperatively and ix's homes module now sets `maintenance.auto = false`, but this repo's profiles re-armed it on the next clean rebuild.

## Changes

- `modules/profiles/base/default.nix`: flip the VM-image root gitconfig default `maintenance.auto = true` -> `false`, with a why-comment citing the stampede.
- `users/andrewgazelka/profiles/workstation.nix`: drop the `includeIf "gitdir:~/Projects/"` block (`gc.autodetach = true` + `maintenance.auto = true`, which covered the ix checkout and all its linked worktrees) and set an explicit global `maintenance.auto = false`. Scheduled maintenance stays: the darwin-only `maintenance.repo` registration keeps the ix checkout registered and carries `strategy = "incremental"` forward from the removed includeIf.

## Notes on the issue's claims

Both cited lines existed as described. Two nuances worth recording:

- `modules/profiles/base/default.nix:453` is root's gitconfig in **VM images** (`home-manager.users.root`), not the workstation's `~/.gitconfig` — same class of bug (agents in VMs commit/fetch at volume), separate surface.
- The workstation's global gitconfig never set `maintenance.auto` at all; only the includeIf did. Since git's *own default* for `maintenance.auto` is true, just dropping the includeIf would not have disarmed anything — the rendered file now says `auto = false` explicitly.

`main-sync.sh`'s command-scope `maintenance.auto=false` override (index#3831) is unchanged: it is a self-contained defense that must hold regardless of global config.

## Verification

- `nix run .#lint`: 13/13 succeeded.
- Workstation `~/.gitconfig` rendered via `home-manager.lib.homeManagerConfiguration` over `homeModules.andrewgazelka-workstation` (private-config options stubbed):

  ```ini
  [maintenance]
      auto = false
      repo = "/Users/andrewgazelka/Projects/indexable-inc/ix"
      strategy = "incremental"
  ```

  The only remaining includeIf is the unrelated private-config submodule one (#3746); no `gitdir:~/Projects/` include and no `autodetach` anywhere in the file.
- VM-image root `git/config` built through `lib.evalImageConfig` (the same eval path as production image builds):

  ```ini
  [maintenance]
      auto = false
  ```

Authored by an AI agent (Claude Code, session 780cc423).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable `maintenance.auto` by default across rendered gitconfigs
> - Sets `maintenance.auto = false` in the base profile ([modules/profiles/base/default.nix](https://github.com/indexable-inc/index/pull/4006/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e)) to prevent background `git maintenance run --auto` from triggering in all governed repos.
> - In the workstation profile ([users/andrewgazelka/profiles/workstation.nix](https://github.com/indexable-inc/index/pull/4006/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962)), removes the `~/Projects/`-scoped `includeIf` block that set `gc.autodetach=true` and `maintenance.auto=true`, replacing it with a top-level `maintenance.auto=false`.
> - On macOS, `maintenance.repo` and `strategy="incremental"` are still set via `lib.optionalAttrs` inside the consolidated maintenance block.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 499d550.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->