### PR TITLE
unibind: emit ts/py async scaffold once per glue module

### DIFF
--- a/clone.toml
+++ b/clone.toml
@@ -55,7 +55,15 @@ ignore = [
 # type2 triple is gone (dead method deleted, pure field dumps now
 # dataclasses.asdict); measured 0.3593%. The 13-line _read_lines type1 twin
 # stays in the scan as a documented pair (see both data.py docstrings).
+#
+# 2026-07-22 (#3996): lowered 0.36 -> 0.305. The unibind ts/py emitters now
+# emit their async scaffold once per glue module (`__unibind_with_abort` next
+# to `__UnibindAbortSignal`; `SharedStream::anext` in unibind-py-runtime)
+# instead of inlining it per binding, and the regenerated snapshots shrank
+# accordingly; measured 0.3024% (1931 -> 1868 duplicated lines). The
+# remaining snapshot groups are per-class stream-handle glue left in the
+# scan as cleanup pressure.
 [budget]
-global_pct = 0.36
+global_pct = 0.305
 diff_pct = 0.0
 diff_base = "origin/main"

--- a/packages/unibind/backend-py/src/stream.rs
+++ b/packages/unibind/backend-py/src/stream.rs
@@ -98,15 +98,7 @@ impl StreamExport<'_> {
                     &self,
                     py: ::pyo3::Python<'py>,
                 ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
-                    let next = self.stream.next();
-                    ::unibind_py_runtime::future_into_py(py, async move {
-                        match next.await {
-                            ::std::option::Option::Some(item) => ::pyo3::PyResult::Ok(item),
-                            ::std::option::Option::None => ::pyo3::PyResult::Err(
-                                ::pyo3::exceptions::PyStopAsyncIteration::new_err(()),
-                            ),
-                        }
-                    })
+                    self.stream.anext(py)
                 }
             }
         }

--- a/packages/unibind/backend-py/tests/snapshots/sample.py.rs
+++ b/packages/unibind/backend-py/tests/snapshots/sample.py.rs
@@ -341,20 +341,7 @@ mod __unibind_py_sample {
             &self,
             py: ::pyo3::Python<'py>,
         ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
-            let next = self.stream.next();
-            ::unibind_py_runtime::future_into_py(
-                py,
-                async move {
-                    match next.await {
-                        ::std::option::Option::Some(item) => ::pyo3::PyResult::Ok(item),
-                        ::std::option::Option::None => {
-                            ::pyo3::PyResult::Err(
-                                ::pyo3::exceptions::PyStopAsyncIteration::new_err(()),
-                            )
-                        }
-                    }
-                },
-            )
+            self.stream.anext(py)
         }
     }
     ///Async iterator produced by `follow`.
@@ -382,20 +369,7 @@ mod __unibind_py_sample {
             &self,
             py: ::pyo3::Python<'py>,
         ) -> ::pyo3::PyResult<::pyo3::Bound<'py, ::pyo3::PyAny>> {
-            let next = self.stream.next();
-            ::unibind_py_runtime::future_into_py(
-                py,
-                async move {
-                    match next.await {
-                        ::std::option::Option::Some(item) => ::pyo3::PyResult::Ok(item),
-                        ::std::option::Option::None => {
-                            ::pyo3::PyResult::Err(
-                                ::pyo3::exceptions::PyStopAsyncIteration::new_err(()),
-                            )
-                        }
-                    }
-                },
-            )
+            self.stream.anext(py)
         }
     }
     ///A sample boundary exercising the phase 0-2 surface.

--- a/packages/unibind/backend-ts/src/function.rs
+++ b/packages/unibind/backend-ts/src/function.rs
@@ -177,8 +177,8 @@ fn sync_body(shape: &CallShape<'_>, value: &TokenStream) -> BodyAndRet {
 }
 
 /// The async wrapper: convert arguments on the JavaScript thread, then
-/// `select!` the user future against the abort notification so an abort
-/// drops the future.
+/// hand the user future to the module's `__unibind_with_abort`, which
+/// races it against the abort notification so an abort drops the future.
 fn async_body(shape: &CallShape<'_>, value: &TokenStream) -> BodyAndRet {
     let CallShape {
         name,
@@ -210,25 +210,8 @@ fn async_body(shape: &CallShape<'_>, value: &TokenStream) -> BodyAndRet {
         },
         ret: quote!(::napi::Result<#ok_decl>),
         body: quote! {
-            let __unibind_future = #call;
-            match __unibind_signal {
-                ::std::option::Option::Some(__unibind_signal) => {
-                    if __unibind_signal.already_aborted {
-                        return ::std::result::Result::Err(__unibind_aborted());
-                    }
-                    ::tokio::select! {
-                        biased;
-                        () = __unibind_signal.notify.notified() => {
-                            ::std::result::Result::Err(__unibind_aborted())
-                        }
-                        value = __unibind_future => #settle,
-                    }
-                }
-                ::std::option::Option::None => {
-                    let value = __unibind_future.await;
-                    #settle
-                }
-            }
+            let value = __unibind_with_abort(__unibind_signal, #call).await?;
+            #settle
         },
     }
 }

--- a/packages/unibind/backend-ts/src/module.rs
+++ b/packages/unibind/backend-ts/src/module.rs
@@ -120,5 +120,31 @@ fn abort_signal() -> TokenStream {
         fn __unibind_aborted() -> ::napi::Error {
             ::napi::Error::new(::napi::Status::Cancelled, "__unibind__:aborted")
         }
+
+        /// Race the user future against the abort notification; dropping
+        /// the future on abort is the cancellation. `None` (the argument
+        /// omitted or `undefined`) awaits the future undisturbed.
+        async fn __unibind_with_abort<F: ::std::future::Future>(
+            __unibind_signal: ::std::option::Option<__UnibindAbortSignal>,
+            __unibind_future: F,
+        ) -> ::napi::Result<F::Output> {
+            match __unibind_signal {
+                ::std::option::Option::Some(__unibind_signal) => {
+                    if __unibind_signal.already_aborted {
+                        return ::std::result::Result::Err(__unibind_aborted());
+                    }
+                    ::tokio::select! {
+                        biased;
+                        () = __unibind_signal.notify.notified() => {
+                            ::std::result::Result::Err(__unibind_aborted())
+                        }
+                        value = __unibind_future => ::std::result::Result::Ok(value),
+                    }
+                }
+                ::std::option::Option::None => {
+                    ::std::result::Result::Ok(__unibind_future.await)
+                }
+            }
+        }
     }
 }

--- a/packages/unibind/backend-ts/tests/snapshots/sample.ts.rs
+++ b/packages/unibind/backend-ts/tests/snapshots/sample.ts.rs
@@ -43,6 +43,29 @@ mod __unibind_ts_sample_ts {
     fn __unibind_aborted() -> ::napi::Error {
         ::napi::Error::new(::napi::Status::Cancelled, "__unibind__:aborted")
     }
+    /// Race the user future against the abort notification; dropping
+    /// the future on abort is the cancellation. `None` (the argument
+    /// omitted or `undefined`) awaits the future undisturbed.
+    async fn __unibind_with_abort<F: ::std::future::Future>(
+        __unibind_signal: ::std::option::Option<__UnibindAbortSignal>,
+        __unibind_future: F,
+    ) -> ::napi::Result<F::Output> {
+        match __unibind_signal {
+            ::std::option::Option::Some(__unibind_signal) => {
+                if __unibind_signal.already_aborted {
+                    return ::std::result::Result::Err(__unibind_aborted());
+                }
+                ::tokio::select! {
+                    biased; () = __unibind_signal.notify.notified() => {
+                    ::std::result::Result::Err(__unibind_aborted()) } value =
+                    __unibind_future => ::std::result::Result::Ok(value),
+                }
+            }
+            ::std::option::Option::None => {
+                ::std::result::Result::Ok(__unibind_future.await)
+            }
+        }
+    }
     ///Map `SampleError` onto a decodable napi rejection reason, message from `Display`.
     impl ::std::convert::From<super::sample_ts::SampleError> for ::napi::Error {
         fn from(error: super::sample_ts::SampleError) -> Self {
@@ -114,23 +137,12 @@ mod __unibind_ts_sample_ts {
         b: i64,
         __unibind_signal: ::std::option::Option<__UnibindAbortSignal>,
     ) -> ::napi::Result<i64> {
-        let __unibind_future = super::sample_ts::slow_add(a, b);
-        match __unibind_signal {
-            ::std::option::Option::Some(__unibind_signal) => {
-                if __unibind_signal.already_aborted {
-                    return ::std::result::Result::Err(__unibind_aborted());
-                }
-                ::tokio::select! {
-                    biased; () = __unibind_signal.notify.notified() => {
-                    ::std::result::Result::Err(__unibind_aborted()) } value =
-                    __unibind_future => ::std::result::Result::Ok(value),
-                }
-            }
-            ::std::option::Option::None => {
-                let value = __unibind_future.await;
-                ::std::result::Result::Ok(value)
-            }
-        }
+        let value = __unibind_with_abort(
+                __unibind_signal,
+                super::sample_ts::slow_add(a, b),
+            )
+            .await?;
+        ::std::result::Result::Ok(value)
     }
     ///Fetch one row.
     #[::napi_derive::napi]
@@ -138,28 +150,15 @@ mod __unibind_ts_sample_ts {
         store: ::std::string::String,
         __unibind_signal: ::std::option::Option<__UnibindAbortSignal>,
     ) -> ::napi::Result<super::sample_ts::Row> {
-        let __unibind_future = super::sample_ts::fetch(store);
-        match __unibind_signal {
-            ::std::option::Option::Some(__unibind_signal) => {
-                if __unibind_signal.already_aborted {
-                    return ::std::result::Result::Err(__unibind_aborted());
-                }
-                ::tokio::select! {
-                    biased; () = __unibind_signal.notify.notified() => {
-                    ::std::result::Result::Err(__unibind_aborted()) } value =
-                    __unibind_future => match value { ::std::result::Result::Ok(value) =>
-                    ::std::result::Result::Ok(value), ::std::result::Result::Err(error)
-                    => { ::std::result::Result::Err(::napi::Error::from(error)) } },
-                }
-            }
-            ::std::option::Option::None => {
-                let value = __unibind_future.await;
-                match value {
-                    ::std::result::Result::Ok(value) => ::std::result::Result::Ok(value),
-                    ::std::result::Result::Err(error) => {
-                        ::std::result::Result::Err(::napi::Error::from(error))
-                    }
-                }
+        let value = __unibind_with_abort(
+                __unibind_signal,
+                super::sample_ts::fetch(store),
+            )
+            .await?;
+        match value {
+            ::std::result::Result::Ok(value) => ::std::result::Result::Ok(value),
+            ::std::result::Result::Err(error) => {
+                ::std::result::Result::Err(::napi::Error::from(error))
             }
         }
     }
@@ -229,33 +228,19 @@ mod __unibind_ts_sample_ts {
         store: ::std::string::String,
         __unibind_signal: ::std::option::Option<__UnibindAbortSignal>,
     ) -> ::napi::Result<__UnibindStreamTailLater> {
-        let __unibind_future = super::sample_ts::tail_later(store);
-        match __unibind_signal {
-            ::std::option::Option::Some(__unibind_signal) => {
-                if __unibind_signal.already_aborted {
-                    return ::std::result::Result::Err(__unibind_aborted());
-                }
-                ::tokio::select! {
-                    biased; () = __unibind_signal.notify.notified() => {
-                    ::std::result::Result::Err(__unibind_aborted()) } value =
-                    __unibind_future => match value { ::std::result::Result::Ok(value) =>
-                    ::std::result::Result::Ok(__UnibindStreamTailLater::__unibind_from(value)),
-                    ::std::result::Result::Err(error) => {
-                    ::std::result::Result::Err(::napi::Error::from(error)) } },
-                }
+        let value = __unibind_with_abort(
+                __unibind_signal,
+                super::sample_ts::tail_later(store),
+            )
+            .await?;
+        match value {
+            ::std::result::Result::Ok(value) => {
+                ::std::result::Result::Ok(
+                    __UnibindStreamTailLater::__unibind_from(value),
+                )
             }
-            ::std::option::Option::None => {
-                let value = __unibind_future.await;
-                match value {
-                    ::std::result::Result::Ok(value) => {
-                        ::std::result::Result::Ok(
-                            __UnibindStreamTailLater::__unibind_from(value),
-                        )
-                    }
-                    ::std::result::Result::Err(error) => {
-                        ::std::result::Result::Err(::napi::Error::from(error))
-                    }
-                }
+            ::std::result::Result::Err(error) => {
+                ::std::result::Result::Err(::napi::Error::from(error))
             }
         }
     }
@@ -360,35 +345,18 @@ mod __unibind_ts_sample_ts {
             amount: i64,
             __unibind_signal: ::std::option::Option<__UnibindAbortSignal>,
         ) -> ::napi::Result<i64> {
-            let __unibind_future = {
-                let __unibind_inner = ::std::sync::Arc::clone(&self.inner);
-                async move { __unibind_inner.add(amount).await }
-            };
-            match __unibind_signal {
-                ::std::option::Option::Some(__unibind_signal) => {
-                    if __unibind_signal.already_aborted {
-                        return ::std::result::Result::Err(__unibind_aborted());
-                    }
-                    ::tokio::select! {
-                        biased; () = __unibind_signal.notify.notified() => {
-                        ::std::result::Result::Err(__unibind_aborted()) } value =
-                        __unibind_future => match value {
-                        ::std::result::Result::Ok(value) =>
-                        ::std::result::Result::Ok(value),
-                        ::std::result::Result::Err(error) => {
-                        ::std::result::Result::Err(::napi::Error::from(error)) } },
-                    }
-                }
-                ::std::option::Option::None => {
-                    let value = __unibind_future.await;
-                    match value {
-                        ::std::result::Result::Ok(value) => {
-                            ::std::result::Result::Ok(value)
-                        }
-                        ::std::result::Result::Err(error) => {
-                            ::std::result::Result::Err(::napi::Error::from(error))
-                        }
-                    }
+            let value = __unibind_with_abort(
+                    __unibind_signal,
+                    {
+                        let __unibind_inner = ::std::sync::Arc::clone(&self.inner);
+                        async move { __unibind_inner.add(amount).await }
+                    },
+                )
+                .await?;
+            match value {
+                ::std::result::Result::Ok(value) => ::std::result::Result::Ok(value),
+                ::std::result::Result::Err(error) => {
+                    ::std::result::Result::Err(::napi::Error::from(error))
                 }
             }
         }
@@ -413,3 +381,4 @@ mod __unibind_ts_sample_ts {
         }
     }
 }
+

--- a/packages/unibind/py-runtime/src/lib.rs
+++ b/packages/unibind/py-runtime/src/lib.rs
@@ -97,6 +97,25 @@ impl<T> SharedStream<T> {
         let inner = Arc::clone(&self.inner);
         async move { inner.lock().await.next().await }
     }
+
+    /// One `__anext__` call: pull the next item as an awaitable Python
+    /// object, mapping exhaustion to `StopAsyncIteration`. Generated
+    /// stream classes delegate their `__anext__` here.
+    ///
+    /// # Errors
+    ///
+    /// Fails when no asyncio event loop can be resolved for the calling
+    /// context.
+    pub fn anext<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>>
+    where
+        T: for<'a> pyo3::IntoPyObject<'a> + Send + 'static,
+    {
+        let next = self.next();
+        future_into_py(py, async move {
+            next.await
+                .ok_or_else(|| pyo3::exceptions::PyStopAsyncIteration::new_err(()))
+        })
+    }
 }
 
 impl<T> fmt::Debug for SharedStream<T> {


### PR DESCRIPTION
`nix run .#clone -- .` put packages/unibind at the top of the duplication report because the ts and py emitters inlined their async scaffold into every binding. This emits each piece once per glue module instead.

- **backend-ts**: every async export repeated the full abort match (the `__unibind_signal` match with the `already_aborted` early return, the `biased` `tokio::select!` arm, and the `None` branch awaiting the future). `async_body` now awaits through a `__unibind_with_abort` helper generic over the future, rendered once next to `__UnibindAbortSignal`.
- **backend-py**: every stream class repeated the `__anext__` body (poll `SharedStream::next`, map `None` to `StopAsyncIteration`, wrap through `future_into_py`). That bridge now lives on `SharedStream::anext` in `unibind-py-runtime`, and generated classes delegate to it.

The ex backend (`unibind_ex_runtime::spawn_reply`) and the jvm backend do not share the pattern and are untouched.

**Measure** (`clone` binary over the tree): 1931 -> 1868 duplicated lines, 0.3125% -> 0.3024%. The clone.toml ratchet drops 0.36 -> 0.305 with a dated entry (same shape as #3901/#3908). The remaining unibind snapshot groups are per-class stream-handle glue, left in the scan as cleanup pressure.

**Verification**
- snapshot tests regenerated and green (`cargo test -p unibind-backend-ts -p unibind-backend-py`)
- ts Node conformance suite: 14/14 locally (includes both abort tests that exercise `__unibind_with_abort`)
- py conformance runner: 6/6 locally (includes stream backpressure through `SharedStream::anext`); stubs check clean under `mypy --strict`
- fork clippy: `nix build .#ciChecks.x86_64-linux.rust-unibind-{backend-ts,backend-py,py-runtime}.clippy` all pass
- `nix run .#lint`: 13/13 lanes, including the `clone` gate at the new ratchet

Closes #3996

---

Authored by an AI agent (Claude Code, Fable 5).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Emit async scaffold helpers once per glue module in unibind TS and Python backends
> - Extracts the abort-racing logic from each generated async TS function into a single module-scoped `__unibind_with_abort` helper in [module.rs](https://github.com/indexable-inc/index/pull/4007/files#diff-5eb3d5093e38a3bdc9e232d200e10b2e33eefccc5bd94d92142b6527bdcba738), reducing per-function boilerplate.
> - Moves the `__anext__` future-wrapping logic from each generated Python stream class into a new `SharedStream::anext` method in [py-runtime/src/lib.rs](https://github.com/indexable-inc/index/pull/4007/files#diff-e5de76fe48834027d3200dd0e788ad5f9979bef1cd0a92f81a53461284764cd7), so generated classes just call `self.stream.anext(py)`.
> - Generated async functions in [function.rs](https://github.com/indexable-inc/index/pull/4007/files#diff-20d248065632f6cb86d42a101da767d5e67379ffd48b4268e8aaa4ee7367c13b) now call `__unibind_with_abort(__unibind_signal, <future>).await?` instead of inlining a `tokio::select!` block.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 105daec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->