### PR TITLE
rules: isolation worktrees are of the session repo, not the task's

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -94,14 +94,19 @@
         branch and verify root and branch before committing. Right after
         `git worktree add`, run `git submodule update --init --recursive`:
         a new worktree leaves submodules uninitialized even when the build
-        needs them. Unmerged branches are unfinished for reasons you may
+        needs them. An isolation worktree belongs to the session's repo,
+        not necessarily your task's: verify its origin, and when the task
+        targets another repo, add your own worktree of the target
+        checkout. Unmerged branches are unfinished for reasons you may
         not see; check for open PRs touching a file before nontrivial
         edits.
       '';
       reason = ''
         Primary-checkout edits collided with concurrent work; parallel
         sessions raced duplicate PRs (#1911, #1914, #1943). Absorbs
-        coordinateBranches (index#3594).
+        coordinateBranches (index#3594). Fixers briefed on ix tasks
+        received index worktrees and hand-rolled replacements, one
+        clobbering a sibling's (index#4008).
       '';
     };
   }


### PR DESCRIPTION
Extends the `worktree` rule in `packages/agent/prompt/rules.nix` with the cross-repo delta from #4008: an isolation worktree belongs to the session's repo, so a task targeting another repo means verifying the worktree's origin first and adding your own worktree of the target checkout. One rule extended, none added; provenance noted in `reason`.

Verified: `nix run .#lint` green; `nix eval` of the rendered systemPrompt contains the new sentence.

Closes #4008

Authored by an AI agent (Claude Code).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify that isolation worktrees belong to the session repo, not the task repo
> Updates the guidance and reason text in [rules.nix](https://github.com/indexable-inc/index/pull/4010/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to clarify that an isolation worktree belongs to the session's repository, which may differ from the task's target repository. Adds a note advising users to add a worktree for the target checkout when needed, and includes a new incident example where fixers on `ix` tasks received index worktrees and hand-rolled replacements caused a clobbering incident.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 600d4b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->