### PR TITLE
update-flake-lock: relock gitlink-pinned flake inputs in the bump commit

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -101,8 +101,10 @@ jobs:
       # #2064 introduced the local action). Referencing the action by repo
       # resolves it from index@main regardless of which repo called the job.
       - name: Install Determinate Nix
-        # Submodule mode never evaluates the flake, so skip the Nix installs.
-        if: ${{ !inputs.nix-preinstalled && inputs.submodule-paths == '' }}
+        # Submodule mode needs nix too: the bump step relocks flake inputs
+        # pinned by a bumped gitlink (ix#8180), and the tool-provision step's
+        # `ensure` builds missing CLIs from nixpkgs.
+        if: ${{ !inputs.nix-preinstalled }}
         uses: indexable-inc/index/.github/actions/install-nix@main
 
       # Underscore digit separators require the patched client in index and in
@@ -158,6 +160,7 @@ jobs:
             done < <(nix build "nixpkgs#$1" --no-link --print-out-paths)
           }
           ensure gh
+          ensure jq
       - name: Bump submodules
         if: ${{ inputs.submodule-paths != '' }}
         env:
@@ -188,6 +191,37 @@ jobs:
             summary="${summary:+${summary}, }${p}@$(git -C "$p" rev-parse --short=8 HEAD)"
           done
           git commit -am "submodules: bump ${summary}"
+          # Relock every flake input pinned by a bumped gitlink (path:./<sub>
+          # locked with a rev, as ix pins `index`; ix#8180): flake.lock
+          # records the gitlink rev plus the input's own nested locks, so a
+          # gitlink-only commit ships a stale lock that fails ix's
+          # check-submodule-lock-sync guard (ix#8149) -- since that guard
+          # landed, an unrelocked bump PR can never go green. Relock AFTER
+          # committing: nix resolves the path input's rev from the committed
+          # HEAD tree, not the submodule worktree or the git index, so a
+          # pre-commit `nix flake update` silently no-ops. Amend so gitlink
+          # and lock move in the same commit (ix#8143: a gitlink-only commit
+          # on main makes the first nix command rewrite flake.lock and dirty
+          # the checkout that prod deploys require clean).
+          relock=()
+          if [ -f flake.lock ]; then
+            for p in "${paths[@]}"; do
+              while IFS= read -r name; do
+                relock+=("$name")
+              done < <(jq -r --arg path "./$p" '.nodes as $n
+                | $n[.root].inputs // {} | to_entries[]
+                | select(.value | type == "string")
+                | select(($n[.value].locked.type? == "path")
+                         and ($n[.value].locked.path? == $path)
+                         and ($n[.value].locked | has("rev")))
+                | .key' flake.lock)
+            done
+          fi
+          if [ "${#relock[@]}" -gt 0 ]; then
+            nix flake update "${relock[@]}"
+            git add flake.lock
+            git commit --amend --no-edit
+          fi
           git push -f origin update-flake-lock
           if [ -z "$(gh pr list --head update-flake-lock --base main --state open --json number --jq '.[0].number // empty')" ]; then
             gh pr create --base main --head update-flake-lock \


### PR DESCRIPTION
A `submodule-paths` bump commits only the gitlink move. ix pins the submodule as a flake path input (`index.url = "path:./index"`), so flake.lock records the gitlink rev plus index's nested input locks — the bump ships a stale lock. Since ix#8149 landed `check-submodule-lock-sync`, every unrelocked bump PR is permanently red, and a gitlink-only push to main turns the nix and lint phases red until someone relocks by hand (ix#8143, ix#8158, run 29910646264).

This makes the bump step relock in the same commit that moves the gitlink:

- map each bumped submodule path to the flake inputs whose lock node pins it (locked `type == "path"`, matching `path`, and a `rev`), via jq over flake.lock;
- `nix flake update` those inputs and amend the lock into the bump commit.

The ordering is load-bearing: nix resolves a path input's rev from the committed HEAD tree, not the submodule worktree or the git index — `nix flake update index` before the commit silently no-ops (verified in the dry run). Hence commit, relock, amend. Submodule mode now installs nix when not preinstalled, and the update job provisions jq (hosted runners have it; ix's minimal-PATH runners build it from nixpkgs).

Dry run against ix `2dd04498e1` (gitlink 8a65a493 -> 37459075), running the step script verbatim as extracted from this branch's YAML: one commit `submodules: bump index@37459075` touching `index` + `flake.lock` (2 files, 3 insertions/deletions), lock rev == gitlink, and ix's `scripts/ci/check-submodule-lock-sync.sh HEAD` exits 0 on it.

Residual: manual gitlink-only `z` pushes to main bypass this workflow entirely; the ix guard still catches those, and its error message names the fix (`nix flake update index`). This PR fixes the automated producer.

Local gates: index repo lint 13/13 green; actionlint clean (same as main baseline).

Refs indexable-inc/ix#8180

Made with Claude Code (Fable 5) on Andrew's behalf.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Relock path-pinned flake inputs when bumping submodules in `update-flake-lock`
> - After committing submodule bumps, the workflow now parses `flake.lock` with `jq` to find inputs with a `path` locked type matching the bumped submodule and a `rev` field, then runs `nix flake update` for those inputs and amends the bump commit so `flake.lock` and gitlinks change together.
> - Installs Determinate Nix even in submodule mode (previously skipped) and ensures `jq` is on `PATH` before the bump step.
> - Behavioral Change: the bump commit now includes `flake.lock` changes for affected path-pinned inputs, and Nix is always installed in submodule workflows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4bcfd8f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->