### PR TITLE
update-flake-lock: make the submodule relock heal, stamp, and fail loud

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -180,18 +180,18 @@ jobs:
           git checkout -B update-flake-lock origin/main
           git submodule update --init -- "${paths[@]}"
           git submodule update --remote -- "${paths[@]}"
-          if git diff --quiet; then
-            echo "submodules already at their remote HEADs; nothing to bump"
-            exit 0
-          fi
           # Plain git/bash: the self-hosted runner PATH has git and gh but
           # not awk (run 29892186766 died on it).
           summary=""
           for p in "${paths[@]}"; do
             summary="${summary:+${summary}, }${p}@$(git -C "$p" rev-parse --short=8 HEAD)"
           done
-          git commit -am "submodules: bump ${summary}"
-          # Relock every flake input pinned by a bumped gitlink (path:./<sub>
+          bumped=""
+          if ! git diff --quiet; then
+            git commit -am "submodules: bump ${summary}"
+            bumped=1
+          fi
+          # Relock every flake input pinned by a listed gitlink (path:./<sub>
           # locked with a rev, as ix pins `index`; ix#8180): flake.lock
           # records the gitlink rev plus the input's own nested locks, so a
           # gitlink-only commit ships a stale lock that fails ix's
@@ -199,28 +199,101 @@ jobs:
           # landed, an unrelocked bump PR can never go green. Relock AFTER
           # committing: nix resolves the path input's rev from the committed
           # HEAD tree, not the submodule worktree or the git index, so a
-          # pre-commit `nix flake update` silently no-ops. Amend so gitlink
-          # and lock move in the same commit (ix#8143: a gitlink-only commit
-          # on main makes the first nix command rewrite flake.lock and dirty
-          # the checkout that prod deploys require clean).
+          # pre-commit `nix flake update` silently no-ops (ix#8143: a
+          # gitlink-only commit on main makes the first nix command rewrite
+          # flake.lock and dirty the checkout that prod deploys require
+          # clean). Staleness decides, not this run's gitlink move: a pin
+          # left stale by an earlier gitlink-only push to main is relocked
+          # and pushed even when the submodule did not move this run.
           relock=()
           if [ -f flake.lock ]; then
             for p in "${paths[@]}"; do
+              gitlink="$(git rev-parse "HEAD:${p}")"
               while IFS= read -r name; do
                 relock+=("$name")
-              done < <(jq -r --arg path "./$p" '.nodes as $n
+              done < <(jq -r --arg path "./$p" --arg rev "$gitlink" '.nodes as $n
                 | $n[.root].inputs // {} | to_entries[]
                 | select(.value | type == "string")
                 | select(($n[.value].locked.type? == "path")
                          and ($n[.value].locked.path? == $path)
-                         and ($n[.value].locked | has("rev")))
+                         and (($n[.value].locked.rev? // "") != $rev))
                 | .key' flake.lock)
             done
           fi
+          if [ -z "$bumped" ] && [ "${#relock[@]}" -eq 0 ]; then
+            echo "submodules already at their remote HEADs and every pin locked; nothing to bump"
+            exit 0
+          fi
           if [ "${#relock[@]}" -gt 0 ]; then
             nix flake update "${relock[@]}"
+            # Re-stamp the gitlink pin on the relocked node(s). The runner's
+            # nix is the immutable fleet client built from whatever index rev
+            # the host last deployed; a client older than index patch 0030
+            # (libflake: stamp submodule metadata on relative path inputs)
+            # locks a relative path input as bare {path,type}, silently
+            # DROPPING the pin (run 29912321315 shipped exactly that to ix;
+            # #3982) -- and bootstrap-patched-nix cannot save it: its pin
+            # predates p30 and its probe only checks underscore parsing. Both
+            # pin fields are pure git facts (the gitlink sha and its
+            # committer time), so stamping them here makes the lock
+            # client-independent; on a >= p30 client the stamp is a
+            # byte-identical no-op (verified against `nix flake lock`
+            # output). Keys re-sorted because nix serializes JSON objects
+            # with sorted keys.
+            for p in "${paths[@]}"; do
+              rev="$(git -C "$p" rev-parse HEAD)"
+              ts="$(git -C "$p" show -s --format=%ct HEAD)"
+              jq --arg path "./${p}" --arg rev "$rev" --argjson ts "$ts" '
+                (.nodes[.root].inputs // {} | [to_entries[]
+                  | select(.value | type == "string") | .value]) as $rootNodes
+                | .nodes |= with_entries(
+                    if (.key as $k | ($rootNodes | index($k)))
+                       and .value.locked.type? == "path" and .value.locked.path? == $path
+                    then .value.locked = ((.value.locked + {rev: $rev, lastModified: $ts})
+                                          | to_entries | sort_by(.key) | from_entries)
+                    else . end)
+              ' flake.lock > flake.lock.tmp
+              mv flake.lock.tmp flake.lock
+            done
             git add flake.lock
-            git commit --amend --no-edit
+            if [ -n "$bumped" ]; then
+              git commit --amend --no-edit
+            else
+              git commit -m "flake.lock: relock ${relock[*]} to the ${summary} gitlink"
+            fi
+          fi
+          # Refuse to push a lock that disagrees with a gitlink pin: a miss
+          # above (renamed input, unexpected lock shape, a client dropping
+          # the pin) is exactly the stale-lock bug the relock exists to
+          # prevent, and the caller's CI (ix's check-submodule-lock-sync)
+          # would reject the commit anyway.
+          if [ -f flake.lock ]; then
+            for p in "${paths[@]}"; do
+              rev="$(git rev-parse "HEAD:${p}")"
+              bad="$(jq -r --arg path "./${p}" --arg rev "$rev" '
+                (.nodes[.root].inputs // {} | [to_entries[]
+                  | select(.value | type == "string") | .value]) as $rootNodes
+                | [.nodes | to_entries[]
+                   | select((.key as $k | ($rootNodes | index($k)))
+                            and .value.locked.type? == "path" and .value.locked.path? == $path)
+                   | select((.value.locked.rev? // "missing") != $rev)
+                   | .key] | join(", ")' flake.lock)"
+              if [ -n "$bad" ]; then
+                echo "::error::flake.lock node(s) ${bad} do not pin ./${p} at gitlink ${rev}; refusing to push a stale lock (#3982)"
+                exit 1
+              fi
+            done
+            jq -r '.nodes | to_entries[]
+                | select(.value.locked.type? == "path" and (.value.locked | has("rev")))
+                | "\(.key) \(.value.locked.path) \(.value.locked.rev)"' flake.lock \
+            | while read -r name lock_path lock_rev; do
+                entry="$(git ls-tree HEAD -- "${lock_path#./}")"
+                read -r mode _type oid _rest <<< "$entry" || true
+                if [ "${mode:-}" != 160000 ] || [ "$oid" != "$lock_rev" ]; then
+                  echo "::error::flake.lock node '${name}' pins ${lock_path} at ${lock_rev} but the tree has '${entry:-nothing}'; refusing to push a stale lock (#3982)"
+                  exit 1
+                fi
+              done
           fi
           git push -f origin update-flake-lock
           if [ -z "$(gh pr list --head update-flake-lock --base main --state open --json number --jq '.[0].number // empty')" ]; then


### PR DESCRIPTION
Fixes #3982. Refs indexable-inc/ix#8180.

## What happened after #4014

#4014 landed the right mechanism (`nix flake update` after the gitlink commit, amended in), but its first production run corrupted the caller's lock instead of fixing it. Run 29912321315 produced ix bump commit `47524fe6` whose `index` node went from `path:./index?lastModified=...&rev=37459075...` to bare `path:./index` -- the pin was silently DROPPED, not moved. Root cause: the relock runs on the runner's immutable fleet nix (`config.nix.package`, nix/modules/base/nix-settings.nix in ix), built from whatever index rev the CI host last deployed. That client predates index patch 0030 (`libflake: stamp submodule metadata on relative path inputs`, 2026-07-19), so it locks a relative path input the upstream way: bare `{path,type}`. The failure is invisible to ix's `check-submodule-lock-sync` (it only inspects nodes that still carry a `rev`), while any patched-client nix command re-adds the pin and dirties the checkout prod deploys require clean (ix#8143) -- and prod deploy is what would refresh the runner's client, a deadlock. `bootstrap-patched-nix` cannot help either: its pinned rev `bf7a9b0d` predates p30, and its compatibility probe only checks underscore parsing (p14).

## Fix

Keep `nix flake update` for what only nix can do -- re-locking the input's nested locks when index moves its own pins (jq cannot reproduce that; verified: a bump crossing index's ghostty-src pin change re-locks the nested node) -- and make the workflow the source of truth for the pin itself:

- **Stamp**: after `nix flake update`, rewrite each matching root-input node's `locked.rev`/`locked.lastModified` from git alone (the gitlink sha and its committer timestamp), keys re-sorted the way nix serializes. On a >= p30 client this is a byte-identical no-op; on an older client it restores exactly the pin the client dropped. The lock becomes client-independent.
- **Heal**: relock on staleness (locked rev != committed gitlink), not on whether this run moved the gitlink, so a pin left stale or dropped by an earlier gitlink-only push (or by #4014's corrupt bumps) heals on the next 5-minute tick, as a lock-only commit when nothing else moved.
- **Fail loud**: refuse to push when any listed submodule's matching lock node does not pin the committed gitlink (catches a client dropping the pin, a renamed input, an unexpected lock shape), and when any rev-carrying path node disagrees with its gitlink (same invariant as ix's `scripts/ci/check-submodule-lock-sync.sh`).

## Verification (scratch ix clone, real flake.lock, patched nix 2.34.7+ix.p37)

Extracted the step's script verbatim from the YAML and ran five scenarios; a pre-p30 client is simulated by a `nix` shim that strips the pin after `flake update` -- exactly what run 29912321315 did:

- **H1** bump from ix main's current stale state (gitlink `37459075`, lock `8a65a493`) with the p37 client: one commit carries gitlink + lock; `nix flake lock` afterwards changes nothing; ix's sync gate passes.
- **H2** same bump with the pre-p30 shim: final flake.lock is **byte-identical** to H1's -- the stamp reproduces the patched client's bytes exactly.
- **H3** bump crossing an index flake.lock/flake.nix change (ghostty-src repin) with the shim: nested node re-locked by nix, pin stamped, fixed point holds, gate passes.
- **H4** heal-only (gitlink already at remote HEAD, lock stale): produces `flake.lock: relock index to the index@37459075 gitlink` (2-line diff), fixed point, gate passes.
- **H5** fully consistent state: clean no-op exit, no commit.

Negative test: a gitlink-only commit is refused with `::error::...refusing to push a stale lock (#3982)` and exit 1 before the push.

Gates: `nix run .#lint` 27 checks rc=0, `actionlint` clean, YAML parses. The one `nix fmt` complaint pre-exists on clean main.

Authored by Claude Code (Fable 5) on andrew's behalf.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden submodule relock in `update-flake-lock` to stamp, heal, and fail on mismatched pins
> - Replaces the early-exit-on-no-diff logic with a `bumped` flag so the workflow continues even when submodules are already at remote HEADs, relocking only stale path-pinned flake inputs.
> - After `nix flake update`, stamps `rev` and `lastModified` into each relative path-typed node in `flake.lock` using submodule git metadata, then re-sorts keys.
> - Amends the submodule bump commit when one exists, or creates a new relock-only commit with a descriptive message.
> - Adds pre-push verification: aborts with a non-zero exit if any `flake.lock` path-pin's `rev` does not match the corresponding gitlink SHA in the Git tree.
> - Behavioral Change: the workflow now fails loudly instead of silently succeeding when flake pins are inconsistent with gitlinks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9182f70.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->