### PR TITLE
kernel: mkapp scaffolder + Serve.app check-gated hot reload (#4015)

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -206,6 +206,10 @@
 
           # Generated manifests, locks, editor settings, and typed data.
           '(^|/)(package|tsconfig)\.json$'
+          # TypeScript's project-variant convention: tsconfig.VARIANT.json.
+          # Vite scaffolds ship tsconfig.node.json, mkapp adds
+          # tsconfig.staging.json; tsc owns these names via `-p`.
+          '(^|/)tsconfig\.[a-z-]+\.json$'
           '(^|/)(package-lock|lock)\.json$'
           '(^|/)(pins|manifest)\.json$'
           '^\.(claude|vscode|zed)/settings\.json$'

--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -669,6 +669,25 @@
     };
   }
   {
+    generatedAppUi = {
+      topics = ["tooling"];
+      text = ''
+        Building a web UI for the user: scaffold with `mkapp`, serve with
+        `Serve.app` in a kernel cell. Edit only the app's `staging/` tree;
+        the gate typechecks it and promotes green code into the live page,
+        and durable state belongs in the store so promotes keep it. Narrate
+        through the store's status field, mark still-generating sections
+        loading so skeletons show, and keep updating the live page until the
+        work is done.
+      '';
+      reason = ''
+        index#4015: the scaffold and serve machinery exists, but nothing
+        told agents to narrate progress on the page or route edits through
+        the checked staging tree instead of the live src/.
+      '';
+    };
+  }
+  {
     noEmDashes = {
       topics = ["writing"];
       text = ''

--- a/packages/mcp-ex/lib/ix_mcp/application.ex
+++ b/packages/mcp-ex/lib/ix_mcp/application.ex
@@ -8,6 +8,7 @@ defmodule IxMcp.Application do
       ├── IxMcp.Checkpoint      ETS keeper for workspace state (survives Workspace restarts)
       ├── IxMcp.Workspace       the shared binding + Macro.Env every cell sees
       ├── IxMcp.Jobs.Registry   id -> job process
+      ├── IxMcp.Serve.State     served-app bookkeeping (url, jobs, gate outcome)
       ├── IxMcp.MCP.Notifier    server-initiated notification fan-out (+ outbox replay)
       ├── IxMcp.MCP.ClientRequests  server-initiated requests (elicitation) awaiting client replies
       ├── IxMcp.Jobs.Reaper     monitors job processes; finalizes any that die unreported
@@ -47,6 +48,9 @@ defmodule IxMcp.Application do
         IxMcp.Checkpoint,
         IxMcp.Workspace,
         {Registry, keys: :unique, name: IxMcp.Jobs.Registry},
+        # Serve bookkeeping outlives the jobs it describes (gate results are
+        # read after a serve's jobs die), so it lives here, not in a job.
+        IxMcp.Serve.State,
         # Notifier and Reaper before the job supervisor: a job registers with
         # the reaper and publishes through the notifier, so both must be up
         # before any job can start (#3839).

--- a/packages/mcp-ex/lib/ix_mcp/serve.ex
+++ b/packages/mcp-ex/lib/ix_mcp/serve.ex
@@ -1,0 +1,369 @@
+defmodule IxMcp.Serve do
+  @moduledoc """
+  Serve an mkapp-scaffolded web app with check-gated hot reload (index#4015).
+
+  `app/2` starts two supervised jobs: the Vite dev server (`npm run dev`,
+  always with `--host` so clients on other tailnet machines can reach it)
+  and a gate loop watching the app's `staging/` tree. The agent edits
+  `staging/` only; once an edit settles, the gate runs `npm run
+  check:staging` and, only when green, `npm run promote` (rsync into
+  `src/`), which Vite hot-reloads. A red check leaves the last good live
+  tree untouched and records the check output where `status/1` shows it.
+
+  Both are ordinary `IxMcp.Jobs` jobs: cancellation kills the whole OS
+  process tree (`IxMcp.OsProc`) and their output reads like any run
+  (`Jobs.tail/2`).
+
+  Once the dev server prints its port, the advertised URL is written to the
+  terminal as the split-view escape `ESC ]5522;open-url;<url> BEL`
+  (ix#8185): to the ix-term session pts when `IX_TERM_SESSION_ID` is set,
+  else to `/dev/tty`, else it is only logged and the serve keeps working.
+  """
+
+  alias IxMcp.Cmd
+  alias IxMcp.Jobs
+  alias IxMcp.Serve.State
+
+  require Logger
+
+  # Server-maintained session -> pts mapping, same contract as the ixterm
+  # CLI (ix crates/tools/ixterm/src/pts.rs): <root>/<id>/pts holds the
+  # absolute pts device path.
+  @sessions_root "/run/ix-term/sessions"
+
+  @poll_ms 150
+  # A staging change counts once the tree holds still this long: agents write
+  # several files per edit, and checking a half-written tree tests a torn
+  # snapshot.
+  @settle_ms 300
+  @url_timeout_ms 120_000
+
+  @typedoc "What `status/1` returns for a served app."
+  @type status :: %{
+          dir: String.t(),
+          url: String.t(),
+          dev_job: String.t(),
+          gate_job: String.t(),
+          last_check: :ok | :failed | nil,
+          last_check_output: String.t() | nil,
+          last_error: String.t() | nil,
+          checked_at: DateTime.t() | nil,
+          promoted_at: DateTime.t() | nil
+        }
+
+  @doc """
+  Serve the app in `dir`: install deps if missing, start the dev server and
+  the staging gate as background jobs, emit the split-view escape, and
+  return `status/1`.
+
+  Options: `:host` overrides the advertised host (default: this machine's
+  hostname, reachable because vite runs with `--host`); `open: false` skips
+  the terminal escape.
+  """
+  @spec app(String.t(), keyword()) :: status()
+  def app(dir, opts \\ []) do
+    dir = Path.expand(dir)
+    ensure_app!(dir)
+    ensure_deps!(dir)
+
+    State.merge(dir, %{
+      last_check: nil,
+      last_check_output: nil,
+      last_error: nil,
+      checked_at: nil,
+      promoted_at: nil
+    })
+
+    {dev, _out} =
+      Jobs.run("IxMcp.Serve.run_dev(#{inspect(dir)})",
+        budget: 0,
+        intent: "serve: npm run dev (#{dir})"
+      )
+
+    url = await_url(dev.id, opts)
+
+    {gate, _out} =
+      Jobs.run("IxMcp.Serve.run_gate(#{inspect(dir)})",
+        budget: 0,
+        intent: "serve: staging gate (#{dir})"
+      )
+
+    State.merge(dir, %{url: url, dev_job: dev.id, gate_job: gate.id})
+    if Keyword.get(opts, :open, true), do: emit_open_url(url)
+    status(dir)
+  end
+
+  @doc "URL, job ids, and last gate outcome for the app served from `dir`."
+  @spec status(String.t()) :: status() | {:error, :not_serving}
+  def status(dir) do
+    dir = Path.expand(dir)
+
+    case State.get(dir) do
+      nil -> {:error, :not_serving}
+      entry -> Map.put(entry, :dir, dir)
+    end
+  end
+
+  @doc "Kill the dev server and gate loop (whole OS process trees) for `dir`."
+  @spec stop(String.t()) :: :ok | {:error, :not_serving}
+  def stop(dir) do
+    dir = Path.expand(dir)
+
+    case State.get(dir) do
+      nil ->
+        {:error, :not_serving}
+
+      entry ->
+        for key <- [:gate_job, :dev_job], id = entry[key], is_binary(id) do
+          Jobs.cancel(id)
+        end
+
+        State.delete(dir)
+        :ok
+    end
+  end
+
+  # -- job bodies (public: they run by name inside `Jobs` cells) -------------
+
+  @doc false
+  @spec run_dev(String.t()) :: {Collectable.t(), non_neg_integer()}
+  def run_dev(dir) do
+    # `into:` streams vite's output line by line to the job's buffer (the
+    # group leader), where `await_url/2` reads the printed port.
+    Cmd.run("npm", ["run", "dev", "--", "--host"],
+      cd: dir,
+      stderr_to_stdout: true,
+      into: IO.stream(:stdio, :line)
+    )
+  end
+
+  @doc false
+  @spec run_gate(String.t(), keyword()) :: no_return()
+  def run_gate(dir, opts \\ []) do
+    runner = Keyword.get(opts, :runner, &npm/2)
+    gate_loop(dir, signature(dir), runner)
+  end
+
+  # -- gate loop --------------------------------------------------------------
+
+  defp gate_loop(dir, sig, runner) do
+    sig = dir |> await_change(sig) |> then(&await_settle(dir, &1))
+    check_and_promote(dir, runner)
+    gate_loop(dir, sig, runner)
+  end
+
+  @doc """
+  One gate decision: run `check:staging`; promote only when it is green.
+  Every outcome is recorded for `status/1`. The `runner` seam ((dir, :check |
+  :promote) -> {output, exit_status}) exists for tests; the default runs npm.
+  """
+  @spec check_and_promote(String.t(), (String.t(), :check | :promote ->
+                                         {String.t(), non_neg_integer()})) ::
+          :promoted | :rejected | :promote_failed
+  def check_and_promote(dir, runner \\ &npm/2) do
+    now = DateTime.utc_now()
+
+    case runner.(dir, :check) do
+      {check_out, 0} ->
+        case runner.(dir, :promote) do
+          {_out, 0} ->
+            State.merge(dir, %{
+              last_check: :ok,
+              last_check_output: check_out,
+              last_error: nil,
+              checked_at: now,
+              promoted_at: DateTime.utc_now()
+            })
+
+            :promoted
+
+          {promote_out, code} ->
+            State.merge(dir, %{
+              last_check: :ok,
+              last_check_output: check_out,
+              last_error: "promote exited #{code}:\n" <> promote_out,
+              checked_at: now
+            })
+
+            :promote_failed
+        end
+
+      {check_out, code} ->
+        # Red: the live tree keeps the last good promote; the agent reads
+        # the failure from status/1 (or Jobs.tail of the gate job).
+        State.merge(dir, %{
+          last_check: :failed,
+          last_check_output: check_out,
+          last_error: "check:staging exited #{code}",
+          checked_at: now
+        })
+
+        :rejected
+    end
+  end
+
+  defp npm(dir, :check),
+    do: Cmd.run("npm", ["run", "check:staging"], cd: dir, stderr_to_stdout: true)
+
+  defp npm(dir, :promote), do: Cmd.run("npm", ["run", "promote"], cd: dir, stderr_to_stdout: true)
+
+  defp await_change(dir, sig) do
+    Process.sleep(@poll_ms)
+
+    case signature(dir) do
+      ^sig -> await_change(dir, sig)
+      changed -> changed
+    end
+  end
+
+  defp await_settle(dir, sig) do
+    Process.sleep(@settle_ms)
+
+    case signature(dir) do
+      ^sig -> sig
+      changed -> await_settle(dir, changed)
+    end
+  end
+
+  @doc false
+  @spec signature(String.t()) :: non_neg_integer()
+  def signature(dir) do
+    dir
+    |> Path.join("staging/**")
+    |> Path.wildcard(match_dot: true)
+    |> Enum.map(fn path ->
+      case File.stat(path, time: :posix) do
+        {:ok, stat} -> {path, stat.mtime, stat.size}
+        {:error, reason} -> {path, reason, 0}
+      end
+    end)
+    |> :erlang.phash2()
+  end
+
+  # -- dev server URL ---------------------------------------------------------
+
+  defp await_url(job_id, opts) do
+    deadline = System.monotonic_time(:millisecond) + @url_timeout_ms
+    poll_url(job_id, opts, deadline)
+  end
+
+  defp poll_url(job_id, opts, deadline) do
+    case parse_port(Jobs.output(job_id)) do
+      {:ok, port} ->
+        advertised_url(port, opts)
+
+      :error ->
+        cond do
+          not Jobs.get(job_id).running ->
+            raise "dev server exited before printing a URL:\n" <> Jobs.tail(job_id, 30)
+
+          System.monotonic_time(:millisecond) > deadline ->
+            Jobs.cancel(job_id)
+            raise "dev server printed no URL in #{@url_timeout_ms}ms:\n" <> Jobs.tail(job_id, 30)
+
+          true ->
+            Process.sleep(200)
+            poll_url(job_id, opts, deadline)
+        end
+    end
+  end
+
+  @doc false
+  @spec parse_port(String.t()) :: {:ok, :inet.port_number()} | :error
+  def parse_port(output) do
+    # Vite colors the Local line and bolds the port mid-URL; strip SGR
+    # sequences before matching.
+    clean = String.replace(output, ~r/\e\[[0-9;]*m/, "")
+
+    case Regex.run(~r{Local:\s+https?://[^:/\s]+:(\d+)}, clean) do
+      [_, port] -> {:ok, String.to_integer(port)}
+      nil -> :error
+    end
+  end
+
+  defp advertised_url(port, opts) do
+    host =
+      Keyword.get_lazy(opts, :host, fn ->
+        {:ok, name} = :inet.gethostname()
+        List.to_string(name)
+      end)
+
+    "http://#{host}:#{port}/"
+  end
+
+  # -- split-view escape (ix#8185) ---------------------------------------------
+
+  @doc """
+  The byte-exact split-view escape: `ESC ]5522;open-url;<url> BEL` (ix#8185).
+  Only http(s) URLs; anything else raises rather than reaching a terminal.
+  """
+  @spec open_url_escape(String.t()) :: binary()
+  def open_url_escape(url) do
+    unless url =~ ~r{\Ahttps?://} do
+      raise ArgumentError, "open-url takes an http(s) URL, got: #{inspect(url)}"
+    end
+
+    "\e]5522;open-url;" <> url <> "\a"
+  end
+
+  @doc false
+  @spec emit_open_url(String.t()) :: :ok
+  def emit_open_url(url) do
+    bytes = open_url_escape(url)
+
+    case write_tty(bytes) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        # No terminal to split: the serve still works, the URL is the story.
+        Logger.info("serve: no terminal for open-url (#{inspect(reason)}); open #{url} yourself")
+        :ok
+    end
+  end
+
+  defp write_tty(bytes) do
+    case System.get_env("IX_TERM_SESSION_ID") do
+      nil ->
+        File.write("/dev/tty", bytes)
+
+      id ->
+        with {:error, _reason} <- write_session_pts(id, bytes) do
+          File.write("/dev/tty", bytes)
+        end
+    end
+  end
+
+  defp write_session_pts(id, bytes) do
+    pts_file = Path.join([@sessions_root, id, "pts"])
+
+    with {:ok, contents} <- File.read(pts_file),
+         pts = String.trim(contents),
+         true <- String.starts_with?(pts, "/") do
+      File.write(pts, bytes)
+    else
+      false -> {:error, {:relative_pts, pts_file}}
+      {:error, reason} -> {:error, {reason, pts_file}}
+    end
+  end
+
+  # -- preflight ----------------------------------------------------------------
+
+  defp ensure_app!(dir) do
+    unless File.exists?(Path.join(dir, "package.json")) do
+      raise ArgumentError, "#{dir} has no package.json; scaffold it with `mkapp` first"
+    end
+  end
+
+  defp ensure_deps!(dir) do
+    unless File.dir?(Path.join(dir, "node_modules")) do
+      {out, code} = Cmd.run("npm", ["install"], cd: dir, stderr_to_stdout: true)
+
+      if code != 0 do
+        raise "npm install failed in #{dir} (exit #{code}):\n" <> out
+      end
+    end
+
+    :ok
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/serve/state.ex
+++ b/packages/mcp-ex/lib/ix_mcp/serve/state.ex
@@ -1,0 +1,37 @@
+defmodule IxMcp.Serve.State do
+  @moduledoc """
+  Serve bookkeeping: app dir -> url, job ids, last gate outcome. An Agent so
+  the gate loop's writes and `Serve.status/1` reads serialize; the jobs may
+  die, the record stays until `Serve.stop/1` clears it.
+  """
+
+  use Agent
+
+  @spec start_link(term()) :: Agent.on_start()
+  def start_link(_opts) do
+    Agent.start_link(fn -> %{} end, name: __MODULE__)
+  end
+
+  @spec put(String.t(), map()) :: :ok
+  def put(dir, entry) when is_binary(dir) and is_map(entry) do
+    Agent.update(__MODULE__, &Map.put(&1, dir, entry))
+  end
+
+  @doc "Merge `fields` into the dir's entry; a missing entry starts from `fields`."
+  @spec merge(String.t(), map()) :: :ok
+  def merge(dir, fields) when is_binary(dir) and is_map(fields) do
+    Agent.update(__MODULE__, fn state ->
+      Map.update(state, dir, fields, &Map.merge(&1, fields))
+    end)
+  end
+
+  @spec get(String.t()) :: map() | nil
+  def get(dir) when is_binary(dir) do
+    Agent.get(__MODULE__, &Map.get(&1, dir))
+  end
+
+  @spec delete(String.t()) :: :ok
+  def delete(dir) when is_binary(dir) do
+    Agent.update(__MODULE__, &Map.delete(&1, dir))
+  end
+end

--- a/packages/mcp-ex/lib/ix_mcp/workspace.ex
+++ b/packages/mcp-ex/lib/ix_mcp/workspace.ex
@@ -19,6 +19,7 @@ defmodule IxMcp.Workspace do
              "alias IxMcp.TuiLocal; alias IxMcp.Gmail; alias IxMcp.Imsg; alias IxMcp.Contacts; " <>
              "alias IxMcp.Kernel, as: Ix; alias IxMcp.Agents; alias IxMcp.Memory; " <>
              "alias IxMcp.Ask; alias IxMcp.Cmd; alias IxMcp.Issues; alias IxMcp.Sessions; " <>
+             "alias IxMcp.Serve; " <>
              "alias IxMcp.Requests"
 
   @spec start_link(term()) :: GenServer.on_start()

--- a/packages/mcp-ex/test/ix_mcp/serve_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/serve_test.exs
@@ -1,0 +1,128 @@
+defmodule IxMcp.ServeTest do
+  use ExUnit.Case, async: true
+
+  alias IxMcp.Serve
+  alias IxMcp.Serve.State
+
+  # Fake app dirs never collide across async tests; State is global.
+  defp unique_dir do
+    Path.join(System.tmp_dir!(), "ix-serve-test-#{System.unique_integer([:positive])}")
+  end
+
+  defp recording_runner(pid, results) do
+    fn _dir, step ->
+      send(pid, {:ran, step})
+      Map.fetch!(results, step)
+    end
+  end
+
+  describe "open_url_escape/1 (the ix#8185 byte contract)" do
+    test "emits exactly ESC ]5522;open-url;<url> BEL" do
+      assert Serve.open_url_escape("http://hydra:5173/") ==
+               <<0x1B, ?], ?5, ?5, ?2, ?2, ?;>> <>
+                 "open-url;http://hydra:5173/" <> <<0x07>>
+    end
+
+    test "accepts https" do
+      assert Serve.open_url_escape("https://hydra:5173/") ==
+               "\e]5522;open-url;https://hydra:5173/\a"
+    end
+
+    test "rejects non-http(s) schemes" do
+      for url <- ["file:///etc/passwd", "javascript:alert(1)", "ftp://x/", "hydra:5173"] do
+        assert_raise ArgumentError, ~r/http\(s\)/, fn -> Serve.open_url_escape(url) end
+      end
+    end
+  end
+
+  describe "check_and_promote/2 (the gate decision)" do
+    test "a green check promotes and records the outcome" do
+      dir = unique_dir()
+      runner = recording_runner(self(), %{check: {"all clear", 0}, promote: {"", 0}})
+
+      assert Serve.check_and_promote(dir, runner) == :promoted
+      assert_received {:ran, :check}
+      assert_received {:ran, :promote}
+
+      assert %{last_check: :ok, last_check_output: "all clear", last_error: nil} =
+               State.get(dir)
+
+      State.delete(dir)
+    end
+
+    test "a red check never promotes and keeps the error readable" do
+      dir = unique_dir()
+
+      runner =
+        recording_runner(self(), %{
+          check: {"src/lib/store.svelte.ts:3 error TS2345", 1},
+          promote: {"", 0}
+        })
+
+      assert Serve.check_and_promote(dir, runner) == :rejected
+      assert_received {:ran, :check}
+      refute_received {:ran, :promote}
+
+      assert %{last_check: :failed, last_check_output: output, last_error: error} =
+               State.get(dir)
+
+      assert output =~ "TS2345"
+      assert error =~ "exited 1"
+      State.delete(dir)
+    end
+
+    test "a failed promote after a green check is recorded, not silent" do
+      dir = unique_dir()
+
+      runner =
+        recording_runner(self(), %{check: {"ok", 0}, promote: {"rsync: no such dir", 23}})
+
+      assert Serve.check_and_promote(dir, runner) == :promote_failed
+      assert %{last_check: :ok, last_error: error} = State.get(dir)
+      assert error =~ "promote exited 23"
+      assert error =~ "rsync"
+      State.delete(dir)
+    end
+  end
+
+  describe "signature/1" do
+    test "changes when a staging file changes and is stable otherwise" do
+      dir = unique_dir()
+      staging = Path.join(dir, "staging")
+      File.mkdir_p!(Path.join(staging, "lib"))
+      File.write!(Path.join(staging, "lib/a.ts"), "export const a = 1;\n")
+      on_exit(fn -> File.rm_rf!(dir) end)
+
+      sig = Serve.signature(dir)
+      assert Serve.signature(dir) == sig
+
+      File.write!(Path.join(staging, "lib/a.ts"), "export const a = 2;;;;;\n")
+      assert Serve.signature(dir) != sig
+    end
+  end
+
+  describe "parse_port/1" do
+    test "finds the vite Local URL through ANSI colors, bold port included" do
+      output =
+        "  VITE v7.0.0  ready in 312 ms\n\n" <>
+          "  \e[32m➜\e[39m  \e[1mLocal\e[22m:   " <>
+          "\e[36mhttp://localhost:\e[1m5173\e[22m/\e[39m\n" <>
+          "  \e[32m➜\e[39m  \e[1mNetwork\e[22m: \e[36mhttp://192.168.1.7:5173/\e[39m\n"
+
+      assert Serve.parse_port(output) == {:ok, 5173}
+    end
+
+    test "reports :error while the URL has not printed yet" do
+      assert Serve.parse_port("") == :error
+      assert Serve.parse_port("VITE v7.0.0 starting...") == :error
+    end
+  end
+
+  describe "status/1 and stop/1" do
+    test "an unserved dir is :not_serving" do
+      dir = unique_dir()
+      assert Serve.status(dir) == {:error, :not_serving}
+      assert Serve.stop(dir) == {:error, :not_serving}
+    end
+  end
+end

--- a/packages/mkapp/cli.mjs
+++ b/packages/mkapp/cli.mjs
@@ -1,0 +1,61 @@
+// mkapp [dir]: copy the embedded Svelte 5 + Vite template into `dir` (or a
+// fresh temp directory) and mirror src/ into staging/, the tree the agent
+// edits. The absolute app path on stdout is the one machine-readable output,
+// so callers (Serve.app pipelines, scripts) can capture it.
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const templateRoot = join(dirname(fileURLToPath(import.meta.url)), 'template');
+
+const arg = process.argv[2];
+if (arg === '--help' || arg === '-h') {
+  console.error('usage: mkapp [dir]');
+  console.error('Scaffold a Svelte 5 + Vite app; prints the absolute app path.');
+  process.exit(0);
+}
+
+let dest;
+if (arg === undefined) {
+  dest = mkdtempSync(join(tmpdir(), 'mkapp-'));
+} else {
+  dest = resolve(arg);
+  mkdirSync(dest, { recursive: true });
+}
+if (readdirSync(dest).length > 0) {
+  console.error(`mkapp: ${dest} is not empty`);
+  process.exit(1);
+}
+
+cpSync(templateRoot, dest, { recursive: true });
+// staging/ starts as an exact copy of src/: the agent edits staging/ only and
+// the serve gate promotes it into src/ once checks pass.
+cpSync(join(dest, 'src'), join(dest, 'staging'), { recursive: true });
+
+// Files copied out of the Nix store keep its read-only mode; the scaffold
+// must be editable.
+const fixPerms = (path) => {
+  if (statSync(path).isDirectory()) {
+    chmodSync(path, 0o755);
+    for (const name of readdirSync(path)) fixPerms(join(path, name));
+  } else {
+    chmodSync(path, 0o644);
+  }
+};
+fixPerms(dest);
+
+if (!existsSync(join(dest, 'package.json'))) {
+  console.error(`mkapp: template copy left no package.json in ${dest}`);
+  process.exit(1);
+}
+
+console.log(dest);

--- a/packages/mkapp/default.nix
+++ b/packages/mkapp/default.nix
@@ -1,0 +1,31 @@
+# mkapp: scaffold a Svelte 5 + Vite + TypeScript app an AI agent serves with
+# the kernel's Serve.app (index#4015). The template carries a durable rune
+# store (state survives hot reloads and full reloads), shadcn-style UI
+# primitives on the dashboard's Obsidian tokens, a self-narrating AgentStatus
+# strip, and a staging/ tree the serve gate typechecks and promotes into the
+# live src/.
+#
+# The template ships inside the package and the CLI only copies files, so
+# scaffolding needs no network; dependencies install in the scaffolded app
+# (`npm install`). The launcher is the Node script itself behind a store
+# shebang: no shell wrapper (shell-allowlist.txt only shrinks).
+{
+  lib,
+  pkgs,
+}:
+pkgs.runCommand "mkapp" {
+  strictDeps = true;
+  meta = {
+    description = "Scaffold a Svelte 5 + Vite app with a durable store, skeleton UI, and a check-gated staging tree";
+    mainProgram = "mkapp";
+  };
+} ''
+  mkdir -p "$out/bin" "$out/libexec/mkapp"
+  cp -R ${./template} "$out/libexec/mkapp/template"
+  {
+    printf '#!%s\n' "${lib.getExe pkgs.nodejs_22}"
+    cat ${./cli.mjs}
+  } > "$out/libexec/mkapp/cli.mjs"
+  chmod +x "$out/libexec/mkapp/cli.mjs"
+  ln -s "$out/libexec/mkapp/cli.mjs" "$out/bin/mkapp"
+''

--- a/packages/mkapp/package.nix
+++ b/packages/mkapp/package.nix
@@ -1,0 +1,6 @@
+{
+  id = "mkapp";
+  packageSet = true;
+  flake = true;
+  overlay = false;
+}

--- a/packages/mkapp/template/.gitignore
+++ b/packages/mkapp/template/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/mkapp/template/AGENTS.md
+++ b/packages/mkapp/template/AGENTS.md
@@ -1,0 +1,17 @@
+# Contract for agents editing this app
+
+Edit `staging/` only. `src/` is the live tree Vite serves; the serve gate
+typechecks `staging/` (`npm run check:staging`) and promotes it into `src/`
+(`npm run promote`) when green. A direct `src/` edit ships unchecked code and
+is overwritten by the next promote.
+
+- Durable state lives in the store (`staging/lib/store.svelte.ts`): it
+  survives hot reloads (`import.meta.hot` handoff) and full reloads
+  (sessionStorage). Anything worth keeping across edits goes there, never in
+  component-local state.
+- Narrate: set `app.status` before each step so the page always says what
+  you are doing right now.
+- A section still being generated sets `loading: true` so skeletons render;
+  clear the flag when its content lands.
+- Keep updating until done: fill sections as results arrive, then set
+  `app.done = true` with a final status when the work is complete.

--- a/packages/mkapp/template/index.html
+++ b/packages/mkapp/template/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>mkapp</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/mkapp/template/package.json
+++ b/packages/mkapp/template/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "mkapp-app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host",
+    "build": "vite build",
+    "check": "svelte-check --tsconfig ./tsconfig.json && tsc -p tsconfig.node.json",
+    "check:staging": "svelte-check --tsconfig ./tsconfig.staging.json && tsc -p tsconfig.node.json",
+    "promote": "rsync -a --delete staging/ src/"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^6.1.0",
+    "@tsconfig/svelte": "^5.0.4",
+    "svelte": "^5.35.0",
+    "svelte-check": "^4.2.0",
+    "typescript": "^5.8.0",
+    "vite": "^7.0.0"
+  }
+}

--- a/packages/mkapp/template/src/App.svelte
+++ b/packages/mkapp/template/src/App.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import AgentStatus from './lib/AgentStatus.svelte';
+  import Button from './lib/components/ui/Button.svelte';
+  import Card from './lib/components/ui/Card.svelte';
+  import Skeleton from './lib/components/ui/Skeleton.svelte';
+  import { app } from './lib/store.svelte';
+
+  function addNote() {
+    app.sections.push({
+      id: `note-${app.sections.length}`,
+      title: 'Note',
+      loading: false,
+      body: 'Added in the browser; durable across hot reloads.',
+    });
+  }
+</script>
+
+<AgentStatus />
+
+<main>
+  {#each app.sections as section (section.id)}
+    <Card title={section.title}>
+      {#if section.loading}
+        <Skeleton width="92%" />
+        <Skeleton width="70%" />
+        <Skeleton width="82%" />
+      {:else}
+        <p>{section.body}</p>
+      {/if}
+    </Card>
+  {/each}
+
+  <footer>
+    <Button variant="outline" onclick={addNote}>Add section</Button>
+  </footer>
+</main>
+
+<style>
+  main {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 12px;
+  }
+  p {
+    margin: 0;
+    white-space: pre-wrap;
+  }
+  footer {
+    margin-top: 8px;
+  }
+</style>

--- a/packages/mkapp/template/src/app.css
+++ b/packages/mkapp/template/src/app.css
@@ -1,0 +1,46 @@
+/* Design tokens follow the dashboard's Obsidian palette
+   (packages/dashboard/dashboard-core/site/src/style.css): near-black dark,
+   calm paper light, one periwinkle accent; light/dark via color-scheme. */
+:root {
+  color-scheme: light dark;
+
+  --bg:          light-dark(#f4f4f5, #08080a);
+  --panel:       light-dark(#fbfbfc, #0d0d10);
+  --elev:        light-dark(#ffffff, #141417);
+  --edge:        light-dark(#e6e6e9, #18181b);
+  --edge-strong: light-dark(#d3d3d8, #242429);
+  --ink:         light-dark(#1b1c21, #ececef);
+  --ink-dim:     light-dark(#5c5e66, #82828c);
+  --ink-faint:   light-dark(#9a9ba2, #4a4a53);
+  --accent:      light-dark(#5358e0, #a8b0ff);
+  --accent-soft: light-dark(rgba(83, 88, 224, 0.1), rgba(168, 176, 255, 0.13));
+  --live:        light-dark(#3f9a52, #52c98e);
+  --dead:        light-dark(#cf4b46, #e0635b);
+
+  --radius: 10px;
+  --ui: ui-sans-serif, system-ui, -apple-system, 'SF Pro Text', 'Segoe UI', sans-serif;
+  --mono: ui-monospace, 'SF Mono', SFMono-Regular, 'JetBrains Mono', Menlo, Consolas, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font: 14px/1.5 var(--ui);
+  letter-spacing: -0.01em;
+  -webkit-font-smoothing: antialiased;
+}
+
+#app {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 24px 20px 64px;
+}
+
+::selection {
+  background: var(--accent-soft);
+}

--- a/packages/mkapp/template/src/lib/AgentStatus.svelte
+++ b/packages/mkapp/template/src/lib/AgentStatus.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+  import Skeleton from './components/ui/Skeleton.svelte';
+  import { app } from './store.svelte';
+
+  const loading = $derived(app.sections.filter((section) => section.loading));
+</script>
+
+<div class="strip" role="status">
+  <span class="led" class:busy={!app.done}></span>
+  <span class="text">{app.status}</span>
+  {#if loading.length > 0}
+    <span class="pending">{loading.length} loading</span>
+  {/if}
+</div>
+
+{#if loading.length > 0}
+  <div class="placeholders">
+    {#each loading as section (section.id)}
+      <div class="placeholder">
+        <span class="label">{section.title}</span>
+        <Skeleton width="62%" height="10px" />
+        <Skeleton width="84%" height="10px" />
+      </div>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .strip {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    background: var(--panel);
+    border: 1px solid var(--edge);
+    border-radius: var(--radius);
+    font-family: var(--mono);
+    font-size: 12px;
+  }
+  .led {
+    flex: none;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    border: 1px solid var(--live);
+    background: transparent;
+  }
+  .led.busy {
+    border-color: transparent;
+    background: var(--accent);
+    animation: led-pulse 1.4s ease-in-out infinite;
+  }
+  @keyframes led-pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.35;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .led.busy {
+      animation: none;
+    }
+  }
+  .text {
+    color: var(--ink);
+  }
+  .pending {
+    margin-left: auto;
+    color: var(--ink-faint);
+  }
+  .placeholders {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 10px;
+  }
+  .placeholder {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px 14px;
+    background: var(--panel);
+    border: 1px dashed var(--edge-strong);
+    border-radius: var(--radius);
+  }
+  .label {
+    color: var(--ink-faint);
+    font-size: 12px;
+  }
+</style>

--- a/packages/mkapp/template/src/lib/components/ui/Button.svelte
+++ b/packages/mkapp/template/src/lib/components/ui/Button.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  type Props = {
+    variant?: 'default' | 'outline' | 'ghost';
+    disabled?: boolean;
+    onclick?: (event: MouseEvent) => void;
+    children: Snippet;
+  };
+
+  let { variant = 'default', disabled = false, onclick, children }: Props = $props();
+</script>
+
+<button class="btn {variant}" {disabled} {onclick}>
+  {@render children()}
+</button>
+
+<style>
+  /* The shadcn button look, in plain scoped CSS on the app tokens. */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    height: 32px;
+    padding: 0 14px;
+    border-radius: calc(var(--radius) - 2px);
+    border: 1px solid transparent;
+    font: 500 13px/1 var(--ui);
+    letter-spacing: -0.01em;
+    cursor: pointer;
+    transition: opacity 120ms ease, background 120ms ease;
+  }
+  .btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .default {
+    background: var(--accent);
+    color: light-dark(#ffffff, #08080a);
+  }
+  .default:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+  .outline {
+    background: var(--panel);
+    border-color: var(--edge-strong);
+    color: var(--ink);
+  }
+  .outline:hover:not(:disabled) {
+    background: var(--elev);
+  }
+  .ghost {
+    background: transparent;
+    color: var(--ink);
+  }
+  .ghost:hover:not(:disabled) {
+    background: var(--accent-soft);
+  }
+</style>

--- a/packages/mkapp/template/src/lib/components/ui/Card.svelte
+++ b/packages/mkapp/template/src/lib/components/ui/Card.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  type Props = {
+    title?: string;
+    children: Snippet;
+  };
+
+  let { title, children }: Props = $props();
+</script>
+
+<section class="card">
+  {#if title}
+    <h2>{title}</h2>
+  {/if}
+  <div class="body">
+    {@render children()}
+  </div>
+</section>
+
+<style>
+  .card {
+    background: var(--panel);
+    border: 1px solid var(--edge);
+    border-radius: var(--radius);
+    padding: 16px 18px;
+  }
+  h2 {
+    margin: 0 0 8px;
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  /* Muted foreground for body copy, the shadcn card rhythm. */
+  .body {
+    color: var(--ink-dim);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+</style>

--- a/packages/mkapp/template/src/lib/components/ui/Skeleton.svelte
+++ b/packages/mkapp/template/src/lib/components/ui/Skeleton.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  type Props = {
+    width?: string;
+    height?: string;
+  };
+
+  let { width = '100%', height = '14px' }: Props = $props();
+</script>
+
+<div class="skeleton" style:width style:height></div>
+
+<style>
+  /* The shadcn skeleton: a muted rounded block with a slow pulse. */
+  .skeleton {
+    border-radius: calc(var(--radius) - 4px);
+    background: var(--edge-strong);
+    animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  }
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.45;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton {
+      animation: none;
+    }
+  }
+</style>

--- a/packages/mkapp/template/src/lib/store.svelte.ts
+++ b/packages/mkapp/template/src/lib/store.svelte.ts
@@ -1,0 +1,82 @@
+/// <reference types="vite/client" />
+// The durable app store. State written here survives:
+//  - hot reloads: dispose() stashes a snapshot in import.meta.hot.data and
+//    the next module instance rehydrates from it, so a promote never resets
+//    the page;
+//  - full reloads: a debounced sessionStorage mirror rehydrates on boot, the
+//    safety net for the reloads HMR cannot cover (vite.config edits, manual
+//    refresh).
+
+export type Section = {
+  id: string;
+  title: string;
+  /** True while the agent is still generating this section: skeletons show. */
+  loading: boolean;
+  body: string;
+};
+
+export type AppState = {
+  /** One line: what the agent is doing right now. */
+  status: string;
+  /** Set once the whole task is finished. */
+  done: boolean;
+  sections: Section[];
+};
+
+const STORAGE_KEY = 'mkapp:state';
+const PERSIST_DEBOUNCE_MS = 250;
+
+function initialState(): AppState {
+  return {
+    status: 'waiting for the agent',
+    done: false,
+    sections: [
+      {
+        id: 'welcome',
+        title: 'Welcome',
+        loading: false,
+        body:
+          'Scaffolded by mkapp. The agent edits staging/ and this page hot ' +
+          'reloads each promoted change without losing this store.',
+      },
+    ],
+  };
+}
+
+function rehydrate(): AppState {
+  const handoff = import.meta.hot?.data.appState as AppState | undefined;
+  if (handoff) return handoff;
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw) as AppState;
+  } catch {
+    // Unreadable storage means a fresh state, never a broken boot.
+  }
+  return initialState();
+}
+
+export const app = $state<AppState>(rehydrate());
+
+if (import.meta.hot) {
+  import.meta.hot.dispose((data) => {
+    data.appState = $state.snapshot(app);
+  });
+}
+
+// Debounced sessionStorage mirror. $effect.root gives module scope an effect
+// context; JSON.stringify reads every property of the state proxy, so any
+// deep change reschedules the write.
+let persistTimer: ReturnType<typeof setTimeout> | undefined;
+$effect.root(() => {
+  $effect(() => {
+    const snapshot = JSON.stringify(app);
+    clearTimeout(persistTimer);
+    persistTimer = setTimeout(() => {
+      try {
+        sessionStorage.setItem(STORAGE_KEY, snapshot);
+      } catch {
+        // Storage full or blocked: the HMR handoff still preserves state.
+      }
+    }, PERSIST_DEBOUNCE_MS);
+  });
+});

--- a/packages/mkapp/template/src/main.ts
+++ b/packages/mkapp/template/src/main.ts
@@ -1,0 +1,7 @@
+import './app.css';
+import { mount } from 'svelte';
+import App from './App.svelte';
+
+const app = mount(App, { target: document.getElementById('app')! });
+
+export default app;

--- a/packages/mkapp/template/svelte.config.js
+++ b/packages/mkapp/template/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: vitePreprocess(),
+};

--- a/packages/mkapp/template/tsconfig.json
+++ b/packages/mkapp/template/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "types": ["vite/client"],
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte"]
+}

--- a/packages/mkapp/template/tsconfig.node.json
+++ b/packages/mkapp/template/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/packages/mkapp/template/tsconfig.staging.json
+++ b/packages/mkapp/template/tsconfig.staging.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["staging/**/*.ts", "staging/**/*.svelte"]
+}

--- a/packages/mkapp/template/vite.config.ts
+++ b/packages/mkapp/template/vite.config.ts
@@ -1,0 +1,6 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [svelte()],
+});

--- a/packages/site/src/lib/updates/mkapp-serve-gated-hot-reload.svx
+++ b/packages/site/src/lib/updates/mkapp-serve-gated-hot-reload.svx
@@ -1,0 +1,33 @@
+---
+id: mkapp-serve-gated-hot-reload
+postedAt: 2026-07-22T12:00:00-07:00
+title: mkapp + Serve.app, check-gated hot reload for AI-built web apps
+tags: [kernel, mcp, agents, web]
+links:
+  - label: issue #4015
+    href: https://github.com/indexable-inc/index/issues/4015
+  - label: ix #8185
+    href: https://github.com/indexable-inc/ix/issues/8185
+---
+
+An agent building a web page for the user used to hand over a file, or worse,
+a screenshot. Now it hands over a live URL. `mkapp` scaffolds a Svelte 5 +
+Vite + TypeScript app whose store survives hot reloads (an
+`import.meta.hot` handoff plus a debounced sessionStorage mirror), with
+shadcn-style Button/Card/Skeleton primitives on the dashboard's Obsidian
+tokens and an AgentStatus strip that narrates what the agent is doing.
+
+The kernel's `Serve.app(dir)` runs `npm run dev` and a gate loop as
+supervised jobs. The agent edits the app's `staging/` tree only; when an
+edit settles (~300ms), the gate runs `npm run check:staging` (svelte-check
+plus tsc) and promotes green code into the live `src/`, which Vite
+hot-reloads without losing the store. A red check leaves the last good page
+up and records the compiler output where `Serve.status(dir)` shows it, so a
+typo never replaces a working page with a blank one.
+
+Once vite prints its port, the kernel writes `ESC ]5522;open-url;<url> BEL`
+to the ix-term session pts (or `/dev/tty`), and the terminal opens the app
+in its split-view doc pane (ix#8185). A new prompt rule tells agents to
+narrate through the store's status field, mark still-generating sections
+loading so skeletons show, and keep updating the page until the work is
+done.


### PR DESCRIPTION
Closes #4015. Counterpart of ix#8185 (the terminal side of the `open-url` OSC verb).

## What

- **packages/mkapp**: Node CLI `mkapp [dir]` (no npm deps; template embedded in the package, launcher is the Node script behind a store shebang, no shell wrapper). Scaffolds Svelte 5 + Vite + TS with:
  - `src/lib/store.svelte.ts`: durable rune store; `import.meta.hot` dispose/data handoff across HMR plus a 250ms-debounced sessionStorage mirror rehydrated on boot.
  - `src/lib/components/ui/{Button,Card,Skeleton}.svelte`: shadcn-style primitives in scoped CSS on the dashboard Obsidian tokens (light/dark via `color-scheme`), Skeleton with pulse.
  - `src/lib/AgentStatus.svelte`: status strip bound to the store, skeleton placeholders for sections marked `loading`.
  - `staging/`: copy of `src/` the agent edits; `AGENTS.md` states the contract.
  - scripts: `dev` (vite --host), `check:staging` (svelte-check + tsc over `tsconfig.staging.json`), `promote` (`rsync -a --delete staging/ src/`), `check`.
- **IxMcp.Serve** (+ `Serve.State`, prelude alias `Serve`): `Serve.app(dir)` installs deps if missing, runs the dev server and a settle-debounced (300ms) gate loop as `IxMcp.Jobs` jobs (cancel kills the OS process tree via OsProc), parses the vite port, advertises `http://<hostname>:<port>/` (vite runs `--host`), and writes the byte-exact `ESC ]5522;open-url;<url> BEL` to the ix-term session pts (`/run/ix-term/sessions/<id>/pts`, same contract as the ixterm CLI) or `/dev/tty`, else logs. `Serve.status(dir)` returns url, job ids, last check result and error output; `Serve.stop(dir)` kills both trees.
- **Prompt rule** `generatedAppUi`: AI-built web UIs go through mkapp + Serve.app, narrate via the status store, skeleton the loading parts, edit staging only.
- `lib/per-system.nix` filenames lint: allow the TypeScript project-variant convention `tsconfig.<variant>.json` (Vite scaffolds ship `tsconfig.node.json`).

## Evidence (local gates)

- `mix test` (mcp-ex): 183 tests, 0 failures (10 new in `serve_test.exs`: escape bytes, gate green-promotes/red-rejects/promote-failure, signature, vite port parse through ANSI).
- `mix credo --strict` (repo config): 0 issues.
- `nix run .#lint`: 13/13 stages succeeded.
- `nix build .#mkapp` green; built CLI scaffolds into a fresh temp dir, staging mirrored, files writable, refuses non-empty dirs.
- Template e2e: `npm install && npm run check && npm run check:staging && npm run build` all exit 0; a planted staging type error fails `check:staging` (exit 1) while `check` stays green.
- Live serve e2e through the real code paths: `Serve.app` returned `http://hydra:5173/` (HTTP 200); a green staging edit promoted into `src/` (~9s); a planted type error was rejected (`last_check: :failed`, bad code never reached `src/`, compiler output in `status/1`); revert recovered; `Serve.stop` freed the port.

(authored by an AI agent via Claude Code, model claude-fable-5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `mkapp` scaffolder and `Serve.app` gated hot-reload for agent-built web UIs
> - Introduces the `mkapp` CLI ([packages/mkapp/cli.mjs](https://github.com/indexable-inc/index/pull/4018/files#diff-a67005662d46c9022421d94d7af74e643b28abf1ae35d845eb3ae8b2ccab1907)) that scaffolds a Svelte 5 + Vite + TypeScript app from an embedded template into a target directory without network access, printing the absolute path to stdout.
> - Adds [`IxMcp.Serve`](https://github.com/indexable-inc/index/pull/4018/files#diff-9ceb2272f63bdc816854933ae561e1890d874fecc1451117af50d348c70ffadb) with `app/2`, `status/1`, and `stop/1`: starts `npm run dev`, detects the Vite URL from streamed output, and launches a background gate loop that watches `staging/` for changes, runs `check` + `promote` on settle, and persists results in [`IxMcp.Serve.State`](https://github.com/indexable-inc/index/pull/4018/files#diff-1b48ceeca3a443f01b00860b93b874a80701c097bef15cc9203e3255e8cbf087).
> - Emits an OSC terminal escape sequence to open the served URL in a compatible terminal split-view when starting a serve.
> - Adds a prompt rule (`generatedAppUi`) guiding agents to scaffold with `mkapp`, serve with `Serve.app`, narrate progress via store status fields, and set loading flags for skeleton rendering.
> - `IxMcp.Serve.State` is supervised at application level so serve metadata outlives individual job lifecycles.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83607c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->