### PR TITLE
mkapp: template dev server allows any Host (#4019)

### DIFF
--- a/packages/mkapp/template/vite.config.ts
+++ b/packages/mkapp/template/vite.config.ts
@@ -3,4 +3,10 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [svelte()],
+  server: {
+    // Serve.app advertises http://<hostname>:<port>/ and the terminal split
+    // iframes load it across the tailnet; Vite 7's DNS-rebinding guard 403s
+    // any non-localhost Host header unless allowed.
+    allowedHosts: true,
+  },
 });


### PR DESCRIPTION
Closes #4019.

Vite 7 403s any request whose Host header is not localhost-ish unless it is in `server.allowedHosts`. The mkapp template set none, so the exact URL Serve.app advertises (`http://<hostname>:<port>/`) and the terminal split iframes got 403 while 127.0.0.1 got 200. The template now sets `server: { allowedHosts: true }` with a comment (the remote terminal iframe reaches the dev server across the tailnet, so any host must be accepted).

Evidence (live Vite 7.3.6, scaffolded app, dev server running): hostname URL 403 before the change, 200 after; 127.0.0.1 200 in both. No automated regression test: the repro needs npm install plus a live dev server, which no CI lane runs, and a string match on the template would restate the source.

Local gates: `nix run .#lint` clean.

(authored by an AI agent via Claude Code, Claude Opus 4.5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow any Host header in mkapp template Vite dev server
> Sets `allowedHosts: true` in [vite.config.ts](https://github.com/indexable-inc/index/pull/4020/files#diff-11033c82bed85161c699a37263cb3b0878e0f14d1b219a98a35615baea5141ff) to bypass Vite's DNS-rebinding guard, which blocks requests with non-localhost Host headers by default. This is needed for dev environments accessed via non-localhost hostnames.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd024bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->