### PR TITLE
mkapp: allow all hosts in the template dev server

### DIFF
--- a/packages/mkapp/template/vite.config.ts
+++ b/packages/mkapp/template/vite.config.ts
@@ -3,4 +3,10 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [svelte()],
+  server: {
+    // The terminal split-view iframe loads this dev server from other tailnet
+    // machines, and Vite's DNS-rebinding guard 403s any non-localhost Host
+    // header unless hosts are allowed (index#4019).
+    allowedHosts: true,
+  },
 });


### PR DESCRIPTION
Fixes #4019.

mkapp's template `vite.config.ts` set no `server.allowedHosts`. Vite 7's DNS-rebinding guard rejects any request whose Host header is not localhost-ish, so the exact URL `Serve.app` advertises (and that the terminal split-view iframe loads from other tailnet machines) returned 403.

Evidence, on merged main 51bd1004: a scaffolded app served 200 on `http://127.0.0.1:5173/` but 403 on `http://hydra:5173/` — the exact URL Serve.app advertises. With `server: { allowedHosts: true }`, both return 200.

Local gates on this branch:
- `nix build .#mkapp` passes.
- Scaffolded an app with the built mkapp; `npm install` + `npm run check` pass (0 errors).
- Live smoke: started the dev server, curled `http://127.0.0.1:5199/` with a normal Host (200), with `Host: hydra:5199` (200), and with an arbitrary `Host: evil.example` (200) — the guard no longer blocks non-localhost hosts. This is a dev-only server that's meant to be reachable across the tailnet.
- `nix run .#lint`: 13/13 tasks succeeded.

No checked-in smoke test starts the template dev server (serve tests use a fake runner), and a real one needs `npm install` network access outside the nix sandbox, so this PR does not add one; the spoofed-Host curl above is the manual equivalent.

Authored by an AI agent (Claude Code).



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow all hosts in the mkapp template Vite dev server
> Sets `server.allowedHosts: true` in [vite.config.ts](https://github.com/indexable-inc/index/pull/4021/files#diff-11033c82bed85161c699a37263cb3b0878e0f14d1b219a98a35615baea5141ff), disabling Vite's DNS-rebinding guard so the dev server accepts requests with non-localhost `Host` headers. Risk: disabling host checks exposes the dev server to DNS-rebinding attacks in untrusted network environments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cbdd1e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->