### PR TITLE
site: update entry for builtins.wasm + js-nix

### DIFF
--- a/packages/site/src/lib/updates/js-nix-wasm-builtin.svx
+++ b/packages/site/src/lib/updates/js-nix-wasm-builtin.svx
@@ -1,0 +1,27 @@
+---
+id: js-nix-wasm-builtin
+postedAt: 2026-07-22T04:30:00-07:00
+title: "js-nix: write Nix in JavaScript syntax, compiled at eval time by `builtins.wasm`"
+tags: [nix, wasm, language]
+links:
+  - label: builtins.wasm import (PR 4009)
+    href: https://github.com/indexable-inc/index/pull/4009
+  - label: ix2nix (PR 4022)
+    href: https://github.com/indexable-inc/index/pull/4022
+  - label: upstream PR
+    href: https://github.com/NixOS/nix/pull/15380
+---
+
+The nix-ix daemon now carries `builtins.wasm` (patches 0038-0039, imported from the open upstream PR NixOS/nix#15380, the upstream form of Determinate Nix's Wasm support): Nix expressions can call functions in WebAssembly modules, gated behind the `wasm-builtin` experimental feature. Our import goes one step past upstream and forces deterministic execution (NaN canonicalization, deterministic relaxed SIMD), because eval results cross machines here and one implementation-defined bit means divergent store hashes. Upstream left that off after measuring ~3.6x on a float-heavy kernel; eval plugins are string/AST-shaped and do not pay it.
+
+First consumer: js-nix. A `.ix` file is JavaScript syntax mapped 1:1 onto Nix semantics; `packages/nix/ix2nix` (Rust, oxc parser, typed Nix AST, one renderer) converts it, compiled to an 884 KB wasm plugin the evaluator runs directly:
+
+```js
+const lib = import("./lib.ix");
+export default ({ pkgs }) => ({
+  packages: [pkgs.ripgrep],
+  motd: `doubled: ${lib.double(21)}`,
+});
+```
+
+`importIx` (from `packages/nix/ix2nix/import-ix.nix`) evaluates that through `builtins.wasm` + `builtins.toFile`; relative `.ix` imports work via a threaded `__dir`. Anything without a 1:1 Nix equivalent is a positioned compile error surfaced through the eval error (`===` gets "use ==" with line and column). The e2e passthru test builds nix-ix from the flake in-sandbox and runs the whole chain.


### PR DESCRIPTION
Operator-facing update for the wasm-builtin daemon import (#4009) and js-nix (#4022). Prose only; lint clone-gate red is pre-existing on main with a byte-identical metric (#4023, fixer dispatched).

(PR authored by an AI agent via Claude Code, Claude Opus)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add site update entry for js-nix and `builtins.wasm` import
> Adds a new update page at [js-nix-wasm-builtin.svx](https://github.com/indexable-inc/index/pull/4024/files#diff-0e865aa51e4b4d0e52864a14a0baf3fbddcab6f95058ac51e0bfafe8c880ec51) documenting the `wasm-builtins` import in js-nix. The page describes evaluator behavior, deterministic execution constraints, and example usage of `importIx`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a8caca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->