### PR TITLE
clone: restore ratchet headroom after the zero-margin #4011 drop

### DIFF
--- a/clone.toml
+++ b/clone.toml
@@ -69,7 +69,12 @@ ignore = [
 # (packages/sdk/typescript, packages/sdk/python) is deleted; the SDK ships as
 # compiled artifacts only, so the mirror's clone cluster left the scan.
 # Measured 0.2497% after the deletion.
+#
+# 2026-07-22 (#4023): raised 0.25 -> 0.275. The #4011 drop set the budget
+# 0.12% above its own 0.2497% measure, so ordinary drift (0.2502%) redded
+# main the same day. Restore the ~10% headroom this file's convention calls
+# for; the gate still trips on any real regression.
 [budget]
-global_pct = 0.25
+global_pct = 0.275
 diff_pct = 0.0
 diff_base = "origin/main"


### PR DESCRIPTION
Closes #4023. Main is red on 0.2502% vs a 0.25 budget that #4011 set just 0.12% above its own measure. Restore the ~10% headroom the file convention documents (0.275); real regressions still trip. Same failure shape as ix#8184 this morning; ratchet drops need headroom over the fresh measure, not equality.

Authored with Claude Code (Anthropic Fable).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase `global_pct` budget threshold in `clone.toml` from 0.25 to 0.275
> Restores ratchet headroom in [clone.toml](https://github.com/indexable-inc/index/pull/4025/files#diff-71d9798ec940a623c1ae0813b562b8a292318681adc4a729e6243e6be7e59385) after it was removed by PR #4011, which had dropped the zero-margin. Raises `budget.global_pct` from `0.25` to `0.275` and adds comments documenting the change rationale and history.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d25928.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->