### PR TITLE
fork-sync: probe every fork input's archive URL anonymously

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -68,6 +68,37 @@ jobs:
           private-key: ${{ secrets.MIRROR_APP_PRIVATE_KEY }}
           owner: indexable-inc
 
+      # Every fork input is fetched by Nix's UNAUTHENTICATED github fetcher,
+      # so a fork repo that is private (or a pinned rev whose pin ref was
+      # lost to GC) breaks flake eval everywhere with a bare HTTP 404. That
+      # exact failure shipped with the migration itself: indexable-inc/ghostty
+      # was created private and the first post-merge Check on #4032 died in
+      # eval. Probe each locked rev's archive URL anonymously -- the
+      # fetcher's own view, before any token exists in this job -- and fail
+      # naming the repo and the remedy.
+      - name: Verify fork repos are anonymously fetchable
+        run: |
+          set -euo pipefail
+          mapfile -t rows < <(
+            nix eval --json '.#lib.forkPackages' \
+              | nix run nixpkgs#jq -- -c '.[] | {name, input, forkRepo}'
+          )
+          failed=0
+          for row in "${rows[@]}"; do
+            name=$(nix run nixpkgs#jq -- -r '.name' <<<"$row")
+            input=$(nix run nixpkgs#jq -- -r '.input' <<<"$row")
+            fork_repo=$(nix run nixpkgs#jq -- -r '.forkRepo' <<<"$row")
+            rev=$(nix run nixpkgs#jq -- -r --arg i "$input" \
+              '.nodes[$i].locked.rev' flake.lock)
+            url="https://github.com/${fork_repo}/archive/${rev}.tar.gz"
+            code=$(curl -sIL -o /dev/null -w '%{http_code}' --max-time 60 "$url")
+            if [ "$code" != "200" ]; then
+              echo "::error::fork-sync: $name: $url is not anonymously fetchable (HTTP $code). A private fork repo must be made public (gh repo edit $fork_repo --visibility public); a vanished rev needs its refs/pins/* ref restored."
+              failed=1
+            fi
+          done
+          [ "$failed" = 0 ]
+
       # Per auto-updatable fork: colocated jj clone, rebase the series onto
       # the upstream tip, refuse to push any conflicted commit (git readers,
       # including GitHub and the Nix fetchers, cannot parse jj's conflict


### PR DESCRIPTION
The first post-merge Check on #4032 (merge commit 4b16ade7) failed in flake eval: `github:indexable-inc/ghostty/c1b4a88a...` returned HTTP 404 because the ghostty fork repo had been created **private** -- the only private repo among the 13 fork series. Nix's `github:` fetcher is unauthenticated, so a private fork repo 404s everywhere.

Remediation already applied out-of-band: `gh repo edit indexable-inc/ghostty --visibility public` (archive URL now 200; the failed Check jobs were rerun).

This PR closes the detection gap: fork-sync now HEADs every registry fork's locked-rev archive URL **without credentials** (the fetchers' exact view) before doing any work, and fails naming the repo and the remedy. Also catches a pinned rev whose `refs/pins/*` ref was lost, which 404s the same way.

Verified locally: the sweep passes for all 13 series post-fix, and flagged ghostty while it was still private.

AI-authored (Claude Fable 5), human-directed; standing force-merge grant per the #4032 fix-forward instruction.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail fork-sync early if any fork archive URL is not anonymously fetchable
> Adds a verification step to [fork-sync.yml](.github/workflows/fork-sync.yml) that runs before the rebase/push step. For each fork input, it resolves the locked rev from `flake.lock`, constructs the GitHub archive URL, and probes it anonymously with `curl`. If any URL returns a non-200 response, the step emits a GitHub Actions error annotation and fails, catching private or missing repos before the sync proceeds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37ceaad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->