### PR TITLE
cache-push-watchdog: clear ready_sha when the pin ref does not exist

### DIFF
--- a/.github/workflows/cache-push-watchdog.yml
+++ b/.github/workflows/cache-push-watchdog.yml
@@ -234,6 +234,12 @@ jobs:
             || fail_loud "reading main ref failed"
           ready_sha=""
           if ! ready_sha="$(gh api "repos/${REPOSITORY}/git/ref/heads/${PIN_REF}" --jq '.object.sha')"; then
+            # gh api prints the HTTP error body to STDOUT, so the failed
+            # substitution still assigns the 404 JSON to ready_sha; clear it
+            # or the [ -n ] guard below feeds that JSON into the compare URL
+            # (every darwin-lane sweep failed this way until the first
+            # cache-ready-darwin publish, exactly the case the note covers).
+            ready_sha=""
             note "${PIN_REF} ref does not exist yet; nothing to compare"
           fi
           if [ -n "$ready_sha" ]; then


### PR DESCRIPTION
While watching the #4032 post-merge runs, the scheduled "Cache push watchdog" was found failing on every sweep (exit 2, all day): `gh api` prints the HTTP error body to **stdout** even on failure, so when `refs/heads/cache-ready-darwin` does not exist (it has never been created, per the workflow's own doc comment), the failed command substitution assigns the 404 JSON to `ready_sha`, the `[ -n ]` guard passes, and the drift compare is called with the JSON blob as a sha:

```
Get "repos/indexable-inc/index/compare/%7B%22message%22:%22Not%20Found%22...": unsupported protocol scheme ""
##[error]watchdog internal failure: comparing cache-ready-darwin to main failed
```

The workflow promises a missing pin ref is "reported and skipped"; this makes the skip actually happen by clearing `ready_sha` in the missing-ref branch. Pre-existing bug (failures predate the megamerge migration), fixed in the same fix-forward lane.

AI-authored (Claude Fable 5), human-directed; standing force-merge grant per the #4032 fix-forward instruction.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ready_sha` being set to error JSON when PIN_REF does not exist in cache-push-watchdog
> When `gh api` fails to resolve the PIN_REF (e.g. the ref doesn't exist), it could emit an error JSON body to STDOUT, leaving `ready_sha` set to that string. The subsequent non-empty check would then attempt a comparison using invalid data. The fix explicitly clears `ready_sha` on failure and logs that the compare step is skipped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ad4c60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->