### PR TITLE
forks: drop the last two references to the deleted nix patch dir

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -129,18 +129,6 @@
   # index's own forks migrated to jj megamerge fork repos (no in-repo series),
   # but ix still keeps patch-dir forks and consumes this via `mkForkChecks`.
   forkDagCheckSrc = paths.root + "/lib/util/fork-dag-check";
-  # Public patch data for consumers whose system Nix is not `nix-ix`. Keep the
-  # patch bytes owned by index so fleet configurations consume one source of
-  # truth instead of copying the fix into each repository.
-  nixPatches = {
-    autoGcInterruptibleLockWait =
-      paths.packagesRoot + "/nix/nix/patches/0018-fix-libstore-interrupt-blocked-automatic-GC.patch";
-    autoGcRecheckAfterLock =
-      paths.packagesRoot + "/nix/nix/patches/0017-fix-libstore-recheck-free-space-after-GC-lock.patch";
-    opaqueTemporaryRootFilenames =
-      paths.packagesRoot
-      + "/nix/nix/patches/0016-fix-libstore-accept-opaque-temporary-root-filenames.patch";
-  };
   secretRefs = import ./util/secret-refs.nix {inherit lib;};
   selfVersionFor = self: import ./util/self-version.nix {inherit lib self;};
   checks = import ./checks.nix {inherit lib;};
@@ -731,7 +719,6 @@
       mkMinecraftSyncManaged
       mutableJson
       netCidr
-      nixPatches
       paths
       patchedSrc
       patchedSrcFor

--- a/packages/nix/nix-ninja-build/default.nix
+++ b/packages/nix/nix-ninja-build/default.nix
@@ -22,13 +22,12 @@ let
   inherit (ix) pkgs;
   inherit (repoPackages) nix-ninja nix-ix;
 
-  # The identical patched tree the fork package builds (same patch dir, same
-  # upstream pin), so this lane can never drift from packages/nix/nix.
-  patchedSrc = ix.patchedSrc {
-    name = "nix";
-    src = ix.nixSrc;
-    patchDir = ix.paths.root + "/packages/nix/nix/patches";
-  };
+  # The identical patched tree the fork package builds: since the jj
+  # megamerge migration the nix-src input IS the patched tree (the
+  # indexable-inc/nix megamerge commit, see lib/fork-packages.nix), so there
+  # is no patch application step left and this lane can never drift from
+  # packages/nix/nix.
+  patchedSrc = ix.nixSrc;
 
   # Run under the fork client, not stock pkgs.nix: the generated derivations
   # are dynamic derivations, which need a >= 2.30 master-based client, and the


### PR DESCRIPTION
Third fix-forward from watching the #4032 post-merge runs (after the ghostty fork-repo visibility flip and #4034's fetchability guard): the migration deleted `packages/nix/nix/patches`, but two stragglers still referenced it, so `flake-check` and `closure-gate` died at eval on every main commit since the merge:

```
error: Path 'packages/nix/nix/patches' does not exist in Git repository
```

(run 29933203238, rerun after the ghostty fix -- same error on 43efb97e's Check.)

- `packages/nix/nix-ninja-build/default.nix` applied the deleted dir onto `ix.nixSrc` via `ix.patchedSrc`. The `nix-src` input already IS the patched megamerge tree, so the lane now consumes it directly -- the identical tree `packages/nix/nix` builds from, drift-free by construction.
- `lib.nixPatches` exported three of the deleted patch files for external fleet configs; org-wide code search finds zero consumers, so the dead export goes instead of duplicating bytes whose source of truth is now the fork repo's commit DAG.

Verified: `nix eval .#packages.x86_64-linux.nix-ninja-build-nix.drvPath` fails on main, passes on this branch; these were the last two live references (`git grep`-swept; the rest are prose/comments). Lint green.

AI-authored (Claude Fable 5), human-directed; standing force-merge grant per the #4032 fix-forward instruction.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop remaining references to the deleted nix patch directory
> - Removes the `nixPatches` attribute set from [lib/default.nix](https://github.com/indexable-inc/index/pull/4037/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188) and drops it from the lib public exports list.
> - Updates `patchedSrc` in [packages/nix/nix-ninja-build/default.nix](https://github.com/indexable-inc/index/pull/4037/files#diff-da7e4fdd0d6ca95e30e6f843273b0237b33d2576cb5ff3d0007e6c3bac606a34) to alias `ix.nixSrc` directly, removing the `ix.patchedSrc` call that referenced the now-deleted patches directory.
> - Risk: any code still referencing `nixPatches` from the lib attribute set will fail at evaluation time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66e8ef3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->