### PR TITLE
fork-sync: resolve curl via nix run in the fetchability probe

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -91,7 +91,10 @@ jobs:
             rev=$(nix run nixpkgs#jq -- -r --arg i "$input" \
               '.nodes[$i].locked.rev' flake.lock)
             url="https://github.com/${fork_repo}/archive/${rev}.tar.gz"
-            code=$(curl -sIL -o /dev/null -w '%{http_code}' --max-time 60 "$url")
+            # The ephemeral fleet runner ships no curl on PATH (exit 127 on
+            # the first live run); resolve it the way every other tool in
+            # this workflow is resolved.
+            code=$(nix run nixpkgs#curl -- -sIL -o /dev/null -w '%{http_code}' --max-time 60 "$url")
             if [ "$code" != "200" ]; then
               echo "::error::fork-sync: $name: $url is not anonymously fetchable (HTTP $code). A private fork repo must be made public (gh repo edit $fork_repo --visibility public); a vanished rev needs its refs/pins/* ref restored."
               failed=1


### PR DESCRIPTION
The anonymous-fetchability guard added in #4034 called bare `curl`; the ephemeral fleet runner has no curl on PATH, so the first live `Sync fork repos` run (29935594637) exited 127 in the new step before doing any work. Resolve curl through `nix run nixpkgs#curl --`, matching how this workflow already resolves `jj` and `jq`.

Fix-forward from watching the #4032 post-merge runs. AI-authored (Claude Fable 5), human-directed; standing force-merge grant applies.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix curl invocation in fork-sync fetchability probe to use `nix run nixpkgs#curl`
> Ephemeral runners don't have curl on PATH, causing the HTTP status check in [fork-sync.yml](https://github.com/indexable-inc/index/pull/4039/files#diff-ab7221dc3add2293b66a01dadb4f0232b8c16b141fdf61004bdc95d49f07eb49) to fail with command-not-found. Replaces the direct `curl` call with `nix run nixpkgs#curl -- ...` so the tool is resolved via Nix regardless of the runner environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62281e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->