### PR TITLE
forks: drop stale updateScript registry flags (fixes the closure-update gate)

### DIFF
--- a/packages/nushell/package.nix
+++ b/packages/nushell/package.nix
@@ -6,5 +6,4 @@
   cross = {
     exposeNativeDarwin = false;
   };
-  updateScript = true;
 }

--- a/packages/terminal/btop/package.nix
+++ b/packages/terminal/btop/package.nix
@@ -8,7 +8,4 @@
   # `packages.aarch64-darwin.btop`, so Macs substitute it from the cache
   # instead of the darwin cache-push lane building it natively.
   cross = true;
-  # Joins `nix run .#update`: bump btop-src and regenerate the patch series via
-  # passthru.updateScript (see default.nix / lib/fork-updater.nix).
-  updateScript = true;
 }


### PR DESCRIPTION
The megamerge migration (#4032) removed the fork updater passthru from btop and nushell, but their package.nix registry flags stayed. The flag now resolved nixpkgs btop's own list-shaped updateScript, and lib.getExe on a list broke eval of requiredGateRoots.x86_64-linux.closure-update, the red Check on main. Fork bumps are the fork-sync cron's job now.

(authored by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop stale `updateScript` flags from nushell and btop package definitions
> Removes the spurious `updateScript = true` attributes from [nushell](https://github.com/indexable-inc/index/pull/4040/files#diff-620fad2c95edc66d6e2edc919f991b7d9c5da2e8fa94d65f6dc91d55b751cef7) and [btop](https://github.com/indexable-inc/index/pull/4040/files#diff-e4de028f6095f7b3d6ea4039ac24332bc21add194e8fb471bdf6ea1637cda40f) package definitions. These stale flags were blocking the closure-update gate in the forks update pipeline.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 767d3cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->