### PR TITLE
forks: drop dead updateScript flags from the megamerge fork packages

### DIFF
--- a/packages/ghostty/package.nix
+++ b/packages/ghostty/package.nix
@@ -7,5 +7,4 @@
     systems = ["aarch64-darwin"];
   };
   overlay = false;
-  updateScript = true;
 }

--- a/packages/nushell/package.nix
+++ b/packages/nushell/package.nix
@@ -6,5 +6,4 @@
   cross = {
     exposeNativeDarwin = false;
   };
-  updateScript = true;
 }

--- a/packages/terminal/btop/package.nix
+++ b/packages/terminal/btop/package.nix
@@ -8,7 +8,4 @@
   # `packages.aarch64-darwin.btop`, so Macs substitute it from the cache
   # instead of the darwin cache-push lane building it natively.
   cross = true;
-  # Joins `nix run .#update`: bump btop-src and regenerate the patch series via
-  # passthru.updateScript (see default.nix / lib/fork-updater.nix).
-  updateScript = true;
 }


### PR DESCRIPTION
Fourth fix-forward from watching the #4032 post-merge runs. After #4037 cleared the deleted-patch-dir eval error, `flake-check` still failed -- now one attr deep in the eval sweep:

```
ERROR:nix_fast_build:Failed attributes: .#requiredGateRoots.x86_64-linux.closure-update
error: lib.meta.getExe': The first argument is of type list, but it should be a derivation instead.
```

The migration removed `lib/fork-updater.nix` and the `passthru.updateScript` overrides on the fork packages, but btop, nushell, and ghostty kept `updateScript = true` in their package.nix. The `update` aggregator then reads whatever updateScript the base package carries: for btop that is nixpkgs' `nix-update-script` (a list -> the getExe error); nushell and ghostty have none at all (updaterFor's throw, latent on the darwin dag). Fork bumps are owned by fork-sync.yml (autoUpdate) or a deliberate manual jj rebase (pinned forks), so the dead flags go.

Verified locally: `requiredGateRoots.{x86_64-linux,aarch64-darwin}.closure-update.drvPath` both eval on this branch and both fail on main. Lint green.

AI-authored (Claude Fable 5), human-directed; standing force-merge grant per the #4032 fix-forward instruction.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove dead `updateScript = true` flags from fork packages
> Removes no-op `updateScript = true` attributes from [ghostty](https://github.com/indexable-inc/index/pull/4041/files#diff-b89b560fee95ad81353af471caba76a314e5bc65ab917f47615fcf48e65957df), [nushell](https://github.com/indexable-inc/index/pull/4041/files#diff-620fad2c95edc66d6e2edc919f991b7d9c5da2e8fa94d65f6dc91d55b751cef7), and [btop](https://github.com/indexable-inc/index/pull/4041/files#diff-e4de028f6095f7b3d6ea4039ac24332bc21add194e8fb471bdf6ea1637cda40f) fork packages. These flags were leftover from a megamerge and have no effect in the current package structure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cfae151.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->