### PR TITLE
fork-sync: provision awk and curl on the minimal fleet runner PATH

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -54,6 +54,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # ix's self-hosted runner jobs expose a minimal PATH (git + nix +
+      # coreutils; no awk, curl -- the first two live runs died 127 on each
+      # in turn). Same ensure idiom as update-flake-lock.yml: extend PATH
+      # from nixpkgs via the preinstalled nix only for what is missing.
+      - name: Provision missing CLI tools
+        run: |
+          set -euo pipefail
+          ensure() {
+            command -v "$1" >/dev/null 2>&1 && return
+            while IFS= read -r p; do
+              echo "${p}/bin" >> "$GITHUB_PATH"
+            done < <(nix build "nixpkgs#$2" --no-link --print-out-paths)
+          }
+          ensure awk gawk
+          ensure curl curl
+
       # MIRROR_TOKEN is minted per run from the org-owned ix-mirror-sync
       # GitHub App (Contents write on the org's repos): short-lived, no
       # long-lived PAT to rotate. The default GITHUB_TOKEN cannot push to
@@ -91,10 +107,7 @@ jobs:
             rev=$(nix run nixpkgs#jq -- -r --arg i "$input" \
               '.nodes[$i].locked.rev' flake.lock)
             url="https://github.com/${fork_repo}/archive/${rev}.tar.gz"
-            # The ephemeral fleet runner ships no curl on PATH (exit 127 on
-            # the first live run); resolve it the way every other tool in
-            # this workflow is resolved.
-            code=$(nix run nixpkgs#curl -- -sIL -o /dev/null -w '%{http_code}' --max-time 60 "$url")
+            code=$(curl -sIL -o /dev/null -w '%{http_code}' --max-time 60 "$url")
             if [ "$code" != "200" ]; then
               echo "::error::fork-sync: $name: $url is not anonymously fetchable (HTTP $code). A private fork repo must be made public (gh repo edit $fork_repo --visibility public); a vanished rev needs its refs/pins/* ref restored."
               failed=1


### PR DESCRIPTION
Fifth fix-forward from watching the #4032 post-merge runs. fork-sync's dispatch validation run (29937536335) got past the #4039 probe fix and then died the same way one step later:

```
.../temp.sh: line 33: awk: command not found  (exit 127)
```

The fleet's ephemeral runners expose git + nix + coreutils only (cache-push.yml documents this; update-flake-lock.yml already carries an ensure step for it). Rather than converting each missing tool to a `nix run` call one failure at a time, this adds the same "Provision missing CLI tools" step to fork-sync.yml (ensure awk via gawk, ensure curl) and returns the probe to plain curl.

After merge I will re-dispatch fork-sync to validate end to end. AI-authored (Claude Fable 5), human-directed; standing force-merge grant per the #4032 fix-forward instruction.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Provision `awk` and `curl` on PATH in the fork-sync workflow runner
> The `fork-sync` workflow runs on a minimal fleet runner that may lack common CLI tools. A new "Provision missing CLI tools" step adds an `ensure()` shell function that checks for each tool and, if absent, appends the corresponding nixpkgs package bin path to `GITHUB_PATH`. The URL fetchability check is updated to call `curl` directly instead of via `nix run nixpkgs#curl`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65332ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->