### PR TITLE
upstream-sync: anchor a fork series on its declared upstreamRef (#4038)

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -126,7 +126,7 @@ jobs:
           mapfile -t rows < <(
             nix eval --json '.#lib.forkPackages' \
               --apply 'fs: builtins.filter (f: f.autoUpdate) fs' \
-              | nix run nixpkgs#jq -- -c '.[] | {name, forkRepo, bookmark, upstreamUrl}'
+              | nix run nixpkgs#jq -- -c '.[] | {name, forkRepo, bookmark, upstreamUrl, upstreamRef}'
           )
           echo "auto-updatable forks: ${#rows[@]}"
           for row in "${rows[@]}"; do
@@ -144,12 +144,20 @@ jobs:
             # rebase (only tracked bookmarks follow their rewritten commits).
             jj bookmark track "${bookmark}@origin"
 
-            # The rebase targets the upstream's CURRENT default branch tip,
-            # discovered from its HEAD symref, not our pinned base.
+            # The rebase targets the CURRENT tip of the branch the fork
+            # tracks: the registry's `upstreamRef` when the base sits off
+            # the default branch (#4038), else the upstream's default
+            # branch, discovered from its HEAD symref -- never our pinned
+            # base.
             git remote add upstream "$upstream_url"
-            head_ref=$(git ls-remote --symref upstream HEAD \
-              | awk '$1 == "ref:" { sub("refs/heads/", "", $2); print $2; exit }')
-            echo "$name: upstream default branch is $head_ref"
+            head_ref=$(nix run nixpkgs#jq -- -r '.upstreamRef // empty' <<<"$row")
+            if [ -n "$head_ref" ]; then
+              echo "$name: upstream ref pinned by the registry: $head_ref"
+            else
+              head_ref=$(git ls-remote --symref upstream HEAD \
+                | awk '$1 == "ref:" { sub("refs/heads/", "", $2); print $2; exit }')
+              echo "$name: upstream default branch is $head_ref"
+            fi
             git fetch --no-tags upstream "refs/heads/$head_ref"
             upstream_tip=$(git rev-parse FETCH_HEAD)
 

--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -31,6 +31,12 @@
 #   input       : flake input pinning the megamerge (flake.lock `locked.rev`;
 #                 branch-loose for autoUpdate forks).
 #   upstreamUrl : upstream git URL rebases target.
+#   upstreamRef : optional upstream branch the fork's base sits on.
+#                 upstream-sync anchors the series base on it (merge-base
+#                 against its tip) and drift compares against it; fork-sync
+#                 rebases target its tip. Default: the upstream's default
+#                 branch (its HEAD symref), which is right for every fork
+#                 except one based off a maintenance branch.
 #   forkRepo    : GitHub `owner/name` of the maintained fork repo.
 #   bookmark    : fork-repo branch holding the megamerge (`ix-patched`; one
 #                 bookmark per series where a repo carries several, e.g.
@@ -457,6 +463,8 @@
       name = "nix";
       input = "nix-src";
       upstreamUrl = "https://github.com/NixOS/nix.git";
+      # The 2.34.7 base lives on the maintenance branch, not master.
+      upstreamRef = "2.34-maintenance";
       forkRepo = "indexable-inc/nix";
       bookmark = "ix-patched";
       autoUpdate = false;

--- a/packages/upstream-sync/src/drift.rs
+++ b/packages/upstream-sync/src/drift.rs
@@ -1,7 +1,8 @@
 //! The read-only drift companion report (RFC 0010, #2098).
 //!
-//! Per fork: how far the pinned base trails upstream's default branch
-//! (commits behind + base age), the declared patch stances, how many tracked
+//! Per fork: how far the pinned base trails its tracked upstream branch
+//! (the registry's `upstreamRef`, else the default branch; commits behind +
+//! base age), the declared patch stances, how many tracked
 //! patches are retired-awaiting-drop, and a one-word next action. The
 //! fork-sync cron surfaces it in its step summary and rolling PR body.
 //!
@@ -104,15 +105,20 @@ fn lock_rev(input: &str) -> Result<Option<String>> {
         .map(str::to_owned))
 }
 
-/// Commits behind = `ahead_by` of `pinned...default_branch`: how many
-/// commits upstream's default branch has that our pinned base does not.
-fn github_behind(ctx: &str, slug: &Slug, rev: &str) -> Result<Option<i64>> {
+/// Commits behind = `ahead_by` of `pinned...branch`: how many commits the
+/// tracked upstream branch (the registry's `upstreamRef`, else the default
+/// branch) has that our pinned base does not.
+fn github_behind(fork: &Fork, slug: &Slug, rev: &str) -> Result<Option<i64>> {
     let repo = format!("repos/{}/{}", slug.owner, slug.repo);
-    let Some(branch) = gh::read(ctx, &repo, ".default_branch")? else {
-        return Ok(None);
+    let branch = match &fork.upstream_ref {
+        Some(configured) => configured.clone(),
+        None => match gh::read(&fork.name, &repo, ".default_branch")? {
+            Some(branch) => branch,
+            None => return Ok(None),
+        },
     };
     let Some(n) = gh::read(
-        ctx,
+        &fork.name,
         &format!("{repo}/compare/{rev}...{branch}"),
         ".ahead_by",
     )?
@@ -234,7 +240,7 @@ fn row(fork: &Fork) -> Result<Row> {
     };
 
     let behind = match (forge, rev.as_deref()) {
-        ("github", Some(rev)) => github_behind(&fork.name, &slug, rev)?,
+        ("github", Some(rev)) => github_behind(fork, &slug, rev)?,
         _ => None,
     };
     let base_date = base_date(fork, forge, &slug, rev.as_deref())?;

--- a/packages/upstream-sync/src/mapping.rs
+++ b/packages/upstream-sync/src/mapping.rs
@@ -32,6 +32,11 @@ pub struct Fork {
     pub bookmark: String,
     /// The upstream git URL contributions target.
     pub upstream_url: String,
+    /// The upstream branch the fork's base sits on (e.g. nix on
+    /// `2.34-maintenance`). `None` means the upstream's default branch,
+    /// discovered from its HEAD symref.
+    #[serde(default)]
+    pub upstream_ref: Option<String>,
     /// Per-patch intent keyed by the patch commit's SUBJECT line (the
     /// identity that survives jj rebases).
     #[serde(default)]
@@ -245,6 +250,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(fork.bookmark, "ix-patched");
+        assert_eq!(fork.upstream_ref, None);
         assert_eq!(fork.fork_owner(), "indexable-inc");
         assert_eq!(
             fork.fork_url(),

--- a/packages/upstream-sync/src/series.rs
+++ b/packages/upstream-sync/src/series.rs
@@ -6,7 +6,9 @@
 //! every patch is a commit whose parents are its true dependencies, sealed by
 //! an "ix megamerge" commit whose tree is the full series applied linearly.
 //! This module opens a scratch commits-only clone, derives the series
-//! (bookmark ancestry minus the upstream base, minus the seal), and exposes
+//! (bookmark ancestry minus the upstream base -- anchored on the registry's
+//! `upstreamRef` when the base sits off the default branch -- minus the
+//! seal), and exposes
 //! the ancestry closure that decides what an upstream contribution drags
 //! along. Patch identity is the commit SUBJECT: it survives jj rebases, and
 //! the intent map in the registry is keyed by it.
@@ -35,12 +37,13 @@ pub struct Repo {
     _scratch: tempfile::TempDir,
     /// The bookmark tip (the megamerge seal commit).
     pub tip: String,
-    /// merge-base(bookmark tip, upstream default branch): the pinned base
+    /// merge-base(bookmark tip, tracked upstream branch): the pinned base
     /// the series sits on.
     pub base: String,
-    /// Upstream's default branch name (PRs target it).
+    /// The tracked upstream branch (the registry's `upstreamRef`, else the
+    /// upstream's default branch). PRs target it.
     pub upstream_branch: String,
-    /// Upstream's default branch tip at open time.
+    /// The tracked upstream branch's tip at open time.
     pub upstream_tip: String,
     /// The patch series in topological order, parents first.
     pub series: Vec<Commit>,
@@ -71,7 +74,14 @@ impl Repo {
         )?;
 
         let tip = fetch(&dir, &fork.name, "fork", &format!("refs/heads/{}", fork.bookmark))?;
-        let upstream_branch = default_branch(&dir, &fork.name, &fork.upstream_url)?;
+        // A fork based off a non-default branch declares `upstreamRef` in
+        // the registry (nix's 2.34.7 base sits on 2.34-maintenance):
+        // merge-basing against the default branch would undershoot the base
+        // and pull upstream commits into the series (#4038).
+        let upstream_branch = match &fork.upstream_ref {
+            Some(configured) => configured.clone(),
+            None => default_branch(&dir, &fork.name, &fork.upstream_url)?,
+        };
         let upstream_tip = fetch(
             &dir,
             &fork.name,

--- a/packages/upstream-sync/tests/common/mod.rs
+++ b/packages/upstream-sync/tests/common/mod.rs
@@ -70,6 +70,18 @@ pub fn git(cwd: &Path, args: &[&str]) -> String {
     String::from_utf8_lossy(&out.stdout).trim().to_owned()
 }
 
+/// A local upstream repo with `main` as its default branch and one base
+/// commit.
+fn init_upstream(root: &Path) -> PathBuf {
+    let upstream = root.join("upstream");
+    fs::create_dir_all(&upstream).unwrap();
+    git(&upstream, &["init", "--quiet", "-b", "main"]);
+    fs::write(upstream.join("README"), "hello\n").unwrap();
+    git(&upstream, &["add", "."]);
+    git(&upstream, &["commit", "--quiet", "-m", "base"]);
+    upstream
+}
+
 /// The https URLs the binaries see; the gitconfig redirects them locally.
 pub const UPSTREAM_URL: &str = "https://github.com/fakeorg/fakerepo.git";
 pub const FORK_REPO: &str = "fakefork/fakerepo";
@@ -94,16 +106,41 @@ impl Fixture {
     /// Build the fixture under `root`. Each patch is `(subject, body)`; an
     /// empty body makes a reason-less commit (for the refusal tests).
     pub fn new(root: &Path, patches: &[(&str, &str)]) -> Self {
-        let upstream = root.join("upstream");
-        fs::create_dir_all(&upstream).unwrap();
-        git(&upstream, &["init", "--quiet", "-b", "main"]);
-        fs::write(upstream.join("README"), "hello\n").unwrap();
-        git(&upstream, &["add", "."]);
-        git(&upstream, &["commit", "--quiet", "-m", "base"]);
+        let upstream = init_upstream(root);
+        Self::seal(root, &upstream, "main", patches)
+    }
 
+    /// The #4038 shape: the fork is based on an upstream MAINTENANCE branch
+    /// whose tip is not an ancestor of the (diverged) default branch, and
+    /// the maintenance commits share a subject ("Bump version", exactly
+    /// NixOS/nix's 2.34-maintenance). A series read anchored on the default
+    /// branch merge-bases at the fork point and drags those commits into
+    /// the series; only an `upstreamRef`-anchored read sees the fork
+    /// patches alone.
+    pub fn on_maintenance_branch(root: &Path, patches: &[(&str, &str)]) -> Self {
+        let upstream = init_upstream(root);
+        git(&upstream, &["checkout", "--quiet", "-b", "maintenance"]);
+        for point in ["2.34.6", "2.34.7"] {
+            fs::write(upstream.join("version"), format!("{point}\n")).unwrap();
+            git(&upstream, &["add", "."]);
+            git(&upstream, &["commit", "--quiet", "-m", "Bump version"]);
+        }
+        git(&upstream, &["checkout", "--quiet", "main"]);
+        fs::write(upstream.join("feature"), "development moved on\n").unwrap();
+        git(&upstream, &["add", "."]);
+        git(
+            &upstream,
+            &["commit", "--quiet", "-m", "diverge the default branch"],
+        );
+        Self::seal(root, &upstream, "origin/maintenance", patches)
+    }
+
+    /// Clone the fork, commit the patch series on `base_ref`, and seal it
+    /// with the megamerge commit under the `ix-patched` bookmark.
+    fn seal(root: &Path, upstream: &Path, base_ref: &str, patches: &[(&str, &str)]) -> Self {
         let fork = root.join("fork");
         git(root, &["clone", "--quiet", upstream.to_str().unwrap(), "fork"]);
-        git(&fork, &["checkout", "--quiet", "-b", "series", "main"]);
+        git(&fork, &["checkout", "--quiet", "-b", "series", base_ref]);
         for (i, (subject, body)) in patches.iter().enumerate() {
             fs::write(fork.join(format!("patch-{i}.txt")), format!("{subject}\n")).unwrap();
             git(&fork, &["add", "."]);
@@ -142,7 +179,7 @@ impl Fixture {
         )
         .unwrap();
         Self {
-            upstream,
+            upstream: upstream.to_path_buf(),
             fork,
             gitconfig,
         }
@@ -173,9 +210,17 @@ impl Fixture {
 
 /// A v2 mapping entry as JSON (subject-keyed intent).
 pub fn mapping_json(name: &str, patches_json: &str) -> String {
+    mapping_json_on(name, None, patches_json)
+}
+
+/// Like [`mapping_json`], optionally declaring the upstream branch the fork
+/// tracks (`upstreamRef`) instead of the upstream's default branch.
+pub fn mapping_json_on(name: &str, upstream_ref: Option<&str>, patches_json: &str) -> String {
+    let upstream_ref =
+        upstream_ref.map_or_else(String::new, |r| format!(r#""upstreamRef":"{r}","#));
     format!(
         r#"[{{"name":"{name}","input":"{name}-src","forkRepo":"{FORK_REPO}","bookmark":"ix-patched",
-  "upstreamUrl":"{UPSTREAM_URL}","autoUpdate":false,
+  "upstreamUrl":"{UPSTREAM_URL}",{upstream_ref}"autoUpdate":false,
   "upstreamPolicy":{{"prsWelcome":true,"aiPrsAllowed":"unknown","citation":"https://example.com","notes":"t"}},
   "patches":{patches_json}}}]"#
     )

--- a/packages/upstream-sync/tests/series_base.rs
+++ b/packages/upstream-sync/tests/series_base.rs
@@ -1,0 +1,84 @@
+//! Regression test for #4038: a fork based on an upstream MAINTENANCE
+//! branch (nix's 2.34.7 base on 2.34-maintenance) while the upstream's
+//! default branch has diverged. Anchoring the series base on the default
+//! branch merge-bases at the fork point and drags the maintenance commits
+//! into the series, dying on their duplicate "Bump version" subjects; the
+//! registry's `upstreamRef` pins the anchor so the series is exactly the
+//! fork's patches.
+
+mod common;
+
+use std::fs;
+use std::path::Path;
+
+use common::{Fixture, mapping_json_on, run_bin};
+
+const PATCH_ONE: &str = "fakefix: repair the frobnicator widget alignment";
+const PATCH_TWO: &str = "fakefix: teach the widget to self-align";
+
+fn run_sync(mapping: &Path, work: &Path, envs: &[(&str, String)]) -> common::Run {
+    let exe = env!("CARGO_BIN_EXE_upstream-sync");
+    let mapping = mapping.display().to_string();
+    run_bin(exe, &["--dry-run", "--mapping", &mapping, "fake"], work, envs)
+}
+
+#[test]
+fn upstream_ref_anchors_the_series_base() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let fixture = Fixture::on_maintenance_branch(
+        root,
+        &[(PATCH_ONE, common::BODY), (PATCH_TWO, common::BODY)],
+    );
+    let work = root.join("work");
+    fs::create_dir(&work).unwrap();
+    let envs = fixture.envs();
+
+    // Without `upstreamRef` the walk anchors on the diverged default
+    // branch: the undershot merge-base pulls the upstream maintenance
+    // commits into the series and the read dies on their duplicate
+    // subject. This guards the fixture itself: if it stops reproducing
+    // #4038, the passing half below proves nothing.
+    let mapping = work.join("mapping-default.json");
+    fs::write(&mapping, mapping_json_on("fake", None, "{}")).unwrap();
+    let run = run_sync(&mapping, &work, &envs);
+    assert_ne!(
+        run.status, 0,
+        "default-branch anchoring should die on the duplicate maintenance subject:\n{}\n{}",
+        run.stdout, run.stderr
+    );
+    assert!(
+        run.stderr.contains("duplicate commit subject"),
+        "expected the duplicate-subject error:\n{}\n{}",
+        run.stdout,
+        run.stderr
+    );
+
+    // With `upstreamRef` the base anchors on the branch the fork is
+    // actually based on: the series is exactly the fork's patches.
+    let mapping = work.join("mapping-ref.json");
+    fs::write(&mapping, mapping_json_on("fake", Some("maintenance"), "{}")).unwrap();
+    let run = run_sync(&mapping, &work, &envs);
+    assert_eq!(
+        run.status, 0,
+        "upstreamRef-anchored read failed:\n{}\n{}",
+        run.stdout, run.stderr
+    );
+    for subject in [PATCH_ONE, PATCH_TWO] {
+        assert!(
+            run.stdout.contains(subject),
+            "series is missing '{subject}':\n{}",
+            run.stdout
+        );
+    }
+    assert!(
+        !run.stdout.contains("Bump version"),
+        "series leaked upstream maintenance commits:\n{}",
+        run.stdout
+    );
+    assert!(
+        run.stdout.contains("2 patch decisions"),
+        "expected exactly the 2 fork patches:\n{}",
+        run.stdout
+    );
+}


### PR DESCRIPTION
Fixes #4038.

Since the jj megamerge migration (#4032), `upstream-sync` derives a fork's series base as `merge-base(bookmark tip, upstream DEFAULT branch)`. NixOS/nix defaults to `master`, but the nix fork's base (2.34.7, `2c6d06e9387c`) sits on `2.34-maintenance`, so the merge-base undershoots and the walk drags upstream maintenance commits into the series, dying on the first duplicate subject (`Bump version`).

The fix is declarative, at the registry: a new optional `upstreamRef` field in `lib/fork-packages.nix` names the upstream branch a fork's base sits on. Default (field absent): the upstream's default branch via its HEAD symref, exactly the previous behavior for every other fork. The nix entry sets `upstreamRef = "2.34-maintenance"`.

Consumers:
- `packages/upstream-sync` `series::Repo::open` anchors the merge-base on the configured ref instead of discovering the default branch; `drift` compares the pinned base against it.
- `.github/workflows/fork-sync.yml` honors `upstreamRef` as the rebase target before falling back to the `ls-remote --symref` default-branch discovery (nix is `autoUpdate = false`, so the cron skips it today, but the flow is now correct for any tracked non-default branch).

New integration test (`tests/series_base.rs`): a local upstream with a diverged default branch and a maintenance branch carrying duplicate `Bump version` subjects, fork based on maintenance. The default-branch anchoring reproduces the #4038 duplicate-subject death (guarding the fixture); the `upstreamRef` anchoring reads exactly the fork's patches.

Verified against the real fork: `upstream-sync --dry-run nix` with the rendered registry now reads the full series from `indexable-inc/nix@ix-patched` with no duplicate-subject error, base `2c6d06e9387c` (2.34.7), 45 patches -- exactly the fork's own seal, `ix megamerge: 45 patches on 2c6d06e9387c` (the series gained one patch since the issue counted 44). `upstream-sync drift nix` now reports drift against `2.34-maintenance` (30 behind) instead of master.

Local checks: `cargo test -p upstream-sync` 18/18 green (10 unit + 8 integration), `nix run .#lint` 13/13 green.

Written by Claude Code (Claude Fable 5).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Anchor fork series rebase on a declared `upstreamRef` branch instead of the upstream default branch
> - Adds an optional `upstreamRef` field to the `Fork` struct in [`mapping.rs`](https://github.com/indexable-inc/index/pull/4043/files#diff-a0c60094764eef977aafd157817ca10d8336c3cadae20be2918ae369010f9227) and to the registry in [`fork-packages.nix`](https://github.com/indexable-inc/index/pull/4043/files#diff-35e5ff5b02c2dcd32c93fd770ad2194f9fcbfc9f35fdcbd56821891b6e7452f4) (e.g. `2.34-maintenance` for nix).
> - Updates [`series.rs`](https://github.com/indexable-inc/index/pull/4043/files#diff-e0c2fa00ee83e9e8bdcda903dbfba380b35022eca28a2c79903418520c2ca76d) and [`drift.rs`](https://github.com/indexable-inc/index/pull/4043/files#diff-a4c4d98908bc2b61f69c2295f3c4d9c303170f0f7c709f16897ef5d1c665e6dd) to use `upstreamRef` as the base branch when set, falling back to the upstream's default branch.
> - Updates [`fork-sync.yml`](https://github.com/indexable-inc/index/pull/4043/files#diff-ab7221dc3add2293b66a01dadb4f0232b8c16b141fdf61004bdc95d49f07eb49) to pass the configured `upstreamRef` to the rebase step, with the same fallback logic.
> - Adds a regression test in [`series_base.rs`](https://github.com/indexable-inc/index/pull/4043/files#diff-c12a2821a86e3aa40edefb21ab5f365f7398eb76e773e7d0c05a22a37a3f9938) confirming that without `upstreamRef`, duplicate maintenance commits cause series derivation to fail, while setting it fixes the issue.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d901660.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->