### PR TITLE
forks: clear the clippy and site-test failures the migration shipped

### DIFF
--- a/packages/site/src/lib/updates/jj-megamerge-forks.svx
+++ b/packages/site/src/lib/updates/jj-megamerge-forks.svx
@@ -3,7 +3,8 @@ id: jj-megamerge-forks
 postedAt: 2026-07-22T14:30:00Z
 title: "Fork patches are now jj megamerge commit DAGs"
 links:
-  - https://github.com/indexable-inc/index/pull/4032
+  - label: index#4032
+    href: https://github.com/indexable-inc/index/pull/4032
 tags:
   - forks
   - infrastructure

--- a/packages/unibind/py-runtime/src/lib.rs
+++ b/packages/unibind/py-runtime/src/lib.rs
@@ -113,10 +113,8 @@ impl<T> SharedStream<T> {
     {
         let next = self.next();
         future_into_py(py, async move {
-            match next.await {
-                Some(item) => Ok(item),
-                None => Err(pyo3::exceptions::PyStopAsyncIteration::new_err(())),
-            }
+            next.await
+                .ok_or_else(|| pyo3::exceptions::PyStopAsyncIteration::new_err(()))
         })
     }
 }

--- a/packages/unibind/runtime/src/lib.rs
+++ b/packages/unibind/runtime/src/lib.rs
@@ -55,10 +55,11 @@ impl<T> fmt::Debug for UniStream<T> {
     }
 }
 
-/// One consumer's pull handle over a [`UniStream`]: checked-out pull
-/// state, a gate serializing concurrent pulls, and a level-triggered
-/// closed flag. The shared body of every generated handle class, so the
-/// per-export types stay thin shells.
+/// One consumer's pull handle over a [`UniStream`].
+///
+/// Holds the checked-out pull state, a gate serializing concurrent
+/// pulls, and a level-triggered closed flag. The shared body of every
+/// generated handle class, so the per-export types stay thin shells.
 ///
 /// `close` is synchronous and race-free: the watch channel flips to
 /// closed, which both wakes a pull blocked inside `next` (dropping the

--- a/packages/upstream-sync/src/main.rs
+++ b/packages/upstream-sync/src/main.rs
@@ -182,6 +182,28 @@ fn repo_gate(fork: &Fork, slug: &Slug, gh_ok: bool) -> RepoGate {
     RepoGate { blocked, reason }
 }
 
+/// Every intent key must name a real series commit: a key orphaned by a
+/// rebase that retitled or dropped its commit is dead intent, and dead
+/// `attempt` intent silently loses the authorization it encodes.
+fn ensure_no_orphaned_intent(fork: &Fork, all_subjects: &[String]) -> Result<()> {
+    let orphaned: Vec<&String> = fork
+        .patches
+        .keys()
+        .filter(|key| !all_subjects.iter().any(|s| s == *key))
+        .collect();
+    if orphaned.is_empty() {
+        return Ok(());
+    }
+    Err(eyre!(
+        "upstream-sync: {}: intent keys in lib/fork-packages.nix match no commit subject on {}@{}: {:?}. Series subjects: {:?}",
+        fork.name,
+        fork.fork_repo,
+        fork.bookmark,
+        orphaned,
+        all_subjects
+    ))
+}
+
 fn process_fork(fork: &Fork, args: &SyncArgs, plan: &mut Vec<PlanEntry>) -> Result<()> {
     let slug = Slug::parse(&fork.upstream_url)?;
     let policy = fork.policy();
@@ -240,25 +262,7 @@ fn process_fork(fork: &Fork, args: &SyncArgs, plan: &mut Vec<PlanEntry>) -> Resu
     );
     let repo = series::Repo::open(fork)?;
     let all_subjects = repo.subjects();
-
-    // Every intent key must name a real series commit: a key orphaned by a
-    // rebase that retitled or dropped its commit is dead intent, and dead
-    // `attempt` intent silently loses the authorization it encodes.
-    let orphaned: Vec<&String> = fork
-        .patches
-        .keys()
-        .filter(|key| !all_subjects.iter().any(|s| s == *key))
-        .collect();
-    if !orphaned.is_empty() {
-        return Err(eyre!(
-            "upstream-sync: {}: intent keys in lib/fork-packages.nix match no commit subject on {}@{}: {:?}. Series subjects: {:?}",
-            fork.name,
-            fork.fork_repo,
-            fork.bookmark,
-            orphaned,
-            all_subjects
-        ));
-    }
+    ensure_no_orphaned_intent(fork, &all_subjects)?;
 
     let selected: Vec<String> = match args.patch.as_deref() {
         None => all_subjects,

--- a/packages/upstream-sync/src/mapping.rs
+++ b/packages/upstream-sync/src/mapping.rs
@@ -15,11 +15,13 @@ use serde::Deserialize;
 /// Environment variable the Nix wrapper points at the baked-in fork list.
 pub const FORK_PACKAGES_ENV: &str = "UPSTREAM_SYNC_FORK_PACKAGES";
 
-/// One de-forked package from the mapping. The fork lives in a real GitHub
-/// fork repo (`fork_repo`) whose `bookmark` points at the megamerge commit;
-/// the patch series is that commit's ancestry down to the upstream base.
-/// Unknown fields (autoUpdate, derivedPatches, ...) belong to other tools
-/// and are ignored here.
+/// One de-forked package from the mapping.
+///
+/// The fork lives in a real GitHub fork repo (`fork_repo`) whose
+/// `bookmark` points at the megamerge commit; the patch series is that
+/// commit's ancestry down to the upstream base. Unknown fields
+/// (autoUpdate, derivedPatches, ...) belong to other tools and are
+/// ignored here.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Fork {

--- a/packages/upstream-sync/tests/common/mod.rs
+++ b/packages/upstream-sync/tests/common/mod.rs
@@ -154,6 +154,10 @@ impl Fixture {
         // The megamerge seal: same tree as the series head, parent(s) = the
         // DAG head(s). Series readers must skip it.
         let head = git(&fork, &["rev-parse", "HEAD"]);
+        #[expect(
+            clippy::literal_string_with_formatting_args,
+            reason = "^{tree} is git revision syntax, not a format placeholder"
+        )]
         let tree = git(&fork, &["rev-parse", "HEAD^{tree}"]);
         let seal = git(
             &fork,
@@ -186,6 +190,10 @@ impl Fixture {
     }
 
     /// The env pairs that make the binaries hit the local fixtures.
+    #[expect(
+        clippy::anonymous_tuple_return_type,
+        reason = "process env pairs feed Command::envs at the only consumers; a named struct would be re-flattened immediately"
+    )]
     pub fn envs(&self) -> Vec<(&'static str, String)> {
         vec![
             ("GIT_CONFIG_GLOBAL", self.gitconfig.display().to_string()),

--- a/packages/upstream-sync/tests/upstream_pr.rs
+++ b/packages/upstream-sync/tests/upstream_pr.rs
@@ -11,6 +11,10 @@ use std::fs;
 
 use common::{BODY, Fixture, SUBJECT, mapping_json, run_bin};
 
+#[expect(
+    clippy::anonymous_tuple_return_type,
+    reason = "process env pairs feed Command::envs at the only consumers; a named struct would be re-flattened immediately"
+)]
 fn base_envs(fixture: &Fixture) -> Vec<(&'static str, String)> {
     let mut envs = fixture.envs();
     envs.push(("PATH", std::env::var("PATH").unwrap()));


### PR DESCRIPTION
Sixth fix-forward from watching the #4032 post-merge runs. With eval fixed (#4037, #4041/#4040), Check reached the build stage and exposed the failures the migration's force-merged Check had masked -- four red gate roots on every main commit:

```
ERROR:nix_fast_build:Failed attributes: .#requiredGateRoots.x86_64-linux.upstream-sync.clippy .#requiredGateRoots.x86_64-linux.rust-unibind-py-runtime.clippy .#requiredGateRoots.x86_64-linux.rust-unibind-runtime.clippy .#requiredGateRoots.x86_64-linux.site-test
```

Two sources: the migration bumped the LLM-tuned clippy base (new nursery/custom lints now fire) and landed new upstream-sync code carrying violations, plus a malformed `links` entry in the new site updates svx (bare URL, so `link.href` was undefined and the vitest absolute-https check threw).

Fixes: real code changes where the lint has a point (ok_or_else over match-Option, doc first-paragraph splits, extracting orphaned-intent validation out of the 101-line `process_fork`), `#[expect(..., reason)]` where it does not (git's `^{tree}` revision syntax flagged as a format placeholder; env-pair tuple returns that feed `Command::envs` directly), and the label/href mapping for the svx link.

Verified on the fleet builders (`--keep-going` over every unit): all upstream-sync units (clippy, bin, tests, doctests), both unibind runtime roots, and site-test now build; each failed before. Lint green.

AI-authored (Claude Fable 5), human-directed; standing force-merge grant per the #4032 fix-forward instruction.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix clippy lint failures and site link format in fork migration output
> - Fixes site-test failure in [jj-megamerge-forks.svx](https://github.com/indexable-inc/index/pull/4044/files#diff-c1e043c74a2c5e65974e40ed1dc4de6853cd78f4bb64c86f151b12a41d710039) by converting a bare URL list item to an object with `label` and `href` fields.
> - Adds `#[allow(clippy::...)]` expectations in upstream-sync tests to silence `literal_string_with_formatting_args` and anonymous tuple return type warnings.
> - Extracts orphaned-intent validation in `process_fork` into a new `ensure_no_orphaned_intent` helper in [main.rs](https://github.com/indexable-inc/index/pull/4044/files#diff-f8543fd12122bf7b97a81e36b6ec57c54073e53d6443fff97115a061e97b5b37).
> - Replaces an explicit `match` in `SharedStream::next_into_py` with `ok_or_else` to address a clippy suggestion in [py-runtime/src/lib.rs](https://github.com/indexable-inc/index/pull/4044/files#diff-e5de76fe48834027d3200dd0e788ad5f9979bef1cd0a92f81a53461284764cd7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47d6497.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->