### PR TITLE
mirror: document the Workflows write permission fork-sync needs

### DIFF
--- a/packages/mirror/README.md
+++ b/packages/mirror/README.md
@@ -120,6 +120,10 @@ org with
 
 - Administration: **write** (create the mirror repos on first publish),
 - Contents: **write** (push `main`),
+- Workflows: **write** (fork-sync pushes megamerge rebases whose range
+  carries upstream changes to `.github/workflows/*`; GitHub rejects any
+  app push that alters workflow files without this permission -- btop's
+  2026-07-22 rebase was bounced exactly this way),
 - Metadata: **read** (implicit baseline).
 
 The app's client id lives in the `MIRROR_APP_CLIENT_ID` repository variable


### PR DESCRIPTION
Companion doc change to #4045: fork-sync's rebase pushes bounce off GitHub's workflow-file guard because the ix-mirror-sync app lacks **Workflows: write** (run 29938943414, btop). The grant itself is an org-owner UI action; this records the requirement in the app's permission list in packages/mirror/README.md so the app is provisioned correctly next time.

AI-authored (Claude Fable 5), human-directed; standing force-merge grant per the #4032 fix-forward instruction.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document the `Workflows: write` GitHub App permission required for fork-sync
> Updates [packages/mirror/README.md](https://github.com/indexable-inc/index/pull/4046/files#diff-d1a17b2f73587a5ebf3ce43eae1a0fee6a68080415e59e0ca57ce7aedda437c4) to add `Workflows: write` to the required GitHub App permissions list. Without this permission, GitHub rejects pushes from the app when a megamerge rebase includes changes to `.github/workflows`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 866d5f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->