### PR TITLE
mcp: turn off the new-issue channel feed by default

### DIFF
--- a/lib/util/mcp/servers.nix
+++ b/lib/util/mcp/servers.nix
@@ -45,6 +45,14 @@
         command = indexCommand;
         args = indexArgs;
         envVars = indexApiEnvVars ++ fleetBeamEnvVars;
+        env = {
+          # New-issue channel broadcasting (IssueWatch, #3877) off for now:
+          # every kernel hears every filed issue, so unrelated agents pick
+          # them up and start working them. Empty = disabled (issue_watch.ex
+          # treats an empty owner list as "feed off"); delete this line to
+          # re-enable the default indexable-inc feed.
+          IX_MCP_ISSUE_WATCH_OWNERS = "";
+        };
       };
     }
     // {


### PR DESCRIPTION
Andrew's request (2026-07-22, mid-session): no issue broadcasting for now; unrelated agents pick up announced issues and start working them.

`IssueWatch` (#3877) already has a disable switch: an empty `IX_MCP_ISSUE_WATCH_OWNERS` makes `init` return `:ignore`. This bakes that empty value into the shared `index` server definition (`lib/util/mcp/servers.nix`), so every wrapper that renders it (Claude Code, Codex, Cursor) launches the kernel with the feed off. No supervision-tree or mcp-ex code change; delete the env line to re-enable the default `indexable-inc` feed.

Takes effect per kernel at its next restart after an HM switch picks this up. Already-running kernels keep their booted behavior.

Written by an AI agent (Claude) via Claude Code, session "ix#8217 tutorial dimming + ix/nix switcher".


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable the new-issue channel feed by default in MCP server config
> Sets an environment variable to an empty string in [servers.nix](https://github.com/indexable-inc/index/pull/4051/files#diff-a74190c62a3086f0b0e05489808b80559c743c45cb2f5d09e9734aa712b7604b) to turn off the new-issue channel feed for the MCP index server by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8708434.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->