### PR TITLE
nwm: refuse a switch from a dirty flake tree

### DIFF
--- a/lib/rust/workspace.nix
+++ b/lib/rust/workspace.nix
@@ -332,6 +332,10 @@
           # stub via CLOUDFLARE_API_BASE in the integration tests). The test
           # sandbox has no curl otherwise, so the executors fail spawning it.
           efx = [workspacePkgs.curl];
+          # nix-web-monitor's switch dirty-tree-guard tests build scratch git
+          # repos and run `git status` against them. The test sandbox has no
+          # git otherwise, so the tests panic spawning it.
+          nix-web-monitor = [workspacePkgs.git];
           # upstream-sync's upstream-pr integration test builds a local git
           # upstream and runs the real fetch/am/branch mechanism against it.
           upstream-sync = [workspacePkgs.git];

--- a/packages/nix/nix-web-monitor/server/src/main.rs
+++ b/packages/nix/nix-web-monitor/server/src/main.rs
@@ -140,8 +140,21 @@ struct SwitchSpec {
 #[derive(clap::Subcommand)]
 enum SwitchAction {
     /// Build the configuration and activate it.
-    Switch(SwitchArgs),
-    /// Build the configuration only, without activating.
+    Switch {
+        #[command(flatten)]
+        args: SwitchArgs,
+
+        /// Switch even if the flake directory has uncommitted git changes.
+        ///
+        /// Without this a dirty tree (any `git status --porcelain` output,
+        /// untracked files included) aborts the switch before anything builds:
+        /// Nix copies dirty tracked files into the eval, so switching from a
+        /// dirty repo deploys uncommitted WIP with no record of what ran.
+        #[arg(long)]
+        allow_dirty: bool,
+    },
+    /// Build the configuration only, without activating. Never guarded: a
+    /// build activates nothing, so a dirty tree deploys nothing.
     Build(SwitchArgs),
 }
 
@@ -771,9 +784,9 @@ async fn build_job(command: NwmCommand) -> Result<Job> {
 }
 
 async fn build_switch_job(kind: SwitchKind, spec: SwitchSpec) -> Result<Job> {
-    let (args, do_switch) = match spec.action {
-        SwitchAction::Switch(args) => (args, true),
-        SwitchAction::Build(args) => (args, false),
+    let (args, do_switch, allow_dirty) = match spec.action {
+        SwitchAction::Switch { args, allow_dirty } => (args, true, allow_dirty),
+        SwitchAction::Build(args) => (args, false, false),
     };
     // `dir#name` overrides the configuration name; a bare value is the flake dir.
     let (flake_dir, name_override) = args.flake.map_or_else(
@@ -783,6 +796,11 @@ async fn build_switch_job(kind: SwitchKind, spec: SwitchSpec) -> Result<Job> {
             None => (value, None),
         },
     );
+    // Guard a switch (not a build) while planning, before the update, build,
+    // and activation phases run and before the web UI even starts.
+    if do_switch && !allow_dirty {
+        ensure_clean_flake_dir(&flake_dir).await?;
+    }
     let config_name = match name_override {
         Some(name) => name,
         None => match kind {
@@ -809,6 +827,38 @@ async fn build_switch_job(kind: SwitchKind, spec: SwitchSpec) -> Result<Job> {
             update: args.update,
         }),
     })
+}
+
+/// Refuse to switch from a dirty flake tree. Nix copies dirty tracked files
+/// into the eval, so a switch from a dirty repo silently deploys uncommitted
+/// WIP; untracked files count because they are one `git add` away from the
+/// same. Any `git status --porcelain` output at all is dirty. A flake dir that
+/// is not a git work tree (a plain directory or a remote flake ref) has no
+/// working tree to be dirty, so it is not guarded; `--allow-dirty` is the
+/// explicit override.
+async fn ensure_clean_flake_dir(flake_dir: &str) -> Result<()> {
+    let output = Command::new("git")
+        .args(["-C", flake_dir, "status", "--porcelain"])
+        .stdin(Stdio::null())
+        .output()
+        .await
+        .with_context(|| format!("running `git -C {flake_dir} status --porcelain`"))?;
+    // `git status` exits nonzero when `flake_dir` is not a git work tree
+    // (or not a local directory at all); that flake has nothing to guard.
+    if !output.status.success() {
+        return Ok(());
+    }
+    let status = String::from_utf8_lossy(&output.stdout);
+    let status = status.trim_end();
+    if status.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "flake dir `{flake_dir}` has uncommitted changes, and a switch would \
+         silently deploy them (Nix copies the dirty tree into the eval); \
+         commit or stash first, or pass --allow-dirty to switch anyway:\n\
+         {status}"
+    );
 }
 
 /// Run a planned job to completion and return its exit code.
@@ -1538,6 +1588,94 @@ mod tests {
             panic!("expected the external passthrough");
         };
         assert_eq!(nix_args, ["build", ".#hello"]);
+    }
+
+    /// A scratch git repository under the temp dir, isolated from the user's
+    /// git config. No commit is needed: `git status --porcelain` works (and
+    /// prints nothing) in a fresh repo.
+    fn scratch_git_repo(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("{name}-{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).expect("create scratch repo dir");
+        let init = std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&dir)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("HOME", &dir)
+            .output()
+            .expect("git init runs");
+        assert!(init.status.success(), "git init failed: {init:?}");
+        dir
+    }
+
+    /// The switch dirty-tree guard: any `git status --porcelain` output at all
+    /// (an untracked file is enough) must abort with the flake dir and the
+    /// status listing in the error, and must name the `--allow-dirty` override.
+    #[tokio::test]
+    async fn switch_guard_rejects_a_dirty_flake_tree() {
+        let dir = scratch_git_repo("nwm-dirty-guard-dirty");
+        std::fs::write(dir.join("wip.nix"), b"{ }\n").expect("write untracked file");
+
+        let error = ensure_clean_flake_dir(dir.to_str().expect("utf-8 path"))
+            .await
+            .expect_err("an untracked file must trip the guard");
+        let message = format!("{error:#}");
+        assert!(
+            message.contains(dir.to_str().expect("utf-8 path")),
+            "error names the flake dir: {message}"
+        );
+        assert!(
+            message.contains("wip.nix"),
+            "error lists the status: {message}"
+        );
+        assert!(
+            message.contains("--allow-dirty"),
+            "error names the override: {message}"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The guard must stay quiet for a clean work tree and for a flake dir
+    /// that is no git repo at all (a plain directory, or a remote flake ref).
+    #[tokio::test]
+    async fn switch_guard_passes_clean_trees_and_non_repos() {
+        let clean = scratch_git_repo("nwm-dirty-guard-clean");
+        ensure_clean_flake_dir(clean.to_str().expect("utf-8 path"))
+            .await
+            .expect("a clean tree passes");
+        std::fs::remove_dir_all(&clean).ok();
+
+        let plain =
+            std::env::temp_dir().join(format!("nwm-dirty-guard-plain-{}", std::process::id()));
+        std::fs::create_dir_all(&plain).expect("create plain dir");
+        ensure_clean_flake_dir(plain.to_str().expect("utf-8 path"))
+            .await
+            .expect("a non-repo passes");
+        std::fs::remove_dir_all(&plain).ok();
+    }
+
+    /// `--allow-dirty` is a switch-only override: `switch` parses it, `build`
+    /// rejects it (a build is never guarded, so the flag would be a lie there).
+    #[test]
+    fn allow_dirty_parses_on_switch_only() {
+        let args = Args::try_parse_from(["nwm", "home", "switch", "--allow-dirty"])
+            .expect("switch takes --allow-dirty");
+        let NwmCommand::Home(spec) = args.command else {
+            panic!("expected the home subcommand");
+        };
+        assert!(matches!(
+            spec.action,
+            SwitchAction::Switch {
+                allow_dirty: true,
+                ..
+            }
+        ));
+        assert!(
+            Args::try_parse_from(["nwm", "os", "build", "--allow-dirty"]).is_err(),
+            "build takes no --allow-dirty"
+        );
     }
 
     /// `/api/state` must be a wired route that serializes the live snapshot to

--- a/packages/site/src/lib/updates/nwm-dirty-flake-guard.svx
+++ b/packages/site/src/lib/updates/nwm-dirty-flake-guard.svx
@@ -1,0 +1,25 @@
+---
+id: nwm-dirty-flake-guard
+postedAt: "2026-07-22"
+title: nwm home|os switch refuses a dirty flake tree by default
+links:
+  - label: "index#4052"
+    href: https://github.com/indexable-inc/index/issues/4052
+tags:
+  - nix
+  - cli
+---
+
+`nwm home switch` and `nwm os switch` used to build and activate whatever
+was sitting in the flake working tree. Nix copies dirty tracked files into
+the eval, so a switch from a dirty repo deployed uncommitted WIP with no
+record of what actually ran.
+
+Both switch subcommands now check the flake directory before anything
+builds: if it is a git repo and `git status --porcelain` prints anything at
+all (untracked files included), the switch aborts with the flake dir and
+the status listing on stderr. Pass `--allow-dirty` to switch anyway. `home
+build` / `os build`, `nwm flake update`, and the plain `nix` passthrough
+are unchanged, and a flake dir that is not a git repo is not guarded. This
+mirrors the guard andrewgazelka/nix#148 added to that repo's
+`scripts/switch.sh`.


### PR DESCRIPTION
Closes #4052.

`nwm home switch` / `nwm os switch` built and activated whatever sat in the flake working tree. Nix copies dirty tracked files into the eval, so a switch from a dirty repo deployed uncommitted WIP with no record of what actually ran. Mirrors the guard andrewgazelka/nix#148 added to that repo's `scripts/switch.sh`.

## What changed

- The switch subcommands now run a dirty-tree check during job planning, before the flake-update, build, and activation phases (and before the web UI starts): if the flake dir is a git repo and `git status --porcelain` prints anything at all (untracked files included), the switch aborts with the flake dir plus the status listing on stderr and a nonzero exit.
- `--allow-dirty` on `home switch` / `os switch` is the explicit override. It is switch-only: `home build` / `os build` reject the flag because a build is never guarded, and `flake update` plus the external `nix` passthrough are untouched.
- A flake dir that is not a git work tree (a plain directory or a remote flake ref) is not guarded; a failure to even spawn git is a hard error, not a silent pass.
- `lib/rust/workspace.nix` adds git to the `nix-web-monitor` test sandbox for the new guard tests, and a site update page documents the operator-facing change.

## Verification

- `cargo nextest run -p nix-web-monitor`: 47/47 pass, including three new tests (dirty repo trips with the dir + status + override in the message; clean repos and non-repos pass; `--allow-dirty` parses on switch only).
- `nix run .#lint`: 13/13 green.
- Built binary against a scratch flake dir with an untracked `wip.nix`:

  ```
  $ nix-web-monitor --site-dir <site> home switch /tmp/.../flake; echo $?
  Error: planning job

  Caused by:
      flake dir `/tmp/andrewgazelka/nwm-guard-verify/flake` has uncommitted changes, and a switch would silently deploy them (Nix copies the dirty tree into the eval); commit or stash first, or pass --allow-dirty to switch anyway:
      ?? wip.nix
  1
  ```

  The same invocation with `--allow-dirty`, the same dir via `home build`, and the dir after committing all proceed past the guard into the normal nix build phase.

(sent by an AI agent via Claude Code, Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse `nwm home|os switch` from a dirty flake git tree
> - Adds a pre-build guard in `build_switch_job` that runs `git status --porcelain` on the flake directory and aborts with a descriptive error if the work tree is dirty.
> - Non-git directories and remote refs bypass the guard silently; only local dirty repos are blocked.
> - A new `--allow-dirty` flag on the `switch` subcommand skips the check; `build` subcommands reject this flag.
> - Behavioral Change: switch operations now fail by default on dirty flake trees, requiring `--allow-dirty` to proceed as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6569aa2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->