### PR TITLE
mcp-ex: make the issue-filed channel feed opt-in (#4054)

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -213,10 +213,11 @@
     claimBeforeDispatch = {
       topics = ["workflow"];
       text = ''
-        A filed-issue notification reaches every session. Before dispatching
-        a fixer, check the issue for a claim (assignee or claim comment);
-        if none, post a claim comment naming your session, then dispatch.
-        An issue already claimed gets watched, not re-dispatched.
+        Before dispatching a fixer for an issue, check it for a claim
+        (assignee or claim comment); if none, post a claim comment naming
+        your session, then dispatch. An issue already claimed gets watched,
+        not re-dispatched. The kernel's issue-filed feed is off by default
+        (opt-in via IX_MCP_ISSUE_WATCH_OWNERS).
       '';
       reason = ''
         Every listening session dispatched its own fixer: ix#8156 got two

--- a/packages/mcp-ex/lib/ix_mcp/application.ex
+++ b/packages/mcp-ex/lib/ix_mcp/application.ex
@@ -15,7 +15,7 @@ defmodule IxMcp.Application do
       ├── IxMcp.Jobs.Supervisor (DynamicSupervisor)  one child per cell/job
       │   └── IxMcp.Jobs.Job*   runs one evaluation in a monitored process
       ├── IxMcp.PrWatch.Supervisor (Task.Supervisor)  one task per PR watch
-      ├── IxMcp.IssueWatch      (only when IX_MCP_STDIO=1) new-issue channel feed
+      ├── IxMcp.IssueWatch      (stdio + IX_MCP_ISSUE_WATCH_OWNERS set) new-issue channel feed
       ├── IxMcp.SessionWatch    (only when IX_MCP_STDIO=1) heartbeat + message/request-feed delivery
       ├── IxMcp.Agents.Harness     (AgentHarness) depth-1 subagent processes (#3700)
       ├── IxMcp.Agents.Events      subagent ledger: events, finals, graph, notifications

--- a/packages/mcp-ex/lib/ix_mcp/issue_watch.ex
+++ b/packages/mcp-ex/lib/ix_mcp/issue_watch.ex
@@ -1,14 +1,16 @@
 defmodule IxMcp.IssueWatch do
   @moduledoc """
-  Always-on feed of newly filed GitHub issues, announced on the channel the
+  Opt-in feed of newly filed GitHub issues, announced on the channel the
   way job finishes are. Background agents (retros, auto-fix dispatches) file
   issues from sessions nobody watches, so without a push they sit unseen
   until someone happens to run `gh issue list` (#3877). One loop per kernel
   instance polls `gh search issues` for issues created since the last sweep
   and pushes each new one as a `source="issues"` channel notification.
 
-  Watched owners come from `IX_MCP_ISSUE_WATCH_OWNERS` (comma-separated,
-  default `indexable-inc`); an empty value disables the feed. The loop
+  Watched owners come from `IX_MCP_ISSUE_WATCH_OWNERS` (comma-separated);
+  unset or empty disables the feed. Off by default: broadcasting every new
+  issue to every session made each listener dispatch its own fixer, two
+  full parallel implementations per issue (#4002, #4054). The loop
   starts only alongside the stdio transport (`IxMcp.Application`), so
   `mix test` and IEx sessions never poll GitHub.
 
@@ -26,7 +28,6 @@ defmodule IxMcp.IssueWatch do
 
   require Logger
 
-  @default_owners ["indexable-inc"]
   @interval_ms 60_000
   # One page bounds a sweep; more issues than this filed inside one interval
   # is a storm, and the next sweep's >= window picks up the remainder anyway.
@@ -138,10 +139,9 @@ defmodule IxMcp.IssueWatch do
   end
 
   defp env_owners do
-    case System.get_env("IX_MCP_ISSUE_WATCH_OWNERS") do
-      nil -> @default_owners
-      value -> value |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
-    end
+    System.get_env("IX_MCP_ISSUE_WATCH_OWNERS", "")
+    |> String.split(",", trim: true)
+    |> Enum.map(&String.trim/1)
   end
 
   defp default_gh do

--- a/packages/mcp-ex/test/ix_mcp/issue_watch_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/issue_watch_test.exs
@@ -10,6 +10,11 @@ defmodule IxMcp.IssueWatchTest do
     assert :ignore = IssueWatch.start_link(owners: [], name: nil)
   end
 
+  test "unset env keeps the feed off by default" do
+    System.delete_env("IX_MCP_ISSUE_WATCH_OWNERS")
+    assert :ignore = IssueWatch.start_link(name: nil)
+  end
+
   test "announces a newly filed issue once", %{tmp_dir: dir} do
     created = DateTime.utc_now() |> DateTime.add(60) |> DateTime.to_iso8601()
 


### PR DESCRIPTION
Closes #4054.

The IssueWatch feed announced every new GitHub issue to every session by default. index#4002 documents the cost: each listening session dispatched its own fixer, so ix#8156 got two full parallel implementations and ix#8155 two live branches.

- `IX_MCP_ISSUE_WATCH_OWNERS` now defaults to empty: the feed is off unless explicitly enabled.
- `env_owners` collapses to one split over a defaulted env read.
- moduledoc, supervision-tree comment, and the `claimBeforeDispatch` rule drop the every-session premise (the claim protocol itself stays).
- new test: unset env keeps the feed off.

Local: mcp-ex `mix test` 184/184, `nix run .#lint` 13/13.

🤖 Generated with Claude Code (Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `IxMcp.IssueWatch` issue-filed channel feed opt-in via `IX_MCP_ISSUE_WATCH_OWNERS`
> Previously, `IxMcp.IssueWatch` defaulted to watching the `indexable-inc` owner when `IX_MCP_ISSUE_WATCH_OWNERS` was unset. Now, an unset or empty `IX_MCP_ISSUE_WATCH_OWNERS` causes `env_owners` to return `[]`, which disables the feed entirely. The feed must be explicitly enabled by setting the env var to a list of owners.
>
> - Behavioral Change: the issue-filed feed is now off by default; existing deployments that relied on the implicit `indexable-inc` default must set `IX_MCP_ISSUE_WATCH_OWNERS=indexable-inc` to restore previous behavior.
> - A new test in [`issue_watch_test.exs`](https://github.com/indexable-inc/index/pull/4055/files#diff-bfc0419e8dec707615437954cd7d429b9a7064b963fb5fff7d4ee0c9b1152d3d) asserts that `start_link` returns `:ignore` when the env var is unset.
> - Agent prompt rules in [`rules.nix`](https://github.com/indexable-inc/index/pull/4055/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) are updated to document the opt-in behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0741262.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->