### PR TITLE
cli: document `ix update` for script-installed binaries

### DIFF
--- a/doc/ix/cli.md
+++ b/doc/ix/cli.md
@@ -33,6 +33,10 @@ As a flake input:
 
 Supported platforms: `aarch64-darwin` and `x86_64-linux`.
 
+A binary installed by the script updates itself in place with `ix update`. A
+Nix-managed binary lives in the read-only store and is refused: update the
+`ix-cli` flake input or profile instead.
+
 ## Mental model
 
 - **You own VMs.** A VM is a boot image wrapped in an ix boundary: networking,
@@ -84,6 +88,7 @@ actions show as `verb <action>`.
 | Secrets | `secret <set\|check\|ls\|rm>` | Store write-only secrets; `set` reads the value from a prompt/stdin/file, never the command line. |
 | Account | `login` | Sign in through the ix website; also switches profiles. |
 | | `billing <status\|top-up\|usage>` | View balance, add funds, inspect usage. |
+| | `update` | Replace this binary with the latest published release (script installs only; Nix installs update through the flake). |
 | Federated | `resources <ls\|get\|act\|attach>` | Drive remote federated TUI resources (agent terminals) over QUIC. |
 
 Hidden verbs exist for debugging (`doctor`, `reload`, `sysrq`, `trace`, `config`,


### PR DESCRIPTION
Companion to indexable-inc/ix#8256, which adds the verb.

- Install section: script-installed binaries update in place with `ix update`; Nix-managed binaries update through the ix-cli flake.
- Verbs table: one row under Account.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document `ix update` command for script-installed binaries in CLI reference
> Adds documentation to [doc/ix/cli.md](https://github.com/indexable-inc/index/pull/4056/files#diff-17f8b8e99082227405e01c4df6a4a35ff8bb772bd1c38d5405bd167ceb437ec6) describing the `ix update` command, which replaces the binary in place with the latest published release. Clarifies that this command applies only to script-installed binaries; Nix-managed installs are read-only and must be updated via the flake input or profile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68ddf74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->