### PR TITLE
fix ix apply builder evaluation and progress

### DIFF
--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -46,20 +46,28 @@ in {
     # system closure from source, which then dies on the guest's no-namespace
     # sandbox and fails `ix apply`. Both fields come from the one cache-identity
     # source of truth (lib/cache.nix), exposed here as `ix.cache`.
-    nix.settings = {
-      substituters = lib.mkBefore [ix.cache.url];
-      trusted-public-keys = lib.mkAfter [ix.cache.publicKey];
+    nix = {
+      # `ix init` emits fleets whose evaluator is `ix2nix-wasm`, so every
+      # managed builder and workload VM must provide IX's patched Nix. Leaving
+      # this at nixpkgs' default makes `ix apply` accept the generated project,
+      # create a builder, and then fail late with `attribute 'wasm' missing`.
+      package = ix.packages.nix-ix;
 
-      # The guest's writable layer (`/`, incl. `/nix/var/nix/db`) is a virtiofs
-      # FUSE mount with no DAX cache capability, so a memory-mapped file is served
-      # through FUSE writeback rather than a coherent shared window. SQLite's WAL
-      # mode needs exactly that: an mmap'd `*-shm` for cross-connection shared
-      # state plus strict WAL/main fsync ordering on checkpoint. Neither holds on
-      # this layer, so the nix DB's WAL silently corrupts and `nix` degrades to
-      # `database disk image is malformed`. Rollback-journal mode drops the `-shm`
-      # mmap dependency and keeps the DB intact. Mitigation for the VCFS layer bug
-      # tracked in indexable-inc/ix#6259; drop this once that layer honors mmap+fsync.
-      use-sqlite-wal = false;
+      settings = {
+        substituters = lib.mkBefore [ix.cache.url];
+        trusted-public-keys = lib.mkAfter [ix.cache.publicKey];
+
+        # The guest's writable layer (`/`, incl. `/nix/var/nix/db`) is a virtiofs
+        # FUSE mount with no DAX cache capability, so a memory-mapped file is served
+        # through FUSE writeback rather than a coherent shared window. SQLite's WAL
+        # mode needs exactly that: an mmap'd `*-shm` for cross-connection shared
+        # state plus strict WAL/main fsync ordering on checkpoint. Neither holds on
+        # this layer, so the nix DB's WAL silently corrupts and `nix` degrades to
+        # `database disk image is malformed`. Rollback-journal mode drops the `-shm`
+        # mmap dependency and keeps the DB intact. Mitigation for the VCFS layer bug
+        # tracked in indexable-inc/ix#6259; drop this once that layer honors mmap+fsync.
+        use-sqlite-wal = false;
+      };
     };
 
     # Install terminfo for every common terminal emulator so ncurses tools

--- a/packages/nix/nix-web-monitor/parser/src/lib.rs
+++ b/packages/nix/nix-web-monitor/parser/src/lib.rs
@@ -51,6 +51,10 @@ mod result_code {
 }
 
 mod activity_code {
+    /// Aggregate progress for derivations being built. Nix also emits the same
+    /// `resProgress` result for transfers and copied paths, whose counters are
+    /// bytes or paths rather than derivations.
+    pub const BUILDS: u64 = 104;
     pub const BUILD: u64 = 105;
     /// Nix emits this right before building a content-addressed derivation: it
     /// "resolves" the derivation (rewrites each input reference to the input's
@@ -885,13 +889,19 @@ impl MonitorState {
                 }
             }
             ActivityResult::Progress { progress } => {
-                self.progress = Some(*progress);
+                let is_build_progress = self
+                    .activities
+                    .get(&action.id)
+                    .is_some_and(|activity| activity.activity_type.code == activity_code::BUILDS);
                 if let Some(activity) = self.activities.get_mut(&action.id) {
                     activity.progress = Some(*progress);
                 }
-                self.emit(Delta::ProgressSet {
-                    progress: *progress,
-                });
+                if is_build_progress {
+                    self.progress = Some(*progress);
+                    self.emit(Delta::ProgressSet {
+                        progress: *progress,
+                    });
+                }
                 self.emit_activity(action.id);
             }
             ActivityResult::SetExpected {
@@ -1685,6 +1695,56 @@ mod tests {
         assert_eq!(snapshot.builds[0].phase.as_deref(), Some("buildPhase"));
         assert_eq!(snapshot.builds[0].log_count, 1);
         assert_eq!(snapshot.logs[0].text, "compiling");
+    }
+
+    #[test]
+    fn transfer_progress_does_not_replace_aggregate_build_progress() {
+        let mut state = MonitorState::default();
+        state.apply_line(r#"@nix {"action":"start","fields":["https://cache.example/nar"],"id":7,"level":3,"text":"downloading","type":101}"#);
+        state.apply_line(
+            r#"@nix {"action":"result","fields":[51987686,51987686,0,0],"id":7,"type":105}"#,
+        );
+
+        let snapshot = state.snapshot();
+        assert_eq!(
+            snapshot.progress, None,
+            "download bytes are not derivations"
+        );
+        assert_eq!(
+            snapshot.activities[0].progress,
+            Some(ActivityProgress {
+                done: 51_987_686,
+                expected: 51_987_686,
+                running: 0,
+                failed: 0,
+            }),
+            "the owning transfer still keeps its own progress"
+        );
+        assert!(
+            state
+                .drain_deltas()
+                .iter()
+                .all(|delta| !matches!(delta, Delta::ProgressSet { .. })),
+            "transfer progress must not become the graph's drv counter"
+        );
+    }
+
+    #[test]
+    fn builds_activity_sets_aggregate_build_progress() {
+        let mut state = MonitorState::default();
+        state.apply_line(r#"@nix {"action":"start","fields":[],"id":9,"level":3,"text":"building derivations","type":104}"#);
+        state.apply_line(r#"@nix {"action":"result","fields":[2,3,1,0],"id":9,"type":105}"#);
+
+        let expected = ActivityProgress {
+            done: 2,
+            expected: 3,
+            running: 1,
+            failed: 0,
+        };
+        assert_eq!(state.snapshot().progress, Some(expected));
+        assert!(state.drain_deltas().iter().any(
+            |delta| matches!(delta, Delta::ProgressSet { progress } if *progress == expected)
+        ));
     }
 
     #[test]

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3513,6 +3513,10 @@
         message = "base profile should route Nix through cache.ix.dev before fallback substituters";
       }
       {
+        assertion = base.config.nix.package == repoPackages.nix-ix;
+        message = "base images must use IX's wasm-enabled Nix so ix apply can evaluate the default ix2nix-wasm scaffold";
+      }
+      {
         assertion = let
           pin = base.config.nix.registry.nixpkgs.to;
         in


### PR DESCRIPTION
## What changed

- make managed `ix/base` images use `ix.packages.nix-ix`
- keep transfer/path progress local to its Nix activity and expose only the aggregate builds activity as derivation progress
- add regression coverage for the base-image Nix package and progress event scoping

## Why

`ix init` emits projects evaluated through `ix2nix-wasm`, but the managed base profile left `nix.package` at nixpkgs' stock Nix. A newly created builder therefore accepted an apply, spent minutes materializing and evaluating it, then failed with `attribute 'wasm' missing`.

Nix also reuses `resProgress` for transfers, copied paths, and builds. Treating every instance as global build progress caused byte counts such as `51987686/51987686` to be displayed as derivation counts.

## Impact

Rebuilt managed images satisfy the evaluator contract of the default scaffold, and build progress reports derivations instead of transfer bytes.

## Validation

- `cargo test -p nix-web-monitor-parser --target aarch64-apple-darwin`: 66 passed
- `git diff --check`

A full Linux base-image evaluation is not available from this aarch64-darwin checkout because the repository's evaluation graph realizes x86_64-linux-only derivations.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix aggregate build progress to exclude transfer and copy activity in nix-web-monitor
> - In [`MonitorState.apply_line`](https://github.com/indexable-inc/index/pull/4059/files#diff-88f540c220f609c6ee81a458c740f318e2505d1bfb3bddc5ac4aef399dedcc6a), global `snapshot.progress` and `Delta::ProgressSet` are now only emitted when the owning activity type is `BUILDS` (code 104); transfer and copy activities previously overwrote the aggregate build progress.
> - Adds the `ix.packages.nix-ix` (wasm-enabled, patched Nix) as `nix.package` in the [base profile](https://github.com/indexable-inc/index/pull/4059/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e), with a test asserting base images use this package.
> - Behavioral Change: transfer and copy progress no longer update `snapshot.progress` or emit `ProgressSet` deltas.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6eccd6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->