### PR TITLE
rules: worktrees live at /tmp/worktree/<org>/<repo>/<name>

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -91,22 +91,25 @@
       topics = ["workflow"];
       text = ''
         Never edit in a primary checkout: work on a dedicated `git worktree`
-        branch and verify root and branch before committing. Right after
-        `git worktree add`, run `git submodule update --init --recursive`:
-        a new worktree leaves submodules uninitialized even when the build
-        needs them. An isolation worktree belongs to the session's repo,
-        not necessarily your task's: verify its origin, and when the task
-        targets another repo, add your own worktree of the target
-        checkout. Unmerged branches are unfinished for reasons you may
-        not see; check for open PRs touching a file before nontrivial
-        edits.
+        branch at `/tmp/worktree/<org>/<repo>/<name>` (org and repo from
+        the checkout's origin URL) and verify root and branch before
+        committing. Right after `git worktree add`, run
+        `git submodule update --init --recursive`: a new worktree leaves
+        submodules uninitialized even when the build needs them. An
+        isolation worktree belongs to the session's repo, not necessarily
+        your task's: verify its origin, and when the task targets another
+        repo, add your own worktree of the target checkout. Unmerged
+        branches are unfinished for reasons you may not see; check for
+        open PRs touching a file before nontrivial edits.
       '';
       reason = ''
         Primary-checkout edits collided with concurrent work; parallel
         sessions raced duplicate PRs (#1911, #1914, #1943). Absorbs
         coordinateBranches (index#3594). Fixers briefed on ix tasks
         received index worktrees and hand-rolled replacements, one
-        clobbering a sibling's (index#4008).
+        clobbering a sibling's (index#4008). Ad-hoc worktree locations
+        made parallel sessions and cleanup unpredictable; standardized
+        path requested in index#4062.
       '';
     };
   }


### PR DESCRIPTION
Closes #4062. Encodes the standard worktree location `/tmp/worktree/<org>/<repo>/<name>` (org and repo from the origin URL) in the worktree rule, and reflows the paragraph.

Verified: `nix eval --raw --impure` render of systemPrompt shows the new text; `nix run .#lint` green (14/14 checks).

(sent by an AI agent via Claude Code, Claude Opus 4.6)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Standardize worktree paths to `/tmp/worktree/<org>/<repo>/<name>` in agent rules
> Updates the worktree rule in [rules.nix](https://github.com/indexable-inc/index/pull/4063/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) to instruct the agent to create worktrees at a consistent path derived from the origin URL. Previously, ad-hoc worktree locations caused unpredictable behavior; this standardization ensures a predictable directory structure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d12922.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->