### PR TITLE
codex: force generation-owned MCP commands

### DIFF
--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -78,8 +78,8 @@
     # warning; a user who sets this key keeps their value.
     suppress_unstable_features_warning = true;
   },
-  # MCP servers rendered as soft Codex defaults. A user's own
-  # `[mcp_servers.<name>]` config wins per-key through config-launch.
+  # MCP servers. Local executable paths are forced because the generation
+  # owns them. Remote servers stay soft so user config can override them.
   mcpServers ?
     (import (ix.paths.packagesRoot + "/agent/common.nix") {
       inherit lib ix;
@@ -150,12 +150,16 @@
       features =
         (forcedSettings.features or {}) // (sharedPermissions.codex.forcedSettings.features or {});
     };
+  localMcpServers = lib.filterAttrs (_: server: server ? command) mcpServers;
+  remoteMcpServers = lib.filterAttrs (_: server: !(server ? command)) mcpServers;
   specValue = {
     target = lib.getExe codexWithNotifications;
     config_dir_env = "CODEX_HOME";
     config_dir_default = "~/.codex";
     config_file = "config.toml";
-    forced = entriesOf (ix.attrs.flattenToDotted effectiveForcedSettings);
+    forced =
+      entriesOf (ix.attrs.flattenToDotted effectiveForcedSettings)
+      ++ ix.mcp.toCodexEntries localMcpServers;
     soft =
       entriesOf (
         ix.attrs.flattenToDotted (
@@ -165,7 +169,7 @@
           // settings
         )
       )
-      ++ ix.mcp.toCodexEntries mcpServers;
+      ++ ix.mcp.toCodexEntries remoteMcpServers;
   };
   spec = (formats.json {}).generate "codex-launch-spec.json" specValue;
 

--- a/packages/agent/home-manager/codex.nix
+++ b/packages/agent/home-manager/codex.nix
@@ -176,8 +176,9 @@ in {
       type = lib.types.nullOr jsonFormat.type;
       default = null;
       description = ''
-        MCP server declarations rendered as soft Codex config defaults. Null
-        keeps the package default; `{ }` intentionally bakes no MCP defaults.
+        MCP server declarations rendered into the Codex wrapper. Local
+        command servers are forced. Remote URL servers are soft defaults. Null
+        keeps the package default; `{ }` intentionally bakes no MCP servers.
       '';
     };
 

--- a/packages/site/src/lib/updates/codex-mcp-wrapper-ownership.svx
+++ b/packages/site/src/lib/updates/codex-mcp-wrapper-ownership.svx
@@ -1,0 +1,23 @@
+---
+id: codex-mcp-wrapper-ownership
+postedAt: 2026-07-22T00:00:00-07:00
+title: "Codex now follows the current MCP generation"
+tags: [codex, mcp-ex, home-manager]
+links:
+  - label: issue 4069
+    href: https://github.com/indexable-inc/index/issues/4069
+  - label: Codex wrapper
+    href: https://github.com/indexable-inc/index/blob/main/packages/agent/codex/default.nix
+---
+
+Fixes #4069. Codex could keep launching the old Python `ix-mcp` after the
+workstation moved to the Elixir `mcp-ex` server. The command was copied into
+`~/.codex/config.toml`; runtime edits made that file conflict with its next
+declared base, so Home Manager left every incoming change unapplied.
+
+MCP server paths now ride Codex's forced wrapper layer. `config.toml` is fully
+app-owned, so project trust and UI settings need no Nix merge. Each wrapper
+generation supplies its matching MCP executable even when the app file still
+contains an older entry.
+
+(sent by an AI agent via Codex)

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4485,6 +4485,17 @@
         message = "Codex wrapper should render built-in tool disables into forced launch config";
       }
       {
+        assertion = let
+          forcedKeys = map (entry: entry.key) repoPackages.codex.passthru.specValue.forced;
+          softKeys = map (entry: entry.key) repoPackages.codex.passthru.specValue.soft;
+        in
+          builtins.elem "mcp_servers.index.command" forcedKeys
+          && !builtins.elem "mcp_servers.index.command" softKeys
+          && !builtins.elem "mcp_servers.exa.url" forcedKeys
+          && builtins.elem "mcp_servers.exa.url" softKeys;
+        message = "Codex wrapper should force local MCP commands and keep remote MCP URLs soft";
+      }
+      {
         # Bypass-permissions is enforced through Claude's managed-settings layer
         # (/etc/claude-code/managed-settings.json): read-only, highest precedence,
         # leaving ~/.claude/settings.json app-owned. Pin both keys so a refactor

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -298,10 +298,8 @@
     })
   agentMcpServers;
 
-  # Native Codex settings, seeded into ~/.codex/config.toml as a writable
-  # mutable file (see `mutable.files` below): Codex appends per-project trust
-  # decisions and runtime toggles to config.toml, which a read-only store
-  # symlink would reject.
+  # Native Codex soft defaults. The wrapper supplies them only when the
+  # app-owned config.toml does not set the same key.
   codexSettings = {
     check_for_update_on_startup = false;
     bypass_hook_trust = true;
@@ -314,11 +312,9 @@
     commit_attribution = "";
     # The features block below opts into under-development features
     # (multi_agent_v2 et al.); without this Codex warns about them on every
-    # startup. Set here (not just the wrapper soft default) so the seeded
-    # config.toml stays quiet even under a stock codex binary.
+    # startup.
     suppress_unstable_features_warning = true;
     agents.max_depth = 3;
-    mcp_servers = codexMcpServers;
     features = {
       steer = true;
       multi_agent = true;
@@ -351,14 +347,13 @@
   # attrset-of-skills vs directory mode, and a flake input is an attrset.
   skillsSrc = indexSkillsSrc;
 
-  # The wrapper remains only for behavior that has no config-file equivalent:
-  # the shared hooks and system prompt plus package selection. Native Codex
-  # settings are declared on programs.codex below and rendered to config.toml.
+  # The wrapper carries the shared hooks, system prompt, soft settings, and
+  # forced MCP transport. config.toml stays entirely app-owned.
   codexBase = indexPkgs.codex;
   codex =
     (codexBase.override {
-      mcpServers = {};
-      settings = {};
+      mcpServers = codexMcpServers;
+      settings = codexSettings;
       forcedSettings = {};
       # On the override, not programs.codex.systemPrompt.omitRules, for the
       # same reason as claudeCode above: the module folds that option only
@@ -1205,13 +1200,10 @@ in {
     # bakes one `--mcp-config=` flag from `agentMcpServers` above.
   };
 
-  # Codex, via Home Manager. Static policy and defaults live in config.toml,
-  # where Codex and its desktop app can inspect the same source of truth. The
-  # wrapper carries only behavior without a native config-file representation.
-  # `settings` is deliberately NOT set here: the module would render
-  # config.toml as a read-only store symlink, and Codex writes to it at
-  # runtime (project trust, model switches). The same values are seeded
-  # writable from `codexSettings` via `mutable.files` below.
+  # Codex, via Home Manager. The wrapper supplies Nix defaults without
+  # claiming config.toml, which Codex owns and edits at runtime. MCP executable
+  # paths are forced by the wrapper so a stale runtime entry cannot pin an old
+  # server generation.
   programs.codex = {
     enable = true;
     package = codex;
@@ -1225,22 +1217,6 @@ in {
     # `finalPackage.hooksJson`, and the two sources conflict as soon as any
     # hook-affecting option diverges from the wrapper defaults.
     installHooks = false;
-  };
-
-  # Codex edits its own config at runtime, so the file cannot be a read-only
-  # store render. Durable: in-app changes survive activation and login; when
-  # the declared base moves under local edits, the file queues in
-  # `index-delta status --json` (both diffs as addressed ops) for an explicit
-  # discard / adopt / absorb-into-Nix via `index-delta apply-ops`.
-  # ~/.claude/settings.json moved off this mechanism (#3180): its declared
-  # base carries store paths that move on every index bump (hooks, statusline),
-  # so durable drift queued a conflict per bump; the claude-code module's
-  # mutable-json 3-way merge updates those keys mechanically while preserving
-  # Claude's runtime writes.
-  mutable.files.".codex/config.toml" = {
-    source = tomlFormat.generate "andrewgazelka-codex-config.toml" codexSettings;
-    persistence = "durable";
-    declaredAt = "users/andrewgazelka/profiles/workstation.nix";
   };
 
   # ~/.claude.json is entirely runtime-owned and intentionally unmanaged.


### PR DESCRIPTION
## What changed

Codex now keeps `~/.codex/config.toml` app-owned. The wrapper forces local MCP command servers, so a stale writable entry cannot pin an older Nix generation. Remote MCP URLs remain soft and user-overridable.

The workstation now supplies `ix-mcp-ex` through that wrapper layer and no longer manages the Codex file with `index-delta`.

## Evidence

- `nix run .#lint`: 13 of 13 checks passed
- `checks.aarch64-darwin.personal-light-profile`: passed
- wrapper eval: `mcp_servers.index.command` is forced, while `mcp_servers.exa.url` is soft
- `checks.x86_64-linux.eval`: running with the repository Nix fork

Fixes #4069

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force generation-owned MCP command servers in Codex wrapper spec
> - Splits `mcpServers` into local (have a `command` field) and remote (URL-only) servers in [default.nix](https://github.com/indexable-inc/index/pull/4070/files#diff-f86191c841f2a39e7a59565f14860841e742d261b42ff0b9f4a5f0d95e7de9d5), emitting local servers as forced entries and remote servers as soft defaults.
> - Updates the workstation profile to pass MCP servers via the wrapper instead of seeding a mutable `config.toml`, removing the `mutable.files` block entirely.
> - Adds a test assertion verifying that local MCP commands appear in forced keys and remote MCP URLs appear only in soft keys.
> - Behavioral Change: local MCP executable paths are now pinned by the wrapper and cannot be overridden by user config; `config.toml` is no longer seeded by Home Manager in the workstation profile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d1eb25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->