### PR TITLE
mcp-ex Memory: about edges into the entity graph

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/memory.ex
+++ b/packages/mcp-ex/lib/ix_mcp/memory.ex
@@ -20,6 +20,15 @@ defmodule IxMcp.Memory do
   facts as typed edges, so corrections and clusters are walkable via
   `graph/1` instead of discoverable only by regex. History is never
   edited: newer facts win, `retract/1` kills a wrong one.
+
+  Memories also link into the store's entity graph: `about` (a plain
+  attribute, not `mem/`-prefixed, so the prelude's `edge/3` and the
+  recall projection walk it) points a memory at the concrete things it
+  describes. Ids are minted, never guessed: `gh:<org>/<repo>#<n>` (issue
+  or PR, unified), `repo:<org>/<name>`, `host:<name>`, `tool:<name>`,
+  `person:<login>`. The full convention, including the short-cite
+  expansion table (ix -> indexable-inc/ix, ...), lives in the store
+  itself as `mem:memory-ontology`.
   """
 
   alias IxMcp.Memory.Semantic
@@ -36,6 +45,12 @@ defmodule IxMcp.Memory do
   as entity-valued facts, which weave treats as typed edges (`graph/1`
   walks them). `supersedes:` makes a correction explicit instead of
   relying on newer-wins; `relates:` links peers.
+
+  `about:` takes minted thing ids (`about: ["gh:indexable-inc/ix#8088",
+  "host:hydra"]`) and links the memory into the entity graph, where the
+  recall projection pulls co-cited memories through shared specific
+  things. One to four specific ids beat a pile of generic ones; the id
+  scheme is in the moduledoc and `mem:memory-ontology`.
   """
   @spec remember(String.t(), String.t(), keyword()) :: :ok
   def remember(slug, desc, opts \\ []) do
@@ -50,6 +65,12 @@ defmodule IxMcp.Memory do
     for key <- [:supersedes, :relates],
         value <- List.wrap(Keyword.get(opts, key)) do
       fact(entity, "mem/#{key}", mem_entity(to_string(value)))
+    end
+
+    # Plain attribute on purpose: the store prelude's edge/3 and the
+    # recall projection walk `about`, not `mem/about`.
+    for value <- List.wrap(Keyword.get(opts, :about)) do
+      fact(entity, "about", to_string(value))
     end
 
     case Keyword.get(opts, :body) do
@@ -154,8 +175,9 @@ defmodule IxMcp.Memory do
 
   @doc """
   The typed-edge neighborhood of `mem:<slug>`: every live entity-valued
-  fact (mem/supersedes, mem/relates, any future edge attribute) pointing
-  into or out of the entity, as `%{from, edge, to}` rows.
+  fact (mem/supersedes, mem/relates, about, any future edge attribute)
+  pointing into or out of the entity, as `%{from, edge, to}` rows, thing
+  ids (`gh:`, `repo:`, `host:`, `tool:`, `person:`, `project:`) included.
   """
   @spec graph(String.t()) :: [map()]
   def graph(slug) do
@@ -163,7 +185,7 @@ defmodule IxMcp.Memory do
 
     rows =
       query("""
-      edge(S, A, O) :- fact(S, A, O), regex(O, "^mem:").
+      edge(S, A, O) :- fact(S, A, O), regex(O, "^(?:mem|gh|repo|host|tool|person|project):").
       hit(S, A, O) :- edge(S, A, O), regex(S, "#{anchor}").
       hit(S, A, O) :- edge(S, A, O), regex(O, "#{anchor}").
       ?- hit(S, A, O).

--- a/packages/mcp-ex/test/ix_mcp/memory_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/memory_test.exs
@@ -87,6 +87,24 @@ defmodule IxMcp.MemoryTest do
                ]
       end
 
+      test "about links a memory to thing ids that graph walks" do
+        Memory.remember("outage", "ix new down in us-west-1",
+          about: ["gh:indexable-inc/ix#8088", "host:hydra"]
+        )
+
+        assert Enum.sort(Memory.graph("outage")) == [
+                 %{from: "mem:outage", edge: "about", to: "gh:indexable-inc/ix#8088"},
+                 %{from: "mem:outage", edge: "about", to: "host:hydra"}
+               ]
+
+        # Plain `about`, never `mem/about`: the store prelude's edge/3 and
+        # the recall projection walk the unprefixed attribute.
+        assert [%{"V" => _} | _] =
+                 Memory.query(~s{?- fact("mem:outage", "about", V).})
+
+        assert [] = Memory.query(~s{?- fact("mem:outage", "mem/about", V).})
+      end
+
       test "verify appends a receipt that recall surfaces" do
         Memory.remember("claim", "checkable claim")
         id = Memory.verify("claim", session: "sess-42")

--- a/packages/site/src/lib/updates/memory-entity-graph.svx
+++ b/packages/site/src/lib/updates/memory-entity-graph.svx
@@ -1,0 +1,27 @@
+---
+id: memory-entity-graph
+postedAt: 2026-07-22T17:45:00-07:00
+title: "Agent memory grows an entity graph: about edges, minted ids, graph-walking recall"
+tags: [memory, weave, mcp-ex]
+links:
+  - label: IxMcp.Memory
+    href: https://github.com/indexable-inc/index/blob/main/packages/mcp-ex/lib/ix_mcp/memory.ex
+  - label: "#4072"
+    href: https://github.com/indexable-inc/index/issues/4072
+---
+
+Memories were flat facts: a slug, a one-line hook, a prose body. Related
+knowledge was findable only by regex or embedding similarity. Now each
+memory links into an entity graph: `Memory.remember(..., about:
+["gh:indexable-inc/ix#8088", "host:hydra"])` writes typed edges to minted
+ids for issues and PRs (`gh:<org>/<repo>#<n>`), repos, hosts, tools, and
+people, and `Memory.graph/1` walks them.
+
+The store's recall projection (journal data, not engine code) traverses
+these edges two hops out, degree-gated so hubs like a whole repo don't
+drown the walk: recalling one memory about an issue now surfaces the
+sibling memories that cite the same issue, host, or tool. The 1,000
+existing memories were backfilled with 2,175 `about` edges; the id
+convention lives in the store itself as `mem:memory-ontology`, and the
+SessionStart digest teaches agents to write the granular form at the
+moment of learning.

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -126,7 +126,8 @@
       fi
       echo "## Memory"
       echo "Durable memory is a weave store at $store: append-only facts, Datalog-derived views."
-      echo "Save at the moment of learning: Memory.remember(\"slug\", \"one-line hook\", type: \"project\", topic: \"nix\", handle: \"cmd/path\", body: long_md) in the index kernel."
+    echo "Save at the moment of learning: Memory.remember(\"slug\", \"one-line hook\", type: \"project\", topic: \"nix\", handle: \"cmd/path\", body: long_md, about: [\"gh:indexable-inc/ix#8088\", \"host:hydra\"]) in the index kernel."
+    echo "Link every memory into the entity graph: 1-4 about: ids for the concrete things it describes -- gh:<org>/<repo>#<n> (issue or PR), repo:<org>/<name>, host:<name>, tool:<name>, person:<login>. Mint ids exactly (short cites expand: ix -> indexable-inc/ix; full table in mem:memory-ontology); a misspelled id fragments the graph silently. Recall walks these edges, so co-cited memories surface together; Memory.graph(\"slug\") shows a memory's neighborhood."
       echo "Recall: Memory.recall(\"regex\") (rich rows: id, time, type, topic, handle, body) or Memory.query(datalog). Recalled facts go stale; verify before use and record the re-check with Memory.verify(\"slug\") -- verified memories rank first below. Never edit history: newer facts win, Memory.retract(id) kills a wrong one."
       echo
       echo "### Hooks (freshest verification first, then recency)"


### PR DESCRIPTION
Closes #4072.

The weave memory store now carries an entity graph (config-repo backfill 2026-07-22: 2175 about edges, 830 gh nodes, degree-gated recall projection). This teaches the write path:

- `Memory.remember/3` gains `about:` -- entity-valued `about` facts (plain attribute, not mem/-prefixed, so prelude `edge/3` + recall projection walk them)
- `Memory.graph/1` surfaces thing edges (gh:/repo:/host:/tool:/person:/project:)
- SessionStart digest teaches the granular form: mint exact ids, 1-4 about edges per memory, convention in `mem:memory-ontology`

Local gates: mcp-ex memory suite 5/5 (new about round-trip test), mix format clean, workstation.nix parses. Full suite 185 tests, 1 pre-existing env failure (#4073, /tmp vs /private/tmp, fails on main too).

(sent by an AI agent via Claude Code, session weave-ontology)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `about` edges to `IxMcp.Memory` entity graph linking memories to thing ids
> - `Memory.remember/3` now accepts an `:about` option; each value is written as a plain `"about"` fact linking the memory entity to an external thing id (e.g. `gh:org/repo#123`, `host:hydra`).
> - `Memory.graph/1` broadens its Datalog edge rule to match object ids starting with `gh:`, `repo:`, `host:`, `tool:`, `person:`, or `project:` in addition to `mem:`, so `about` edges appear in graph traversals.
> - Module docs and the workstation profile guidance are updated to document minted id conventions and the `:about` option.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a49ac30.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->