### PR TITLE
mcp-ex: compare physical paths in CmdCwdTest pwd assertions

### DIFF
--- a/packages/mcp-ex/test/ix_mcp/cmd_cwd_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/cmd_cwd_test.exs
@@ -11,7 +11,12 @@ defmodule IxMcp.CmdCwdTest do
   # worktree. The fix removes the OS cwd from command spawning entirely:
   # pathless commands run in the boot-time launch directory, immutably.
   test "File.cd! cannot redirect pathless commands off the launch cwd (#3902)" do
-    assert {launch, 0} = Cmd.run("pwd")
+    # Every pwd here runs with -P: pwd defaults to -L and echoes the caller's
+    # $PWD spelling (/tmp/... in a checkout under macOS's /tmp ->
+    # /private/tmp symlink), while the launch cwd is captured
+    # symlink-resolved via File.cwd!(), so only physical paths compare
+    # byte-equal on both sides.
+    assert {launch, 0} = Cmd.run("pwd", ["-P"])
 
     elsewhere = Path.join(System.tmp_dir!(), "ix-cwd-test-15235")
     File.mkdir_p!(elsewhere)
@@ -23,11 +28,11 @@ defmodule IxMcp.CmdCwdTest do
     try do
       # Session A moved the OS cwd; session B's pathless commands must not
       # follow it -- run/3 and sh/2 both still answer with the launch dir.
-      assert {^launch, 0} = Cmd.run("pwd")
-      assert {^launch, 0} = Cmd.sh("pwd")
+      assert {^launch, 0} = Cmd.run("pwd", ["-P"])
+      assert {^launch, 0} = Cmd.sh("pwd -P")
 
       # An explicit cd: still selects exactly the directory the caller names.
-      assert {moved, 0} = Cmd.run("pwd", [], cd: elsewhere)
+      assert {moved, 0} = Cmd.run("pwd", ["-P"], cd: elsewhere)
       assert moved != launch
       assert Path.basename(String.trim(moved)) == Path.basename(elsewhere)
     after


### PR DESCRIPTION
`CmdCwdTest` pinned the launch cwd (symlink-resolved, `/private/tmp/...` on macOS) and asserted `pwd` output byte-equal, but `pwd` defaults to `-L` and echoes the caller's `$PWD` spelling — `/tmp/...` in any worktree under `/tmp` — so the test failed on origin/main in every /tmp-located checkout.

Fix at the source: run every `pwd` in the #3902 test with `-P` so both sides of the comparison are physical paths. No skip, no /tmp special-case; the test's intent (`File.cd!` in a cell must not redirect pathless commands off the launch cwd) is unchanged.

Verified: `env -u IX_MCP_STDIO mix test test/ix_mcp/cmd_cwd_test.exs` is green in the /tmp worktree both with and without an inherited `PWD=/tmp/...` (the previously failing mode); `mix format` clean.

Fixes #4073

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `pwd -P` in `CmdCwdTest` to compare physical paths in cwd assertions
> Updates [cmd_cwd_test.exs](https://github.com/indexable-inc/index/pull/4075/files#diff-0c69b326b37e42f288bd38f53403cbb2332a6c3e1afd32dc6e0b1062496e62c1) to pass `-P` to all `pwd` invocations so that symlink-resolved (physical) paths are compared instead of logical paths. Affects both `Cmd.run/2` and `Cmd.sh/1` call sites within the launch-cwd redirection test.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e5488b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->