### PR TITLE
codex: pass the neutral MCP registry to the wrapper

### DIFF
--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -119,25 +119,25 @@
   memoryDigest = ix.writeBashApplication pkgs {
     name = "claude-memory-digest";
     text = ''
-      store=${lib.escapeShellArg memoryStore}
-      if [ ! -d "$store" ]; then
-        echo "Memory store missing at $store; create it with: weave --store \"$store\" init"
-        exit 0
-      fi
-      echo "## Memory"
-      echo "Durable memory is a weave store at $store: append-only facts, Datalog-derived views."
-    echo "Save at the moment of learning: Memory.remember(\"slug\", \"one-line hook\", type: \"project\", topic: \"nix\", handle: \"cmd/path\", body: long_md, about: [\"gh:indexable-inc/ix#8088\", \"host:hydra\"]) in the index kernel."
-    echo "Link every memory into the entity graph: 1-4 about: ids for the concrete things it describes -- gh:<org>/<repo>#<n> (issue or PR), repo:<org>/<name>, host:<name>, tool:<name>, person:<login>. Mint ids exactly (short cites expand: ix -> indexable-inc/ix; full table in mem:memory-ontology); a misspelled id fragments the graph silently. Recall walks these edges, so co-cited memories surface together; Memory.graph(\"slug\") shows a memory's neighborhood."
-      echo "Recall: Memory.recall(\"regex\") (rich rows: id, time, type, topic, handle, body) or Memory.query(datalog). Recalled facts go stale; verify before use and record the re-check with Memory.verify(\"slug\") -- verified memories rank first below. Never edit history: newer facts win, Memory.retract(id) kills a wrong one."
-      echo
-      echo "### Hooks (freshest verification first, then recency)"
-      # Rank by the newest mem/verified-at seq per entity (0 when never
-      # verified), then by the desc fact's own seq: a re-checked memory
-      # outranks a merely recent one (index#3865).
-      ${lib.getExe cfg.packages.weave} --store "$store" query 'vseq(E, max(S)) :- fact_id(I, E, "mem/verified-at", V), fact_seq(I, S). rank(V, S, E, D) :- latest(E, "mem/desc", D), fact_id(I, E, "mem/desc", D), fact_seq(I, S), vseq(E, V). rank(0, S, E, D) :- latest(E, "mem/desc", D), fact_id(I, E, "mem/desc", D), fact_seq(I, S), not vseq(E, _). ?- rank(V, S, E, D) order V desc, S desc limit 150.'
-      echo
-      echo "### Counts by type"
-      ${lib.getExe cfg.packages.weave} --store "$store" query 'per_type(T, count(E)) :- latest(E, "mem/type", T). ?- per_type(T, N) order N desc.'
+        store=${lib.escapeShellArg memoryStore}
+        if [ ! -d "$store" ]; then
+          echo "Memory store missing at $store; create it with: weave --store \"$store\" init"
+          exit 0
+        fi
+        echo "## Memory"
+        echo "Durable memory is a weave store at $store: append-only facts, Datalog-derived views."
+      echo "Save at the moment of learning: Memory.remember(\"slug\", \"one-line hook\", type: \"project\", topic: \"nix\", handle: \"cmd/path\", body: long_md, about: [\"gh:indexable-inc/ix#8088\", \"host:hydra\"]) in the index kernel."
+      echo "Link every memory into the entity graph: 1-4 about: ids for the concrete things it describes -- gh:<org>/<repo>#<n> (issue or PR), repo:<org>/<name>, host:<name>, tool:<name>, person:<login>. Mint ids exactly (short cites expand: ix -> indexable-inc/ix; full table in mem:memory-ontology); a misspelled id fragments the graph silently. Recall walks these edges, so co-cited memories surface together; Memory.graph(\"slug\") shows a memory's neighborhood."
+        echo "Recall: Memory.recall(\"regex\") (rich rows: id, time, type, topic, handle, body) or Memory.query(datalog). Recalled facts go stale; verify before use and record the re-check with Memory.verify(\"slug\") -- verified memories rank first below. Never edit history: newer facts win, Memory.retract(id) kills a wrong one."
+        echo
+        echo "### Hooks (freshest verification first, then recency)"
+        # Rank by the newest mem/verified-at seq per entity (0 when never
+        # verified), then by the desc fact's own seq: a re-checked memory
+        # outranks a merely recent one (index#3865).
+        ${lib.getExe cfg.packages.weave} --store "$store" query 'vseq(E, max(S)) :- fact_id(I, E, "mem/verified-at", V), fact_seq(I, S). rank(V, S, E, D) :- latest(E, "mem/desc", D), fact_id(I, E, "mem/desc", D), fact_seq(I, S), vseq(E, V). rank(0, S, E, D) :- latest(E, "mem/desc", D), fact_id(I, E, "mem/desc", D), fact_seq(I, S), not vseq(E, _). ?- rank(V, S, E, D) order V desc, S desc limit 150.'
+        echo
+        echo "### Counts by type"
+        ${lib.getExe cfg.packages.weave} --store "$store" query 'per_type(T, count(E)) :- latest(E, "mem/type", T). ?- per_type(T, N) order N desc.'
     '';
   };
 
@@ -283,22 +283,6 @@
     indexCommand = lib.getExe indexPkgs.mcp-ex;
     indexArgs = [];
   };
-  codexMcpServers = lib.mapAttrs (_: def:
-    if (def.transport or "stdio") == "stdio"
-    then
-      {
-        inherit (def) command;
-        default_tools_approval_mode = "approve";
-      }
-      // lib.optionalAttrs (def ? args) {inherit (def) args;}
-      // lib.optionalAttrs (def ? env) {inherit (def) env;}
-      // lib.optionalAttrs (def ? envVars) {env_vars = def.envVars;}
-    else {
-      inherit (def) url;
-      default_tools_approval_mode = "approve";
-    })
-  agentMcpServers;
-
   # Native Codex soft defaults. The wrapper supplies them only when the
   # app-owned config.toml does not set the same key.
   codexSettings = {
@@ -353,7 +337,7 @@
   codexBase = indexPkgs.codex;
   codex =
     (codexBase.override {
-      mcpServers = codexMcpServers;
+      mcpServers = agentMcpServers;
       settings = codexSettings;
       forcedSettings = {};
       # On the override, not programs.codex.systemPrompt.omitRules, for the


### PR DESCRIPTION
## What changed

Passes the neutral shared MCP registry into the Codex wrapper. The first landing passed an already Codex-rendered map instead. That erased the remote transport discriminator and made the standalone Home Manager build read Exa as a local command.

The touched file also had formatter drift on `main`; the required Alejandra indentation is included.

## Reproduction

The deployed consumer failed at `lib/util/mcp/renderers.nix:84` with `attribute command missing` while evaluating the Exa server.

## Evidence

- `nix run .#lint`: 13 of 13 checks passed
- the consumer standalone Home Manager build is the post-merge validation gate

Fixes #4069

(sent by an AI agent via Codex)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass the neutral MCP registry directly to the codex wrapper
> Changes the `mcpServers` field in the codex override from the transformed `codexMcpServers` set to the raw `agentMcpServers` set in [workstation.nix](https://github.com/indexable-inc/index/pull/4076/files#diff-92994d0c09d060a94c2474660b3f13f7ec27c73c00f02484fb737ac0eb467962). Risk: `default_tools_approval_mode = "approve"` and any field normalization previously applied by `codexMcpServers` no longer take effect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d8769a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->