### PR TITLE
doc/ix: mark fleets deprecated on the product surface (ix#8306)

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -10,7 +10,7 @@ From-source documentation for the packages in the `index` repo (a shared, open-s
 - Every page opens with its title and a one-line summary, so this index (and an
   agent's `llms.txt` map) can be generated from the pages themselves.
 - `doc/ix/` is the platform guide for users of the hosted `ix` platform (the
-  CLI, fleets, networking, secrets, ...). Those pages defer CLI flags to
+  CLI, networking, secrets, ...). Those pages defer CLI flags to
   `ix <verb> --help` and cite only public source. Start at
   [ix/overview.md](ix/overview.md).
 - The `doc/assets/demo-*` files are README assets, not documentation pages.
@@ -25,7 +25,7 @@ User-facing guides for the hosted `ix` platform. Start at
 | [ix/overview.md](ix/overview.md) | The platform map: open-source vs hosted boundary, a first VM, and where each "how do I" lives. |
 | [ix/cli.md](ix/cli.md) | The `ix` verb map and mental model; flags live in `ix <verb> --help`. |
 | [ix/lifecycle.md](ix/lifecycle.md) | "I want to X" -> command: create, run, converge, stop, snapshot, destroy (single VM and fleet). |
-| [ix/fleet.md](ix/fleet.md) | Declarative multi-VM fleets via the separate `ix-fleet` tool. |
+| [ix/fleet.md](ix/fleet.md) | Deprecated (indexable-inc/ix#8306): multi-VM fleets via the separate `ix-fleet` tool. |
 | [ix/images.md](ix/images.md) | Build an image, tag and push to `registry.ix.dev`, boot a VM from it. |
 | [ix/networking.md](ix/networking.md) | Expose ports, private VM-to-VM groups, `<host>.ix.internal`, and public ingress. |
 | [ix/secrets.md](ix/secrets.md) | Declare a secret, attach it to a VM, materialize it in the guest. |

--- a/doc/ix-fleet/overview.md
+++ b/doc/ix-fleet/overview.md
@@ -7,6 +7,11 @@ converges the live fleet to it. It is the operational front end over the ix
 control plane: where [vmkit](../vmkit/overview.md) owns one local guest, `ix-fleet`
 manages many remote ix VMs (the SDK calls them branches) by name.
 
+> **Deprecated.** Fleets are removed from the ix product surface
+> (indexable-inc/ix#8306); the hosted platform's model is one VM per project,
+> converged with `ix apply`. This page remains the from-source reference for
+> the standalone tool.
+
 Unlike the rest of this domain, `ix-fleet` does not touch a local hypervisor. It
 talks to the ix API through the Python SDK (`ix_sdk.Client`) and fans per-node
 work out through [dag-runner](../dag-runner/overview.md). All logic

--- a/doc/ix/cli.md
+++ b/doc/ix/cli.md
@@ -53,10 +53,11 @@ Nix-managed binary lives in the read-only store and is refused: update the
 - **`ix run` is the imperative one-off.** It boots a fresh VM, runs one command,
   streams its output, and leaves the VM up. Reach for `apply`
   for a config you own and re-converge; reach for `run` for a quick command.
-- **Fleets are a separate tool.** Multi-VM declarative fleets live in `ix-fleet`
-  (`nix run .#ix-fleet -- --plan plan.json <verb>`), not in `ix`. See
-  [fleet.md](fleet.md). There is no `ix down`, `ix health`, `ix diff`, or
-  `ix fleet`. Single-VM teardown is `ix rm` (or `ix stop` to keep it).
+- **There is no fleet concept.** A project defines one VM and `ix apply`
+  converges it. The standalone multi-VM `ix-fleet` tool is deprecated
+  (indexable-inc/ix#8306, see [fleet.md](fleet.md)). There is no `ix down`,
+  `ix health`, `ix diff`, or `ix fleet`. Single-VM teardown is `ix rm` (or
+  `ix stop` to keep it).
 
 ## Verbs
 
@@ -109,7 +110,7 @@ current flag list on any verb. Four global flags apply everywhere:
 
 ## See also
 
-- [fleet.md](fleet.md): multi-VM declarative fleets via the separate `ix-fleet`.
+- [fleet.md](fleet.md): the deprecated multi-VM `ix-fleet` tool (indexable-inc/ix#8306).
 - [lifecycle.md](lifecycle.md): provision -> run -> stop -> snapshot -> rm.
 - [networking.md](networking.md): groups, the overlay, and shares.
 - [secrets.md](secrets.md): the write-only secret store and default attachment.

--- a/doc/ix/fleet.md
+++ b/doc/ix/fleet.md
@@ -7,6 +7,11 @@ command per lifecycle verb; `ix-fleet` (`packages/ix-fleet`, Python) reads that
 plan and converges the live fleet to it. This page is the short how-to; the
 exhaustive from-source reference is [../ix-fleet/overview.md](../ix-fleet/overview.md).
 
+> **Deprecated.** Fleets are removed from the ix product surface
+> (indexable-inc/ix#8306): the model is one VM per project, defined by your
+> config and converged with `ix apply`. The standalone `ix-fleet` tool still
+> lives in this repo, and this page remains its how-to.
+
 > `ix-fleet` is a separate tool from the [`ix` CLI](cli.md). It drives the same
 > ix control plane (a node is an ix branch) through the Python SDK and `IX_TOKEN`
 > from the environment, but you do not call `ix` directly to run a fleet.

--- a/doc/ix/glossary.md
+++ b/doc/ix/glossary.md
@@ -60,7 +60,8 @@ Three unrelated things:
 
 - **`.#ix-fleet`** - the CLI/tool that renders and executes fleet plans
   (`packages/ix-fleet/Cargo.toml:2,4`).
-- A **fleet** - the set of remote ix VMs a plan describes.
+- A **fleet** - the set of remote ix VMs a plan describes. Off the product
+  surface since indexable-inc/ix#8306: an ix project defines one VM.
 - A node in that fleet is called a **branch** by the ix SDK (`ix_sdk.BranchStatus`)
   (`packages/ix-fleet/src/ix_fleet/__init__.py:221`).
 

--- a/doc/ix/overview.md
+++ b/doc/ix/overview.md
@@ -60,7 +60,7 @@ Start here, then follow the page that matches the question:
 | --- | --- |
 | [cli.md](cli.md) | The `ix` verb map and mental model. For flags, run `ix <verb> --help`. |
 | [lifecycle.md](lifecycle.md) | "I want to X" -> command: create, run, converge, stop, snapshot, destroy. |
-| [fleet.md](fleet.md) | Declarative multi-VM fleets via the separate `ix-fleet` tool. |
+| [fleet.md](fleet.md) | Deprecated (indexable-inc/ix#8306): multi-VM fleets via the separate `ix-fleet` tool. |
 | [images.md](images.md) | Build an image, tag/push to `registry.ix.dev`, boot a VM from it. |
 | [networking.md](networking.md) | Expose ports, private VM-to-VM groups, `<host>.ix.internal`, public ingress. |
 | [secrets.md](secrets.md) | Declare a secret, attach it to a VM, materialize it in the guest. |
@@ -77,5 +77,5 @@ per-package docs under [`doc/`](../index.md), for example the
 
 - [cli.md](cli.md): the `ix` verb map and mental model.
 - [lifecycle.md](lifecycle.md): which command for create, run, converge, snapshot, destroy.
-- [fleet.md](fleet.md): declarative multi-VM fleets via `ix-fleet`.
+- [fleet.md](fleet.md): the deprecated multi-VM `ix-fleet` tool.
 - [glossary.md](glossary.md): disambiguating overloaded names.


### PR DESCRIPTION
Docs companion to indexable-inc/ix#8306 (no fleets on the product surface; one VM per project, `ix apply` converges it). Prose only.

## What changed

- `doc/ix/fleet.md`, `doc/ix-fleet/overview.md`: deprecation note after the opening summary (kept after the title+summary line so the generated index/llms.txt summaries are unchanged).
- `doc/ix/cli.md`: the mental-model bullet now leads with "There is no fleet concept"; see-also updated.
- `doc/ix/glossary.md`: the **fleet** entry notes it is off the product surface.
- `doc/ix/overview.md`, `doc/index.md`: fleet.md table rows marked deprecated; the `doc/ix/` conventions line drops "fleets".

## Deliberately left

- The `ix-fleet` tool, `lib/image/fleet.nix`, and examples: code, not wording; #2912 (delete ix-fleet) and #3441 (drop buildOn/buildVm) own that. This PR is note-at-top only so either rebases over it trivially.
- The lifecycle.md fleet column and the factual `ix-fleet` behavior sections in health-checks/secrets/images/networking/environment: they describe the tool as it exists and go away with the tool.

Refs indexable-inc/ix#8306.

(sent by an AI agent via Claude Code, model Fable 5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark fleets as deprecated on the ix product surface
> Adds deprecation notices across the ix documentation to reflect that fleets are no longer part of the ix product surface. The notices clarify that the hosted model is one VM per project managed via `ix apply`, and that the standalone `ix-fleet` tool is deprecated. Affected files include [fleet.md](https://github.com/indexable-inc/index/pull/4077/files#diff-b13fbad0e6f76e8e1a5c0b123f45d88c2f556af18ca9aee01d1cb1d931daf4d8), [overview.md](https://github.com/indexable-inc/index/pull/4077/files#diff-fd9441b9d8f808f51aa7f791e3c3e4c33eb096e0333d4f4e833895207f069a43), [cli.md](https://github.com/indexable-inc/index/pull/4077/files#diff-17f8b8e99082227405e01c4df6a4a35ff8bb772bd1c38d5405bd167ceb437ec6), [glossary.md](https://github.com/indexable-inc/index/pull/4077/files#diff-a106f7b20be746a93c3f8922204bb40588091c2b3983abf80ea058b3c89bd735), and [index.md](https://github.com/indexable-inc/index/pull/4077/files#diff-47c5f70f455a0039334dd042f30fbb585c977a73ad838ee4747e5cd304ffb412).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e45e6f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->