### PR TITLE
image: stop the binsh/usrbinenv activation snippets failing every boot

### DIFF
--- a/lib/image/oci-layer.nix
+++ b/lib/image/oci-layer.nix
@@ -65,17 +65,27 @@
         then "WAL"
         else "DELETE";
 
-      # FHS layout pointing into the NixOS toplevel. Keep activation-owned
-      # paths writable: NixOS first boot populates /etc and creates /bin/sh
-      # and /usr/bin/env, so those cannot be symlinks into the immutable store.
+      # FHS layout pointing into the NixOS toplevel. /etc stays a writable
+      # directory: NixOS first boot populates it. /bin/sh and /usr/bin/env
+      # are baked at build time with the exact targets the binsh/usrbinenv
+      # activation snippets would have linked: platform.nix blanks those
+      # snippets because the CAS-booted guest reaches /bin and /usr through
+      # symlinks into the read-only store, where their recreate-and-rename
+      # can never succeed (ix#8307).
       systemRoot = pkgs.runCommand "system-root" {} ''
         mkdir -p $out
         ln -s ${toplevel}/init $out/init
         mkdir -p $out/etc
         mkdir -p $out/bin
+        ${lib.optionalString (config.environment.binsh != null) ''
+          ln -s ${config.environment.binsh} $out/bin/sh
+        ''}
         ln -s ${toplevel}/sw/sbin $out/sbin
         ln -s ${toplevel}/sw/lib $out/lib
         mkdir -p $out/usr/bin
+        ${lib.optionalString (config.environment.usrbinenv != null) ''
+          ln -s ${config.environment.usrbinenv} $out/usr/bin/env
+        ''}
         ln -s ${toplevel}/sw/lib $out/usr/lib
         ln -s ${toplevel}/sw/sbin $out/usr/sbin
         mkdir -p $out/tmp $out/var $out/run $out/proc $out/sys $out/dev $out/root

--- a/lib/image/platform.nix
+++ b/lib/image/platform.nix
@@ -765,6 +765,21 @@ in {
       daemonIOSchedClass = "idle";
     };
 
+    # /bin/sh and /usr/bin/env are baked into every image root at build time
+    # (oci-layer.nix systemRoot here; the CAS systemRoot on the ix side), and
+    # the CAS-booted guest reaches /bin and /usr through symlinks into the
+    # read-only store, so the stock recreate-and-rename these snippets run
+    # can never succeed there: both fail on every boot and would fail the
+    # Activating phase of a switch (ix#8307). Blank them; the attrs stay
+    # defined so snippet dependency resolution is unaffected. mkForce because
+    # nixpkgs assigns both snippets unconditionally, not as defaults.
+    system.activationScripts = {
+      # astlog-ignore: no-mkforce nixpkgs sets this unconditionally; the image bakes /bin/sh (ix#8307)
+      binsh = lib.mkForce "";
+      # astlog-ignore: no-mkforce nixpkgs sets this unconditionally; the image bakes /usr/bin/env (ix#8307)
+      usrbinenv = lib.mkForce "";
+    };
+
     system.stateVersion = "25.05";
   };
 }


### PR DESCRIPTION
Every ix/base guest boot logs:

```
chmod: changing permissions of '/bin': Read-only file system
Activation script snippet 'binsh' failed (1)
chmod: changing permissions of '/usr/bin': Read-only file system
Activation script snippet 'usrbinenv' failed (1)
```

The CAS-booted guest reaches /bin and /usr through symlinks into the read-only store (ix `nix/packages/cas-image.nix` links `bin -> sw/bin`, `usr -> sw`), so the stock NixOS recreate-and-rename (tmpfile + rename after a `chmod 0755` of the directory) can never succeed there. Cosmetic at boot, but it would fail the Activating phase of a switch, and it reads as a crash to anyone debugging (it cost real time in the ix#7937 triage).

## Change

- `lib/image/platform.nix`: blank both snippets. mkForce (with the file's existing `astlog-ignore: no-mkforce` pattern) because nixpkgs assigns them unconditionally, not as defaults. `environment.usrbinenv = null` is not a substitute: its null branch still runs `rm -f /usr/bin/env`, which fails identically on the read-only path.
- `lib/image/oci-layer.nix`: the OCI systemRoot deliberately kept `/bin` and `/usr/bin` writable so first-boot activation could create the symlinks; with the snippets gone, bake them at build time with the exact targets the snippets would have linked (`config.environment.binsh`, `config.environment.usrbinenv`). OCI-ingested guests end up byte-identical to today's post-activation state.

## Verification

Evaluated `packages.x86_64-linux.base.passthru.toplevel` and extracted the generated `activate` script text from the drv:

- main: both snippets present, including the failing `chmod 0755 /bin` / `chmod 0755 /usr/bin` lines (`/bin/sh` target resolves to `bash-interactive/bin/sh`, `/usr/bin/env` to `coreutils/bin/env` -- the same targets now baked into the OCI systemRoot).
- this branch: zero mentions of `binsh`/`usrbinenv`; the script contains only the `users`, `specialfs`, and `etc` snippets.

`nix run .#lint`: 13/13 stages green (astlog accepts the per-line ignores).

After merge, ix needs the submodule gitlink bump + `nix flake update index` in one commit; boot-console cleanliness is verified there.

Fixes indexable-inc/ix#8307

(sent by an AI agent via Claude Code, model Fable 5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `/bin/sh` and `/usr/bin/env` activation scripts failing on every boot in OCI images
> - Symlinks for `/bin/sh` and `/usr/bin/env` are now baked into the image system root at build time in [oci-layer.nix](https://github.com/indexable-inc/index/pull/4078/files#diff-2f593cc5e1a07acba76a950c1132a06b5d7646750989d806816be811310a32f4), using `lib.optionalString` guards keyed on `config.environment.binsh` and `config.environment.usrbinenv`.
> - The `binsh` and `usrbinenv` activation scripts in [platform.nix](https://github.com/indexable-inc/index/pull/4078/files#diff-4e9f8a1975e02453aa569916bd7b0c3a25baa581602e105115a45921f41bf7d7) are forced to empty strings via `lib.mkForce`, since the symlinks are already present in the layer and the scripts were failing on each boot trying to recreate them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c8f5eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->