### PR TITLE
policy: allow Bash as kernel-outage fallback (#4080)

### DIFF
--- a/packages/agent/policy/permissions.nix
+++ b/packages/agent/policy/permissions.nix
@@ -53,7 +53,12 @@
   # per-model upstream with no config toggle to reach it.
   kernelSuperseded = {
     shell = {
-      claudeTools = ["Bash"];
+      # Claude keeps Bash even with the kernel baked: the kernel is the
+      # preferred shell (prompt rules steer there), but a kernel BEAM crash
+      # (index#4080, 2026-07-23) left sessions with NO shell or file IO at
+      # all, since a dead MCP connection never auto-reattaches. Bash is the
+      # degraded-mode fallback, not a second first-class path.
+      claudeTools = [];
       codexFeatures = {
         shell_tool = false;
         unified_exec = false;


### PR DESCRIPTION
One-row change in packages/agent/policy/permissions.nix: the kernelSuperseded shell row no longer denies Bash for Claude Code. Rationale in index#4080: tonight's kernel BEAM crash left the orchestrating session and all freshly spawned subagents with zero shell/file tools (dead MCP connection + hard deny), unrecoverable without a human /mcp reconnect. Kernel remains the primary via prompt rules; file IO/search denies stay; codex untouched; scoped Bash(gh pr merge...) protections unaffected. Verified: claude-code package evals, repo lint green.

Refs #4080

(sent by an AI agent via Claude Code, model Fable 5, directed by andrewgazelka)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove Bash from `kernelSuperseded.shell` claudeTools fallback list
> Clears the `claudeTools` list for `kernelSuperseded.shell` in [permissions.nix](https://github.com/indexable-inc/index/pull/4081/files#diff-c9733b1461e1c4084b3b81090b51274bf4a156b58a7110dfb75a5d40bef2df1d), so Bash is no longer declared as an available tool when the kernel is superseded. Explanatory comments are added to clarify the intent of this setting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1009cd5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->