### PR TITLE
mcp-ex: keep jobs on the record and reads answerable under load (#4082)

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/action_log.ex
+++ b/packages/mcp-ex/lib/ix_mcp/action_log.ex
@@ -590,13 +590,22 @@ defmodule IxMcp.ActionLog do
   read of another job's terminal state, not news, so its outbox row is born
   acked -- on the record, never announced. Only `done` goes quiet; a
   wrapper's own failure or death still announces (the invariant).
+
+  `start:` is the job's start metadata (the `job_started/2` map, #4082).
+  With it, a missing jobs row is reconstructed inside this transition
+  instead of no-opping as `:already_final`: under load a job's `job_started`
+  write can be absorbed by the job's ledger seam (#3874), and before #4082
+  that single lost write erased the whole run from the record -- finish and
+  output had no row to land on, `Jobs.history` never listed the job, and
+  the durability contract ("history survives even a crash or kill") broke.
   """
   @spec finish_job(String.t(), Job.status(), String.t() | nil, keyword(), GenServer.server()) ::
           {:notify, outbox()} | :already_final
   def finish_job(id, status, result, opts \\ [], server \\ __MODULE__)
       when status in [:done, :failed, :cancelled, :killed] do
     quiet = Keyword.get(opts, :quiet, false)
-    call(server, {:finish_job, id, Atom.to_string(status), result, quiet, now()})
+    start = Keyword.get(opts, :start)
+    call(server, {:finish_job, id, Atom.to_string(status), result, quiet, now(), start})
   end
 
   @doc """
@@ -995,22 +1004,7 @@ defmodule IxMcp.ActionLog do
   end
 
   def handle_call({:job_started, job}, _from, %{db: db} = state) do
-    run(
-      db,
-      "INSERT OR IGNORE INTO jobs (id, session_id, action_id, intent, session_name, topic_name, code, status, watch, started_at) VALUES (?, ?, ?, ?, ?, ?, ?, 'running', ?, ?)",
-      [
-        job.id,
-        job.session_id,
-        job.action_id,
-        job.intent,
-        job.session_name,
-        job.topic_name,
-        job.code,
-        bool_to_int(job.watch),
-        job.started_at
-      ]
-    )
-
+    insert_job_row(db, job)
     {:reply, :ok, state}
   end
 
@@ -1050,7 +1044,12 @@ defmodule IxMcp.ActionLog do
   # never catch the two logs disagreeing and no terminal transition escapes
   # the outbox. The single-writer GenServer serializes this against every
   # other write, so the guard needs no locking of its own.
-  def handle_call({:finish_job, id, status, result, quiet, at}, _from, %{db: db} = state) do
+  def handle_call({:finish_job, id, status, result, quiet, at, start}, _from, %{db: db} = state) do
+    # Reconstruct a lost start row before the guarded transition (#4082):
+    # idempotent by primary key, so a row that already exists -- running or
+    # terminal -- is untouched and the guard below still decides the race.
+    if is_map(start), do: insert_job_row(db, start)
+
     reply =
       case fetch(
              db,
@@ -1435,7 +1434,9 @@ defmodule IxMcp.ActionLog do
   defp disabled_reply({:create_session, _name, _at}), do: 0
   defp disabled_reply({:create_topic, _session_id, _name, _at}), do: 0
   defp disabled_reply({:start_action, _action}), do: 0
-  defp disabled_reply({:finish_job, _id, _status, _result, _quiet, _at}), do: :already_final
+
+  defp disabled_reply({:finish_job, _id, _status, _result, _quiet, _at, _start}),
+    do: :already_final
 
   defp disabled_reply({:post_request, _kind, _ref, _title, _body, _session_id, _at}),
     do: :disabled
@@ -1559,6 +1560,27 @@ defmodule IxMcp.ActionLog do
   end
 
   defp now, do: DateTime.utc_now() |> DateTime.to_iso8601()
+
+  # One idempotent write shared by `job_started` and the reconstructing
+  # `finish_job` (#4082): INSERT OR IGNORE on the primary key, so replays
+  # and reconstructions never clobber a row that already landed.
+  defp insert_job_row(db, job) do
+    run(
+      db,
+      "INSERT OR IGNORE INTO jobs (id, session_id, action_id, intent, session_name, topic_name, code, status, watch, started_at) VALUES (?, ?, ?, ?, ?, ?, ?, 'running', ?, ?)",
+      [
+        job.id,
+        job.session_id,
+        job.action_id,
+        job.intent,
+        job.session_name,
+        job.topic_name,
+        job.code,
+        bool_to_int(job.watch),
+        job.started_at
+      ]
+    )
+  end
 
   defp bool_to_int(true), do: 1
   defp bool_to_int(false), do: 0

--- a/packages/mcp-ex/lib/ix_mcp/jobs.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs.ex
@@ -15,6 +15,10 @@ defmodule IxMcp.Jobs do
   when the job process is gone, so a crashed or killed run is still readable
   and still on record. `history/1` is a view over the `jobs` table scoped to
   this server instance's session.
+
+  Live reads go through the job's Registry-value snapshot (#4082) -- an ETS
+  read -- rather than GenServer calls into the control process, which under
+  load can sit parked in a ledger write far past the default call timeout.
   """
 
   alias IxMcp.ActionLog
@@ -50,9 +54,14 @@ defmodule IxMcp.Jobs do
         {Job, {id, code, Keyword.take(opts, [:intent, :action_id, :watch])}}
       )
 
+    # Read back by id, not by 5s GenServer calls into the control process
+    # (#4082): a process parked in a ledger write under load answers no
+    # call inside the default timeout, and that exit killed the exec
+    # handler. The id path reads the Registry-value snapshot (falling back
+    # to the ledger), which answers regardless.
     case Job.await(pid, round(budget_s * 1000)) do
-      {:ok, summary} -> {summary, Job.output(pid)}
-      :timeout -> {Job.summary(pid), Job.output(pid)}
+      {:ok, summary} -> {summary, output(id)}
+      :timeout -> {get(id), output(id)}
     end
   end
 
@@ -65,10 +74,16 @@ defmodule IxMcp.Jobs do
     end
   end
 
-  @doc "Summary of a job -- live from its process, or reconstructed from the ledger."
+  @doc "Summary of a job -- from its snapshot or process, or reconstructed from the ledger."
   @spec get(String.t()) :: Job.summary()
   def get(id) do
-    live_or_ledger(id, &Job.summary/1, &summary_from_ledger/1)
+    # Snapshot first (#4082): an ETS read that stays answerable while the
+    # control process sits in a ledger call. The call path only covers the
+    # sliver before the job publishes its snapshot in init.
+    case Job.read_summary(id) do
+      nil -> live_or_ledger(id, &Job.summary/1, &summary_from_ledger/1)
+      summary -> summary
+    end
   end
 
   @doc """
@@ -176,7 +191,13 @@ defmodule IxMcp.Jobs do
   @doc "Full captured output -- from the live buffer, or the durable table if the job is gone."
   @spec output(String.t()) :: String.t()
   def output(id) do
-    live_or_ledger(id, &Job.output/1, &output_from_ledger/1)
+    # Snapshot first (#4082), same reasoning as `get/1`: the hot buffer is
+    # public ETS, so reading it must not queue behind a parked control
+    # process.
+    case Job.read_output(id) do
+      nil -> live_or_ledger(id, &Job.output/1, &output_from_ledger/1)
+      output -> output
+    end
   end
 
   defp output_from_ledger(id) do
@@ -223,11 +244,15 @@ defmodule IxMcp.Jobs do
   @doc "Ids and summaries of jobs that are still running."
   @spec running() :: [Job.summary()]
   def running do
-    IxMcp.Jobs.Supervisor
-    |> DynamicSupervisor.which_children()
-    |> Enum.flat_map(fn
-      {_, pid, :worker, _} when is_pid(pid) -> [Job.summary(pid)]
-      _ -> []
+    # Snapshot reads (#4082): scanning with per-child GenServer calls would
+    # stall on the first control process parked in a ledger write.
+    IxMcp.Jobs.Registry
+    |> Registry.select([{{:"$1", :_, :_}, [], [:"$1"]}])
+    |> Enum.flat_map(fn id ->
+      case Job.read_summary(id) do
+        nil -> []
+        summary -> [summary]
+      end
     end)
     |> Enum.filter(& &1.running)
   end

--- a/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
@@ -30,6 +30,17 @@ defmodule IxMcp.Jobs.Job do
   output flush leaves the hot buffer unflushed for the next tick; a failed
   terminal transition re-arms itself (`:record_terminal`) until the ledger
   takes it, so the notification is delayed, never lost.
+
+  Reads never queue behind those ledger calls (#4082): the job publishes a
+  snapshot (status, rendered result, buffer/counter handles) as its Registry
+  value at init and again at finish, so `Jobs.get`/`Jobs.output` are plain
+  ETS reads while this process is parked in a 30s `ActionLog` call -- under
+  concurrent load the old call path timed out at the default 5s and killed
+  the exec handler. The same load can lose the `job_started` write itself
+  (`safe_log` absorbs it), so the start metadata rides with the reaper and
+  with the terminal transition, either of which reconstructs the jobs row;
+  before that, a lost start row made `finish_job` no-op as `:already_final`
+  and the whole run vanished from the record.
   """
 
   use GenServer, restart: :temporary
@@ -174,7 +185,9 @@ defmodule IxMcp.Jobs.Job do
   """
   @spec await(GenServer.server(), timeout()) :: {:ok, summary()} | :timeout
   def await(server, timeout_ms) do
-    case GenServer.call(server, {:subscribe, self()}) do
+    started_mono = System.monotonic_time(:millisecond)
+
+    case subscribe(server, timeout_ms) do
       {:finished, summary} ->
         {:ok, summary}
 
@@ -182,16 +195,46 @@ defmodule IxMcp.Jobs.Job do
         receive do
           {:ix_job_finished, _id, summary} -> {:ok, summary}
         after
-          timeout_ms ->
-            GenServer.cast(server, {:unsubscribe, self()})
-
-            # The finish notification may have raced the timeout; prefer it.
-            receive do
-              {:ix_job_finished, _id, summary} -> {:ok, summary}
-            after
-              0 -> :timeout
-            end
+          remaining_ms(timeout_ms, started_mono) ->
+            give_up(server)
         end
+
+      :busy ->
+        give_up(server)
+    end
+  end
+
+  # Subscribing must never outlive the caller's own budget (#4082): a control
+  # process parked in a ledger write under load cannot take the subscription
+  # for up to the ledger's 30s call bound, and the old default-5s call here
+  # died with `{:timeout, {GenServer, :call, [pid, {:subscribe, ...}]}}` --
+  # killing the exec handler. A subscribe that cannot land within the budget
+  # means the same thing as a budget that ran out: the job stays backgrounded.
+  defp subscribe(server, timeout_ms) do
+    GenServer.call(server, {:subscribe, self()}, subscribe_timeout(timeout_ms))
+  catch
+    :exit, {:timeout, {GenServer, :call, _args}} -> :busy
+  end
+
+  defp subscribe_timeout(:infinity), do: :infinity
+  # The floor keeps a tiny budget from turning the subscription itself into
+  # a guaranteed timeout race on a healthy process.
+  defp subscribe_timeout(timeout_ms), do: max(timeout_ms, 1_000)
+
+  defp remaining_ms(:infinity, _started_mono), do: :infinity
+
+  defp remaining_ms(timeout_ms, started_mono) do
+    max(timeout_ms - (System.monotonic_time(:millisecond) - started_mono), 0)
+  end
+
+  defp give_up(server) do
+    GenServer.cast(server, {:unsubscribe, self()})
+
+    # The finish notification may have raced the timeout; prefer it.
+    receive do
+      {:ix_job_finished, _id, summary} -> {:ok, summary}
+    after
+      0 -> :timeout
     end
   end
 
@@ -200,9 +243,67 @@ defmodule IxMcp.Jobs.Job do
   def output(server) do
     server
     |> GenServer.call(:buffer)
+    |> read_buffer()
+    |> Kernel.||("")
+  end
+
+  @doc """
+  The job's summary read from its Registry-value snapshot -- an ETS read
+  that never touches the control process (#4082): a process parked in a
+  ledger write under load answers no GenServer.call within the default 5s,
+  and reads must not inherit that stall. `nil` when the job is not resident
+  (finished-and-gone, or the sliver before `init` publishes the snapshot);
+  callers fall back to the call path or the durable ledger.
+  """
+  @spec read_summary(String.t()) :: summary() | nil
+  def read_summary(id) do
+    with {pid, %{} = snap} <- lookup_snapshot(id),
+         true <- Process.alive?(pid) do
+      finished = snap.finished_mono || System.monotonic_time(:millisecond)
+
+      %{
+        id: id,
+        status: snap.status,
+        running: snap.status == :running,
+        intent: snap.intent,
+        elapsed_s: (finished - snap.started_mono) / 1000,
+        output_bytes: :counters.get(snap.counter, 1),
+        diagnostics: snap.diagnostics,
+        result: snap.result
+      }
+    else
+      _not_resident -> nil
+    end
+  end
+
+  @doc "The job's output read straight from its hot buffer via the snapshot (#4082), or nil."
+  @spec read_output(String.t()) :: String.t() | nil
+  def read_output(id) do
+    with {pid, %{buffer: buffer}} <- lookup_snapshot(id),
+         true <- Process.alive?(pid) do
+      read_buffer(buffer)
+    else
+      _not_resident -> nil
+    end
+  end
+
+  defp lookup_snapshot(id) do
+    case Registry.lookup(IxMcp.Jobs.Registry, id) do
+      [{pid, value}] -> {pid, value}
+      [] -> nil
+    end
+  end
+
+  # The buffer is a public ETS table owned by the control process; it can be
+  # deleted between the aliveness check and the read when the process dies
+  # right then, which means the same as "not resident".
+  defp read_buffer(buffer) do
+    buffer
     |> :ets.tab2list()
     |> Enum.sort()
     |> Enum.map_join("", fn {_seq, chunk} -> chunk end)
+  rescue
+    ArgumentError -> nil
   end
 
   # -- server ----------------------------------------------------------------
@@ -232,31 +333,29 @@ defmodule IxMcp.Jobs.Job do
       started_at: DateTime.utc_now()
     }
 
+    # Publish the read snapshot before anything can block: from here on,
+    # summary and output reads are ETS lookups against the Registry value,
+    # never calls into this process (#4082).
+    publish_snapshot(state)
+
     {:ok, state, {:continue, :spawn_eval}}
   end
 
   @impl true
   def handle_continue(:spawn_eval, state) do
-    # Record the durable jobs row and arm the reaper before anything can die,
-    # so a death in the first instants is still finalized (#3839). A ledger
-    # outage must not abort the job itself (#3874): without the row, later
-    # reads degrade to the hot buffer, which beats dying before the eval
-    # even starts.
-    safe_log(fn ->
-      ActionLog.job_started(%{
-        id: state.id,
-        session_id: state.session_id,
-        action_id: state.action_id,
-        intent: state.intent,
-        session_name: state.session,
-        topic_name: state.topic,
-        code: state.code,
-        watch: state.watch,
-        started_at: DateTime.to_iso8601(state.started_at)
-      })
-    end)
+    # Arm the reaper before the ledger write, not after (#4082): the write
+    # below can park this process for the ledger's full call bound under
+    # load, and a kill inside that window used to escape the reaper
+    # entirely. The reaper carries the start metadata so it can finalize
+    # this job even when the `job_started` row itself never landed.
+    Reaper.watch(state.id, self(), start_meta(state))
 
-    Reaper.watch(state.id, self())
+    # Record the durable jobs row before the eval can die, so a death in the
+    # first instants is still finalized (#3839). A ledger outage must not
+    # abort the job itself (#3874): without the row, later reads degrade to
+    # the hot buffer, and the terminal transition reconstructs the row from
+    # the same metadata (#4082), which beats dying before the eval starts.
+    safe_log(fn -> ActionLog.job_started(start_meta(state)) end)
 
     buffer = state.buffer
     counter = state.counter
@@ -461,6 +560,11 @@ defmodule IxMcp.Jobs.Job do
         finished_mono: System.monotonic_time(:millisecond)
     }
 
+    # Snapshot first (#4082): the flush and terminal write below can park
+    # this process on the ledger, and readers must already see the terminal
+    # state through the Registry value while that happens.
+    publish_snapshot(state)
+
     # Persist all captured output before the transition, so a reader that
     # sees the job finish finds its output already complete on disk.
     state = flush(state)
@@ -479,7 +583,10 @@ defmodule IxMcp.Jobs.Job do
   defp record_terminal(state) do
     recorded =
       safe_log(fn ->
-        ActionLog.finish_job(state.id, state.status, render_result(state), quiet: state.quiet)
+        ActionLog.finish_job(state.id, state.status, render_result(state),
+          quiet: state.quiet,
+          start: start_meta(state)
+        )
       end)
 
     case recorded do
@@ -577,6 +684,46 @@ defmodule IxMcp.Jobs.Job do
   end
 
   defp schedule_flush, do: Process.send_after(self(), :flush, @flush_interval_ms)
+
+  # The job's start metadata, exactly as `ActionLog.job_started/2` takes it.
+  # Built once per use from state and handed to the ledger, the reaper, and
+  # the terminal transition (#4082): any of them can then (re)create the
+  # jobs row, so losing the start write under load no longer loses the job.
+  defp start_meta(state) do
+    %{
+      id: state.id,
+      session_id: state.session_id,
+      action_id: state.action_id,
+      intent: state.intent,
+      session_name: state.session,
+      topic_name: state.topic,
+      code: state.code,
+      watch: state.watch,
+      started_at: DateTime.to_iso8601(state.started_at)
+    }
+  end
+
+  # The Registry value doubles as the job's hot read model (#4082): summary
+  # fields plus the buffer/counter handles, so `Jobs.get`/`Jobs.output` are
+  # plain ETS reads that keep answering while this process sits in a ledger
+  # call. Only the owning process may update its own Registry value, which
+  # is exactly who calls this.
+  defp publish_snapshot(state) do
+    Registry.update_value(IxMcp.Jobs.Registry, state.id, fn _old ->
+      %{
+        intent: state.intent,
+        status: state.status,
+        result: render_result(state),
+        diagnostics: state.diagnostics,
+        started_mono: state.started_mono,
+        finished_mono: state.finished_mono,
+        counter: state.counter,
+        buffer: state.buffer
+      }
+    end)
+
+    state
+  end
 
   defp build_summary(state) do
     finished = state.finished_mono || System.monotonic_time(:millisecond)

--- a/packages/mcp-ex/lib/ix_mcp/jobs/reaper.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs/reaper.ex
@@ -35,10 +35,17 @@ defmodule IxMcp.Jobs.Reaper do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  @doc "Monitor a job control process so its unreported death is finalized."
-  @spec watch(String.t(), pid()) :: :ok
-  def watch(id, pid) do
-    GenServer.cast(__MODULE__, {:watch, id, pid})
+  @doc """
+  Monitor a job control process so its unreported death is finalized.
+  `start` is the job's start metadata (`ActionLog.job_start()`): the
+  finalizing transition hands it to `ActionLog.finish_job/5`, which
+  reconstructs the jobs row when the `job_started` write itself was lost
+  under load (#4082) -- without it, a kill after a lost start write
+  no-opped as `:already_final` and the job vanished from the record.
+  """
+  @spec watch(String.t(), pid(), map() | nil) :: :ok
+  def watch(id, pid, start \\ nil) do
+    GenServer.cast(__MODULE__, {:watch, id, pid, start})
   end
 
   @doc "A job reported a terminal transition itself; stop guarding it."
@@ -49,13 +56,20 @@ defmodule IxMcp.Jobs.Reaper do
 
   @impl true
   def init(_) do
-    {:ok, %{refs: %{}, ids: %{}}}
+    {:ok, %{refs: %{}, ids: %{}, starts: %{}}}
   end
 
   @impl true
-  def handle_cast({:watch, id, pid}, state) do
+  def handle_cast({:watch, id, pid, start}, state) do
     ref = Process.monitor(pid)
-    {:noreply, %{state | refs: Map.put(state.refs, ref, id), ids: Map.put(state.ids, id, ref)}}
+
+    {:noreply,
+     %{
+       state
+       | refs: Map.put(state.refs, ref, id),
+         ids: Map.put(state.ids, id, ref),
+         starts: put_start(state.starts, id, start)
+     }}
   end
 
   def handle_cast({:reported, id}, state) do
@@ -65,7 +79,14 @@ defmodule IxMcp.Jobs.Reaper do
 
       {ref, ids} ->
         Process.demonitor(ref, [:flush])
-        {:noreply, %{state | refs: Map.delete(state.refs, ref), ids: ids}}
+
+        {:noreply,
+         %{
+           state
+           | refs: Map.delete(state.refs, ref),
+             ids: ids,
+             starts: Map.delete(state.starts, id)
+         }}
     end
   end
 
@@ -73,17 +94,18 @@ defmodule IxMcp.Jobs.Reaper do
   def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
     {id, refs} = Map.pop(state.refs, ref)
     ids = if id, do: Map.delete(state.ids, id), else: state.ids
+    {start, starts} = if id, do: Map.pop(state.starts, id), else: {nil, state.starts}
 
     if id do
       result = "killed: " <> inspect(reason, limit: 25, printable_limit: 2_000)
-      finalize(id, result, @finalize_retries)
+      finalize(id, result, start, @finalize_retries)
     end
 
-    {:noreply, %{state | refs: refs, ids: ids}}
+    {:noreply, %{state | refs: refs, ids: ids, starts: starts}}
   end
 
-  def handle_info({:finalize, id, result, attempts}, state) do
-    finalize(id, result, attempts)
+  def handle_info({:finalize, id, result, start, attempts}, state) do
+    finalize(id, result, start, attempts)
     {:noreply, state}
   end
 
@@ -91,17 +113,24 @@ defmodule IxMcp.Jobs.Reaper do
   # the ledger call (it died mid-request, #3874) must not crash the reaper
   # -- that would drop every monitor it holds -- so the attempt re-arms
   # itself instead.
-  defp finalize(id, result, attempts) do
-    case ActionLog.finish_job(id, :killed, result) do
+  defp finalize(id, result, start, attempts) do
+    case ActionLog.finish_job(id, :killed, result, start: start) do
       {:notify, outbox} -> Notifier.publish(outbox)
       :already_final -> :ok
     end
   catch
     :exit, reason ->
       if attempts > 0 do
-        Process.send_after(self(), {:finalize, id, result, attempts - 1}, @finalize_retry_ms)
+        Process.send_after(
+          self(),
+          {:finalize, id, result, start, attempts - 1},
+          @finalize_retry_ms
+        )
       else
         Logger.error("reaper: job #{id} terminal write lost: #{inspect(reason, limit: 5)}")
       end
   end
+
+  defp put_start(starts, _id, nil), do: starts
+  defp put_start(starts, id, start), do: Map.put(starts, id, start)
 end

--- a/packages/mcp-ex/test/action_log_test.exs
+++ b/packages/mcp-ex/test/action_log_test.exs
@@ -915,4 +915,39 @@ defmodule IxMcp.ActionLogTest do
     :ok = Sqlite3.execute(blocker, "ROLLBACK")
     :ok = Sqlite3.close(blocker)
   end
+
+  # Under load a job's `job_started` write can be absorbed by the job's
+  # ledger seam (#3874) and never land. The terminal transition used to
+  # answer `:already_final` for the missing row, erasing the run from the
+  # record entirely (#4082); with the start metadata it reconstructs the
+  # row inside the same transition.
+  test "finish_job reconstructs a jobs row whose start write never landed (#4082)" do
+    path = tmp_db()
+    log = start_supervised!({ActionLog, path: path, name: :action_log_4082_ghost})
+    session_id = ActionLog.create_session("ghost", log)
+
+    start = %{
+      id: "gh4082",
+      session_id: session_id,
+      action_id: nil,
+      intent: "ghost",
+      session_name: "ghost",
+      topic_name: nil,
+      code: ":ok",
+      watch: false,
+      started_at: DateTime.to_iso8601(DateTime.utc_now())
+    }
+
+    # No job_started call: the start write was lost.
+    assert {:notify, outbox} =
+             ActionLog.finish_job("gh4082", :done, ":ok", [start: start], log)
+
+    refute outbox.acked
+    assert %{status: :done, code: ":ok", intent: "ghost"} = ActionLog.job("gh4082", log)
+    assert [%{id: "gh4082"}] = ActionLog.recent_jobs(session_id, 10, log)
+
+    # The guard still decides the race: a second finalize no-ops.
+    assert ActionLog.finish_job("gh4082", :killed, "late", [start: start], log) ==
+             :already_final
+  end
 end

--- a/packages/mcp-ex/test/ix_mcp/jobs_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/jobs_test.exs
@@ -3,6 +3,7 @@ defmodule IxMcp.JobsTest do
 
   alias IxMcp.ActionLog
   alias IxMcp.Jobs
+  alias IxMcp.Jobs.Reaper
   alias IxMcp.MCP.Notifier
   alias IxMcp.Session
 
@@ -319,6 +320,83 @@ defmodule IxMcp.JobsTest do
              end)
 
     assert Jobs.tail(summary.id, 2) =~ "tick 40"
+  end
+
+  # -- #4082: reads and finishes survive a parked or lossy ledger --------------
+
+  test "a ledger parked in a slow write cannot kill the exec path (#4082)" do
+    # Force the lazy session row before parking the log: Session.ids/0 must
+    # not itself queue behind the suspended server.
+    _ = Session.ids()
+
+    log = Process.whereis(ActionLog)
+    :ok = :sys.suspend(log)
+
+    {summary, output} =
+      try do
+        # The job's control process parks in `job_started` against the
+        # suspended log. Pre-fix, Jobs.run died here: the {:subscribe, pid}
+        # call hit its default 5s timeout and the exit killed the caller
+        # (the exec handler, in production).
+        Jobs.run(~s|IO.puts("parked"); :ok|, budget: 0.2, intent: "under parked ledger")
+      after
+        :ok = :sys.resume(log)
+      end
+
+    # The budget elapsed while the ledger was parked: the run degrades to
+    # the budget-then-background contract instead of an exit, and reads
+    # answer from the snapshot.
+    assert summary.running
+    assert is_binary(output)
+    assert Jobs.get(summary.id).id == summary.id
+
+    final = Jobs.await(summary.id, 10_000)
+    assert final.status == :done
+
+    # And the run is on the durable record once the ledger drains.
+    assert %{status: :done} =
+             eventually(fn ->
+               case ActionLog.job(summary.id) do
+                 %{status: :done} = row -> row
+                 _not_yet -> nil
+               end
+             end)
+
+    assert Enum.find(Jobs.history(20), &(&1.id == summary.id))
+  end
+
+  test "a killed job whose start write was lost is still finalized via reaper meta (#4082)" do
+    %{session_id: session_id} = Session.ids()
+    id = "gh" <> Base.encode16(:crypto.strong_rand_bytes(3), case: :lower)
+
+    start = %{
+      id: id,
+      session_id: session_id,
+      action_id: nil,
+      intent: "ghost start",
+      session_name: nil,
+      topic_name: nil,
+      code: ":ok",
+      watch: false,
+      started_at: DateTime.to_iso8601(DateTime.utc_now())
+    }
+
+    # No job_started write ever happens: the load shape where safe_log
+    # absorbed it. The reaper holds the start metadata and reconstructs the
+    # row when it finalizes the kill.
+    victim = spawn(fn -> Process.sleep(:infinity) end)
+    :ok = Reaper.watch(id, victim, start)
+    Process.exit(victim, :kill)
+
+    assert %{status: :killed, intent: "ghost start"} =
+             eventually(fn ->
+               case ActionLog.job(id) do
+                 %{status: :killed} = row -> row
+                 _not_yet -> nil
+               end
+             end)
+
+    assert Enum.find(Jobs.history(20), &(&1.id == id))
   end
 
   # Graceful stop/start through the supervisor: unlike a kill, this does


### PR DESCRIPTION
Fixes #4082.

## Diagnosis

Both failure shapes in the incident trace to the same bottleneck: the job control process (`IxMcp.Jobs.Job`) makes synchronous calls into the single `IxMcp.ActionLog` GenServer with a 30s call bound (`action_log.ex` `@call_timeout_ms`), while every exec-side read called into the control process with GenServer's default 5s timeout.

**Shape 1: exec handlers dying with `{:timeout, {GenServer, :call, [pid, :summary | {:subscribe, pid}, 5000]}}`.**
- `Jobs.run/2` -> `Job.await/2` did `GenServer.call(server, {:subscribe, self()})` with the default 5s (`jobs/job.ex`), and its `:timeout` branch called `Job.summary(pid)`, also 5s (`jobs.ex`).
- The control process is legitimately parked far past 5s: `handle_continue(:spawn_eval)` blocks in `ActionLog.job_started`, every 250ms flush blocks in `ActionLog.append_job_output`, the terminal transition in `ActionLog.finish_job` -- each up to the ledger's 30s bound, longer across busy-crash restarts (the shared SQLite file has a 5s busy budget per statement against sibling kernels). Under 3-4 subagents plus streaming nix builds the ledger queue makes this routine; the 5s caller exits killed the exec handlers.

**Shape 2: jobs vanishing from `Jobs.history` after the work completed.**
- `Job.handle_continue` writes the start row through `safe_log/1`, which deliberately absorbs ledger failures (#3874) -- including the 30s timeout exit, which the client seam does not retry. Lost start write => no `jobs` row.
- `ActionLog.finish_job`'s guard `SELECT ... WHERE id = ? AND status = 'running'` maps the **missing** row to `:already_final`. `record_terminal` then treats that as recorded (`Reaper.reported`, `terminal_recorded: true`) and never retries; the reaper's own finalize hits the same `:already_final`. One absorbed start write permanently erased the run: `ActionLog.job(id) == nil`, absent from `history`, no output -- despite the underlying shell work having succeeded. This is what contradicted the documented durability promise.

## Fix

- `ActionLog.finish_job` now takes the job's start metadata (`start:`) and reconstructs a missing jobs row inside the terminal transition (the same idempotent `INSERT OR IGNORE` as `job_started`), so the guard still decides races but a lost start write can no longer erase the run.
- The reaper carries that metadata (`Reaper.watch/3`) so an outside kill after a lost start write is still finalized as `killed`; it is armed **before** the first ledger call, closing the kill-while-parked-in-`job_started` window.
- Jobs publish a summary/buffer snapshot as their Registry value at init and at finish: `Jobs.get`, `Jobs.output`, and `Jobs.running` are now plain ETS reads that keep answering while the control process sits in a ledger call.
- `Job.await` bounds its subscribe call by the caller's budget and converts a subscribe timeout into the documented budget-then-background `:timeout` instead of inheriting the exit; `Jobs.run` reads its reply back through the snapshot/ledger path.

## Regression tests

- `jobs_test.exs`: suspending the ActionLog while `Jobs.run` executes -- pre-fix this reproduces the incident exit verbatim (`GenServer.call(pid, {:subscribe, pid}, 5000)` timeout); post-fix it degrades to a running handle and the run lands on the durable record once the ledger drains.
- `jobs_test.exs`: a watched process killed when its start write never landed is still finalized `killed` and listed in history.
- `action_log_test.exs`: `finish_job` reconstructs the row from start metadata and stays idempotent.

## Gates

- `mix test`: 188 tests, 0 failures (new tests run 3x for flake check)
- `mix format --check-formatted`: clean
- `mix credo --strict` (shared `lib/elixir/credo.exs`): no issues

## Disclosure

Investigated, written, and tested by an AI agent (Claude Code, Opus 4.6), dispatched from session 5848fa1b. Please review before merge; do not merge without human sign-off.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep jobs on the ledger and reads answerable when the action log is slow or a job is killed
> - Introduces ETS-backed snapshots via `Job.read_summary/1` and `Job.read_output/1` so callers can read job state without messaging the control process, avoiding stalls when it is busy or parked.
> - `Jobs.get/1`, `Jobs.output/1`, and `Jobs.running/0` now prefer snapshot reads and fall back to GenServer calls or the ledger only when needed.
> - `Job.await/2` is made budget-aware: it respects the caller's timeout, returns `:timeout` instead of crashing, and treats GenServer call timeouts as `:busy`.
> - `ActionLog.finish_job` now accepts optional start metadata and performs an idempotent `INSERT OR IGNORE` to reconstruct a missing jobs row before guarding the terminal transition.
> - The `Reaper` retains start metadata per watched job and passes it through to finalization, so jobs killed before their start row landed are still recorded in history.
> - Behavioral Change: `Jobs.run` now reads output and summary by job id (via snapshot/ledger) on timeout or completion instead of calling the pid directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa15769.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->