### PR TITLE
tests: policy assertion follows #4081 (Bash is the kernel-outage fallback)

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4439,8 +4439,10 @@
           && overlay.codex.forcedSettings.features.standalone_web_search == false
           # With the index kernel + exa baked, every superseded native tool is
           # folded in, in each agent's own vocabulary.
+          # Bash is deliberately absent: it survives the kernel deny as the
+          # degraded-mode fallback for kernel outages (index#4080, PR #4081).
+          && !(builtins.elem "Bash" baked.claude.deniedToolPatterns)
           && builtins.all (tool: builtins.elem tool baked.claude.deniedToolPatterns) [
-            "Bash"
             "Read"
             "Write"
             "Edit"


### PR DESCRIPTION
Fixes the flake-check red on every index PR since #4081 merged: the dev-base eval assertion still required Bash in the kernel-superseded deny list. Now asserts the new contract (Bash intentionally NOT denied, ref index#4080/#4081; all other superseded tools still gated). My omission in #4081; fix-forward. (sent by an AI agent via Claude Code, model Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Assert `Bash` is excluded from `baked.claude.deniedToolPatterns` as a degraded-mode fallback
> Updates [tests/default.nix](https://github.com/indexable-inc/index/pull/4086/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) to reflect the policy from #4081 that Bash remains allowed as a kernel-outage fallback. Adds an explicit assertion that `Bash` is not present in `baked.claude.deniedToolPatterns`, and removes `Bash` from the set of tools verified to be denied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2710a61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->