### PR TITLE
mcp-ex: run the shared action log in WAL mode

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/action_log.ex
+++ b/packages/mcp-ex/lib/ix_mcp/action_log.ex
@@ -875,6 +875,8 @@ defmodule IxMcp.ActionLog do
     :ok = Sqlite3.set_busy_timeout(conn, min(@busy_nif_wait_ms, busy_budget(opts)))
     db = %{conn: conn, busy_timeout_ms: busy_budget(opts)}
 
+    ensure_wal(db)
+
     # index#3539: on 2026-07-17 a server binary match-crashed right here
     # against an action log written under a newer schema, and the failed
     # child took the whole application down -- every tool call died over a
@@ -916,6 +918,28 @@ defmodule IxMcp.ActionLog do
   end
 
   def terminate(_reason, _state), do: :ok
+
+  # The shared file must run in WAL mode (#4092): under the default rollback
+  # journal one instance's long read -- a history scan over a grown log --
+  # holds the lock every sibling's writes need, and on 2026-07-23 those
+  # blocked writes outlived the busy budget, crash-looped every instance's
+  # log, and killed two whole kernels through restart intensity. WAL keeps
+  # readers and the single writer independent, leaving busy_wait to genuine
+  # writer-writer contention. The pragma is persistent and converts an
+  # existing rollback-journal file in place; conversion needs a moment of
+  # exclusivity, so it rides the same busy budget as any write. Anything but
+  # wal (or memory, for the ":memory:" test databases) means the conversion
+  # failed and this instance would reintroduce the blocking mode for every
+  # sibling, so it refuses to run rather than degrade silently.
+  defp ensure_wal(db) do
+    case fetch(db, "PRAGMA journal_mode=WAL", []) do
+      [[mode]] when mode in ["wal", "memory"] ->
+        :ok
+
+      [[mode]] ->
+        raise "action log could not enter WAL mode (#4092), still #{inspect(mode)}"
+    end
+  end
 
   # index#3539 degraded mode: the file belongs to a newer server, so writes
   # are dropped and reads answer empty rather than crashing every caller.

--- a/packages/mcp-ex/test/ix_mcp/action_log_wal_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/action_log_wal_test.exs
@@ -1,0 +1,41 @@
+defmodule IxMcp.ActionLogWalTest do
+  @moduledoc """
+  Regression for #4092, the 2026-07-23 parallel-session incident: several kernels
+  share one action-log file, and under the default rollback journal a
+  sibling's open read transaction holds the lock every write needs. Writes
+  outlived the busy budget, every instance's log crash-looped, and two
+  kernels died wholesale through restart intensity, closing their MCP
+  connections mid-call. WAL keeps readers and the writer independent, so a
+  held read snapshot must not block writes at all.
+  """
+  use ExUnit.Case, async: true
+
+  alias Exqlite.Sqlite3
+  alias IxMcp.ActionLog
+
+  @moduletag :tmp_dir
+
+  test "a sibling's open read transaction does not block writes", %{tmp_dir: dir} do
+    path = Path.join(dir, "actions.db")
+    name = :"action_log_wal_#{System.unique_integer([:positive])}"
+
+    # The short busy budget is the point: under the rollback journal the
+    # write below sat blocked behind the reader until this budget expired
+    # and the log crashed; under WAL it must not wait at all.
+    log = start_supervised!({ActionLog, path: path, name: name, busy_timeout_ms: 500})
+
+    # A concurrent server instance parked in a read transaction -- a
+    # history/recent_jobs scan over a grown log holds its lock long enough
+    # for sibling writes to pile into it.
+    {:ok, holder} = Sqlite3.open(path)
+    :ok = Sqlite3.execute(holder, "BEGIN")
+    {:ok, stmt} = Sqlite3.prepare(holder, "SELECT count(*) FROM sessions")
+    {:ok, _rows} = Sqlite3.fetch_all(holder, stmt)
+
+    assert is_integer(ActionLog.create_session("wal", name))
+    assert Process.alive?(log)
+
+    :ok = Sqlite3.execute(holder, "COMMIT")
+    :ok = Sqlite3.close(holder)
+  end
+end


### PR DESCRIPTION
Fixes #4092.

## What happened

Parallel sessions on 2026-07-23 crash-looped every kernel instance action log and killed two kernels outright. The shared `actions.db` runs in the default rollback-journal mode, where one instance holding an open read transaction (a history scan over the now-300MB log) blocks every sibling write. Blocked writes outlived the 5s busy budget and hit the #3890 raise:

    ** (RuntimeError) action log write still blocked after the busy-timeout wait (#3890): UPDATE sessions SET last_seen_at = ? WHERE id = ?

`kernel.log` records 254 of these; each raise restarts the log into the same held lock, restart intensity ran out, and the `erl_crash.dump` slogan is `{application_terminated,ix_mcp,shutdown}` -- Claude Code saw `MCP error -32000: Connection closed` on every in-flight tool call, plus `request handler died: {:noproc, ...start_action...}` during the restart blips.

## Fix

Open the log in WAL mode (`PRAGMA journal_mode=WAL`, persistent, converts the existing file in place). Readers and the single writer proceed independently, so `busy_wait` only sees genuine writer-writer contention -- the short writes the 5s budget was designed for. A conversion that cannot complete raises rather than silently running in the blocking mode.

## Test

`test/ix_mcp/action_log_wal_test.exs` pins the incident shape: a sibling holding an open read transaction must not block writes. Before the fix it reproduces the production crash verbatim (same raise, same crash loop); after, the write is immediate.

Validated with the package suite (189 tests, 0 failures) and the CI gates (`mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict` with the shared config).

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run the `IxMcp.ActionLog` SQLite database in WAL journal mode
> - Adds `ensure_wal/1` in [action_log.ex](https://github.com/indexable-inc/index/pull/4094/files#diff-3e72adde29b4a1c32aaa66b83a963485a2f67735bd45ed8c1652532de4c4adab) that runs `PRAGMA journal_mode=WAL` after opening the SQLite connection; accepts `"wal"` or `"memory"` and raises for any other result.
> - Adds a concurrent-access test in [action_log_wal_test.exs](https://github.com/indexable-inc/index/pull/4094/files#diff-9a365ad3b53f8bfdabd45df63baf782dd872960a71c0052db2d9216c4bad64e8) that holds an open read transaction on a sibling connection while asserting session creation succeeds.
> - Risk: `ActionLog` setup now raises if the database cannot be set to WAL or memory mode (e.g. on read-only filesystems or certain SQLite builds).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee1d5e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->