### PR TITLE
lib: quote antiquote in legacyPackages access (#4096)

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -825,7 +825,7 @@
   Example flakes use the in-eval `import-ix.nix` wasm shim instead.
   */
   importIxFor = hostSystem: let
-    hostPkgs = nixpkgs.legacyPackages.${hostSystem};
+    hostPkgs = nixpkgs.legacyPackages."${hostSystem}";
   in
     import ./import-ix-native.nix {
       pkgs = hostPkgs;

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1938,25 +1938,25 @@ in {
     examplePackages
     // healthChecks.lifecyclePackages
     // lib.optionalAttrs (system == "x86_64-linux") {
-    kernel-unit = (ix.kernelUnitFor pkgs).buildKernel {
-      inherit (pkgs.linux_6_12) src;
+      kernel-unit = (ix.kernelUnitFor pkgs).buildKernel {
+        inherit (pkgs.linux_6_12) src;
+      };
+      # defconfig-scale lane (#3412): thousands of units per eval, kept here
+      # solely so the eval-cost measurement has a stable attr to time.
+      kernel-unit-defconfig = (ix.kernelUnitFor pkgs).buildKernel {
+        inherit (pkgs.linux_6_12) src;
+        configTarget = "defconfig";
+      };
+      # Static fallback lane (#3413): keeps the ccache plan strategy exercised
+      # so a config whose plan-time tooling rejects skeleton stub objects has a
+      # validated escape hatch to flip to (strategy selection is per-lane and
+      # never auto-detected; Nix cannot catch a failed drv, and a silent flip
+      # would hide skeleton regressions).
+      kernel-unit-ccache = (ix.kernelUnitFor pkgs).buildKernel {
+        inherit (pkgs.linux_6_12) src;
+        planStrategy = "ccache";
+      };
     };
-    # defconfig-scale lane (#3412): thousands of units per eval, kept here
-    # solely so the eval-cost measurement has a stable attr to time.
-    kernel-unit-defconfig = (ix.kernelUnitFor pkgs).buildKernel {
-      inherit (pkgs.linux_6_12) src;
-      configTarget = "defconfig";
-    };
-    # Static fallback lane (#3413): keeps the ccache plan strategy exercised
-    # so a config whose plan-time tooling rejects skeleton stub objects has a
-    # validated escape hatch to flip to (strategy selection is per-lane and
-    # never auto-detected; Nix cannot catch a failed drv, and a silent flip
-    # would hide skeleton regressions).
-    kernel-unit-ccache = (ix.kernelUnitFor pkgs).buildKernel {
-      inherit (pkgs.linux_6_12) src;
-      planStrategy = "ccache";
-    };
-  };
 
   # `nix run .#bench` runs the repo's self-demo perf job (timing + RSS + custom
   # metrics, gated on regressions). The flake's package-with-mainProgram


### PR DESCRIPTION
Fixes #4096.

`nix run .#lint` on main was red: astlog's `no-unquoted-splice` flagged `nixpkgs.legacyPackages.${hostSystem}` in `lib/default.nix:828`. Quote the antiquote (`legacyPackages."${hostSystem}"`), matching the existing access in `lib/image/default.nix`. Also reformat `lib/per-system.nix`, which had drifted and was failing alejandra under the same lint entry point.

Verified locally: `nix run .#lint` is green (13/13) and `nix eval --raw .#claude-code.drvPath` still evaluates.

(sent by an AI agent via Claude Code, model Claude Opus)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Quote dynamic attribute access for `nixpkgs.legacyPackages` in `importIxFor`
> Changes `.${hostSystem}` to `."{hostSystem}"` in [lib/default.nix](https://github.com/indexable-inc/index/pull/4098/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188) to properly quote the antiquote when accessing `nixpkgs.legacyPackages`. Also fixes brace indentation in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/4098/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) with no logical changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ee24f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->