### PR TITLE
gherkin-poc: cucumber-rs Gherkin example plus cargo-mutants audit (and a cargo-unit name-collision fix)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "jnoortheen.nix-ide",
+    "CucumberOpen.cucumber-official",
     "coopermaruyama.nix-embedded-languages",
     "rust-lang.rust-analyzer",
     "mkhl.direnv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,6 +2755,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "cucumber"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a87e18d925b19ebe0fd47ea45316abd216d81ec0879c2448c3f9a0e9da62be"
+dependencies = [
+ "anyhow",
+ "clap",
+ "console",
+ "cucumber-codegen",
+ "cucumber-expressions",
+ "derive_more",
+ "either",
+ "futures",
+ "gherkin",
+ "globwalk",
+ "humantime",
+ "inventory",
+ "itertools 0.14.0",
+ "linked-hash-map",
+ "pin-project",
+ "ref-cast",
+ "regex",
+ "sealed",
+ "smart-default",
+]
+
+[[package]]
+name = "cucumber-codegen"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2fc8a8bbb73af3230db699e8690c5c786655f75eb89e5f18d76055fa1a9a4d"
+dependencies = [
+ "cucumber-expressions",
+ "inflections",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.118",
+ "synthez",
+]
+
+[[package]]
+name = "cucumber-expressions"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6401038de3af44fe74e6fccdb8a5b7db7ba418f480c8e9ad584c6f65c05a27a6"
+dependencies = [
+ "derive_more",
+ "either",
+ "nom 8.0.0",
+ "nom_locate",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4365,6 +4422,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "gherkin"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e2c0d8c632f8a251ce9a8198079b1022adc586ff4e3d33e18debd40eb463b31"
+dependencies = [
+ "heck 0.5.0",
+ "peg",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.118",
+ "textwrap",
+ "thiserror 2.0.18",
+ "typed-builder 0.23.2",
+]
+
+[[package]]
+name = "gherkin-poc"
+version = "0.1.0"
+dependencies = [
+ "cucumber",
+ "futures",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4564,6 +4646,17 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.13.0",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -5244,7 +5337,7 @@ dependencies = [
  "serde_with",
  "strum 0.27.2",
  "tokio",
- "typed-builder",
+ "typed-builder 0.20.1",
  "typetag",
  "url",
  "uuid",
@@ -5268,7 +5361,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "typed-builder",
+ "typed-builder 0.20.1",
  "uuid",
 ]
 
@@ -5589,6 +5682,12 @@ checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "inflections"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "inotify"
@@ -7288,6 +7387,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nom_locate"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -9103,6 +9213,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "peg"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f76678828272f177ac33b7e2ac2e3e73cc6c1cd1e3e387928aa69562fa51367"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636d60acf97633e48d266d7415a9355d4389cea327a193f87df395d88cd2b14d"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9347,6 +9484,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11090,6 +11247,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sealed"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "search"
 version = "0.1.0"
 dependencies = [
@@ -11634,6 +11802,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12221,6 +12400,39 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "synthez"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8a928f38f1bc873f28e0d2ba8298ad65374a6ac2241dabd297271531a736cd"
+dependencies = [
+ "syn 2.0.118",
+ "synthez-codegen",
+ "synthez-core",
+]
+
+[[package]]
+name = "synthez-codegen"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb83b8df4238e11746984dfb3819b155cd270de0e25847f45abad56b3671047"
+dependencies = [
+ "syn 2.0.118",
+ "synthez-core",
+]
+
+[[package]]
+name = "synthez-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "906fba967105d822e7c7ed60477b5e76116724d33de68a585681fb253fc30d5c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sealed",
  "syn 2.0.118",
 ]
 
@@ -13647,7 +13859,16 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
 dependencies = [
- "typed-builder-macro",
+ "typed-builder-macro 0.20.1",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda"
+dependencies = [
+ "typed-builder-macro 0.23.2",
 ]
 
 [[package]]
@@ -13655,6 +13876,17 @@ name = "typed-builder-macro"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ members = [
   "packages/flecs-query/core",
   "packages/flecs-query/mcp",
   "packages/flecs-query/py",
+  "packages/gherkin-poc",
   "packages/git-log-pretty",
   "packages/github-avatar",
   "packages/google/auth",
@@ -255,6 +256,7 @@ kitty = { path = "packages/terminal/kitty" }
 lake-iceberg = { path = "packages/search/lake/iceberg" }
 color-eyre = "0.6"
 crossterm = "0.29"
+cucumber = "0.23"
 dashboard-core = { path = "packages/dashboard/dashboard-core" }
 deadpool-postgres = "0.14"
 devicons = "0.6"

--- a/packages/gherkin-poc/Cargo.toml
+++ b/packages/gherkin-poc/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "gherkin-poc"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+description = "Worked example: Gherkin (cucumber-rs) specs audited with cargo-mutants"
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+cucumber.workspace = true
+futures.workspace = true
+
+# cargo-unit flattens every workspace test target into one namespace, so a
+# generic name like `integration` would collide; keep it crate-unique (same
+# reasoning as dag-runner's `integration_dag_runner`).
+[[test]]
+name = "gherkin_account"
+path = "tests/gherkin_account.rs"

--- a/packages/gherkin-poc/README.md
+++ b/packages/gherkin-poc/README.md
@@ -1,0 +1,45 @@
+# gherkin-poc
+
+A worked example of two techniques, kept deliberately tiny: Gherkin
+(behavior-driven) tests via [cucumber-rs], and a [cargo-mutants] audit of how
+well those tests pin the behavior down. Tracked in
+[indexable-inc/index#4091](https://github.com/indexable-inc/index/issues/4091).
+
+The domain is an `Account` holding integer cents with an agreed overdraft.
+The behavior lives in `tests/features/account.feature` as plain-language
+Given/When/Then scenarios; `tests/gherkin_account.rs` binds each step to the
+crate API. The suite runs under the normal libtest harness (cucumber's
+suggested `harness = false` only affects output ordering), so nextest and
+cargo-unit treat it like any other test:
+
+```sh
+cargo test --package gherkin-poc
+```
+
+## Mutation audit
+
+Per the rust-style skill, cargo-mutants is a package-owner audit tool, not a
+CI gate. The recorded run (cargo-mutants 27.1.0, 2026-07-23):
+
+```sh
+nix shell nixpkgs#cargo-mutants -c cargo mutants --package gherkin-poc --cap-lints=true
+# 19 mutants tested in 33s: 18 caught, 1 unviable
+```
+
+Notes from the audit, in the order they happened:
+
+- Without `--cap-lints=true` the workspace's `warnings = "deny"` makes whole
+  function-body replacements (`withdraw -> Ok(())`) fail to compile on unused
+  parameters, so they report as unviable instead of being exercised. Cap
+  lints to actually test them.
+- The first capped run left one survivor: replacing
+  `Display for AccountError` with an empty write, because no scenario
+  asserted error text. The feature gained
+  `And the error reads "..."` steps; the survivor is now caught. That
+  tighten-the-spec loop is the point of pairing the two tools.
+- The one remaining unviable mutant replaces `const fn with_overdraft` with
+  `Default::default()`, which cannot compile in a const context: a
+  write-off, not a gap.
+
+[cucumber-rs]: https://github.com/cucumber-rs/cucumber
+[cargo-mutants]: https://mutants.rs/

--- a/packages/gherkin-poc/package.nix
+++ b/packages/gherkin-poc/package.nix
@@ -1,0 +1,5 @@
+{
+  id = "gherkin-poc";
+  inRustWorkspace = true;
+  passthruTests = true;
+}

--- a/packages/gherkin-poc/src/lib.rs
+++ b/packages/gherkin-poc/src/lib.rs
@@ -1,0 +1,98 @@
+//! Toy account domain backing the Gherkin proof of concept.
+//!
+//! The behavior lives in `tests/features/account.feature` as plain-language
+//! Given/When/Then scenarios; `tests/gherkin_account.rs` binds each step to
+//! this API with [cucumber-rs](https://github.com/cucumber-rs/cucumber). The
+//! crate exists to demonstrate that pairing, plus a `cargo mutants` audit of
+//! how well the scenarios pin the arithmetic down (see `README.md` for the
+//! recorded run). Tracked in indexable-inc/index#4091.
+
+use core::fmt;
+
+/// Why a deposit or withdrawal was rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccountError {
+    /// The amount was zero or negative; money movements must be positive.
+    NonPositiveAmount,
+    /// The withdrawal would overshoot the overdraft floor by this much.
+    InsufficientFunds {
+        /// Cents missing even after exhausting the overdraft.
+        missing_cents: i64,
+    },
+}
+
+impl fmt::Display for AccountError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NonPositiveAmount => write!(f, "amount must be positive"),
+            Self::InsufficientFunds { missing_cents } => {
+                write!(f, "insufficient funds: {missing_cents} cents short")
+            }
+        }
+    }
+}
+
+impl core::error::Error for AccountError {}
+
+/// A balance in integer cents with an agreed overdraft.
+///
+/// The invariant the Gherkin scenarios defend: the balance never drops below
+/// `-overdraft_limit_cents`, and a rejected operation leaves it untouched.
+#[derive(Debug, Default)]
+pub struct Account {
+    balance_cents: i64,
+    overdraft_limit_cents: i64,
+}
+
+impl Account {
+    /// An empty account allowed to go `limit_cents` below zero.
+    #[must_use]
+    pub const fn with_overdraft(limit_cents: i64) -> Self {
+        Self {
+            balance_cents: 0,
+            overdraft_limit_cents: limit_cents,
+        }
+    }
+
+    /// Current balance in cents; negative once inside the overdraft.
+    #[must_use]
+    pub const fn balance_cents(&self) -> i64 {
+        self.balance_cents
+    }
+
+    /// Add `amount_cents` to the balance.
+    ///
+    /// # Errors
+    ///
+    /// [`AccountError::NonPositiveAmount`] when `amount_cents <= 0`.
+    pub const fn deposit(&mut self, amount_cents: i64) -> Result<(), AccountError> {
+        if amount_cents <= 0 {
+            return Err(AccountError::NonPositiveAmount);
+        }
+        self.balance_cents += amount_cents;
+        Ok(())
+    }
+
+    /// Remove `amount_cents` from the balance, dipping into the overdraft
+    /// down to (and including) its limit.
+    ///
+    /// # Errors
+    ///
+    /// [`AccountError::NonPositiveAmount`] when `amount_cents <= 0`;
+    /// [`AccountError::InsufficientFunds`] when the withdrawal would land
+    /// below the overdraft floor, in which case the balance is unchanged.
+    pub const fn withdraw(&mut self, amount_cents: i64) -> Result<(), AccountError> {
+        if amount_cents <= 0 {
+            return Err(AccountError::NonPositiveAmount);
+        }
+        let floor = -self.overdraft_limit_cents;
+        let after = self.balance_cents - amount_cents;
+        if after < floor {
+            return Err(AccountError::InsufficientFunds {
+                missing_cents: floor - after,
+            });
+        }
+        self.balance_cents = after;
+        Ok(())
+    }
+}

--- a/packages/gherkin-poc/tests/features/account.feature
+++ b/packages/gherkin-poc/tests/features/account.feature
@@ -1,0 +1,34 @@
+Feature: Account balance arithmetic
+  Withdrawals may dip into an agreed overdraft but never past it,
+  and a rejected operation leaves the balance untouched.
+
+  Scenario: Deposits accumulate
+    Given an account with a balance of $10.00
+    When I deposit $2.50
+    Then the balance is $12.50
+
+  Scenario: A withdrawal may land exactly on the overdraft floor
+    Given an account with a $5.00 overdraft and a balance of $10.00
+    When I withdraw $15.00
+    Then the balance is $-5.00
+
+  Scenario: A withdrawal past the overdraft is rejected without side effects
+    Given an account with a $5.00 overdraft and a balance of $10.00
+    When I try to withdraw $15.01
+    Then the operation fails, short $0.01
+    And the error reads "insufficient funds: 1 cents short"
+    And the balance is $10.00
+
+  Scenario Outline: Non-positive amounts are rejected without side effects
+    Given an account with a balance of $10.00
+    When I try to <operation> $<amount>
+    Then the operation fails as a non-positive amount
+    And the error reads "amount must be positive"
+    And the balance is $10.00
+
+    Examples:
+      | operation | amount |
+      | deposit   | 0.00   |
+      | deposit   | -1.00  |
+      | withdraw  | 0.00   |
+      | withdraw  | -1.00  |

--- a/packages/gherkin-poc/tests/gherkin_account.rs
+++ b/packages/gherkin-poc/tests/gherkin_account.rs
@@ -1,0 +1,134 @@
+//! Step definitions binding `features/account.feature` to the crate API.
+//!
+//! Runs under the normal libtest harness (cucumber's suggested
+//! `harness = false` is only about output ordering), so nextest and
+//! cargo-unit treat it like any other test.
+
+use core::str::FromStr;
+
+use cucumber::{World, given, then, when};
+use gherkin_poc::{Account, AccountError};
+
+/// A dollars literal such as `12.50` or `-0.01`, parsed to signed cents.
+///
+/// A dedicated `FromStr` type keeps step signatures on Copy values instead of
+/// `String` captures parsed inline in every step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Cents(i64);
+
+impl FromStr for Cents {
+    type Err = core::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (sign, digits) = s.strip_prefix('-').map_or((1, s), |rest| (-1, rest));
+        let (dollars, cents) = digits
+            .split_once('.')
+            .expect("money literals in the feature file carry a decimal point");
+        Ok(Self(
+            sign * (dollars.parse::<i64>()? * 100 + cents.parse::<i64>()?),
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Operation {
+    Deposit,
+    Withdraw,
+}
+
+impl FromStr for Operation {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "deposit" => Ok(Self::Deposit),
+            "withdraw" => Ok(Self::Withdraw),
+            other => Err(format!("unknown operation {other:?}")),
+        }
+    }
+}
+
+#[derive(Debug, Default, World)]
+struct AccountWorld {
+    account: Account,
+    last_result: Option<Result<(), AccountError>>,
+}
+
+#[given(regex = r"^an account with a balance of \$(-?\d+\.\d{2})$")]
+fn account_with_balance(world: &mut AccountWorld, balance: Cents) {
+    world.account = Account::default();
+    world
+        .account
+        .deposit(balance.0)
+        .expect("feature files seed accounts with positive balances");
+}
+
+#[given(regex = r"^an account with a \$(\d+\.\d{2}) overdraft and a balance of \$(-?\d+\.\d{2})$")]
+fn account_with_overdraft(world: &mut AccountWorld, overdraft: Cents, balance: Cents) {
+    world.account = Account::with_overdraft(overdraft.0);
+    world
+        .account
+        .deposit(balance.0)
+        .expect("feature files seed accounts with positive balances");
+}
+
+#[when(regex = r"^I deposit \$(-?\d+\.\d{2})$")]
+fn deposit(world: &mut AccountWorld, amount: Cents) {
+    world
+        .account
+        .deposit(amount.0)
+        .expect("a bare `I deposit` step expects success; use `I try to`");
+}
+
+#[when(regex = r"^I withdraw \$(-?\d+\.\d{2})$")]
+fn withdraw(world: &mut AccountWorld, amount: Cents) {
+    world
+        .account
+        .withdraw(amount.0)
+        .expect("a bare `I withdraw` step expects success; use `I try to`");
+}
+
+#[when(regex = r"^I try to (deposit|withdraw) \$(-?\d+\.\d{2})$")]
+fn try_operation(world: &mut AccountWorld, operation: Operation, amount: Cents) {
+    world.last_result = Some(match operation {
+        Operation::Deposit => world.account.deposit(amount.0),
+        Operation::Withdraw => world.account.withdraw(amount.0),
+    });
+}
+
+#[then(regex = r"^the balance is \$(-?\d+\.\d{2})$")]
+fn balance_is(world: &mut AccountWorld, expected: Cents) {
+    assert_eq!(world.account.balance_cents(), expected.0);
+}
+
+#[then(regex = r"^the operation fails, short \$(\d+\.\d{2})$")]
+fn fails_insufficient(world: &mut AccountWorld, missing: Cents) {
+    assert_eq!(
+        world.last_result,
+        Some(Err(AccountError::InsufficientFunds {
+            missing_cents: missing.0
+        }))
+    );
+}
+
+#[then(regex = r#"^the error reads "([^"]+)"$"#)]
+fn error_reads(world: &mut AccountWorld, expected: String) {
+    let error = world
+        .last_result
+        .expect("an `I try to` step ran before this assertion")
+        .expect_err("the operation was expected to fail");
+    assert_eq!(error.to_string(), expected);
+}
+
+#[then("the operation fails as a non-positive amount")]
+fn fails_non_positive(world: &mut AccountWorld) {
+    assert_eq!(world.last_result, Some(Err(AccountError::NonPositiveAmount)));
+}
+
+#[test]
+fn account_features() {
+    futures::executor::block_on(AccountWorld::run(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/features"
+    )));
+}

--- a/packages/gherkin-poc/tests/gherkin_account.rs
+++ b/packages/gherkin-poc/tests/gherkin_account.rs
@@ -89,7 +89,7 @@ fn withdraw(world: &mut AccountWorld, amount: Cents) {
 }
 
 #[when(regex = r"^I try to (deposit|withdraw) \$(-?\d+\.\d{2})$")]
-fn try_operation(world: &mut AccountWorld, operation: Operation, amount: Cents) {
+const fn try_operation(world: &mut AccountWorld, operation: Operation, amount: Cents) {
     world.last_result = Some(match operation {
         Operation::Deposit => world.account.deposit(amount.0),
         Operation::Withdraw => world.account.withdraw(amount.0),
@@ -97,11 +97,19 @@ fn try_operation(world: &mut AccountWorld, operation: Operation, amount: Cents) 
 }
 
 #[then(regex = r"^the balance is \$(-?\d+\.\d{2})$")]
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "cucumber's macro requires steps to take `&mut World`"
+)]
 fn balance_is(world: &mut AccountWorld, expected: Cents) {
     assert_eq!(world.account.balance_cents(), expected.0);
 }
 
 #[then(regex = r"^the operation fails, short \$(\d+\.\d{2})$")]
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "cucumber's macro requires steps to take `&mut World`"
+)]
 fn fails_insufficient(world: &mut AccountWorld, missing: Cents) {
     assert_eq!(
         world.last_result,
@@ -112,6 +120,14 @@ fn fails_insufficient(world: &mut AccountWorld, missing: Cents) {
 }
 
 #[then(regex = r#"^the error reads "([^"]+)"$"#)]
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "cucumber step parameters are parsed via FromStr into owned values"
+)]
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "cucumber's macro requires steps to take `&mut World`"
+)]
 fn error_reads(world: &mut AccountWorld, expected: String) {
     let error = world
         .last_result
@@ -121,6 +137,10 @@ fn error_reads(world: &mut AccountWorld, expected: String) {
 }
 
 #[then("the operation fails as a non-positive amount")]
+#[expect(
+    clippy::needless_pass_by_ref_mut,
+    reason = "cucumber's macro requires steps to take `&mut World`"
+)]
 fn fails_non_positive(world: &mut AccountWorld) {
     assert_eq!(world.last_result, Some(Err(AccountError::NonPositiveAmount)));
 }

--- a/packages/nix/nix-cargo-unit/src/render.rs
+++ b/packages/nix/nix-cargo-unit/src/render.rs
@@ -725,9 +725,11 @@ fn compute_hash(
     let unit = &graph.units[index];
     let mut dependency_hashes = Vec::new();
     for dependency in &unit.dependencies {
-        if graph.units[dependency.index].is_run_custom_build() {
-            continue;
-        }
+        // Include run-custom-build deps: `merge_identity_hash` dedupes units
+        // over every dependency, so a name hash that skipped runs collided
+        // two merged units differing only in a build-script-run variant
+        // (indexable-inc/index#4093). The unit graph is a DAG, so recursing
+        // through runs terminates.
         dependency_hashes.push(format!(
             "{}:{}:{}:{}",
             dependency.extern_crate_name,

--- a/packages/site/src/lib/updates/cargo-unit-run-dep-name-collision.svx
+++ b/packages/site/src/lib/updates/cargo-unit-run-dep-name-collision.svx
@@ -1,0 +1,17 @@
+---
+id: cargo-unit-run-dep-name-collision
+postedAt: 2026-07-23T12:00:00-07:00
+title: "nix-cargo-unit: unit names now hash build-script-run deps (collision fix)"
+tags: [nix, rust, cargo-unit, bug]
+links:
+  - label: issue
+    href: https://github.com/indexable-inc/index/issues/4093
+  - label: render.rs
+    href: https://github.com/indexable-inc/index/blob/main/packages/nix/nix-cargo-unit/src/render.rs
+---
+
+`nix-cargo-unit` dedupes units by a full-identity hash that walks every dependency, but named the resulting derivations with a second hash that skipped build-script-run dependencies. Two merged units that differed only in which build-script-run variant they depended on rendered under the same attr key, and the generated `cargo-units.nix` failed to import with `attribute already defined`.
+
+The trigger was mundane: adding a dev-dependency (`cucumber`, for the Gherkin POC) perturbed feature unification between the `[--workspace]` and `[--workspace --tests]` target sets, producing two `tree-sitter` build-script-run variants whose downstream `tree-sitter-dockerfile-updated` run units collided.
+
+The name hash now includes run-custom-build dependency edges, mirroring the merge hash, so names are injective over merged units. Cost: a one-time rename of every unit whose closure contains a build script, i.e. most of the workspace rebuilds once. Toolchain bumps already rename every unit the same way, so this is an established event class, not a new one.

--- a/packages/site/src/lib/updates/gherkin-mutation-poc.svx
+++ b/packages/site/src/lib/updates/gherkin-mutation-poc.svx
@@ -1,0 +1,18 @@
+---
+id: gherkin-mutation-poc
+postedAt: 2026-07-23T12:05:00-07:00
+title: "POC: Gherkin (cucumber-rs) specs audited with cargo-mutants"
+tags: [rust, testing, bdd, mutation-testing]
+links:
+  - label: issue
+    href: https://github.com/indexable-inc/index/issues/4091
+  - label: gherkin-poc
+    href: https://github.com/indexable-inc/index/tree/main/packages/gherkin-poc
+---
+
+`packages/gherkin-poc` is a worked example of two testing techniques the repo had no sample of:
+
+- **Gherkin / BDD**: the behavior lives in `tests/features/account.feature` as plain-language Given/When/Then scenarios (overdraft floor, rejected operations leaving the balance untouched), bound to the crate API by cucumber-rs step definitions. The suite runs under the normal libtest harness (cucumber's suggested `harness = false` is only about output ordering), so nextest and cargo-unit treat it like any other test.
+- **Mutation testing**: the crate README records a `cargo mutants --package gherkin-poc` run against the suite, per the rust-style skill's guidance that cargo-mutants is a package-owner audit tool, not a CI gate.
+
+The crate is deliberately tiny: an `Account` with integer-cent balances and an overdraft limit, just enough arithmetic and boundary conditions to give mutants something to bite.


### PR DESCRIPTION
Fixes #4091. Fixes #4093.

Two commits:

**`packages/gherkin-poc`** — a worked example of Gherkin (BDD) testing plus a mutation audit, kept deliberately tiny (an `Account` in integer cents with an overdraft limit):

- `tests/features/account.feature`: 7 plain-language Given/When/Then scenarios (overdraft floor boundary, rejected operations leaving the balance untouched, a `Scenario Outline` over non-positive amounts). 31 steps, all passing.
- `tests/gherkin_account.rs`: cucumber-rs step definitions running under the normal libtest harness (no `harness = false`), so nextest and cargo-unit treat it like any other test target.
- README records the `cargo mutants --package gherkin-poc --cap-lints=true` audit: **19 mutants — 18 caught, 1 unviable (const-fn write-off), 0 missed.** The first run surfaced a real survivor (`Display` body replacement; no scenario asserted error text); the feature gained `And the error reads "..."` steps to kill it. That tighten-the-spec loop is the point of the POC.

**`nix-cargo-unit` fix** — adding the dev-dependency exposed a latent bug: the render-side unit name hash (`compute_hash`) skipped build-script-run dependencies while `merge_identity_hash` (dedup) includes every edge, so two merged units differing only in a build-script-run variant collided on one attr key and the generated `cargo-units.nix` failed to import (`attribute '"tree-sitter-dockerfile-updated-build-script-run-..."' already defined`). Names now hash run deps too, making them injective over merged units.

Cost disclosure: the fix renames every unit whose closure contains a build script, so most of the workspace rebuilds once (same event class as a toolchain bump, which also renames all units).

Verified locally:
- `cargo test -p gherkin-poc`: 7 scenarios / 31 steps pass
- `cargo test` in `packages/nix/nix-cargo-unit`: 52/52 pass
- `nix eval .#ciChecks.aarch64-darwin` (the failing repro): green with the fix, duplicate attr gone
- `nix run .#lint`: zero findings on touched files
- Not yet verified: the `rust-gherkin-poc` fork-clippy lane (`nix build .#ciChecks.x86_64-linux.rust-gherkin-poc`) — was mid-build on vc1-nix when this PR was opened; PR CI covers it

(authored by Claude Code / Claude Opus 4.5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cucumber-rs Gherkin proof-of-concept and fix `compute_hash` name collision for build-script-run deps
> - Adds a new `gherkin-poc` crate ([packages/gherkin-poc/src/lib.rs](https://github.com/indexable-inc/index/pull/4100/files#diff-8b868ebf70df2aeb56b49e6f81f4b799649524ae70d1cc20a13dcb99ea1189ec)) with an `Account` type and structured `AccountError`, exercised via Gherkin scenarios using `cucumber-rs` ([packages/gherkin-poc/tests/gherkin_account.rs](https://github.com/indexable-inc/index/pull/4100/files#diff-c93326890b2401229d81bb23da7ec6a06faecb6c65e15a26be886d9499b105da)).
> - Fixes `compute_hash` in [packages/nix/nix-cargo-unit/src/render.rs](https://github.com/indexable-inc/index/pull/4100/files#diff-91be6a053ea25b59c072a514f469215dbbfeb6abbba3ddb8d77ad99ffa244e7f) to include run-custom-build dependencies when computing unit identity hashes, resolving a name collision bug.
> - Risk: the hash fix changes computed names/deduplication for units with build-script-run dependencies, which may affect Nix derivation outputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3032d70.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->