### PR TITLE
agent: default to Elixir MCP and native shell

### DIFF
--- a/packages/agent/claude-code/default.nix
+++ b/packages/agent/claude-code/default.nix
@@ -148,7 +148,7 @@
   # namespace (where ids like `btop` or `kitty` would shadow the nixpkgs attrs
   # other packages resolve, and a self-named override like packages/btop would
   # recurse into itself). The overlay eval context does not provide it (the
-  # `mcp` package needs `ix.rustWorkspace` rebound to the caller's pkgs, which
+  # `mcp-ex` package needs the flake package set, which
   # only the flake package set does), so the overlay build of
   # `pkgs.claude-code` falls back to `{ }` and drops the defaults below that
   # need a sibling.
@@ -163,8 +163,8 @@
   # the old pattern of consumers symlinkJoin-wrapping this wrapper a second time
   # just to add it. Defaults to the default pair, additions only (no stock tool is
   # disabled or overridden):
-  #  - `index`: the ix notebook kernel (`ix-mcp serve`, packages/mcp) over
-  #    stdio. Present only when the `mcp` sibling is in scope, i.e. in the
+  #  - `index`: the Elixir ix kernel (`ix-mcp-ex`, packages/mcp-ex) over
+  #    stdio. Present only when the `mcp-ex` sibling is in scope, i.e. in the
   #    flake package set but not the overlay (see `repoPackages`).
   #  - `exa`: Exa's hosted web-search server over streamable HTTP at
   #    https://mcp.exa.ai/mcp. Keyless works with rate limits; for higher
@@ -179,7 +179,7 @@
   # Claude Code "channels" (research preview, needs claude-code >= 2.1.80): MCP
   # servers whose events push into the running session, so the agent reacts to
   # things that happen while you are away. Our `index` server (baked above via
-  # `mcpServers`, packages/mcp) is a channel: kernel `notify(...)` and
+  # `mcpServers`, packages/mcp-ex) is a channel: kernel `notify(...)` and
   # interactive-resource actions emit `notifications/claude/channel` events. It
   # is our OWN stdio server, baked into this package from the same trusted
   # registry as `mcpServers`. Each entry is a channel spec:

--- a/packages/agent/codex/default.nix
+++ b/packages/agent/codex/default.nix
@@ -84,15 +84,13 @@
     (import (ix.paths.packagesRoot + "/agent/common.nix") {
       inherit lib ix;
       # Cross (Linux->Darwin) lane: repoPackages are host-native builds, so
-      # baking `index` would point mcp_servers.index.command at a Linux ix-mcp
-      # the Mac cannot exec (and no Darwin ix-mcp exists in this eval -- it is
-      # a host Python env, not a cross Rust unit). Bake no kernel there: the
-      # same exa-only fallback as the overlay set, and the permissions gate
-      # below then keeps codex's native shell tools enabled instead of
-      # assuming a baked kernel.
+      # baking `index` would point mcp_servers.index.command at a Linux
+      # ix-mcp-ex the Mac cannot exec. No Darwin ix-mcp-ex exists in this
+      # eval. Bake no kernel there: use the exa-only overlay fallback and keep
+      # Codex's native shell tools enabled.
       repoPackages =
         if ix.cross.isCross or false
-        then builtins.removeAttrs repoPackages ["mcp"]
+        then builtins.removeAttrs repoPackages ["mcp-ex"]
         else repoPackages;
       promptOmitRules = omitRules;
       promptOmitTopics = omitTopics;
@@ -135,9 +133,8 @@
     })
     flat;
 
-  # Gates fold in the native tools each baked MCP server supersedes: with the
-  # `index` kernel present the codex shell is force-disabled, and the overlay
-  # build (no kernel baked) keeps its shell rather than losing every tool.
+  # Gates fold in the native tools each baked MCP server supersedes. The native
+  # shell remains available with or without the kernel.
   sharedPermissions = import (ix.paths.packagesRoot + "/agent/policy/permissions.nix") {
     inherit lib;
     indexKernelBaked = mcpServers ? index;

--- a/packages/agent/mcp.nix
+++ b/packages/agent/mcp.nix
@@ -5,12 +5,13 @@
   repoPackages ? {},
 }: {
   # Rendered from the shared `ix.mcp` registry with the kernel pointed at the
-  # `mcp` sibling when it is in scope. Each wrapper adapts this to its own
-  # config shape (`ix.mcp.toClaudeJson` / `ix.mcp.toCodexEntries` / `ix.mcp.toCursorJson`).
+  # Elixir `mcp-ex` sibling when it is in scope. Each wrapper adapts this to
+  # its own config shape.
   defaultServers = ix.mcp.defaultServers {
     indexCommand =
-      if repoPackages ? mcp
-      then lib.getExe repoPackages.mcp
+      if repoPackages ? mcp-ex
+      then lib.getExe repoPackages.mcp-ex
       else null;
+    indexArgs = [];
   };
 }

--- a/packages/agent/policy/permissions.nix
+++ b/packages/agent/policy/permissions.nix
@@ -21,14 +21,9 @@
 # connection shared instead (#2382), which is no isolation at all.
 {
   lib,
-  # True when the wrapper bakes the `index` MCP server (the ix kernel,
-  # packages/mcp). The kernel owns shell, file IO, and code search
-  # (python_exec/nu, read, grep/find), so the stock native tools this table
-  # maps are disabled wherever it is present. A wrapper without the kernel
-  # (the overlay package set) keeps the kernel-superseded tools: denying them
-  # there would leave the agent with no hands. (The exa-gated web pair below
-  # is a separate gate and is still denied in the overlay build, since exa is
-  # baked unconditionally by the default server set.)
+  # True when the wrapper bakes the `index` MCP server. The kernel owns stateful
+  # data and fleet work. Native file tools are disabled wherever it is present,
+  # while the native shell remains available as the direct command path.
   indexKernelBaked ? false,
   # True when the wrapper bakes the `exa` MCP server, which supersedes the
   # stock web search/fetch surface.
@@ -49,21 +44,9 @@
   # Code tool names for `permissions.deny`; `codexFeatures` are codex
   # `features.*` leaves for the forced `-c` layer. The file IO and search rows
   # carry no codex handle: codex reads, writes, and searches through its shell
-  # (covered by the `shell` row), and its `apply_patch` tool is enabled
-  # per-model upstream with no config toggle to reach it.
+  # and its `apply_patch` tool is enabled per-model upstream with no config
+  # toggle to reach it.
   kernelSuperseded = {
-    shell = {
-      # Claude keeps Bash even with the kernel baked: the kernel is the
-      # preferred shell (prompt rules steer there), but a kernel BEAM crash
-      # (index#4080, 2026-07-23) left sessions with NO shell or file IO at
-      # all, since a dead MCP connection never auto-reattaches. Bash is the
-      # degraded-mode fallback, not a second first-class path.
-      claudeTools = [];
-      codexFeatures = {
-        shell_tool = false;
-        unified_exec = false;
-      };
-    };
     fileRead = {
       claudeTools = ["Read"];
       codexFeatures = {};

--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -365,13 +365,15 @@
     indexKernel = {
       topics = ["tooling"];
       text = ''
-        Do shell, search, and data work through the index kernel MCP; its
-        connection-delivered instructions own the how-to.
+        Use the native shell for commands and search. Use the index kernel for
+        stateful Elixir, fleet, and data work; its connection instructions own
+        the kernel how-to.
       '';
       reason = ''
-        Restated MCP mechanics went stale (index#1986, index#1999, the
-        Python-to-Elixir cutover). Absorbs mcpGuidanceOwnership
-        (index#3594).
+        The Elixir kernel owns persistent state and fleet work. Native shell
+        stays available for direct commands and when the MCP connection dies
+        (index#4080). Connection-delivered instructions own kernel mechanics
+        so the prompt does not drift (index#1986, index#1999, index#3594).
       '';
     };
   }

--- a/packages/site/src/lib/updates/elixir-mcp-native-shell.svx
+++ b/packages/site/src/lib/updates/elixir-mcp-native-shell.svx
@@ -1,0 +1,13 @@
+---
+id: elixir-mcp-native-shell
+postedAt: 2026-07-23T12:00:00-07:00
+title: "Agents use the Elixir kernel and keep a native shell"
+tags: [agent, mcp, elixir]
+links:
+  - label: issue
+    href: https://github.com/indexable-inc/index/issues/4099
+---
+
+Agent wrappers now start the persistent Elixir MCP server by default. The old default started the Python notebook kernel even after the workstation configuration had moved to BEAM.
+
+Codex also keeps its native shell when the kernel is present. Commands and search use the native shell. Stateful Elixir, fleet, and data work stay in the kernel. A dead MCP connection no longer removes the only command path.

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3116,6 +3116,13 @@
       }
       {
         assertion =
+          agentCommon.defaultServers.index.command
+          == lib.getExe repoPackages.mcp-ex
+          && agentCommon.defaultServers.index.args == [];
+        message = "agent wrappers should use the argument-free Elixir MCP server by default";
+      }
+      {
+        assertion =
           ix.mcp.houseServers {
             indexCommand = "/bin/ix-mcp";
           }
@@ -4525,11 +4532,9 @@
           ]
           && !(overlay.codex.forcedSettings.features ? shell_tool)
           && overlay.codex.forcedSettings.features.standalone_web_search == false
-          # With the index kernel + exa baked, every superseded native tool is
-          # folded in, in each agent's own vocabulary — except Bash, which
-          # Claude keeps as the kernel-outage fallback (index#4080): a dead MCP
-          # connection never auto-reattaches, so a kernel BEAM crash must
-          # degrade to a stock shell rather than leave the session toolless.
+          # With the index kernel + exa baked, file and web tools are folded in.
+          # Both agents keep their native shell as the direct command path and
+          # as the kernel-outage path (index#4080).
           && !(builtins.elem "Bash" baked.claude.deniedToolPatterns)
           && builtins.all (tool: builtins.elem tool baked.claude.deniedToolPatterns) [
             "Read"
@@ -4545,8 +4550,8 @@
             "WebSearch"
             "WebFetch"
           ]
-          && baked.codex.forcedSettings.features.shell_tool == false
-          && baked.codex.forcedSettings.features.unified_exec == false
+          && !(baked.codex.forcedSettings.features ? shell_tool)
+          && !(baked.codex.forcedSettings.features ? unified_exec)
           && baked.codex.forcedSettings.features.standalone_web_search == false;
         message = "agent policy should gate kernel/exa-superseded native tools on the baked MCP servers";
       }
@@ -4569,10 +4574,10 @@
             "computer_use"
             "image_generation"
             "in_app_browser"
-            "shell_tool"
             "standalone_web_search"
-            "unified_exec"
-          ];
+          ]
+          && !(builtins.elem "features.shell_tool" (map (entry: entry.key) forced))
+          && !(builtins.elem "features.unified_exec" (map (entry: entry.key) forced));
         message = "Codex wrapper should render built-in tool disables into forced launch config";
       }
       {


### PR DESCRIPTION
Fixes #4099.

The shared agent wrapper now starts `mcp-ex` with no subcommand. Codex keeps its native shell flags unset, so commands and search do not depend on MCP health. The prompt assigns persistent state, fleet work, and data work to the Elixir kernel.

Checks:

* `nix run .#lint`
* `nix run .#nix-ix -- build .#checks.x86_64-linux.eval`
* `nix build .#mcp-ex`
* rendered Codex prompt inspection
* `git diff --check`

(sent by an AI agent via Codex)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default agent MCP server to Elixir `mcp-ex` and keep native shell when index kernel is present
> - Switches `defaultServers.index.command` to use the Elixir MCP executable (`repoPackages.mcp-ex`) with an explicit empty `args` list, replacing the previous `mcp` server.
> - Removes the `shell` entry from `kernelSuperseded` in [permissions.nix](https://github.com/indexable-inc/index/pull/4101/files#diff-c9733b1461e1c4084b3b81090b51274bf4a156b58a7110dfb75a5d40bef2df1d), so the native shell is no longer disabled when the index kernel is baked (`features.shell_tool` and `unified_exec` are no longer forced off).
> - Updates cross-lane handling in [codex/default.nix](https://github.com/indexable-inc/index/pull/4101/files#diff-f86191c841f2a39e7a59565f14860841e742d261b42ff0b9f4a5f0d95e7de9d5) to exclude `mcp-ex` (instead of `mcp`) from `repoPackages` when only the Linux Elixir kernel is available.
> - Updates prompt rules to instruct agents to use the native shell for commands and search, reserving the index kernel for stateful Elixir and fleet work.
> - Behavioral Change: agents with a baked index kernel now retain shell access; previously shell tooling was suppressed in that configuration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58f8935.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->