### PR TITLE
examples: kernel-build VM with sandboxed, key-blind, offline Claude

### DIFF
--- a/examples/kernel-build/claude/README.md
+++ b/examples/kernel-build/claude/README.md
@@ -1,0 +1,154 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/hero-dark.svg">
+    <img src="assets/hero.svg" width="720" alt="a kernel-build VM where the claude uid can only reach a loopback proxy that owns the Anthropic API key and forwards to api.anthropic.com; direct egress is rejected">
+  </picture>
+</p>
+
+# Kernel build with a sandboxed Claude
+
+How do you hand an AI agent a kernel tree and a compiler without also
+handing it your API key or an internet connection? This VM fetches a Linux
+checkout on first boot, carries the whole kbuild toolchain, and installs a
+`claude` command that runs Claude Code as an unprivileged user whose only
+network reach is a loopback proxy — the proxy holds the key, the agent
+never sees it.
+
+## Run
+
+```sh
+# From this directory (examples/kernel-build/claude in the index repo).
+ix secret set anthropic_api_key   # paste an Anthropic API key at the hidden prompt
+ix apply .#kernel-build
+```
+
+Get the repo with `git clone https://github.com/indexable-inc/index`.
+
+The kernel clone starts shortly after boot (it is timer-activated so a
+~1.5 GB fetch never blocks VM readiness). Watch it land, then build:
+
+```sh
+ix shell kernel-build
+journalctl -u git-clone.service -f   # until "Finished Clone ..."
+cd /src/linux
+make defconfig && make -j"$(nproc)"
+```
+
+And to hack with the agent, from the same shell:
+
+```sh
+cd /src/linux
+claude
+```
+
+`claude` on PATH is a wrapper: it drops from the root shell into the
+sandboxed `claude` user (keeping your working directory) and starts the real
+Claude Code with `ANTHROPIC_BASE_URL` pointed at the proxy. The agent edits
+the tree, runs `make`, reads `/nix/store` — everything a kernel developer
+does, minus the key and the network.
+
+## Shape
+
+- [`default.ix`](default.ix) declares the VM. The repo URL, ref, and
+  checkout path are the three consts at the top; the tree is fetched by the
+  repo's boot-time [`services.git-clone`](../../../modules/services/git-clone/default.nix)
+  module (shallow, idempotent across reboots). The
+  `deployment.secrets.anthropic_api_key` attachment materializes the stored
+  key as `/run/secrets/anthropic/api-key`, owner `anthropic-proxy`, mode
+  `0400`.
+- [`toolchain.nix`](toolchain.nix) is the kbuild host: gcc, binutils, make,
+  flex, bison, bc, perl, openssl, libelf, ncurses, pahole, and the
+  `CPATH`/`LIBRARY_PATH` wiring that makes kbuild's host tools (objtool,
+  menuconfig, extract-cert) compile outside a nix-shell. It also sets zsh as
+  the VM shell.
+- [`claude.nix`](claude.nix) is the sandbox: the `claude` and
+  `anthropic-proxy` users, the proxy service, the nftables egress policy,
+  and the `claude` wrapper ([`claude-wrapper.py`](claude-wrapper.py)).
+- [`anthropic-proxy.py`](anthropic-proxy.py) is the proxy, small enough to
+  audit in one sitting: accept plain HTTP on `127.0.0.1:8402`, drop the
+  client's credential headers, inject the real key from the 0400 file, and
+  stream the TLS response from `api.anthropic.com` back.
+- [`check-claude-egress.py`](check-claude-egress.py) backs the
+  `claude-egress` health check: connect to the proxy as the claude uid,
+  then assert a direct `https://api.anthropic.com` attempt from that uid
+  fails.
+
+## The trust model, in plain words
+
+Claude builds kernels as a normal user. The `claude` user owns
+`/src/linux` (handed over after the root-run clone), its own home with
+`~/.claude`, and `/tmp`; the nix store and toolchain are world-readable.
+There is no bwrap or chroot layer — a plain uid is already the right
+isolation for "can work, cannot read that file", and it keeps the build
+environment identical to the one a human gets.
+
+The key lives in another uid's 0400 file and only transits the proxy.
+`/run/secrets/anthropic/api-key` is readable exclusively by the
+`anthropic-proxy` user. The agent's `ANTHROPIC_API_KEY` is a dummy string;
+the proxy strips it and injects the real header on the way to
+`api.anthropic.com`. The key is never in the agent's environment, never in
+a file it can open, never in a process it can ptrace (different uid).
+
+The network policy pins claude to the proxy. An nftables output-hook rule
+set keyed on the `claude` uid accepts TCP to `127.0.0.1:8402` and rejects
+everything else — external addresses, IPv6, other loopback ports (so the
+agent cannot probe local control-plane listeners either). The uid is
+inherited by every process the agent spawns, and the wrapper starts the
+session with `NoNewPrivileges`, so no descendant can shed it. Even a fully
+hostile agent can neither read the key, nor exfiltrate it, nor reach the
+internet: its packets die at the kernel's socket layer.
+
+Two deliberate closures of indirect paths:
+
+- DNS is irrelevant to the guarantee. The agent talks to a literal loopback
+  address, and resolver traffic from its uid is rejected like any other
+  packet, so there is no name-lookup step to poison and no DNS tunnel to
+  ride.
+- The nix daemon is scoped away. Any local user may normally ask the root
+  daemon to realise a fixed-output derivation, which would fetch an
+  attacker-chosen URL from outside the uid filter;
+  `nix.settings.allowed-users` limits the daemon socket to operators.
+
+What this does not defend against: the VM's root user (it can read
+anything, including the key file), and the proxy's own upstream — the agent
+can spend your Anthropic quota, because talking to the API is the one thing
+it is supposed to do.
+
+## Why an nftables uid match, not a network namespace
+
+A netns-per-agent design (bwrap or `systemd-run` with only loopback, plus a
+socket bridge to the proxy) isolates harder on paper but adds exactly the
+moving parts that break the "can do real work" requirement: a private netns
+needs the proxy socket bridged in (socat/unix-socket forwarders that buffer
+SSE streams), and the sandbox mount plumbing has to replicate a working
+kbuild host. The uid rule needs none of that: the agent lives in the real
+filesystem and the real netns, and the kernel filters its sockets by owner.
+The match is on the uid, not on a process tree or an interface, so it
+covers forks, daemons, and anything the agent leaves behind. `reject`
+rather than `drop` keeps failure fast and honest (telemetry and update
+probes error immediately instead of hanging).
+
+The `claude-egress` health check proves the behavior, not the config: see
+[`check-claude-egress.py`](check-claude-egress.py).
+
+## Known gaps
+
+- `ix shell` currently lands in bash even though the VM's default shell is
+  zsh (`users.defaultUserShell`); the fix is in flight in ix. Run `zsh`
+  after `ix shell` meanwhile.
+- The agent cannot `git fetch` — by design (no network). The tree is
+  whatever ref the boot-time clone pinned; change the consts in
+  `default.ix` and reapply to move it.
+- Rotating the key follows the ix secrets model: `ix secret set
+  anthropic_api_key` updates the store, but an existing VM keeps its
+  materialized copy until recreated.
+
+## Bad fit if
+
+- You want CI-grade, cached, per-translation-unit kernel builds. That is
+  [`lib/kernel/kbuild-unit.nix`](../../../lib/kernel/kbuild-unit.nix)
+  (index#3442), which builds kernels as content-addressed derivations. This
+  example is the interactive complement: a mutable tree, a warm shell, an
+  agent.
+- You need the agent to browse docs or fetch crates. The only egress is the
+  Anthropic API; that is the point.

--- a/examples/kernel-build/claude/anthropic-proxy.py
+++ b/examples/kernel-build/claude/anthropic-proxy.py
@@ -1,0 +1,128 @@
+"""Loopback proxy that owns the Anthropic API key so the agent never does.
+
+Runs as the `anthropic-proxy` user, the only uid that can read the key file
+(materialized 0400 by ix's secret machinery). It accepts plain HTTP on
+127.0.0.1, drops whatever credential the client sent, injects the real key,
+and forwards the request to api.anthropic.com over TLS, streaming the
+response back chunk by chunk so SSE works. The sandboxed agent's entire
+network world is this listener (claude.nix pins its uid to it with
+nftables); this process's entire upstream world is the UPSTREAM constant
+below.
+
+argv: PORT KEY_FILE -- wired by claude.nix, the single source of truth.
+"""
+
+import http.client
+import http.server
+import sys
+from pathlib import Path
+
+UPSTREAM = "api.anthropic.com"
+
+# Client-supplied identity and framing headers are rewritten here, never
+# passed through: the whole point is that the client's credential is a dummy.
+STRIPPED_REQUEST_HEADERS = frozenset(
+    {"authorization", "connection", "content-length", "host", "x-api-key"}
+)
+
+# Upstream framing headers that stop being true once the body is re-streamed
+# over a close-delimited connection.
+STRIPPED_RESPONSE_HEADERS = frozenset(
+    {"connection", "content-length", "transfer-encoding"}
+)
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    # Assigned in main() before the server starts.
+    key_file: Path
+
+    def do_GET(self) -> None:
+        self._forward()
+
+    def do_POST(self) -> None:
+        self._forward()
+
+    def do_PUT(self) -> None:
+        self._forward()
+
+    def do_PATCH(self) -> None:
+        self._forward()
+
+    def do_DELETE(self) -> None:
+        self._forward()
+
+    def do_HEAD(self) -> None:
+        self._forward()
+
+    def _forward(self) -> None:
+        # Read the key per request, not at startup: the service comes up on a
+        # fresh VM before the secret is attached, and rotation (recreate the
+        # VM, or replace the file) needs no proxy restart.
+        try:
+            key = self.key_file.read_text().strip()
+        except OSError:
+            self.send_error(
+                503,
+                "API key not materialized",
+                "attach the anthropic_api_key secret (ix secret set "
+                "anthropic_api_key, then recreate the VM)",
+            )
+            return
+
+        # The Anthropic SDK always sends Content-Length; an absent header is
+        # a bodiless request, not a chunked one.
+        length = int(self.headers.get("Content-Length") or "0")
+        body = self.rfile.read(length) if length > 0 else b""
+
+        headers: dict[str, str] = {
+            name: value
+            for name, value in self.headers.items()
+            if name.lower() not in STRIPPED_REQUEST_HEADERS
+        }
+        headers["Host"] = UPSTREAM
+        headers["x-api-key"] = key
+        headers["Content-Length"] = str(len(body))
+        headers["Connection"] = "close"
+
+        # The timeout bounds the gap between reads, not the whole response,
+        # so long SSE streams survive as long as they keep producing.
+        upstream = http.client.HTTPSConnection(UPSTREAM, timeout=600)
+        try:
+            upstream.request(self.command, self.path, body=body, headers=headers)
+            response = upstream.getresponse()
+        except OSError:
+            self.send_error(502, "upstream unreachable")
+            upstream.close()
+            return
+
+        self.send_response(response.status)
+        for name, value in response.getheaders():
+            if name.lower() not in STRIPPED_RESPONSE_HEADERS:
+                self.send_header(name, value)
+        self.send_header("Connection", "close")
+        self.close_connection = True
+        self.end_headers()
+        try:
+            # read1 returns whatever is buffered instead of blocking for a
+            # full chunk, which is what keeps SSE tokens flowing immediately.
+            while chunk := response.read1(65536):
+                self.wfile.write(chunk)
+                self.wfile.flush()
+        except OSError:
+            # Client hung up mid-stream; nothing to salvage.
+            pass
+        finally:
+            upstream.close()
+
+
+def main() -> None:
+    port = int(sys.argv[1])
+    Handler.key_file = Path(sys.argv[2])
+    # Threading: the agent runs tool calls and API turns concurrently.
+    http.server.ThreadingHTTPServer(("127.0.0.1", port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/kernel-build/claude/assets/hero-dark.svg
+++ b/examples/kernel-build/claude/assets/hero-dark.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 210" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #e6edf3; }
+    .muted { fill: #8b949e; }
+    .accent { fill: #a371f7; }
+    .deny { stroke: #f85149; stroke-width: 2.5; }
+    .denyText { fill: #f85149; }
+    text { fill: currentColor; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <!-- the VM -->
+  <rect class="box" x="20" y="24" width="470" height="172" rx="10"/>
+  <text x="36" y="46" font-size="12" font-weight="600">kernel-build VM</text>
+
+  <!-- claude user -->
+  <rect class="box" x="40" y="60" width="180" height="112" rx="8"/>
+  <text x="130" y="82" text-anchor="middle" font-size="14" font-weight="600">claude</text>
+  <text x="130" y="98" text-anchor="middle" font-size="11" class="muted">unprivileged uid</text>
+  <text x="130" y="118" text-anchor="middle" font-size="11">/src/linux rw</text>
+  <text x="130" y="134" text-anchor="middle" font-size="11">make -j$(nproc)</text>
+  <text x="130" y="152" text-anchor="middle" font-size="11" class="muted">dummy API key</text>
+
+  <!-- proxy -->
+  <rect class="box" x="300" y="60" width="170" height="80" rx="8"/>
+  <text x="385" y="82" text-anchor="middle" font-size="14" font-weight="600">anthropic-proxy</text>
+  <text x="385" y="98" text-anchor="middle" font-size="11" class="muted">another uid</text>
+  <text x="385" y="118" text-anchor="middle" font-size="11" class="accent">key file 0400</text>
+
+  <!-- claude -> proxy -->
+  <line class="edge" x1="220" y1="96" x2="298" y2="96"/>
+  <text x="259" y="88" text-anchor="middle" font-size="11" class="muted">127.0.0.1:8402</text>
+
+  <!-- claude -> internet, rejected -->
+  <line class="edge" x1="220" y1="152" x2="618" y2="152"/>
+  <text x="420" y="168" text-anchor="middle" font-size="11" class="muted">everything else from the claude uid</text>
+  <line class="deny" x1="252" y1="140" x2="276" y2="164"/>
+  <line class="deny" x1="276" y1="140" x2="252" y2="164"/>
+  <text x="264" y="132" text-anchor="middle" font-size="11" class="denyText">nftables reject</text>
+
+  <!-- proxy -> api -->
+  <line class="edge" x1="470" y1="96" x2="558" y2="96"/>
+  <text x="514" y="88" text-anchor="middle" font-size="11" class="accent">TLS + x-api-key</text>
+
+  <!-- upstream -->
+  <rect class="box" x="560" y="70" width="140" height="52" rx="8"/>
+  <text x="630" y="92" text-anchor="middle" font-size="13" font-weight="600">api.anthropic.com</text>
+  <text x="630" y="108" text-anchor="middle" font-size="11" class="muted">the only egress</text>
+</svg>

--- a/examples/kernel-build/claude/assets/hero.svg
+++ b/examples/kernel-build/claude/assets/hero.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 210" role="img"
+     font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <style>
+    svg { color: #1f2328; }
+    .muted { fill: #656d76; }
+    .accent { fill: #8250df; }
+    .deny { stroke: #cf222e; stroke-width: 2.5; }
+    .denyText { fill: #cf222e; }
+    text { fill: currentColor; }
+    .box { stroke: currentColor; fill: none; }
+    .edge { stroke: currentColor; fill: none; marker-end: url(#arrow); }
+    @media (prefers-color-scheme: dark) {
+      svg { color: #e6edf3; }
+      .muted { fill: #8b949e; }
+      .accent { fill: #a371f7; }
+      .deny { stroke: #f85149; }
+      .denyText { fill: #f85149; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <!-- the VM -->
+  <rect class="box" x="20" y="24" width="470" height="172" rx="10"/>
+  <text x="36" y="46" font-size="12" font-weight="600">kernel-build VM</text>
+
+  <!-- claude user -->
+  <rect class="box" x="40" y="60" width="180" height="112" rx="8"/>
+  <text x="130" y="82" text-anchor="middle" font-size="14" font-weight="600">claude</text>
+  <text x="130" y="98" text-anchor="middle" font-size="11" class="muted">unprivileged uid</text>
+  <text x="130" y="118" text-anchor="middle" font-size="11">/src/linux rw</text>
+  <text x="130" y="134" text-anchor="middle" font-size="11">make -j$(nproc)</text>
+  <text x="130" y="152" text-anchor="middle" font-size="11" class="muted">dummy API key</text>
+
+  <!-- proxy -->
+  <rect class="box" x="300" y="60" width="170" height="80" rx="8"/>
+  <text x="385" y="82" text-anchor="middle" font-size="14" font-weight="600">anthropic-proxy</text>
+  <text x="385" y="98" text-anchor="middle" font-size="11" class="muted">another uid</text>
+  <text x="385" y="118" text-anchor="middle" font-size="11" class="accent">key file 0400</text>
+
+  <!-- claude -> proxy -->
+  <line class="edge" x1="220" y1="96" x2="298" y2="96"/>
+  <text x="259" y="88" text-anchor="middle" font-size="11" class="muted">127.0.0.1:8402</text>
+
+  <!-- claude -> internet, rejected -->
+  <line class="edge" x1="220" y1="152" x2="618" y2="152"/>
+  <text x="420" y="168" text-anchor="middle" font-size="11" class="muted">everything else from the claude uid</text>
+  <line class="deny" x1="252" y1="140" x2="276" y2="164"/>
+  <line class="deny" x1="276" y1="140" x2="252" y2="164"/>
+  <text x="264" y="132" text-anchor="middle" font-size="11" class="denyText">nftables reject</text>
+
+  <!-- proxy -> api -->
+  <line class="edge" x1="470" y1="96" x2="558" y2="96"/>
+  <text x="514" y="88" text-anchor="middle" font-size="11" class="accent">TLS + x-api-key</text>
+
+  <!-- upstream -->
+  <rect class="box" x="560" y="70" width="140" height="52" rx="8"/>
+  <text x="630" y="92" text-anchor="middle" font-size="13" font-weight="600">api.anthropic.com</text>
+  <text x="630" y="108" text-anchor="middle" font-size="11" class="muted">the only egress</text>
+</svg>

--- a/examples/kernel-build/claude/check-claude-egress.py
+++ b/examples/kernel-build/claude/check-claude-egress.py
@@ -1,0 +1,54 @@
+"""Health check: the claude uid reaches the proxy and nothing else.
+
+Proves the containment behaves rather than that the units exist: the policy
+table is loaded, a connect to the proxy port succeeds from the claude uid,
+and a direct https attempt from the same uid fails fast (reject, not a
+timeout hang). Secret-independent, so it passes on a fresh VM and in CI
+where no key is attached.
+
+argv (wired by claude.nix): SYSTEMD_RUN NFT NC CURL PROXY_PORT.
+"""
+
+import subprocess
+import sys
+
+
+def run_as_claude(systemd_run: str, argv: list[str]) -> int:
+    return subprocess.run(
+        [
+            systemd_run,
+            "--quiet",
+            "--collect",
+            "--pipe",
+            "--wait",
+            "--uid=claude",
+            "--gid=claude",
+            *argv,
+        ],
+        check=False,
+    ).returncode
+
+
+def main() -> None:
+    _self, systemd_run, nft, nc, curl, proxy_port = sys.argv
+
+    subprocess.run(
+        [nft, "list", "table", "inet", "claude-egress"],
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+
+    if run_as_claude(systemd_run, [nc, "-z", "127.0.0.1", proxy_port]) != 0:
+        raise SystemExit("the claude uid cannot reach the loopback proxy")
+
+    reached = run_as_claude(
+        systemd_run,
+        [curl, "--silent", "--output", "/dev/null", "--max-time", "5",
+         "https://api.anthropic.com/"],
+    )
+    if reached == 0:
+        raise SystemExit("the claude uid unexpectedly reached the internet directly")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/kernel-build/claude/claude-wrapper.py
+++ b/examples/kernel-build/claude/claude-wrapper.py
@@ -1,0 +1,77 @@
+"""Root's entry point to the sandboxed agent, installed on PATH as `claude`.
+
+Drops from the operator's root shell into the unprivileged `claude` user via
+systemd-run (a fresh cgroup-scoped pty session in the caller's working
+directory) and execs the real Claude Code with its network world rewired:
+ANTHROPIC_BASE_URL points at the loopback key-injecting proxy and the API
+key env var is a decoy. NoNewPrivileges pins the uid for every descendant,
+which is exactly the identity the claude-egress nftables policy keys on.
+
+argv prefix (wired by claude.nix): SYSTEMD_RUN CLAUDE_BIN BASE_URL PATH
+CPATH LIBRARY_PATH PKG_CONFIG_PATH, then the operator's own claude args.
+"""
+
+import os
+import sys
+
+
+def main() -> None:
+    (
+        _self,
+        systemd_run,
+        claude_bin,
+        base_url,
+        path,
+        cpath,
+        library_path,
+        pkg_config_path,
+        *claude_args,
+    ) = sys.argv
+
+    if os.getuid() != 0:
+        sys.stderr.write(
+            "claude: run this from the VM's root shell (ix shell); "
+            "it drops to the sandboxed 'claude' user itself\n"
+        )
+        raise SystemExit(1)
+
+    env = {
+        "HOME": "/home/claude",
+        # Transient units start from systemd's compiled-in default PATH,
+        # which points nowhere on NixOS.
+        "PATH": path,
+        "TERM": os.environ.get("TERM", "xterm-256color"),
+        # The kbuild host-tool search paths from toolchain.nix, so the
+        # agent's build commands see the same environment a human shell does.
+        "CPATH": cpath,
+        "LIBRARY_PATH": library_path,
+        "PKG_CONFIG_PATH": pkg_config_path,
+        "ANTHROPIC_BASE_URL": base_url,
+        # Never the real key; the proxy strips this and injects its own.
+        "ANTHROPIC_API_KEY": "dummy-key-the-proxy-injects-the-real-one",
+        # Skip telemetry/update probes that would only burn timeouts against
+        # the egress policy.
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    }
+
+    argv = [
+        systemd_run,
+        "--quiet",
+        "--collect",
+        "--wait",
+        "--pty",
+        "--same-dir",
+        "--uid=claude",
+        "--gid=claude",
+        "--property=NoNewPrivileges=yes",
+        *[f"--setenv={name}={value}" for name, value in env.items()],
+        claude_bin,
+        *claude_args,
+    ]
+    # Replacing this process (no shell involved) is the point: the wrapper
+    # vanishes and systemd-run owns the pty. Hence the S606 exemption.
+    os.execv(argv[0], argv)  # noqa: S606
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/kernel-build/claude/claude.nix
+++ b/examples/kernel-build/claude/claude.nix
@@ -1,0 +1,182 @@
+/**
+A key-blind, offline Claude Code agent that can still build kernels.
+
+Three properties, each with one owner:
+
+1. Claude can do real work. It runs as the unprivileged `claude` user in
+   the ordinary mount namespace: /nix/store and the toolchain read-only,
+   the kernel tree (chowned to it after the clone), its own ~/.claude and
+   /tmp read-write. No bwrap/chroot layer to keep a working kbuild host.
+2. Claude can never read the API key. The key file is owned by the
+   `anthropic-proxy` user, mode 0400 (declared in default.ix); only the
+   loopback proxy (anthropic-proxy.py) reads it, per request, and injects
+   it upstream. The agent gets a dummy ANTHROPIC_API_KEY and a loopback
+   ANTHROPIC_BASE_URL.
+3. Claude can never reach the internet. An nftables output-hook policy
+   keyed on the `claude` uid rejects every packet except TCP to the proxy's
+   127.0.0.1 port. The uid is the boundary, so it covers every descendant
+   process, and the `claude` wrapper pins the uid with NoNewPrivileges.
+   DNS is irrelevant to the guarantee: the agent talks to a literal
+   loopback address, and any resolver traffic from its uid is rejected
+   like everything else.
+*/
+{
+  config,
+  ix,
+  lib,
+  pkgs,
+  ...
+}: let
+  # Pinned so the nftables rules below match a literal number instead of
+  # depending on name resolution at ruleset load.
+  claudeUid = 1100;
+
+  # Loopback-only. Claimed in ix.networking.portClaims so an eval-time error
+  # (not a runtime bind race) catches another module wanting the port.
+  proxyPort = 8402;
+
+  # Where default.ix's secret declaration materializes the key: owner
+  # anthropic-proxy, mode 0400. The `claude` uid cannot pass the DAC check.
+  keyFile = "/run/secrets/anthropic/api-key";
+
+  # Single source of truth for the checkout path is the git-clone declaration
+  # in default.ix.
+  srcDir = config.services.git-clone.dest;
+
+  systemdRun = "${config.systemd.package}/bin/systemd-run";
+
+  proxy = ix.writePythonApplication pkgs {
+    name = "anthropic-proxy";
+    src = ./anthropic-proxy.py;
+    args = [
+      (toString proxyPort)
+      keyFile
+    ];
+  };
+
+  # Interactive entry point, installed as `claude`; the real claude-code
+  # binary stays off PATH. See claude-wrapper.py for the mechanism.
+  claudeWrapper = ix.writePythonApplication pkgs {
+    name = "claude";
+    src = ./claude-wrapper.py;
+    args = [
+      systemdRun
+      "${pkgs.claude-code}/bin/claude"
+      "http://127.0.0.1:${toString proxyPort}"
+      # Transient units start from systemd's compiled-in default PATH, which
+      # points nowhere on NixOS; hand the agent the system profile.
+      "/run/current-system/sw/bin:/run/wrappers/bin"
+      config.environment.variables.CPATH
+      config.environment.variables.LIBRARY_PATH
+      config.environment.variables.PKG_CONFIG_PATH
+    ];
+  };
+
+  egressCheck = ix.writePythonApplication pkgs {
+    name = "check-claude-egress";
+    src = ./check-claude-egress.py;
+    args = [
+      systemdRun
+      (lib.getExe' pkgs.nftables "nft")
+      (lib.getExe' pkgs.netcat-openbsd "nc")
+      (lib.getExe pkgs.curl)
+      (toString proxyPort)
+    ];
+  };
+in {
+  users = {
+    groups = {
+      claude.gid = claudeUid;
+      anthropic-proxy = {};
+    };
+    users = {
+      claude = {
+        isNormalUser = true;
+        uid = claudeUid;
+        group = "claude";
+        description = "Sandboxed kernel-hacking agent";
+      };
+      anthropic-proxy = {
+        isSystemUser = true;
+        group = "anthropic-proxy";
+        description = "Owns the Anthropic API key and the loopback proxy";
+      };
+    };
+  };
+
+  environment.systemPackages = [claudeWrapper];
+
+  systemd.services = {
+    anthropic-proxy = {
+      description = "Key-injecting loopback proxy to api.anthropic.com";
+      # No network-online ordering: the listener is loopback and the upstream
+      # connection happens lazily per request.
+      wantedBy = ["multi-user.target"];
+      serviceConfig =
+        ix.systemdHardening
+        // {
+          User = "anthropic-proxy";
+          Group = "anthropic-proxy";
+          ExecStart = lib.getExe proxy;
+          Restart = "on-failure";
+          RestartSec = "2s";
+        };
+    };
+
+    # The clone runs as root (it needs the network the agent is denied); hand
+    # the tree to the agent afterwards. Re-runs alongside the idempotent
+    # clone on every boot; a re-chown of an existing tree is a few seconds.
+    git-clone = lib.mkIf config.services.git-clone.enable {
+      serviceConfig.ExecStartPost = "${pkgs.coreutils}/bin/chown -R claude:claude ${srcDir}";
+    };
+  };
+
+  # The network boundary. An output-hook filter keyed on the socket's uid
+  # covers every process the agent ever spawns (uid is inherited and, with
+  # NoNewPrivileges, unchangeable). reject rather than drop so a hostile or
+  # merely curious process fails fast instead of hanging on timeouts.
+  # Loopback is inside the deny: the agent cannot probe other local
+  # listeners (ix-console, the guest agent), only the proxy port.
+  networking.nftables.tables.claude-egress = {
+    family = "inet";
+    content = ''
+      chain output {
+        type filter hook output priority filter; policy accept;
+
+        meta skuid ${toString claudeUid} ip daddr 127.0.0.1 tcp dport ${toString proxyPort} accept
+        meta skuid ${toString claudeUid} meta l4proto tcp reject with tcp reset
+        meta skuid ${toString claudeUid} counter reject
+      }
+    '';
+  };
+
+  # The nix daemon would otherwise be an indirect egress path: any local uid
+  # may ask it to realise a fixed-output derivation, and the daemon (root,
+  # outside the nftables policy) fetches the URL for it. Scope the socket to
+  # operators so the agent's only network reach really is the proxy.
+  nix.settings.allowed-users = [
+    "root"
+    "@wheel"
+  ];
+
+  ix = {
+    networking.portClaims.anthropic-proxy = {
+      protocol = "tcp";
+      port = proxyPort;
+      address = "127.0.0.1";
+      description = "Anthropic key-injecting loopback proxy";
+    };
+
+    healthChecks = {
+      anthropic-proxy = {
+        description = "key-injecting loopback proxy is listening";
+        tcp = {port = proxyPort;};
+      };
+      claude-egress = {
+        description = "claude's uid reaches the proxy and nothing else";
+        attempts = 3;
+        command = [(lib.getExe egressCheck)];
+      };
+    };
+  };
+}

--- a/examples/kernel-build/claude/default.ix
+++ b/examples/kernel-build/claude/default.ix
@@ -1,0 +1,48 @@
+// A Linux kernel hack-station: one VM that fetches a kernel tree on first
+// boot, carries the whole kbuild toolchain, and ships a `claude` command
+// whose agent can build kernels but can neither read the Anthropic API key
+// nor reach the internet (see claude.nix for the sandbox, README for the
+// trust model).
+//
+// The key is attached through the ix secret store (`ix secret set
+// anthropic_api_key`) and materializes as a file only the proxy user can
+// read; claude.nix resolves the same path from this declaration.
+export default ({ index }) => {
+  // The tree to hack on. Edit these three to target another repo, tag, or
+  // checkout path; everything else (ownership handoff, the agent's cwd docs)
+  // follows the dest through `config.services.git-clone`.
+  const repoUrl = "https://github.com/torvalds/linux";
+  const repoRef = "v6.16";
+  const srcDir = "/src/linux";
+  return index.lib.mkVm({
+    name: "kernel-build",
+    deployment: {
+      secrets: {
+        anthropic_api_key: {
+          file: "anthropic/api-key",
+          owner: "anthropic-proxy",
+          mode: "0400",
+        },
+      },
+    },
+    modules: [
+      {
+        services: {
+          // The repo's boot-time clone service (modules/services/git-clone).
+          // `timer` activation fetches after boot readiness instead of
+          // holding multi-user.target hostage to a ~1.5 GB checkout.
+          "git-clone": {
+            enable: true,
+            url: repoUrl,
+            ref: repoRef,
+            dest: srcDir,
+            shallow: true,
+            activation: "timer",
+          },
+        },
+      },
+      import("./toolchain.nix"),
+      import("./claude.nix"),
+    ],
+  });
+};

--- a/examples/kernel-build/claude/flake.nix
+++ b/examples/kernel-build/claude/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "ix example: kernel-build";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    index = {
+      url = "github:indexable-inc/index";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {index, ...}: let
+    # `default.ix` is JavaScript-syntax Nix. `builtins.wasm` converts it during
+    # evaluation, so evaluating this flake takes index's patched nix with
+    # `wasm-builtin` in `extra-experimental-features` (`ix apply` and `ix eval`
+    # pass the flag).
+    importIx = import (index + "/packages/nix/ix2nix/import-ix.nix") {
+      converter = "${index.packages.${index.lib.system}.ix2nix-wasm}/lib/ix2nix.wasm";
+    };
+    vm = importIx ./default.ix {inherit index;};
+  in {
+    ix.default = vm;
+    inherit (vm) nixosConfigurations;
+  };
+}

--- a/examples/kernel-build/claude/toolchain.nix
+++ b/examples/kernel-build/claude/toolchain.nix
@@ -1,0 +1,70 @@
+/**
+The interactive kernel build environment: everything `make defconfig &&
+make -j$(nproc)` needs, wired for a plain VM shell rather than a nix-shell.
+
+Tool selection mirrors `lib/kernel/kbuild-unit.nix`'s `kbuildInputs` (the
+repo's CI-grade kernel builder), plus the compiler and binutils that stdenv
+provides implicitly there.
+*/
+{
+  lib,
+  pkgs,
+  ...
+}: let
+  # Libraries kbuild's host tools link against: objtool wants libelf + zlib,
+  # extract-cert wants openssl, menuconfig wants ncurses. In a derivation
+  # stdenv's cc-wrapper injects their search paths; in an interactive shell
+  # nothing does, so the `environment.variables` below carry the dev outputs
+  # through gcc's standard CPATH/LIBRARY_PATH lookup instead.
+  hostToolLibs = [
+    pkgs.elfutils
+    pkgs.ncurses
+    pkgs.openssl
+    pkgs.zlib
+  ];
+in {
+  environment.systemPackages =
+    [
+      pkgs.gcc
+      # setlocalversion shells out to git when the tree has .git, and the
+      # agent's whole edit loop lives in a git checkout.
+      pkgs.git
+      # kbuild execs ld/objcopy/nm/ar directly (LD=, OBJCOPY=, ...), not
+      # through the gcc driver, so the wrapped compiler's baked-in bintools
+      # path does not cover it.
+      pkgs.binutils
+      pkgs.gnumake
+      pkgs.flex
+      pkgs.bison
+      pkgs.bc
+      pkgs.perl
+      pkgs.python3
+      # scripts/kconfig probes ncurses through HOSTPKG_CONFIG.
+      pkgs.pkg-config
+      # BTF generation when a config sets CONFIG_DEBUG_INFO_BTF=y.
+      pkgs.pahole
+      pkgs.kmod
+      pkgs.cpio
+    ]
+    ++ hostToolLibs;
+
+  # gcc and ld honor these as ordinary search-path env vars, which makes the
+  # system shell a working kbuild host without an FHS emulation layer or a
+  # nix-shell wrapper. Scoped globally on purpose: this VM exists to build
+  # kernels, and the `claude` wrapper (claude.nix) re-exports the same values
+  # into the agent's session.
+  environment.variables = {
+    CPATH = lib.makeSearchPathOutput "dev" "include" hostToolLibs;
+    LIBRARY_PATH = lib.makeLibraryPath hostToolLibs;
+    PKG_CONFIG_PATH = lib.makeSearchPathOutput "dev" "lib/pkgconfig" hostToolLibs;
+  };
+
+  # zsh as the VM shell for every user. The platform sets nushell at normal
+  # priority (lib/image/platform.nix), so taking this example's brief --
+  # a zsh VM -- requires force. Known gap: `ix shell` currently drops into
+  # bash regardless of the account shell; the fix is in flight in ix, and
+  # `zsh` (or `su - claude`) gets you there meanwhile.
+  programs.zsh.enable = true;
+  # astlog-ignore: no-mkforce
+  users.defaultUserShell = lib.mkForce pkgs.zsh;
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -92,6 +92,7 @@
     "hermes/minecraft-operator"
     "hermes/telegram"
     "k8s/k3s"
+    "kernel-build/claude"
     "minecraft/blocks"
     "minecraft/crazy-terrain"
     "minecraft/factions"


### PR DESCRIPTION
A new `examples/kernel-build/claude` single-VM example: a Linux kernel hack-station with a Claude Code agent inside that can build kernels but can neither read the Anthropic API key nor reach the internet.

## What it does

- **Kernel tree on first boot** via the existing `services.git-clone` module (this is its first in-repo consumer). Shallow, timer-activated so the ~1.5 GB fetch never blocks readiness; repo url / ref / dest are plain consts at the top of `default.ix`. The tree is chowned to the agent after the root-run clone.
- **kbuild toolchain** (`toolchain.nix`): mirrors `lib/kernel/kbuild-unit.nix`'s tool set plus gcc/binutils, with `CPATH`/`LIBRARY_PATH`/`PKG_CONFIG_PATH` wiring so `make defconfig && make -j` works in a plain VM shell (no nix-shell). zsh is the VM shell; the README documents the known `ix shell`-lands-in-bash gap.
- **Sandboxed Claude** (`claude.nix`):
  - runs as an unprivileged `claude` uid via a `systemd-run --pty --same-dir` wrapper installed as `claude` (NoNewPrivileges pins the uid); real filesystem, real kbuild host.
  - the key attaches through ix secrets (`deployment.secrets.anthropic_api_key`, file, owner `anthropic-proxy`, mode 0400). Only `anthropic-proxy.py` — a ~120-line stdlib loopback proxy, its own uid — reads it, per request, and injects it toward `api.anthropic.com`. The agent gets `ANTHROPIC_BASE_URL=http://127.0.0.1:8402` and a dummy key.
  - an nftables output-hook policy keyed on the claude uid accepts TCP to `127.0.0.1:8402` and rejects everything else (fast reject, not drop). DNS is irrelevant to the guarantee; `nix.settings.allowed-users` closes the nix-daemon indirect-fetch path.
  - health checks are secret-independent: proxy tcp probe plus a behavioral egress check (`check-claude-egress.py`: the claude uid reaches the proxy, and only the proxy).

The README walks the trust model in plain words and defends uid+nftables over a netns/bwrap sandbox.

## Checks

* `nix run .#lint` (13/13)
* `nix run .#nix-ix -- build .#checks.x86_64-linux.eval`
* `nix eval .#legacyPackages.aarch64-darwin.kernel-build-claude-health.drvPath`
* `zuban check --strict` / `mypy --strict` / repo-config ruff over the three Python entrypoints
* `nix fmt`

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add sandboxed, key-blind, offline Claude Code example for kernel builds in a VM
> - Adds a NixOS VM example (`examples/kernel-build/claude/`) that runs Claude Code under a dedicated `claude` user whose network egress is locked down via nftables to a single loopback port.
> - A local proxy ([`anthropic-proxy.py`](https://github.com/indexable-inc/index/pull/4102/files#diff-c77da908785e241e3bda0bc8af0b8a4d96266a13fbcc122159bfe24138df15ab)) binds to that loopback port, injects the Anthropic API key from a root-owned `0400` secret file, and forwards requests to `api.anthropic.com` over TLS — so Claude never sees the key directly.
> - A [`claude-wrapper.py`](https://github.com/indexable-inc/index/pull/4102/files#diff-d204b72a74cf78e56c74e2c6b6497c676f104998c4225162bb1204948e88d74a) CLI (run as root) drops into the `claude` uid via `systemd-run` with `NoNewPrivileges`, a dummy `ANTHROPIC_API_KEY`, and the loopback base URL.
> - [`toolchain.nix`](https://github.com/indexable-inc/index/pull/4102/files#diff-fbb7a070476665bc31d5f9081894bbe406235d33a3871f7001c52b1c9b6d5e18) installs the full kernel build toolchain and exports the necessary `CPATH`/`LIBRARY_PATH`/`PKG_CONFIG_PATH` so builds work in a normal shell outside `nix-shell`.
> - [`check-claude-egress.py`](https://github.com/indexable-inc/index/pull/4102/files#diff-3c357a04885f8c5e68708e9f69a05f14ee8301412278ec92fe1d8145534c2fa4) provides health checks that verify the proxy is reachable from the `claude` uid and that direct access to `api.anthropic.com` is blocked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7dc4b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->