### PR TITLE
prompt: default backend code to Rust over Python/JS

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -246,6 +246,24 @@
     };
   }
   {
+    backendLanguage = {
+      topics = ["architecture"];
+      text = ''
+        Backend and service code defaults to Rust, not Python or JavaScript.
+        An agent writes it, so ease of authoring counts for little; runtime
+        cost, type safety, and a single deployable binary count for more.
+        Reach for Python or JS only where the ecosystem forces it (a library
+        with no Rust equivalent, an existing app in that language) and say
+        why.
+      '';
+      reason = ''
+        New backend code kept landing in Python and JS for authoring
+        convenience that does not apply when an agent writes it; performance
+        and single-binary deploys matter more (Andrew, 2026-07-23).
+      '';
+    };
+  }
+  {
     oneSourceOfTruth = {
       topics = ["architecture"];
       text = ''


### PR DESCRIPTION
Adds one house-prompt rule, `backendLanguage` (topics: `architecture`), to `packages/agent/prompt/rules.nix`:

> Backend and service code defaults to Rust, not Python or JavaScript. An agent writes it, so ease of authoring counts for little; runtime cost, type safety, and a single deployable binary count for more. Reach for Python or JS only where the ecosystem forces it (a library with no Rust equivalent, an existing app in that language) and say why.

Andrew's intent (2026-07-23): always prefer Rust over Python/JS on the backend; agents write the code, so we care about performance more than ease of writing.

The existing `style` rule's "Type Python boundaries" line is untouched; Python still happens where the ecosystem forces it, and both rules read coherently together.

Validated: `nix build .#checks.aarch64-darwin.eval` (provider-prompts assertions) green, `nix run .#lint` green, `nix fmt` clean, rendered prompt rereads with the new rule in place.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default backend code to Rust over Python/JavaScript in prompt rules
> Adds a `backendLanguage` rule to [rules.nix](https://github.com/indexable-inc/index/pull/4104/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) that instructs the agent to prefer Rust for backend and service code unless ecosystem constraints require otherwise. The rule cites performance and single-binary deployment as the rationale.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fff2352.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->