### PR TITLE
readme: drop [-] prefix from flywheel diagram title

### DIFF
--- a/.github/readme/flywheel-dark.svg
+++ b/.github/readme/flywheel-dark.svg
@@ -376,8 +376,8 @@
       <path class="mhead" d="M 0 0 L 8 4 L 0 8 z"/>
     </marker>
   </defs>
-  <path class="frame" d="M 136 14 H 711 Q 719 14 719 22 V 218 Q 719 226 711 226 H 9 Q 1 226 1 218 V 22 Q 1 14 9 14 H 22"/>
-  <text x="28" y="18.5">[-] flywheel</text>
+  <path class="frame" d="M 105 14 H 711 Q 719 14 719 22 V 218 Q 719 226 711 226 H 9 Q 1 226 1 218 V 22 Q 1 14 9 14 H 22"/>
+  <text x="28" y="18.5">flywheel</text>
   <text x="80" y="92">a change lands once</text>
   <text id="s0" class="m tool r0" x="80" y="112">nix'</text>
   <text class="m tool r1" x="80" y="112">clippy'</text>

--- a/.github/readme/flywheel.svg
+++ b/.github/readme/flywheel.svg
@@ -379,8 +379,8 @@
       <path class="mhead" d="M 0 0 L 8 4 L 0 8 z"/>
     </marker>
   </defs>
-  <path class="frame" d="M 136 14 H 711 Q 719 14 719 22 V 218 Q 719 226 711 226 H 9 Q 1 226 1 218 V 22 Q 1 14 9 14 H 22"/>
-  <text x="28" y="18.5">[-] flywheel</text>
+  <path class="frame" d="M 105 14 H 711 Q 719 14 719 22 V 218 Q 719 226 711 226 H 9 Q 1 226 1 218 V 22 Q 1 14 9 14 H 22"/>
+  <text x="28" y="18.5">flywheel</text>
   <text x="80" y="92">a change lands once</text>
   <text id="s0" class="m tool r0" x="80" y="112">nix'</text>
   <text class="m tool r1" x="80" y="112">clippy'</text>


### PR DESCRIPTION
Closes #4106. Removes the retired `[-]` window-control prefix from the flywheel SVG title (light and dark) and closes the frame's top-edge gap to fit the shorter label, matching the style already used on ix.dev.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `[-]` prefix from flywheel diagram titles in readme SVGs
> Updates the title text in the light and dark flywheel SVG assets used in the readme.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 436676c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->