### PR TITLE
base: remove a stale SQLite dotfile lock on the nix DB at boot

### DIFF
--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -656,10 +656,26 @@ in {
         ix.packages.mcp
       ];
 
-    # Pre-create the workspace at boot so login.nu can cd into it
-    # without racing tmpfiles or relying on mkdir from the shell.
-    systemd.tmpfiles.rules = lib.mkIf cfg.shellWorkspace.enable [
-      "d ${cfg.shellWorkspace.directory} 0755 root root -"
-    ];
+    systemd.tmpfiles.rules =
+      [
+        # With `use-sqlite-wal = false` (above) nix opens db.sqlite on
+        # SQLite's unix-dotfile VFS, whose lock is a real directory entry
+        # (`db.sqlite.lock`) rather than a POSIX lock that dies with its
+        # holder. A rootfs captured while nix held that lock (golden
+        # template capture of a mid-write guest) therefore boots with the
+        # lock still present, and every later nix invocation spins forever
+        # in SQLITE_BUSY retries -- `ix apply` then fails its 5s
+        # wasm-capability probe with "stream into guest failed" (ix#8389).
+        # After a fresh boot no process can hold the lock, so removing it
+        # here ("!" = boot only, before nix-daemon or any login shell can
+        # run nix) is always safe. The sibling db.sqlite-journal must
+        # stay: a hot journal is how SQLite rolls back the interrupted
+        # write on next open.
+        "R! /nix/var/nix/db/db.sqlite.lock"
+      ]
+      # Pre-create the workspace at boot so login.nu can cd into it
+      # without racing tmpfiles or relying on mkdir from the shell.
+      ++ lib.optional cfg.shellWorkspace.enable
+      "d ${cfg.shellWorkspace.directory} 0755 root root -";
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3546,6 +3546,15 @@
         message = "base profile should pre-create the workspace directory via systemd-tmpfiles";
       }
       {
+        # Regression fence for ix#8389: a rootfs captured while nix held the
+        # unix-dotfile lock boots with /nix/var/nix/db/db.sqlite.lock still
+        # present, and every guest nix invocation then spins forever in
+        # SQLITE_BUSY retries. The lock cleanup must run unconditionally at
+        # boot (not gated behind shellWorkspace or any other toggle).
+        assertion = builtins.elem "R! /nix/var/nix/db/db.sqlite.lock" base.config.systemd.tmpfiles.rules;
+        message = "base profile should remove a stale SQLite dotfile lock on the nix DB at boot (ix#8389)";
+      }
+      {
         assertion = let
           firewall = base.config.networking.firewall;
         in


### PR DESCRIPTION
## Problem

indexable-inc/ix#8389: `ix apply` fails consistently right after source upload with

```
error: switch failed: nix wasm capability probe stream into guest failed
```

The server trace on hil-compute-3 shows the real error the probe wraps:

```
F_ERROR=ExecStream { phase: "nix wasm capability probe", source: ResponseTimeout { source: Elapsed(()) } }
```

The guest's nix is not missing `wasm-builtin` — the probe (`nix eval --expr 'builtins ? wasm'`) never answers at all. Inside the affected guest, the probe process from the original apply was still alive 12+ minutes later, sleeping in an `hrtimer_nanosleep` retry loop, and `/nix/var/nix/db/` contained:

```
drwxr-xr-x 2 root root 0 Jul 23 15:50 db.sqlite.lock   <- stale, baked into the rootfs
-r--r--r-- 1 root root 0 Jul 23 15:50 db.sqlite-journal
```

With `use-sqlite-wal = false` (the #6259 mitigation in this profile) nix opens the DB on SQLite's unix-dotfile VFS, whose lock is a real directory entry, not a POSIX lock that dies with its holder. The guest's rootfs was captured (golden template, built 15:50 UTC) while a nix process held that lock, so every boot of that rootfs inherits the lock and every nix invocation spins forever in SQLITE_BUSY retries. Removing the stale lock by hand makes the probe answer `true` in 25 ms.

## Fix

A boot-only tmpfiles rule (`R! /nix/var/nix/db/db.sqlite.lock`) in the base profile. After a fresh boot no process can hold a dotfile lock, so any lock present at boot is stale by definition; systemd-tmpfiles-setup runs before nix-daemon or any login shell can run nix. Warm restores that resume a mid-write guest are untouched (tmpfiles does not re-run, and there the lock has a live owner). The journal file stays: a hot journal is how SQLite rolls back the interrupted write on next open.

Also adds a regression fence next to the existing tmpfiles assertion so the rule cannot be dropped or gated behind a toggle.

Fixes indexable-inc/ix#8389.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove stale SQLite dotfile lock on the Nix DB at boot
> Adds an unconditional `systemd-tmpfiles` rule (`R! /nix/var/nix/db/db.sqlite.lock`) in [base/default.nix](https://github.com/indexable-inc/index/pull/4108/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e) to delete the SQLite lock file before `nix-daemon` or any login shell starts. The shell workspace directory creation rule is preserved via `lib.optional`, conditioned on `cfg.shellWorkspace.enable`. A regression test in [tests/default.nix](https://github.com/indexable-inc/index/pull/4108/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) asserts the lock cleanup rule is always present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 951d0f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->