### PR TITLE
flake: make nix fmt format the tree when given no paths (closes #4105)

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1901,25 +1901,43 @@ in {
   # so they key identically in both views.
   ciChecks = catalogFor rustPackageTestSets.sharded // forkChecks;
 
-  # `nix fmt` runs alejandra directly on the paths it is given. A single `-q`
+  # `nix fmt` runs alejandra on the paths it is given. A single `-q`
   # (`--quiet`) drops alejandra's informational chatter -- the
   # "Congratulations! Your code complies with the Alejandra style." success
   # line and the rotating "Special thanks ... for being a sponsor of
   # Alejandra" promo -- while still surfacing genuine formatting/parse errors
   # (a second `-q` would suppress those too, which we do not want). The
   # lint-fix `nix` lane above already runs `alejandra --quiet`; this wraps the
-  # interactive `nix fmt` entrypoint the same way. A makeWrapper wrapper (not a
-  # hand-rolled shell script, per no-write-shell-application) over the cached
-  # `pkgs.alejandra` store path, so there is nothing extra to rebuild.
-  formatter = pkgs.symlinkJoin {
+  # interactive `nix fmt` entrypoint the same way.
+  #
+  # Since Nix 2.24, `nix fmt` invokes the formatter from the flake root with
+  # NO path arguments (older Nix appended `.`); bare alejandra then reads
+  # stdin, sees EOF, and fails with "<anonymous file on stdin>: unexpected
+  # end of file" (#4105). Defaulting to `.` needs an arity check, which
+  # makeWrapper cannot express and the shell fence (#3823) bars a new shell
+  # wrapper from doing, so this is a compiled exec shim
+  # (ix.writeRustApplication) over the realized alejandra store path.
+  formatter = ix.writeRustApplication pkgs {
     name = "alejandra-quiet";
-    paths = [pkgs.alejandra];
-    nativeBuildInputs = [pkgs.makeWrapper];
-    postBuild = ''
-      # shell
-      wrapProgram $out/bin/alejandra --add-flags --quiet
+    text = ''
+      fn main() {
+          // for .exec(); kept inside main so the astlog Nushell-text
+          // heuristic (which keys on a leading `use `) does not fire
+          use std::os::unix::process::CommandExt;
+
+          let mut args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();
+          if args.is_empty() {
+              args.push(".".into());
+          }
+          let err = std::process::Command::new("${lib.getExe pkgs.alejandra}")
+              .arg("--quiet")
+              .args(args)
+              .exec();
+          eprintln!("alejandra-quiet: exec alejandra failed: {err}");
+          std::process::exit(1);
+      }
     '';
-    meta.mainProgram = "alejandra";
+    meta.description = "alejandra for `nix fmt`: quiet, and formats the whole tree when given no paths";
   };
 
   # Per-TU content-addressed kernel build (kbuild-unit, #3411), exposed under


### PR DESCRIPTION
## Problem

`nix fmt` on a clean tree failed with:

    Failed! 1 error found at:
    - <anonymous file on stdin>: unexpected end of file

while `nix run .#lint`'s alejandra gate passed on the same tree.

## Root cause

Since Nix 2.24, `nix fmt` invokes the flake formatter from the flake root with **no path arguments** (older Nix appended `.`). The formatter was alejandra wrapped only with `--quiet`; with zero path args alejandra switches to stdin mode, reads EOF, and reports the anonymous-stdin parse error. The lint gate passes explicit paths, so it never hit the zero-arg case.

## Fix

Replace the symlinkJoin+wrapProgram formatter with a compiled exec shim (`ix.writeRustApplication`) that defaults to `.` when invoked with no paths and passes any given paths through to `alejandra --quiet` unchanged. makeWrapper cannot express the arity check, and the shell fence (#3823) bars a new shell wrapper, so the shim is Rust exec'ing the realized alejandra store path.

## Verification

- `nix fmt` on a clean tree: exit 0, no changes
- `nix fmt` with a deliberately mangled file: file reformatted
- `nix fmt <path>`: formats just that path
- `nix run .#lint`: 13/13 stages green

Fixes #4105

(PR by an AI agent via Claude Code, Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `nix fmt` to format the current directory when given no paths
> Replaces the `makeWrapper`-based alejandra wrapper in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/4109/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) with a compiled Rust shim via `pkgs.writeRustApplication`. The shim injects `.` as the path argument when none are provided, and always passes `--quiet` to alejandra. Previously, invoking `nix fmt` with no arguments would read from stdin and fail. Behavioral Change: `nix fmt` now always passes `--quiet` to alejandra, suppressing output that was previously visible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46958d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->