### PR TITLE
ix2nix: lower TypeScript annotations to runtime type checks

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -830,6 +830,7 @@
     import ./import-ix-native.nix {
       pkgs = hostPkgs;
       inherit (packageSetFor hostPkgs) ix2nix;
+      ixTy = import (paths.root + "/packages/nix/ix2nix/ix-ty.nix") {mode = "assert";};
     };
 
   importIx = importIxFor system;

--- a/lib/import-ix-native.nix
+++ b/lib/import-ix-native.nix
@@ -11,15 +11,18 @@
 # converter derivations and lose their cache hits for every edit here.
 #
 # Same calling convention as the wasm shim: every converted module renders as
-# `{ __dir, __importIx }: <body>`, so `__dir` anchors the module's relative
-# `import()` specifiers and `__importIx` recurses through this same function
-# for `.ix` imports.
+# `{ __dir, __importIx, __ixTy }: <body>`, so `__dir` anchors the module's
+# relative `import()` specifiers, `__importIx` recurses through this same
+# function for `.ix` imports, and `__ixTy` runs the emitted type checks.
 {
   # Package set the conversion derivation builds with; must match the
   # evaluating system so the IFD can build locally.
   pkgs,
   # The compiled converter CLI (`packages.<system>.ix2nix`).
   ix2nix,
+  # The imported type runtime (`packages/nix/ix2nix/ix-ty.nix`, applied to a
+  # mode); threaded in because up-paths out of lib/ are banned.
+  ixTy,
 }: let
   importIx = path: let
     nixSource =
@@ -32,6 +35,7 @@
     import nixSource {
       __dir = dirOf path;
       __importIx = importIx;
+      __ixTy = ixTy.forModule (toString path);
     };
 in
   importIx

--- a/packages/nix/ix2nix/examples/typed-error.ix
+++ b/packages/nix/ix2nix/examples/typed-error.ix
@@ -1,0 +1,5 @@
+// `b` fails its Int check in assert mode; erase mode never reads `b`, so
+// the same module evaluates to 1. The wasm e2e asserts both.
+const first = (a: Int, b: Int): Int => a;
+
+export default first(1, "two");

--- a/packages/nix/ix2nix/examples/typed.ix
+++ b/packages/nix/ix2nix/examples/typed.ix
@@ -1,0 +1,3 @@
+const inc = (n: Int): Int => n + 1;
+
+export default inc(41);

--- a/packages/nix/ix2nix/import-ix.nix
+++ b/packages/nix/ix2nix/import-ix.nix
@@ -2,15 +2,20 @@
 # ix2nix plugin (`builtins.wasm`, behind the `wasm-builtin` experimental
 # feature of the patched nix-ix evaluator), then `import` the result.
 #
-# Every converted module renders as `{ __dir, __importIx }: <body>` -- one
-# calling convention regardless of whether the source uses `import()` -- so
-# this shim applies exactly that attrset: `__dir` anchors the module's
-# relative `import()` specifiers and `__importIx` recurses through this same
-# function for `.ix` imports.
+# Every converted module renders as `{ __dir, __importIx, __ixTy }: <body>`
+# -- one calling convention regardless of whether the source uses `import()`
+# or type annotations -- so this shim applies exactly that attrset: `__dir`
+# anchors the module's relative `import()` specifiers, `__importIx` recurses
+# through this same function for `.ix` imports, and `__ixTy` is the type
+# runtime that decides whether emitted annotations check (`assert`) or cost
+# nothing (`erase`).
 {
   # Store path of the compiled converter (`ix2nix.wasm`).
   converter,
+  # Type-check mode for every module this shim imports; see `ix-ty.nix`.
+  typeMode ? "assert",
 }: let
+  ixTy = import ./ix-ty.nix {mode = typeMode;};
   importIx = path: let
     nixSource = builtins.wasm {
       path = converter;
@@ -20,6 +25,7 @@
     import (builtins.toFile (baseNameOf path + ".nix") nixSource) {
       __dir = dirOf path;
       __importIx = importIx;
+      __ixTy = ixTy.forModule (toString path);
     };
 in
   importIx

--- a/packages/nix/ix2nix/ix-ty.nix
+++ b/packages/nix/ix2nix/ix-ty.nix
@@ -1,0 +1,126 @@
+# The `__ixTy` runtime behind ix2nix's emitted type checks: every converted
+# module renders as `{ __dir, __importIx, __ixTy }: <body>` and calls only
+# `arg` (parameter check) and `ret` (return and `as` check), passing checker
+# values built from the other attributes. The import shims construct one
+# runtime per module via `forModule`, so failures carry the module path next
+# to the emitted `line:col` location.
+#
+# Force policy in `assert` mode: a check may force the checked value to weak
+# head normal form and read its attribute *names*, never attribute values or
+# list elements (even `drv` and `describe` probe by name, so a throwing
+# attribute can never mask a diagnostic). The only force typed code adds
+# over untyped code is WHNF of the annotated values themselves; element and
+# field types are a future deep-checking mode's job.
+{
+  # "assert" runs the checks; "erase" turns both entry points into no-ops
+  # (checker arguments are lazy, so erased checks cost nothing).
+  mode,
+}: let
+  # Attr-name probe for derivations: `v.type or null` would force the value
+  # of a `type` attribute, so a throwing member could mask the diagnostic.
+  isDrvShaped = v: builtins.isAttrs v && v ? drvPath && v ? outPath;
+
+  # Scalars show their value (strings truncated), so a failed refinement
+  # like `Port` names the offending number, not just "int".
+  describe = v: let
+    t = builtins.typeOf v;
+  in
+    if isDrvShaped v
+    then "derivation"
+    else if t == "int" || t == "float" || t == "bool"
+    then "${t} (${builtins.toJSON v})"
+    else if t == "string"
+    then "string (${builtins.toJSON (builtins.substring 0 40 v)})"
+    else t;
+
+  fieldNames = fields: builtins.concatStringsSep ", " (map (f: "`${f.name}`") fields);
+
+  # A checker is `{ desc, check }`: `check loc v` returns true or throws a
+  # positioned error. `loc` arrives as "<line>:<col> <what>" from the
+  # converter; `path` comes from the importer.
+  checkersFor = path: let
+    fail = loc: expected: v:
+      throw ".ix type error at ${path}:${loc}: expected ${expected}, got ${describe v}";
+    mk = desc: pred: {
+      inherit desc;
+      check = loc: v: pred v || fail loc desc v;
+    };
+    prim = name: mk name (v: builtins.typeOf v == name);
+  in {
+    string = prim "string";
+    int = prim "int";
+    float = prim "float";
+    bool = prim "bool";
+    # Refinements borrowed from nixpkgs `lib.types` basics; each stays a
+    # single WHNF-safe predicate.
+    uint = mk "unsigned int" (v: builtins.isInt v && v >= 0);
+    port = mk "port (0-65535)" (v: builtins.isInt v && v >= 0 && v <= 65535);
+    path = mk "path" (
+      v:
+        builtins.typeOf v
+        == "path"
+        || (builtins.isString v && builtins.substring 0 1 v == "/")
+    );
+    nonEmptyString = mk "non-empty string" (v: builtins.isString v && v != "");
+    func = mk "function" builtins.isFunction;
+    any = {
+      desc = "any";
+      check = _: _: true;
+    };
+    drv = mk "derivation" isDrvShaped;
+    enum = values: mk "one of ${builtins.toJSON values}" (v: builtins.elem v values);
+    nullable = ty: {
+      desc = "${ty.desc} | null";
+      check = loc: v: v == null || ty.check loc v;
+    };
+    listOf = ty: mk "list of ${ty.desc}" builtins.isList;
+    attrsOf = ty: mk "set of ${ty.desc}" builtins.isAttrs;
+    req = name: ty: {
+      required = true;
+      inherit name ty;
+    };
+    opt = name: ty: {
+      required = false;
+      inherit name ty;
+    };
+    attrs = fields: let
+      required = builtins.filter (f: f.required) fields;
+      desc =
+        if required == []
+        then "set"
+        else "set with ${fieldNames required}";
+    in {
+      inherit desc;
+      check = loc: v:
+        if !(builtins.isAttrs v)
+        then fail loc desc v
+        else let
+          missing = builtins.filter (f: !(builtins.hasAttr f.name v)) required;
+        in
+          missing
+          == []
+          || throw ".ix type error at ${path}:${loc}: missing field(s) ${fieldNames missing}";
+    };
+  };
+
+  assertForModule = path:
+    checkersFor path
+    // {
+      arg = loc: ty: v: body: builtins.seq (ty.check loc v) body;
+      ret = loc: ty: v: builtins.seq (ty.check loc v) v;
+    };
+
+  # Same attribute shape, no-op entry points: emitted source is identical
+  # across modes, so the importer picks the cost at import time.
+  eraseForModule = path:
+    checkersFor path
+    // {
+      arg = _: _: _: body: body;
+      ret = _: _: v: v;
+    };
+in
+  if mode == "assert"
+  then {forModule = assertForModule;}
+  else if mode == "erase"
+  then {forModule = eraseForModule;}
+  else throw "ix-ty: unknown mode `${mode}`; expected \"assert\" or \"erase\""

--- a/packages/nix/ix2nix/src/error.rs
+++ b/packages/nix/ix2nix/src/error.rs
@@ -15,17 +15,27 @@ pub struct Error {
     line_text: String,
 }
 
+/// 1-based line and column (in characters) of byte `offset` in `source`.
+/// Shared by diagnostics and the `__ixTy` check locations the mapper emits,
+/// so both spell positions identically.
+pub(crate) fn line_col(offset: usize, source: &str) -> (usize, usize) {
+    let offset = offset.min(source.len());
+    let line_start = source[..offset].rfind('\n').map_or(0, |i| i + 1);
+    let line = source[..line_start].matches('\n').count() + 1;
+    let column = source[line_start..offset].chars().count() + 1;
+    (line, column)
+}
+
 impl Error {
     /// Builds an error pointing at byte `offset` of `source`.
     pub(crate) fn at(offset: usize, source: &str, message: impl Into<String>) -> Self {
         let offset = offset.min(source.len());
 
-        let line_start = source[..offset].rfind('\n').map_or(0, |i| i + 1);
         let line_end = source[offset..]
             .find('\n')
             .map_or(source.len(), |i| offset + i);
-        let line = source[..line_start].matches('\n').count() + 1;
-        let column = source[line_start..offset].chars().count() + 1;
+        let (line, column) = line_col(offset, source);
+        let line_start = source[..offset].rfind('\n').map_or(0, |i| i + 1);
 
         Self {
             message: message.into(),

--- a/packages/nix/ix2nix/src/lib.rs
+++ b/packages/nix/ix2nix/src/lib.rs
@@ -1,6 +1,6 @@
 //! `ix2nix`: a pure source-to-source converter from `.ix` modules to Nix.
 //!
-//! A `.ix` file is `JavaScript` *syntax* used as a 1:1 skin over Nix
+//! A `.ix` file is TypeScript *syntax* used as a 1:1 skin over Nix
 //! *semantics*: no `JavaScript` runtime behavior, no evaluation. [`convert`]
 //! takes `.ix` source in and returns Nix source out. Anything without exactly
 //! one Nix spelling is a positioned [`Error`] — there are no fallbacks.
@@ -27,9 +27,31 @@
 //! | `+ - * / == != < <= > >= && \|\| !` | the same operators |
 //! | `true` / `false` / `null` | `true` / `false` / `null` |
 //!
-//! Every module renders wrapped as `{ __dir, __importIx }: <body>` -- one
-//! calling convention for importers, whether or not the source used
-//! `import()`.
+//! # Types
+//!
+//! TypeScript annotations lower to *runtime checks* against the `__ixTy`
+//! runtime the importer passes (`ix-ty.nix`; `assert` mode checks, `erase`
+//! mode no-ops). Static checking is tsc's job, never this converter's.
+//!
+//! | `.ix` (TypeScript syntax) | emitted Nix |
+//! |---|---|
+//! | `(a: T) => e` | `a: __ixTy.arg "<line>:<col> ..." <T> a e` |
+//! | `(a): R => e` | `a: __ixTy.ret "<line>:<col> return" <R> e` |
+//! | `e as T` | `__ixTy.ret "<line>:<col> as" <T> e` (`as any`/`as unknown`: nothing) |
+//! | `type X = T` | `let ty'X = <T>` (referenced by annotations) |
+//! | `({ a }: { a: T }) => e` | per-field `__ixTy.arg` checks on the bound names |
+//!
+//! Type spellings: `string`, `bool`, `Int`, `Float`, `Drv`, `any`/`unknown`,
+//! `object`, `T[]`, `Record<string, T>`, `{ a: T; b?: U }`, function types
+//! (callability only), literal unions, and `T \| null`, plus refinements
+//! borrowed from nixpkgs `lib.types` basics: `Uint`, `Port`, `Path`,
+//! `NonEmptyString`. `number` is a hard error (Nix splits int and float),
+//! as are interfaces, generics, `satisfies`, non-null `!`, and unions
+//! beyond `T \| null` / literals.
+//!
+//! Every module renders wrapped as `{ __dir, __importIx, __ixTy }: <body>`
+//! -- one calling convention for importers, whether or not the source used
+//! `import()` or type annotations.
 //!
 //! Deliberate hard errors (no 1:1): `===`/`!==` (use `==`/`!=`), `undefined`
 //! (use `null`), bare `??` or bare `?.`, `let`/`var`, mutation, loops and
@@ -40,6 +62,7 @@ pub mod error;
 pub mod map;
 pub mod nix;
 pub mod render;
+pub mod ty;
 
 pub use error::Error;
 
@@ -55,7 +78,7 @@ use oxc_span::SourceType;
 /// uses any `JavaScript` form without a 1:1 Nix equivalent.
 pub fn convert(source: &str) -> Result<String, Error> {
     let allocator = Allocator::default();
-    let parsed = Parser::new(&allocator, source, SourceType::mjs()).parse();
+    let parsed = Parser::new(&allocator, source, SourceType::ts()).parse();
 
     if let Some(diagnostic) = parsed.diagnostics.as_slice().first() {
         let offset = diagnostic

--- a/packages/nix/ix2nix/src/map.rs
+++ b/packages/nix/ix2nix/src/map.rs
@@ -3,10 +3,13 @@
 //! Every `JavaScript` form either has exactly one Nix spelling or is a
 //! positioned [`Error`]; there are no fallbacks.
 
+use std::collections::HashSet;
+
 use oxc_ast::ast;
 use oxc_span::{GetSpan as _, Span};
 
 use crate::error::Error;
+use crate::ty::{BUILTIN_TYPES, alias_binding, arg_check, nullable};
 use crate::nix::{
     Attr, BinaryOp, Binding, Expr, LetBinding, Module, Param, PatternField, StrPart, UnaryOp,
     is_bare_ident,
@@ -19,7 +22,25 @@ use crate::nix::{
 /// Returns a positioned [`Error`] for any `JavaScript` form without a 1:1 Nix
 /// equivalent.
 pub fn module(program: &ast::Program<'_>, source: &str) -> Result<Module, Error> {
-    let mapper = Mapper { source };
+    // Alias names are collected up front so annotations anywhere in the
+    // module can reference an alias declared after them (Nix `let` is
+    // recursive, so the emitted bindings tolerate any order).
+    let mut type_aliases = HashSet::new();
+    for statement in &program.body {
+        if let ast::Statement::TSTypeAliasDeclaration(alias) = statement
+            && !type_aliases.insert(alias.id.name.to_string())
+        {
+            return Err(Error::at_offset32(
+                alias.id.span.start,
+                source,
+                format!("duplicate `type {}`", alias.id.name),
+            ));
+        }
+    }
+    let mapper = Mapper {
+        source,
+        type_aliases,
+    };
 
     let mut bindings = Vec::new();
     let mut default = None;
@@ -27,6 +48,15 @@ pub fn module(program: &ast::Program<'_>, source: &str) -> Result<Module, Error>
         match statement {
             ast::Statement::VariableDeclaration(declaration) => {
                 mapper.const_bindings(declaration, &mut bindings)?;
+            }
+            ast::Statement::TSTypeAliasDeclaration(alias) => {
+                mapper.alias_bindings(alias, &mut bindings)?;
+            }
+            ast::Statement::TSInterfaceDeclaration(interface) => {
+                return Err(mapper.err(
+                    interface.span,
+                    "`interface` has no runtime lowering; use `type`",
+                ));
             }
             ast::Statement::ExportDefaultDeclaration(export) => {
                 let Some(expression) = export.declaration.as_expression() else {
@@ -78,12 +108,15 @@ fn make_let(bindings: Vec<LetBinding>, body: Expr) -> Expr {
     }
 }
 
-struct Mapper<'s> {
-    source: &'s str,
+pub(crate) struct Mapper<'s> {
+    pub(crate) source: &'s str,
+    /// Names of this module's top-level `type` aliases; the only type names
+    /// [`crate::ty`] resolves beyond the built-ins.
+    pub(crate) type_aliases: HashSet<String>,
 }
 
 impl Mapper<'_> {
-    fn err(&self, span: Span, message: impl Into<String>) -> Error {
+    pub(crate) fn err(&self, span: Span, message: impl Into<String>) -> Error {
         Error::at_offset32(span.start, self.source, message)
     }
 
@@ -116,6 +149,16 @@ impl Mapper<'_> {
             ast::Expression::BinaryExpression(binary) => self.binary(binary),
             ast::Expression::UnaryExpression(unary) => self.unary(unary),
             ast::Expression::ParenthesizedExpression(paren) => self.expr(&paren.expression),
+            ast::Expression::TSAsExpression(cast) => self.cast(cast),
+            ast::Expression::TSSatisfiesExpression(satisfies) => Err(self.err(
+                satisfies.span,
+                "`satisfies` is a static-only assertion and nothing static runs \
+                 here; use `as` for a runtime check",
+            )),
+            ast::Expression::TSNonNullExpression(non_null) => Err(self.err(
+                non_null.span,
+                "`!` has no runtime lowering; use `x.y ?? default` or `T | null`",
+            )),
             ast::Expression::ChainExpression(chain) => Err(self.err(
                 chain.span,
                 "optional chaining maps only as `expr?.path ?? default` \
@@ -158,7 +201,7 @@ impl Mapper<'_> {
         }
     }
 
-    fn number(&self, lit: &ast::NumericLiteral<'_>) -> Result<Expr, Error> {
+    pub(crate) fn number(&self, lit: &ast::NumericLiteral<'_>) -> Result<Expr, Error> {
         let Some(raw) = lit.raw.as_ref() else {
             return Err(self.err(lit.span, "numeric literal without source text"));
         };
@@ -301,6 +344,48 @@ impl Mapper<'_> {
         })
     }
 
+    /// `expr as T` checks at the cast site, the opposite of TypeScript's
+    /// erasure, on purpose: casts are exactly where unchecked values (JSON,
+    /// imported plain Nix) enter typed code. `as any` / `as unknown` is the
+    /// uncheckable escape hatch and lowers to nothing.
+    fn cast(&self, cast: &ast::TSAsExpression<'_>) -> Result<Expr, Error> {
+        let value = self.expr(&cast.expression)?;
+        if matches!(
+            cast.type_annotation,
+            ast::TSType::TSAnyKeyword(_) | ast::TSType::TSUnknownKeyword(_)
+        ) {
+            return Ok(value);
+        }
+        let ty = self.ty(&cast.type_annotation)?;
+        Ok(self.ret_check(cast.type_annotation.span(), "as", ty, value))
+    }
+
+    /// `type X = T` becomes a `ty'X` checker binding in the emitted `let`.
+    fn alias_bindings(
+        &self,
+        alias: &ast::TSTypeAliasDeclaration<'_>,
+        bindings: &mut Vec<LetBinding>,
+    ) -> Result<(), Error> {
+        if let Some(type_parameters) = &alias.type_parameters {
+            return Err(self.err(
+                type_parameters.span,
+                "generic type aliases are not lowered yet",
+            ));
+        }
+        let name = self.checked_name(alias.id.span, alias.id.name.as_str())?;
+        if BUILTIN_TYPES.contains(&name.as_str()) {
+            return Err(self.err(
+                alias.id.span,
+                format!("`type {name}` shadows the built-in type `{name}`"),
+            ));
+        }
+        bindings.push(LetBinding {
+            name: alias_binding(&name),
+            value: self.ty(&alias.type_annotation)?,
+        });
+        Ok(())
+    }
+
     fn arrow(&self, arrow: &ast::ArrowFunctionExpression<'_>) -> Result<Expr, Error> {
         if arrow.r#async {
             return Err(self.err(arrow.span, "`async` has no Nix equivalent"));
@@ -319,9 +404,31 @@ impl Mapper<'_> {
             ));
         }
 
+        if let Some(type_parameters) = &arrow.type_parameters {
+            return Err(self.err(
+                type_parameters.span,
+                "generic arrows are not lowered yet; annotate concrete types",
+            ));
+        }
+
         let mut body = self.arrow_body(arrow)?;
+        // For a curried `(a, b): R => e`, the declared return is the value of
+        // the innermost body, so its check wraps `e` before the lambdas fold.
+        if let Some(return_type) = &arrow.return_type {
+            let ty = self.ty(&return_type.type_annotation)?;
+            body = self.ret_check(return_type.span, "return", ty, body);
+        }
         // `(a, b) => e` curries to `a: b: e`, matching curried call mapping.
+        // Each parameter's checks wrap the body directly inside that
+        // parameter's own lambda, so a check reads exactly its own binder
+        // (immune to shadowing) and fires on partial application.
         for item in arrow.params.items.iter().rev() {
+            if item.optional {
+                return Err(self.err(
+                    item.span,
+                    "optional parameters have no Nix equivalent; use `T | null`",
+                ));
+            }
             if let Some(initializer) = &item.initializer {
                 return Err(self.err(
                     initializer.span(),
@@ -329,12 +436,108 @@ impl Mapper<'_> {
                      parameter (Nix `{ a ? default }`)",
                 ));
             }
+            if let Some(annotation) = &item.type_annotation {
+                let mut checks = Vec::new();
+                self.param_checks(&item.pattern, annotation, &mut checks)?;
+                for (loc, ty, value) in checks.into_iter().rev() {
+                    body = arg_check(loc, ty, value, body);
+                }
+            }
             body = Expr::Lambda {
                 param: self.param(&item.pattern)?,
                 body: Box::new(body),
             };
         }
         Ok(body)
+    }
+
+    /// Collects the checks one annotated parameter contributes.
+    ///
+    /// A plain parameter checks its own binding. A destructured parameter has
+    /// no binding for the whole attrset, so its annotation must be an inline
+    /// object type and lowers to per-field checks on the bound names; the
+    /// pattern itself already makes Nix demand the fields exist.
+    fn param_checks(
+        &self,
+        pattern: &ast::BindingPattern<'_>,
+        annotation: &ast::TSTypeAnnotation<'_>,
+        checks: &mut Vec<(String, Expr, Expr)>,
+    ) -> Result<(), Error> {
+        match pattern {
+            ast::BindingPattern::BindingIdentifier(ident) => {
+                let loc =
+                    self.check_loc(ident.span, &format!("argument `{}`", ident.name));
+                checks.push((
+                    loc,
+                    self.ty(&annotation.type_annotation)?,
+                    Expr::Ident(ident.name.to_string()),
+                ));
+            }
+            ast::BindingPattern::ObjectPattern(object) => {
+                let ast::TSType::TSTypeLiteral(literal) = &annotation.type_annotation else {
+                    return Err(self.err(
+                        annotation.span,
+                        "a destructured parameter needs an inline object type \
+                         (`({ a }: { a: T })`); there is no binding for the whole set",
+                    ));
+                };
+                for member in &literal.members {
+                    let ast::TSSignature::TSPropertySignature(property) = member else {
+                        return Err(self.err(
+                            member.span(),
+                            "only property signatures lower; index, call, and method \
+                             signatures have no runtime check",
+                        ));
+                    };
+                    let ast::PropertyKey::StaticIdentifier(key) = &property.key else {
+                        return Err(self.err(
+                            property.key.span(),
+                            "pattern field types use plain identifier keys",
+                        ));
+                    };
+                    let bound = object.properties.iter().any(|bound| {
+                        matches!(
+                            &bound.key,
+                            ast::PropertyKey::StaticIdentifier(name) if name.name == key.name
+                        )
+                    });
+                    if !bound {
+                        return Err(self.err(
+                            key.span,
+                            format!(
+                                "field `{}` is declared but not bound by the pattern; \
+                                 only bound fields can be checked",
+                                key.name
+                            ),
+                        ));
+                    }
+                    let Some(field_annotation) = &property.type_annotation else {
+                        return Err(
+                            self.err(property.span, "property signature needs a type")
+                        );
+                    };
+                    let loc =
+                        self.check_loc(key.span, &format!("argument field `{}`", key.name));
+                    let field_ty = self.ty(&field_annotation.type_annotation)?;
+                    // An optional field's Nix default (conventionally `null`)
+                    // binds when the caller omits it; `T | null` is the type
+                    // the bound name actually has.
+                    let field_ty = if property.optional {
+                        nullable(field_ty)
+                    } else {
+                        field_ty
+                    };
+                    checks.push((loc, field_ty, Expr::Ident(key.name.to_string())));
+                }
+            }
+            other => {
+                return Err(self.err(
+                    other.span(),
+                    "this parameter shape cannot carry a type annotation",
+                ));
+            }
+        }
+        Ok(())
     }
 
     fn arrow_body(&self, arrow: &ast::ArrowFunctionExpression<'_>) -> Result<Expr, Error> {
@@ -355,6 +558,12 @@ impl Mapper<'_> {
             match statement {
                 ast::Statement::VariableDeclaration(declaration) => {
                     self.const_bindings(declaration, &mut bindings)?;
+                }
+                ast::Statement::TSTypeAliasDeclaration(alias) => {
+                    return Err(self.err(
+                        alias.span,
+                        "`type` aliases live at module top level only",
+                    ));
                 }
                 ast::Statement::ReturnStatement(ret) => {
                     let Some(argument) = &ret.argument else {
@@ -467,6 +676,12 @@ impl Mapper<'_> {
     fn call(&self, call: &ast::CallExpression<'_>) -> Result<Expr, Error> {
         if call.optional {
             return Err(self.err(call.span, "optional calls have no Nix equivalent"));
+        }
+        if let Some(type_arguments) = &call.type_arguments {
+            return Err(self.err(
+                type_arguments.span,
+                "call-site type arguments are not lowered yet",
+            ));
         }
         if call.arguments.is_empty() {
             return Err(self.err(
@@ -686,10 +901,18 @@ impl Mapper<'_> {
             let Some(init) = &declarator.init else {
                 return Err(self.err(declarator.span, "`const` must have an initializer"));
             };
-            bindings.push(LetBinding {
-                name,
-                value: self.expr(init)?,
-            });
+            if declarator.definite {
+                return Err(self.err(
+                    declarator.span,
+                    "definite assignment (`!`) has no runtime lowering",
+                ));
+            }
+            let mut value = self.expr(init)?;
+            if let Some(annotation) = &declarator.type_annotation {
+                let ty = self.ty(&annotation.type_annotation)?;
+                value = self.ret_check(annotation.span(), &format!("const `{name}`"), ty, value);
+            }
+            bindings.push(LetBinding { name, value });
         }
         Ok(())
     }

--- a/packages/nix/ix2nix/src/render.rs
+++ b/packages/nix/ix2nix/src/render.rs
@@ -50,12 +50,12 @@ impl Ctx {
     }
 }
 
-/// Renders a whole module under the `{ __dir, __importIx }:` wrapper, so every
+/// Renders a whole module under the `{ __dir, __importIx, __ixTy }:` wrapper, so every
 /// converted module presents one calling convention to its importer.
 #[must_use]
 pub fn module(module: &Module) -> String {
     let mut out = String::new();
-    out.push_str("{ __dir, __importIx }:\n");
+    out.push_str("{ __dir, __importIx, __ixTy }:\n");
     expr(
         &mut out,
         &module.body,
@@ -405,7 +405,7 @@ mod tests {
     /// only the expression under test.
     fn rendered(body: Expr) -> String {
         let out = module(&Module { body });
-        out.strip_prefix("{ __dir, __importIx }:\n")
+        out.strip_prefix("{ __dir, __importIx, __ixTy }:\n")
             .expect("every module renders under the wrapper")
             .to_owned()
     }

--- a/packages/nix/ix2nix/src/ty.rs
+++ b/packages/nix/ix2nix/src/ty.rs
@@ -1,0 +1,248 @@
+//! Lowers TypeScript type annotations onto `__ixTy` checker expressions.
+//!
+//! Same contract as the value mapper: every type either has exactly one
+//! runtime lowering or is a positioned [`Error`]. The static half of the
+//! type story (tsc against ambient declarations) never runs here; this pass
+//! only decides what the emitted Nix asserts at eval time, and the `__ixTy`
+//! runtime an importer passes decides whether those assertions run
+//! (`assert` mode) or vanish (`erase` mode).
+
+use oxc_ast::ast;
+use oxc_span::{GetSpan as _, Span};
+
+use crate::error::{Error, line_col};
+use crate::map::Mapper;
+use crate::nix::{Attr, Expr, StrPart};
+
+/// Spells `__ixTy.<field>`, the only way emitted code reaches the runtime.
+fn runtime(field: &str) -> Expr {
+    Expr::Select {
+        base: Box::new(Expr::Ident("__ixTy".into())),
+        path: vec![Attr::Name(field.into())],
+        or_default: None,
+    }
+}
+
+fn apply(function: Expr, argument: Expr) -> Expr {
+    Expr::Apply {
+        function: Box::new(function),
+        argument: Box::new(argument),
+    }
+}
+
+fn str_lit(text: String) -> Expr {
+    Expr::Str(vec![StrPart::Lit(text)])
+}
+
+/// `__ixTy.arg "<loc>" <ty> <value> <body>`: checks `value`, then is `body`.
+/// Parameter checks wrap the innermost body, where every curried parameter
+/// is in scope.
+pub(crate) fn arg_check(loc: String, ty: Expr, value: Expr, body: Expr) -> Expr {
+    apply(
+        apply(apply(apply(runtime("arg"), str_lit(loc)), ty), value),
+        body,
+    )
+}
+
+/// Type names with a fixed meaning; `type` aliases may not shadow them
+/// ([`crate::map`] rejects the declaration), so a reference is never
+/// ambiguous between a built-in and a module alias.
+pub(crate) const BUILTIN_TYPES: [&str; 8] = [
+    "Int", "Uint", "Port", "Float", "Path", "NonEmptyString", "Drv", "Record",
+];
+
+/// Wraps a checker as `__ixTy.nullable <ty>`; optional pattern fields check
+/// against `T | null` because their Nix default binds when the field is
+/// absent, and `null` is the conventional "absent" default.
+pub(crate) fn nullable(ty: Expr) -> Expr {
+    apply(runtime("nullable"), ty)
+}
+
+/// The `let` binding carrying a `type X = ...` alias checker. The `'` is
+/// valid in Nix identifiers but not JavaScript ones, so alias bindings can
+/// never collide with `const` bindings.
+pub(crate) fn alias_binding(name: &str) -> String {
+    format!("ty'{name}")
+}
+
+impl Mapper<'_> {
+    /// `"<line>:<col> <what>"`: the source location a failed check reports.
+    /// The runtime prefixes the module path, which only the importer knows.
+    pub(crate) fn check_loc(&self, span: Span, what: &str) -> String {
+        let (line, column) = line_col(span.start as usize, self.source);
+        format!("{line}:{column} {what}")
+    }
+
+    /// `__ixTy.ret "<loc>" <ty> <value>`: checks `value`, then is `value`.
+    pub(crate) fn ret_check(&self, span: Span, what: &str, ty: Expr, value: Expr) -> Expr {
+        apply(
+            apply(apply(runtime("ret"), str_lit(self.check_loc(span, what))), ty),
+            value,
+        )
+    }
+
+    /// Lowers one type to its `__ixTy` checker expression.
+    pub(crate) fn ty(&self, t: &ast::TSType<'_>) -> Result<Expr, Error> {
+        match t {
+            ast::TSType::TSAnyKeyword(_) | ast::TSType::TSUnknownKeyword(_) => Ok(runtime("any")),
+            ast::TSType::TSStringKeyword(_) => Ok(runtime("string")),
+            ast::TSType::TSBooleanKeyword(_) => Ok(runtime("bool")),
+            // `object` is any attrset: `attrsOf any`, one spelling for both.
+            ast::TSType::TSObjectKeyword(_) => Ok(apply(runtime("attrsOf"), runtime("any"))),
+            ast::TSType::TSNumberKeyword(number) => Err(self.err(
+                number.span,
+                "Nix distinguishes integers from floats; use `Int` or `Float`",
+            )),
+            ast::TSType::TSNullKeyword(null) => Err(self.err(
+                null.span,
+                "`null` is only checkable in a union: `T | null`",
+            )),
+            ast::TSType::TSUndefinedKeyword(undefined) => Err(self.err(
+                undefined.span,
+                "`undefined` has no Nix equivalent; use `T | null`",
+            )),
+            ast::TSType::TSArrayType(array) => {
+                Ok(apply(runtime("listOf"), self.ty(&array.element_type)?))
+            }
+            // Parameter and return types of a function value cannot be probed
+            // without calling it; `func` checks callability only.
+            ast::TSType::TSFunctionType(_) => Ok(runtime("func")),
+            ast::TSType::TSParenthesizedType(paren) => self.ty(&paren.type_annotation),
+            ast::TSType::TSTypeLiteral(literal) => self.type_literal(literal),
+            ast::TSType::TSUnionType(union) => self.union(union),
+            ast::TSType::TSLiteralType(literal) => {
+                Ok(apply(runtime("enum"), Expr::List(vec![self.ty_literal(literal)?])))
+            }
+            ast::TSType::TSTypeReference(reference) => self.reference(reference),
+            other => Err(self.err(
+                other.span(),
+                "this type has no runtime lowering; see the ix2nix type table",
+            )),
+        }
+    }
+
+    /// `{ a: T; b?: U }` lowers to `__ixTy.attrs [ (__ixTy.req "a" tyT) ... ]`.
+    fn type_literal(&self, literal: &ast::TSTypeLiteral<'_>) -> Result<Expr, Error> {
+        let mut fields = Vec::new();
+        for member in &literal.members {
+            let ast::TSSignature::TSPropertySignature(property) = member else {
+                return Err(self.err(
+                    member.span(),
+                    "only property signatures lower; index, call, and method signatures have no runtime check",
+                ));
+            };
+            let Some(annotation) = &property.type_annotation else {
+                return Err(self.err(property.span, "property signature needs a type"));
+            };
+            if property.computed {
+                return Err(self.err(property.span, "computed keys have no runtime check"));
+            }
+            let name = match &property.key {
+                ast::PropertyKey::StaticIdentifier(ident) => ident.name.to_string(),
+                ast::PropertyKey::StringLiteral(lit) => lit.value.to_string(),
+                other => {
+                    return Err(self.err(other.span(), "property key must be a name or string"));
+                }
+            };
+            let field = if property.optional { "opt" } else { "req" };
+            fields.push(apply(
+                apply(runtime(field), str_lit(name)),
+                self.ty(&annotation.type_annotation)?,
+            ));
+        }
+        Ok(apply(runtime("attrs"), Expr::List(fields)))
+    }
+
+    /// Unions lower in exactly two shapes: `T | null` and literal enums
+    /// (optionally `| null`). Anything else has no single runtime check.
+    fn union(&self, union: &ast::TSUnionType<'_>) -> Result<Expr, Error> {
+        let mut nullable = false;
+        let mut literals = Vec::new();
+        let mut others = Vec::new();
+        for member in &union.types {
+            match member {
+                ast::TSType::TSNullKeyword(_) => nullable = true,
+                ast::TSType::TSLiteralType(literal) => literals.push(self.ty_literal(literal)?),
+                other => others.push(other),
+            }
+        }
+        let inner = match (literals.is_empty(), others.as_slice()) {
+            (false, []) => apply(runtime("enum"), Expr::List(literals)),
+            (true, [single]) => self.ty(single)?,
+            _ => {
+                return Err(self.err(
+                    union.span,
+                    "unions lower only as `T | null` or a union of literals",
+                ));
+            }
+        };
+        Ok(if nullable {
+            apply(runtime("nullable"), inner)
+        } else {
+            inner
+        })
+    }
+
+    fn ty_literal(&self, literal: &ast::TSLiteralType<'_>) -> Result<Expr, Error> {
+        match &literal.literal {
+            ast::TSLiteral::StringLiteral(lit) => Ok(str_lit(lit.value.to_string())),
+            ast::TSLiteral::NumericLiteral(lit) => self.number(lit),
+            ast::TSLiteral::BooleanLiteral(lit) => {
+                Ok(Expr::Ident(if lit.value { "true" } else { "false" }.into()))
+            }
+            other => Err(self.err(other.span(), "this literal type has no runtime check")),
+        }
+    }
+
+    /// Named types: the built-ins (`Int`, `Float`, `Drv`, `Record<string, T>`)
+    /// and in-module `type` aliases. Everything else is unknown here; ambient
+    /// declaration files are tsc's world, not the converter's.
+    fn reference(&self, reference: &ast::TSTypeReference<'_>) -> Result<Expr, Error> {
+        let ast::TSTypeName::IdentifierReference(ident) = &reference.type_name else {
+            return Err(self.err(
+                reference.span,
+                "qualified type names have no runtime lowering",
+            ));
+        };
+        let name = ident.name.as_str();
+        if name == "Record" {
+            let Some(arguments) = &reference.type_arguments else {
+                return Err(self.err(reference.span, "`Record` needs `<string, T>` arguments"));
+            };
+            let [key, value] = arguments.params.as_slice() else {
+                return Err(self.err(arguments.span, "`Record` takes exactly two arguments"));
+            };
+            if !matches!(key, ast::TSType::TSStringKeyword(_)) {
+                return Err(self.err(
+                    key.span(),
+                    "Nix attrset keys are strings; use `Record<string, T>`",
+                ));
+            }
+            return Ok(apply(runtime("attrsOf"), self.ty(value)?));
+        }
+        if let Some(arguments) = &reference.type_arguments {
+            return Err(self.err(arguments.span, "generic types are not lowered yet"));
+        }
+        // The refinement names mirror nixpkgs `lib.types` basics (`port`,
+        // `path`, unsigned ints), so `.ix` types speak the vocabulary NixOS
+        // modules already do; TypeScript's bare `number` stays banned.
+        match name {
+            "Int" => Ok(runtime("int")),
+            "Uint" => Ok(runtime("uint")),
+            "Port" => Ok(runtime("port")),
+            "Float" => Ok(runtime("float")),
+            "Path" => Ok(runtime("path")),
+            "NonEmptyString" => Ok(runtime("nonEmptyString")),
+            "Drv" => Ok(runtime("drv")),
+            _ if self.type_aliases.contains(name) => Ok(Expr::Ident(alias_binding(name))),
+            _ => Err(self.err(
+                ident.span,
+                format!(
+                    "unknown type `{name}`; built-ins are Int, Uint, Port, Float, Path, \
+                     NonEmptyString, Drv, and Record<string, T>, plus this \
+                     module's `type` aliases"
+                ),
+            )),
+        }
+    }
+}

--- a/packages/nix/ix2nix/tests/convert.rs
+++ b/packages/nix/ix2nix/tests/convert.rs
@@ -5,13 +5,166 @@ use ix2nix::convert;
 
 fn nix(source: &str) -> String {
     let out = convert(source).expect("source should convert");
-    out.strip_prefix("{ __dir, __importIx }:\n")
+    out.strip_prefix("{ __dir, __importIx, __ixTy }:\n")
         .expect("every module renders under the wrapper")
         .to_owned()
 }
 
 fn diagnostic(source: &str) -> ix2nix::Error {
     convert(source).expect_err("source should be rejected")
+}
+
+// --- types ---
+
+#[test]
+fn parameter_annotation_lowers_to_arg_check() {
+    let out = nix("export default (a: string) => a;\n");
+    assert_eq!(out, "a: __ixTy.arg \"1:17 argument `a`\" __ixTy.string a a\n");
+}
+
+#[test]
+fn return_annotation_wraps_the_innermost_body() {
+    let out = nix("export default (a, b): Int => a;\n");
+    assert_eq!(out, "a: b: __ixTy.ret \"1:22 return\" __ixTy.int a\n");
+}
+
+#[test]
+fn as_cast_checks_but_as_unknown_erases() {
+    let out = nix("export default x as Int;\n");
+    assert_eq!(out, "__ixTy.ret \"1:21 as\" __ixTy.int x\n");
+    assert_eq!(nix("export default x as unknown;\n"), "x\n");
+    assert_eq!(nix("export default x as any;\n"), "x\n");
+}
+
+#[test]
+fn type_alias_becomes_a_checker_binding() {
+    let out = nix("type P = \"a\" | \"b\";\nexport default (x: P) => x;\n");
+    assert!(out.contains("ty'P = __ixTy.enum [ \"a\" \"b\" ]"), "{out}");
+    assert!(out.contains("__ixTy.arg \"2:17 argument `x`\" ty'P x"), "{out}");
+}
+
+#[test]
+fn nullable_union_lowers_to_nullable() {
+    let out = nix("export default (x: Int | null) => x;\n");
+    assert!(out.contains("__ixTy.nullable __ixTy.int"), "{out}");
+}
+
+#[test]
+fn destructured_parameter_checks_bound_fields() {
+    let out = nix("export default ({ a }: { a: Int }) => a;\n");
+    assert_eq!(
+        out,
+        "{ a }: __ixTy.arg \"1:26 argument field `a`\" __ixTy.int a a\n"
+    );
+}
+
+#[test]
+fn destructured_annotation_must_be_inline_and_bound() {
+    let error = diagnostic("type T = { a: Int };\nexport default ({ a }: T) => a;\n");
+    assert!(error.message().contains("inline object type"), "{error}");
+    let error = diagnostic("export default ({ a }: { b: Int }) => a;\n");
+    assert!(error.message().contains("not bound by the pattern"), "{error}");
+}
+
+#[test]
+fn number_is_rejected_naming_int_and_float() {
+    let error = diagnostic("export default (x: number) => x;\n");
+    assert!(error.message().contains("`Int` or `Float`"), "{error}");
+}
+
+#[test]
+fn lib_types_refinements_lower_to_runtime_checkers() {
+    let out = nix("export default (p: Port, d: Path, s: NonEmptyString, u: Uint) => p;\n");
+    for checker in ["__ixTy.port", "__ixTy.path", "__ixTy.nonEmptyString", "__ixTy.uint"] {
+        assert!(out.contains(checker), "{checker} missing in {out}");
+    }
+}
+
+#[test]
+fn optional_pattern_fields_check_as_nullable() {
+    // The Nix default binds when the caller omits the field, so the bound
+    // name's type is `T | null`, not `T`.
+    let out = nix("export default ({ a = null }: { a?: Int }) => a;\n");
+    assert!(out.contains("(__ixTy.nullable __ixTy.int)"), "{out}");
+}
+
+#[test]
+fn each_parameter_checks_inside_its_own_lambda() {
+    // Checks fire on partial application and read exactly their own binder.
+    let out = nix("export default (a: Int, b: string) => a;\n");
+    assert_eq!(
+        out,
+        "a: __ixTy.arg \"1:17 argument `a`\" __ixTy.int a (b: \
+         __ixTy.arg \"1:25 argument `b`\" __ixTy.string b a)\n"
+    );
+}
+
+#[test]
+fn const_annotations_lower_to_ret_checks() {
+    let out = nix("const x: Int = 1;\nexport default x;\n");
+    assert!(out.contains("x = __ixTy.ret \"1:8 const `x`\" __ixTy.int 1"), "{out}");
+}
+
+#[test]
+fn builtin_shadowing_aliases_are_rejected() {
+    let error = diagnostic("type Port = string;\nexport default 1;\n");
+    assert!(error.message().contains("shadows the built-in"), "{error}");
+}
+
+#[test]
+fn optional_parameters_are_rejected_even_unannotated() {
+    let error = diagnostic("export default (a?) => a;\n");
+    assert!(error.message().contains("optional parameters"), "{error}");
+}
+
+#[test]
+fn call_site_type_arguments_are_rejected() {
+    let error = diagnostic("export default f<Int>(2);\n");
+    assert!(error.message().contains("call-site type arguments"), "{error}");
+}
+
+#[test]
+fn definite_assignment_is_rejected() {
+    let error = diagnostic("const x!: Int = 1;\nexport default x;\n");
+    assert!(error.message().contains("definite assignment"), "{error}");
+}
+
+#[test]
+fn unknown_type_names_are_rejected() {
+    let error = diagnostic("export default (x: Widget) => x;\n");
+    assert!(error.message().contains("unknown type `Widget`"), "{error}");
+}
+
+#[test]
+fn mixed_unions_are_rejected() {
+    let error = diagnostic("export default (x: Int | string) => x;\n");
+    assert!(error.message().contains("`T | null`"), "{error}");
+}
+
+#[test]
+fn generics_interfaces_satisfies_and_nonnull_are_rejected() {
+    let error = diagnostic("export default <A>(x: A) => x;\n");
+    assert!(error.message().contains("generic arrows"), "{error}");
+    let error = diagnostic("type Box<A> = { v: A };\nexport default 1;\n");
+    assert!(error.message().contains("generic type aliases"), "{error}");
+    let error = diagnostic("interface I { a: Int }\nexport default 1;\n");
+    assert!(error.message().contains("use `type`"), "{error}");
+    let error = diagnostic("export default x satisfies Int;\n");
+    assert!(error.message().contains("static-only"), "{error}");
+    let error = diagnostic("export default x!;\n");
+    assert!(error.message().contains("no runtime lowering"), "{error}");
+}
+
+#[test]
+fn duplicate_type_aliases_are_rejected() {
+    let error = diagnostic("type A = Int;\ntype A = Float;\nexport default 1;\n");
+    assert!(error.message().contains("duplicate `type A`"), "{error}");
+}
+
+#[test]
+fn unannotated_modules_lower_without_any_ixty_reference() {
+    let out = nix("const f = (a) => a;\nexport default f(1);\n");
+    assert!(!out.contains("__ixTy"), "{out}");
 }
 
 // --- module shape ---

--- a/packages/nix/ix2nix/tests/golden/attrset.golden
+++ b/packages/nix/ix2nix/tests/golden/attrset.golden
@@ -1,4 +1,4 @@
-{ __dir, __importIx }:
+{ __dir, __importIx, __ixTy }:
 let
   defaults = {
     retries = 3;

--- a/packages/nix/ix2nix/tests/golden/call.golden
+++ b/packages/nix/ix2nix/tests/golden/call.golden
@@ -1,4 +1,4 @@
-{ __dir, __importIx }:
+{ __dir, __importIx, __ixTy }:
 let
   add = a: b: a + b;
 in

--- a/packages/nix/ix2nix/tests/golden/imports.golden
+++ b/packages/nix/ix2nix/tests/golden/imports.golden
@@ -1,4 +1,4 @@
-{ __dir, __importIx }:
+{ __dir, __importIx, __ixTy }:
 let
   lib = __importIx (__dir + "/lib.ix");
   overlay = import (__dir + "/../overlays/default.nix");

--- a/packages/nix/ix2nix/tests/golden/lambda.golden
+++ b/packages/nix/ix2nix/tests/golden/lambda.golden
@@ -1,2 +1,2 @@
-{ __dir, __importIx }:
+{ __dir, __importIx, __ixTy }:
 a: b: c: a + b * c

--- a/packages/nix/ix2nix/tests/golden/let.golden
+++ b/packages/nix/ix2nix/tests/golden/let.golden
@@ -1,4 +1,4 @@
-{ __dir, __importIx }:
+{ __dir, __importIx, __ixTy }:
 let
   base = 10;
   scale = x: let

--- a/packages/nix/ix2nix/tests/golden/list.golden
+++ b/packages/nix/ix2nix/tests/golden/list.golden
@@ -1,4 +1,4 @@
-{ __dir, __importIx }:
+{ __dir, __importIx, __ixTy }:
 let
   tail = [ 4 5 ];
 in

--- a/packages/nix/ix2nix/tests/golden/minimal.golden
+++ b/packages/nix/ix2nix/tests/golden/minimal.golden
@@ -1,2 +1,2 @@
-{ __dir, __importIx }:
+{ __dir, __importIx, __ixTy }:
 42

--- a/packages/nix/ix2nix/tests/golden/operators.golden
+++ b/packages/nix/ix2nix/tests/golden/operators.golden
@@ -1,4 +1,4 @@
-{ __dir, __importIx }:
+{ __dir, __importIx, __ixTy }:
 a: b: {
   sum = a + b;
   difference = a - b - 1;

--- a/packages/nix/ix2nix/tests/golden/pattern.golden
+++ b/packages/nix/ix2nix/tests/golden/pattern.golden
@@ -1,4 +1,4 @@
-{ __dir, __importIx }:
+{ __dir, __importIx, __ixTy }:
 { host, port ? 8080, tls ? false, ... } @ extra: {
   url = "https://${host}:${port}";
   secure = tls;

--- a/packages/nix/ix2nix/tests/golden/select.golden
+++ b/packages/nix/ix2nix/tests/golden/select.golden
@@ -1,4 +1,4 @@
-{ __dir, __importIx }:
+{ __dir, __importIx, __ixTy }:
 let
   config = {
     server = {

--- a/packages/nix/ix2nix/tests/golden/strings.golden
+++ b/packages/nix/ix2nix/tests/golden/strings.golden
@@ -1,4 +1,4 @@
-{ __dir, __importIx }:
+{ __dir, __importIx, __ixTy }:
 let
   who = "world";
 in

--- a/packages/nix/ix2nix/tests/golden/typed.golden
+++ b/packages/nix/ix2nix/tests/golden/typed.golden
@@ -1,0 +1,19 @@
+{ __dir, __importIx, __ixTy }:
+let
+  ty'Proto = __ixTy.enum [ "tcp" "udp" ];
+  ty'Endpoint = __ixTy.attrs [ (__ixTy.req "host" __ixTy.string) (__ixTy.req "port" __ixTy.int) (__ixTy.opt "proto" ty'Proto) ];
+  mkEndpoint = host: __ixTy.arg "9:21 argument `host`" __ixTy.string host (port: __ixTy.arg "9:35 argument `port`" __ixTy.int port (__ixTy.ret "9:45 return" ty'Endpoint {
+    host = host;
+    port = port;
+  }));
+in
+{ config }: __ixTy.arg "13:31 argument field `config`" (__ixTy.attrsOf ty'Endpoint) config (let
+  raw = __ixTy.ret "14:29 as" ty'Endpoint config.web;
+  anything = config.web;
+in
+{
+  web = mkEndpoint "web" 80;
+  raw = raw;
+  anything = anything;
+  ports = __ixTy.ret "20:25 as" (__ixTy.listOf __ixTy.int) [ 80 443 ];
+})

--- a/packages/nix/ix2nix/tests/golden/typed.ix
+++ b/packages/nix/ix2nix/tests/golden/typed.ix
@@ -1,0 +1,22 @@
+// Every kind of type-annotation lowering in one module.
+type Proto = "tcp" | "udp";
+type Endpoint = {
+  host: string;
+  port: Int;
+  proto?: Proto;
+};
+
+const mkEndpoint = (host: string, port: Int): Endpoint => {
+  return { host: host, port: port };
+};
+
+export default ({ config }: { config: Record<string, Endpoint> }) => {
+  const raw = config.web as Endpoint;
+  const anything = config.web as unknown;
+  return {
+    web: mkEndpoint("web", 80),
+    raw: raw,
+    anything: anything,
+    ports: [80, 443] as Int[],
+  };
+};

--- a/packages/nix/ix2nix/wasm/default.nix
+++ b/packages/nix/ix2nix/wasm/default.nix
@@ -61,11 +61,13 @@
 
   # End-to-end over every boundary this package exists for: the patched
   # nix-ix evaluator loads the plugin (`wasm-builtin`), the shim's calling
-  # convention matches the renderer's `{ __dir, __importIx }:` wrapper, a
-  # relative `.ix` import recurses through the shim, and a conversion error
-  # surfaces its positioned diagnostic as a Nix eval error. Client-side eval
-  # against a scratch store; no daemon. The crate's sibling files are reached
-  # through the repo root (`../` literals are banned: no-parent-path).
+  # convention matches the renderer's `{ __dir, __importIx, __ixTy }:`
+  # wrapper, a relative `.ix` import recurses through the shim, a conversion
+  # error surfaces its positioned diagnostic as a Nix eval error, and type
+  # annotations check in `assert` mode and cost nothing in `erase` mode.
+  # Client-side eval against a scratch store; no daemon. The crate's sibling
+  # files are reached through the repo root (`../` literals are banned:
+  # no-parent-path).
   crateDir = ix.paths.root + "/packages/nix/ix2nix";
 
   e2e =
@@ -83,13 +85,33 @@
         nix eval \
           --extra-experimental-features 'nix-command wasm-builtin' \
           --impure \
-          --expr "let importIx = import ${crateDir + "/import-ix.nix"} { converter = ${package}/lib/ix2nix.wasm; }; in importIx $1"
+          --expr "let importIx = import ${crateDir}/import-ix.nix { converter = ${package}/lib/ix2nix.wasm; typeMode = \"$2\"; }; in importIx $1"
       }
 
-      value=$(evalIx ${crateDir + "/examples"}/main.ix)
+      value=$(evalIx ${crateDir + "/examples"}/main.ix assert)
       expected='"doubled: 42"'
       if [ "$value" != "$expected" ]; then
         printf 'expected: %s\nactual:   %s\n' "$expected" "$value" >&2
+        exit 1
+      fi
+
+      # Type annotations: assert mode passes a well-typed module ...
+      value=$(evalIx ${crateDir + "/examples"}/typed.ix assert)
+      if [ "$value" != "42" ]; then
+        printf 'typed.ix: expected 42, got %s\n' "$value" >&2
+        exit 1
+      fi
+      # ... fails an ill-typed one with a positioned error naming the module ...
+      if evalIx ${crateDir + "/examples"}/typed-error.ix assert 2> typed.log; then
+        echo "typed-error.ix unexpectedly passed its checks" >&2
+        exit 1
+      fi
+      grep -F 'expected int, got string' typed.log
+      grep -F '3:24 argument `b`' typed.log
+      # ... and erase mode evaluates the same module with the checks free.
+      value=$(evalIx ${crateDir + "/examples"}/typed-error.ix erase)
+      if [ "$value" != "1" ]; then
+        printf 'typed-error.ix under erase: expected 1, got %s\n' "$value" >&2
         exit 1
       fi
 

--- a/packages/site/src/lib/updates/typed-ix-annotations.svx
+++ b/packages/site/src/lib/updates/typed-ix-annotations.svx
@@ -1,0 +1,47 @@
+---
+id: typed-ix-annotations
+postedAt: 2026-07-23T12:00:00-07:00
+title: "`.ix` modules accept TypeScript type annotations, lowered to runtime checks"
+tags: [ix2nix, types, nix]
+links:
+  - label: ix2nix
+    href: https://github.com/indexable-inc/index/tree/main/packages/nix/ix2nix
+  - label: "issue #4103"
+    href: https://github.com/indexable-inc/index/issues/4103
+---
+
+`.ix` files can now carry TypeScript annotations: parameter and return
+types, `type` aliases, and `as` casts. ix2nix lowers each annotation to a
+runtime check in the emitted Nix, so passing a set where a string goes
+fails with a positioned error naming the module, line, column, and
+argument instead of a deep eval trace:
+
+```text
+error: .ix type error at examples/typed-error.ix:3:24 argument `b`: expected int, got string
+```
+
+The pieces:
+
+- Annotations lower to calls against a small `__ixTy` runtime the import
+  shims pass per module; the wrapper convention is now
+  `{ __dir, __importIx, __ixTy }:`.
+- Two modes, chosen at import time over identical emitted source:
+  `assert` (the default in both shims) runs the checks; `erase` makes
+  them free.
+- Checks are force-safe: a check may force the annotated value to weak
+  head normal form and read attrset keys, never field values or list
+  elements, so typed code never evaluates deeper than untyped code.
+- Type spellings: `string`, `bool`, `Int`, `Float`, `Drv`, `object`,
+  `T[]`, `Record<string, T>`, inline object types with optional fields,
+  function types, literal unions, `T | null`, and refinements borrowed
+  from nixpkgs `lib.types` basics: `Uint`, `Port`, `Path`,
+  `NonEmptyString`. `number` is a hard
+  error (Nix splits int and float), as are interfaces, generics, and
+  `satisfies`, in keeping with the converter's no-fallbacks rule.
+- `as T` checks at the cast site, the opposite of TypeScript erasure, on
+  purpose: casts are where JSON and imported plain Nix enter typed code.
+  `as unknown` stays the escape hatch.
+
+Annotations are optional everywhere; unannotated modules emit no
+`__ixTy` reference at all. Static checking (tsc against an ambient
+`ix.d.ts`) and a deep-checking mode are follow-ups.


### PR DESCRIPTION
Closes #4103.

`.ix` source is now parsed as TypeScript. Parameter and return annotations, top-level `type` aliases, and `as` casts lower to checks against a new `__ixTy` runtime (`packages/nix/ix2nix/ix-ty.nix`); the module wrapper grows to `{ __dir, __importIx, __ixTy }:` and both import shims (wasm and native IFD) pass a per-module runtime, so failures read like:

    error: .ix type error at refine.ix:1:17 argument `port`: expected port (0-65535), got int (70000)

Design points:

- **Two modes over identical emitted source**: `assert` (default in both shims) runs checks; `erase` no-ops them, so the importer picks the cost at import time.
- **Force-safe**: a check may force the annotated value to WHNF and read attr names, never field values or list elements; typed code never evaluates deeper than untyped code.
- **No fallbacks**: types without exactly one runtime lowering are positioned hard errors, like the existing `===`/`let` bans. `number` is banned (use `Int`/`Float`); refinements borrowed from `lib.types` basics: `Uint`, `Port`, `Path`, `NonEmptyString`.
- **`as T` checks at the cast site** (opposite of TS erasure, deliberately): casts are where JSON and imported plain Nix enter typed code; `as unknown` is the escape hatch.
- Annotations optional everywhere; unannotated modules emit no `__ixTy` reference.

Verified locally: 67 cargo tests including 15 new type tests and a `typed.golden` pair; `nix build .#ix2nix` green; `nix build .#ix2nix-wasm` green including the extended e2e (assert passes well-typed, fails ill-typed with the positioned error, erase evaluates the same module free); all 27 lint stages; every existing `.ix` example still converts.

Follow-ups (out of scope): tsc static checking against an ambient `ix.d.ts`, deep-check mode, generic arrows/aliases.

(PR by an AI agent via Claude Code, Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lower TypeScript type annotations to runtime `__ixTy` checks in ix2nix
> - Adds [ix-ty.nix](https://github.com/indexable-inc/index/pull/4110/files#diff-19fb3eccc62fca3011db592ffdb12fe006a6e1c5cec96ef31d3e630171397afa), a Nix runtime that performs evaluation-time type checks for converted `.ix` modules, with `assert` mode (checked) and `erase` mode (no-ops).
> - Switches the ix2nix parser from JavaScript to TypeScript mode and adds a new [ty.rs](https://github.com/indexable-inc/index/pull/4110/files#diff-e15ff6046ccfb2bcaa4e794f318db4257b827fbe1ec85fb96b108f9f96281ce6) module that lowers TS type annotations on parameters, return types, `const` declarations, and cast expressions to `__ixTy` checker calls.
> - Emitted Nix modules now accept `__ixTy` as a third wrapper argument; the WASM shim ([import-ix.nix](https://github.com/indexable-inc/index/pull/4110/files#diff-3621885d40575694740f8c3d397c3ffba6827a274ae936e114dc25d86f2b667d)) and native importer ([import-ix-native.nix](https://github.com/indexable-inc/index/pull/4110/files#diff-41656170da55392cb25d080eb9171c6dc5fb0a8e51e2dda967289268a9f6183d)) are updated to supply it.
> - Supports primitives, refinements (`uint`, `port`, `nonEmptyString`), `Record<K,V>`, `listOf`, `nullable`, unions, and top-level type aliases that materialize as `ty'<Name>` checker bindings.
> - Behavioral Change: all emitted modules now require `__ixTy` in their wrapper; existing golden test outputs are updated, but any out-of-tree consumers that manually construct the wrapper attribute set will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7da074.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->