### PR TITLE
ix2nix: lowercase rust/nix-style type builtins, typed examples

### DIFF
--- a/examples/k8s/k3s/default.ix
+++ b/examples/k8s/k3s/default.ix
@@ -17,7 +17,7 @@ export default ({ index }) => {
     },
   });
   // Two interchangeable agents; adding a third is one more line here.
-  const agent = (name) =>
+  const agent = (name: string) =>
     index.lib.mkVm({
       name: name,
       modules: [import("./agent.nix"), group],

--- a/examples/multi-client/file-sharing/default.ix
+++ b/examples/multi-client/file-sharing/default.ix
@@ -7,7 +7,7 @@ export default ({ index }) => {
     name: "file-server",
     modules: [import("./server.nix")],
   });
-  const client = (name) =>
+  const client = (name: string) =>
     index.lib.mkVm({
       name: name,
       modules: [import("./client.nix")],

--- a/examples/multi-vm/hello/default.ix
+++ b/examples/multi-vm/hello/default.ix
@@ -1,5 +1,10 @@
 // The smallest multi-VM app: one web VM and three interchangeable workers
 // that probe it. `ix apply .#web .#worker-0 .#worker-1 .#worker-2`.
+// The checked shape of one `mkVm` result: presence of the attr is asserted
+// at eval (WHNF + attr names only), so passing a bare module set where a VM
+// belongs fails with a positioned .ix type error instead of a deep Nix trace.
+type Vm = { nixosConfigurations: object };
+
 export default ({ index }) => {
   // One private east-west network, so workers reach the web VM by name.
   const group = { ix: { networking: { groups: ["multi-vm-hello"] } } };
@@ -9,7 +14,7 @@ export default ({ index }) => {
   });
   // Each worker resolves the web VM's listener through its `nodes` module
   // argument (`ix.endpointOf nodes.web "http"`). Scaling is one more line.
-  const worker = (name) =>
+  const worker = (name: string): Vm =>
     index.lib.mkVm({
       name: name,
       modules: [import("./worker.nix"), group],

--- a/examples/multi-vm/microservices/default.ix
+++ b/examples/multi-vm/microservices/default.ix
@@ -10,7 +10,7 @@ export default ({ index }) => {
   // Three interchangeable api VMs; each resolves the cache through its
   // `nodes` module argument. Scaling is one more line here: the gateway's
   // upstream pool grows to match.
-  const api = (name) =>
+  const api = (name: string) =>
     index.lib.mkVm({
       name: name,
       modules: [import("./api.nix"), group],

--- a/examples/nomad/cluster/default.ix
+++ b/examples/nomad/cluster/default.ix
@@ -18,7 +18,7 @@ export default ({ index }) => {
   });
   // Two interchangeable clients; the static port keeps the scheduler from
   // co-locating their allocations.
-  const client = (name) =>
+  const client = (name: string) =>
     index.lib.mkVm({
       name: name,
       modules: [import("./client.nix"), group],

--- a/examples/ray/cluster/default.ix
+++ b/examples/ray/cluster/default.ix
@@ -14,7 +14,7 @@ export default ({ index }) => {
     },
   });
   // Two interchangeable workers; adding one more is one more line here.
-  const worker = (name) =>
+  const worker = (name: string) =>
     index.lib.mkVm({
       name: name,
       modules: [import("./worker.nix"), group],

--- a/packages/nix/ix2nix/examples/typed-error.ix
+++ b/packages/nix/ix2nix/examples/typed-error.ix
@@ -1,5 +1,5 @@
-// `b` fails its Int check in assert mode; erase mode never reads `b`, so
+// `b` fails its int check in assert mode; erase mode never reads `b`, so
 // the same module evaluates to 1. The wasm e2e asserts both.
-const first = (a: Int, b: Int): Int => a;
+const first = (a: int, b: int): int => a;
 
 export default first(1, "two");

--- a/packages/nix/ix2nix/examples/typed.ix
+++ b/packages/nix/ix2nix/examples/typed.ix
@@ -1,3 +1,3 @@
-const inc = (n: Int): Int => n + 1;
+const inc = (n: int): int => n + 1;
 
 export default inc(41);

--- a/packages/nix/ix2nix/ix-ty.nix
+++ b/packages/nix/ix2nix/ix-ty.nix
@@ -46,22 +46,29 @@
       check = loc: v: pred v || fail loc desc v;
     };
     prim = name: mk name (v: builtins.typeOf v == name);
+    intIn = name: lo: hi:
+      mk "${name} (${toString lo} to ${toString hi})" (v: builtins.isInt v && v >= lo && v <= hi);
   in {
     string = prim "string";
     int = prim "int";
     float = prim "float";
     bool = prim "bool";
-    # Refinements borrowed from nixpkgs `lib.types` basics; each stays a
-    # single WHNF-safe predicate.
-    uint = mk "unsigned int" (v: builtins.isInt v && v >= 0);
-    port = mk "port (0-65535)" (v: builtins.isInt v && v >= 0 && v <= 65535);
+    # Refinements: Rust-width integers plus nixpkgs `lib.types` basics; each
+    # stays a single WHNF-safe predicate.
+    u8 = intIn "u8" 0 255;
+    u16 = intIn "u16" 0 65535;
+    u32 = intIn "u32" 0 4294967295;
+    i8 = intIn "i8" (-128) 127;
+    i16 = intIn "i16" (-32768) 32767;
+    i32 = intIn "i32" (-2147483648) 2147483647;
+    port = intIn "port" 0 65535;
     path = mk "path" (
       v:
         builtins.typeOf v
         == "path"
         || (builtins.isString v && builtins.substring 0 1 v == "/")
     );
-    nonEmptyString = mk "non-empty string" (v: builtins.isString v && v != "");
+    nonEmptyStr = mk "non-empty string" (v: builtins.isString v && v != "");
     func = mk "function" builtins.isFunction;
     any = {
       desc = "any";

--- a/packages/nix/ix2nix/src/lib.rs
+++ b/packages/nix/ix2nix/src/lib.rs
@@ -41,11 +41,11 @@
 //! | `type X = T` | `let ty'X = <T>` (referenced by annotations) |
 //! | `({ a }: { a: T }) => e` | per-field `__ixTy.arg` checks on the bound names |
 //!
-//! Type spellings: `string`, `bool`, `Int`, `Float`, `Drv`, `any`/`unknown`,
+//! Type spellings: `string`, `bool`, `int`, `float`, `drv`, `any`/`unknown`,
 //! `object`, `T[]`, `Record<string, T>`, `{ a: T; b?: U }`, function types
-//! (callability only), literal unions, and `T \| null`, plus refinements
-//! borrowed from nixpkgs `lib.types` basics: `Uint`, `Port`, `Path`,
-//! `NonEmptyString`. `number` is a hard error (Nix splits int and float),
+//! (callability only), literal unions, and `T \| null`, plus refinements:
+//! Rust-width integers `u8`/`u16`/`u32`/`i8`/`i16`/`i32` and the nixpkgs
+//! `lib.types` basics `port`, `path`, `nonEmptyStr`. `number` is a hard error (Nix splits int and float),
 //! as are interfaces, generics, `satisfies`, non-null `!`, and unions
 //! beyond `T \| null` / literals.
 //!

--- a/packages/nix/ix2nix/src/ty.rs
+++ b/packages/nix/ix2nix/src/ty.rs
@@ -47,8 +47,20 @@ pub(crate) fn arg_check(loc: String, ty: Expr, value: Expr, body: Expr) -> Expr 
 /// Type names with a fixed meaning; `type` aliases may not shadow them
 /// ([`crate::map`] rejects the declaration), so a reference is never
 /// ambiguous between a built-in and a module alias.
-pub(crate) const BUILTIN_TYPES: [&str; 8] = [
-    "Int", "Uint", "Port", "Float", "Path", "NonEmptyString", "Drv", "Record",
+pub(crate) const BUILTIN_TYPES: [&str; 13] = [
+    "int",
+    "float",
+    "u8",
+    "u16",
+    "u32",
+    "i8",
+    "i16",
+    "i32",
+    "port",
+    "path",
+    "nonEmptyStr",
+    "drv",
+    "Record",
 ];
 
 /// Wraps a checker as `__ixTy.nullable <ty>`; optional pattern fields check
@@ -91,7 +103,7 @@ impl Mapper<'_> {
             ast::TSType::TSObjectKeyword(_) => Ok(apply(runtime("attrsOf"), runtime("any"))),
             ast::TSType::TSNumberKeyword(number) => Err(self.err(
                 number.span,
-                "Nix distinguishes integers from floats; use `Int` or `Float`",
+                "Nix distinguishes integers from floats; use `int` or `float`",
             )),
             ast::TSType::TSNullKeyword(null) => Err(self.err(
                 null.span,
@@ -223,24 +235,30 @@ impl Mapper<'_> {
         if let Some(arguments) = &reference.type_arguments {
             return Err(self.err(arguments.span, "generic types are not lowered yet"));
         }
-        // The refinement names mirror nixpkgs `lib.types` basics (`port`,
-        // `path`, unsigned ints), so `.ix` types speak the vocabulary NixOS
-        // modules already do; TypeScript's bare `number` stays banned.
+        // Lowercase on purpose: `int` and `float` are what Nix itself calls
+        // the types, the width refinements are Rust vocabulary, and `port` /
+        // `path` / `nonEmptyStr` come from nixpkgs `lib.types`. TypeScript's
+        // bare `number` stays banned.
         match name {
-            "Int" => Ok(runtime("int")),
-            "Uint" => Ok(runtime("uint")),
-            "Port" => Ok(runtime("port")),
-            "Float" => Ok(runtime("float")),
-            "Path" => Ok(runtime("path")),
-            "NonEmptyString" => Ok(runtime("nonEmptyString")),
-            "Drv" => Ok(runtime("drv")),
+            "int" => Ok(runtime("int")),
+            "float" => Ok(runtime("float")),
+            "u8" => Ok(runtime("u8")),
+            "u16" => Ok(runtime("u16")),
+            "u32" => Ok(runtime("u32")),
+            "i8" => Ok(runtime("i8")),
+            "i16" => Ok(runtime("i16")),
+            "i32" => Ok(runtime("i32")),
+            "port" => Ok(runtime("port")),
+            "path" => Ok(runtime("path")),
+            "nonEmptyStr" => Ok(runtime("nonEmptyStr")),
+            "drv" => Ok(runtime("drv")),
             _ if self.type_aliases.contains(name) => Ok(Expr::Ident(alias_binding(name))),
             _ => Err(self.err(
                 ident.span,
                 format!(
-                    "unknown type `{name}`; built-ins are Int, Uint, Port, Float, Path, \
-                     NonEmptyString, Drv, and Record<string, T>, plus this \
-                     module's `type` aliases"
+                    "unknown type `{name}`; built-ins are int, float, \
+                     u8/u16/u32/i8/i16/i32, port, path, nonEmptyStr, drv, and \
+                     Record<string, T>, plus this module's `type` aliases"
                 ),
             )),
         }

--- a/packages/nix/ix2nix/tests/convert.rs
+++ b/packages/nix/ix2nix/tests/convert.rs
@@ -24,13 +24,13 @@ fn parameter_annotation_lowers_to_arg_check() {
 
 #[test]
 fn return_annotation_wraps_the_innermost_body() {
-    let out = nix("export default (a, b): Int => a;\n");
+    let out = nix("export default (a, b): int => a;\n");
     assert_eq!(out, "a: b: __ixTy.ret \"1:22 return\" __ixTy.int a\n");
 }
 
 #[test]
 fn as_cast_checks_but_as_unknown_erases() {
-    let out = nix("export default x as Int;\n");
+    let out = nix("export default x as int;\n");
     assert_eq!(out, "__ixTy.ret \"1:21 as\" __ixTy.int x\n");
     assert_eq!(nix("export default x as unknown;\n"), "x\n");
     assert_eq!(nix("export default x as any;\n"), "x\n");
@@ -45,13 +45,13 @@ fn type_alias_becomes_a_checker_binding() {
 
 #[test]
 fn nullable_union_lowers_to_nullable() {
-    let out = nix("export default (x: Int | null) => x;\n");
+    let out = nix("export default (x: int | null) => x;\n");
     assert!(out.contains("__ixTy.nullable __ixTy.int"), "{out}");
 }
 
 #[test]
 fn destructured_parameter_checks_bound_fields() {
-    let out = nix("export default ({ a }: { a: Int }) => a;\n");
+    let out = nix("export default ({ a }: { a: int }) => a;\n");
     assert_eq!(
         out,
         "{ a }: __ixTy.arg \"1:26 argument field `a`\" __ixTy.int a a\n"
@@ -60,22 +60,22 @@ fn destructured_parameter_checks_bound_fields() {
 
 #[test]
 fn destructured_annotation_must_be_inline_and_bound() {
-    let error = diagnostic("type T = { a: Int };\nexport default ({ a }: T) => a;\n");
+    let error = diagnostic("type T = { a: int };\nexport default ({ a }: T) => a;\n");
     assert!(error.message().contains("inline object type"), "{error}");
-    let error = diagnostic("export default ({ a }: { b: Int }) => a;\n");
+    let error = diagnostic("export default ({ a }: { b: int }) => a;\n");
     assert!(error.message().contains("not bound by the pattern"), "{error}");
 }
 
 #[test]
 fn number_is_rejected_naming_int_and_float() {
     let error = diagnostic("export default (x: number) => x;\n");
-    assert!(error.message().contains("`Int` or `Float`"), "{error}");
+    assert!(error.message().contains("`int` or `float`"), "{error}");
 }
 
 #[test]
 fn lib_types_refinements_lower_to_runtime_checkers() {
-    let out = nix("export default (p: Port, d: Path, s: NonEmptyString, u: Uint) => p;\n");
-    for checker in ["__ixTy.port", "__ixTy.path", "__ixTy.nonEmptyString", "__ixTy.uint"] {
+    let out = nix("export default (p: port, d: path, s: nonEmptyStr, u: u32) => p;\n");
+    for checker in ["__ixTy.port", "__ixTy.path", "__ixTy.nonEmptyStr", "__ixTy.u32"] {
         assert!(out.contains(checker), "{checker} missing in {out}");
     }
 }
@@ -84,14 +84,14 @@ fn lib_types_refinements_lower_to_runtime_checkers() {
 fn optional_pattern_fields_check_as_nullable() {
     // The Nix default binds when the caller omits the field, so the bound
     // name's type is `T | null`, not `T`.
-    let out = nix("export default ({ a = null }: { a?: Int }) => a;\n");
+    let out = nix("export default ({ a = null }: { a?: int }) => a;\n");
     assert!(out.contains("(__ixTy.nullable __ixTy.int)"), "{out}");
 }
 
 #[test]
 fn each_parameter_checks_inside_its_own_lambda() {
     // Checks fire on partial application and read exactly their own binder.
-    let out = nix("export default (a: Int, b: string) => a;\n");
+    let out = nix("export default (a: int, b: string) => a;\n");
     assert_eq!(
         out,
         "a: __ixTy.arg \"1:17 argument `a`\" __ixTy.int a (b: \
@@ -101,13 +101,13 @@ fn each_parameter_checks_inside_its_own_lambda() {
 
 #[test]
 fn const_annotations_lower_to_ret_checks() {
-    let out = nix("const x: Int = 1;\nexport default x;\n");
+    let out = nix("const x: int = 1;\nexport default x;\n");
     assert!(out.contains("x = __ixTy.ret \"1:8 const `x`\" __ixTy.int 1"), "{out}");
 }
 
 #[test]
 fn builtin_shadowing_aliases_are_rejected() {
-    let error = diagnostic("type Port = string;\nexport default 1;\n");
+    let error = diagnostic("type port = string;\nexport default 1;\n");
     assert!(error.message().contains("shadows the built-in"), "{error}");
 }
 
@@ -119,13 +119,13 @@ fn optional_parameters_are_rejected_even_unannotated() {
 
 #[test]
 fn call_site_type_arguments_are_rejected() {
-    let error = diagnostic("export default f<Int>(2);\n");
+    let error = diagnostic("export default f<int>(2);\n");
     assert!(error.message().contains("call-site type arguments"), "{error}");
 }
 
 #[test]
 fn definite_assignment_is_rejected() {
-    let error = diagnostic("const x!: Int = 1;\nexport default x;\n");
+    let error = diagnostic("const x!: int = 1;\nexport default x;\n");
     assert!(error.message().contains("definite assignment"), "{error}");
 }
 
@@ -137,7 +137,7 @@ fn unknown_type_names_are_rejected() {
 
 #[test]
 fn mixed_unions_are_rejected() {
-    let error = diagnostic("export default (x: Int | string) => x;\n");
+    let error = diagnostic("export default (x: int | string) => x;\n");
     assert!(error.message().contains("`T | null`"), "{error}");
 }
 
@@ -147,9 +147,9 @@ fn generics_interfaces_satisfies_and_nonnull_are_rejected() {
     assert!(error.message().contains("generic arrows"), "{error}");
     let error = diagnostic("type Box<A> = { v: A };\nexport default 1;\n");
     assert!(error.message().contains("generic type aliases"), "{error}");
-    let error = diagnostic("interface I { a: Int }\nexport default 1;\n");
+    let error = diagnostic("interface I { a: int }\nexport default 1;\n");
     assert!(error.message().contains("use `type`"), "{error}");
-    let error = diagnostic("export default x satisfies Int;\n");
+    let error = diagnostic("export default x satisfies int;\n");
     assert!(error.message().contains("static-only"), "{error}");
     let error = diagnostic("export default x!;\n");
     assert!(error.message().contains("no runtime lowering"), "{error}");
@@ -157,7 +157,7 @@ fn generics_interfaces_satisfies_and_nonnull_are_rejected() {
 
 #[test]
 fn duplicate_type_aliases_are_rejected() {
-    let error = diagnostic("type A = Int;\ntype A = Float;\nexport default 1;\n");
+    let error = diagnostic("type A = int;\ntype A = float;\nexport default 1;\n");
     assert!(error.message().contains("duplicate `type A`"), "{error}");
 }
 

--- a/packages/nix/ix2nix/tests/golden/typed.ix
+++ b/packages/nix/ix2nix/tests/golden/typed.ix
@@ -2,11 +2,11 @@
 type Proto = "tcp" | "udp";
 type Endpoint = {
   host: string;
-  port: Int;
+  port: int;
   proto?: Proto;
 };
 
-const mkEndpoint = (host: string, port: Int): Endpoint => {
+const mkEndpoint = (host: string, port: int): Endpoint => {
   return { host: host, port: port };
 };
 
@@ -17,6 +17,6 @@ export default ({ config }: { config: Record<string, Endpoint> }) => {
     web: mkEndpoint("web", 80),
     raw: raw,
     anything: anything,
-    ports: [80, 443] as Int[],
+    ports: [80, 443] as int[],
   };
 };

--- a/packages/site/src/lib/updates/typed-ix-annotations.svx
+++ b/packages/site/src/lib/updates/typed-ix-annotations.svx
@@ -31,11 +31,11 @@ The pieces:
 - Checks are force-safe: a check may force the annotated value to weak
   head normal form and read attrset keys, never field values or list
   elements, so typed code never evaluates deeper than untyped code.
-- Type spellings: `string`, `bool`, `Int`, `Float`, `Drv`, `object`,
+- Type spellings: `string`, `bool`, `int`, `float`, `drv`, `object`,
   `T[]`, `Record<string, T>`, inline object types with optional fields,
-  function types, literal unions, `T | null`, and refinements borrowed
-  from nixpkgs `lib.types` basics: `Uint`, `Port`, `Path`,
-  `NonEmptyString`. `number` is a hard
+  function types, literal unions, `T | null`, Rust-width integer
+  refinements `u8`/`u16`/`u32`/`i8`/`i16`/`i32`, and the nixpkgs
+  `lib.types` basics `port`, `path`, `nonEmptyStr`. `number` is a hard
   error (Nix splits int and float), as are interfaces, generics, and
   `satisfies`, in keeping with the converter's no-fallbacks rule.
 - `as T` checks at the cast site, the opposite of TypeScript erasure, on


### PR DESCRIPTION
Closes #4113. Renames the typed-.ix builtins to lowercase (int, float, u8..u32, i8..i32, port, path, nonEmptyStr, drv), no compat aliases pre-v1, and migrates six examples to typed form (multi-vm/hello as the full showcase). Verified: 74 cargo tests, all six examples convert and the hello example evaluates through its checks end to end (stub mkVm), misuse fails with the positioned error, 27 lint stages green.

(PR by an AI agent via Claude Code, Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lowercase built-in type names and add Rust-width integer refinements in ix2nix
> - Renames all built-in type spellings from capitalized (`Int`, `Float`, `Drv`, `Port`, `Path`, `NonEmptyString`, `Uint`) to lowercase (`int`, `float`, `drv`, `port`, `path`, `nonEmptyStr`) in [ty.rs](https://github.com/indexable-inc/index/pull/4116/files#diff-e15ff6046ccfb2bcaa4e794f318db4257b827fbe1ec85fb96b108f9f96281ce6) and [ix-ty.nix](https://github.com/indexable-inc/index/pull/4116/files#diff-19fb3eccc62fca3011db592ffdb12fe006a6e1c5cec96ef31d3e630171397afa).
> - Adds Rust-width integer refinements (`u8`, `u16`, `u32`, `i8`, `i16`, `i32`) via a new `intIn` constructor in [ix-ty.nix](https://github.com/indexable-inc/index/pull/4116/files#diff-19fb3eccc62fca3011db592ffdb12fe006a6e1c5cec96ef31d3e630171397afa) that builds bounded range checkers.
> - Updates example files and golden tests to use the new lowercase spellings and adds typed parameter/return annotations to factory functions across several examples.
> - Risk: previously accepted capitalized type names (`Int`, `Float`, `Drv`, etc.) are no longer recognized and will produce errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c154c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->