### PR TITLE
ix2nix: hegel property tests, property-testing skill, typed kernel example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,7 @@ dependencies = [
 name = "ast-merge-ast"
 version = "0.1.0"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "snafu",
  "tree-sitter",
  "tree-sitter-rust",
@@ -769,7 +769,7 @@ dependencies = [
  "ast-merge-ast",
  "ast-merge-langs",
  "ast-merge-matcher",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "similar",
  "tree-sitter",
 ]
@@ -823,7 +823,7 @@ version = "0.1.0"
 dependencies = [
  "ast-merge-ast",
  "rayon",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "tracing",
  "tree-sitter",
  "tree-sitter-rust",
@@ -1227,7 +1227,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "shlex 1.3.0",
  "syn 2.0.118",
 ]
@@ -1614,6 +1614,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbindgen"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
+dependencies = [
+ "clap",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.118",
+ "tempfile",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,33 +1769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,7 +1895,7 @@ dependencies = [
  "clone-scanner",
  "clone-test-support",
  "rayon",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_json",
  "tempfile",
@@ -1915,7 +1907,7 @@ version = "0.1.0"
 dependencies = [
  "ast-merge-ast",
  "ast-merge-langs",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "tree-sitter",
 ]
 
@@ -1939,7 +1931,7 @@ dependencies = [
  "clone-test-support",
  "ignore",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "snafu",
  "tempfile",
  "tracing",
@@ -2316,6 +2308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
 name = "cow-utils"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2469,7 +2467,7 @@ dependencies = [
  "postcard",
  "pulley-interpreter",
  "regalloc2",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_derive",
  "sha2 0.10.9",
@@ -3812,7 +3810,7 @@ dependencies = [
  "log",
  "notify 9.0.0-rc.4",
  "notify-types",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "walkdir",
 ]
 
@@ -4022,7 +4020,7 @@ dependencies = [
  "fluent-syntax",
  "intl-memoizer",
  "intl_pluralrules",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "self_cell",
  "smallvec",
  "unic-langid",
@@ -4359,7 +4357,7 @@ dependencies = [
  "itertools 0.11.0",
  "loro-thunderdome",
  "proc-macro2",
- "rustc-hash",
+ "rustc-hash 2.1.3",
 ]
 
 [[package]]
@@ -5044,27 +5042,43 @@ dependencies = [
 
 [[package]]
 name = "hegeltest"
-version = "0.14.27"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8e84ddc1f22b055b011f6698759f9161123e4dc4d6a27c8276360e307e5228"
+checksum = "a5701dedf265f0843636826fdbbb1fc93ae013ccd37dc52357a4c0a1bf14d003"
 dependencies = [
- "ciborium",
  "crc32fast",
  "dashu-int",
+ "hegeltest-c",
  "hegeltest-macros",
+ "miniz_oxide",
  "parking_lot",
  "paste",
  "rand 0.10.2",
- "rustc-hash",
- "serde",
+ "rustc-hash 2.1.3",
+ "tempfile",
+]
+
+[[package]]
+name = "hegeltest-c"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f2ed09c0cf2259e0660c87d5959fd41ad60fe676e074c64e0a7d0eb37ad209"
+dependencies = [
+ "cbindgen",
+ "crc32fast",
+ "dashu-int",
+ "miniz_oxide",
+ "parking_lot",
+ "rand 0.10.2",
+ "rustc-hash 2.1.3",
  "tempfile",
 ]
 
 [[package]]
 name = "hegeltest-macros"
-version = "0.14.27"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67743643fd380fcab53c7f2e106fe31752cde495416177336a8de6c8b85b81e"
+checksum = "34220b7df7a680766537f5ee6882c0dbef3a45fbe794c212520db2bbb19b79ef"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5978,11 +5992,13 @@ dependencies = [
 name = "ix2nix"
 version = "0.1.0"
 dependencies = [
+ "hegeltest",
  "oxc_allocator",
  "oxc_ast",
  "oxc_diagnostics",
  "oxc_parser",
  "oxc_span",
+ "rnix",
 ]
 
 [[package]]
@@ -6568,7 +6584,7 @@ dependencies = [
  "loro-delta",
  "loro-internal",
  "loro-kv-store",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "tracing",
 ]
 
@@ -6583,7 +6599,7 @@ dependencies = [
  "leb128",
  "loro-rle",
  "nonmax",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_columnar",
  "serde_json",
@@ -6637,7 +6653,7 @@ dependencies = [
  "postcard",
  "pretty_assertions",
  "rand 0.8.6",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_columnar",
  "serde_json",
@@ -6661,7 +6677,7 @@ dependencies = [
  "lz4_flex 0.11.6",
  "once_cell",
  "quick_cache",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "tracing",
  "xxhash-rust",
 ]
@@ -7126,7 +7142,7 @@ dependencies = [
  "itertools 0.15.0",
  "markdown",
  "miette",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "smol_str",
 ]
 
@@ -7180,7 +7196,7 @@ dependencies = [
  "napi-build",
  "napi-sys",
  "nohash-hasher",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "tokio",
 ]
 
@@ -8108,7 +8124,7 @@ dependencies = [
  "num-traits",
  "pyo3",
  "pyo3-build-config",
- "rustc-hash",
+ "rustc-hash 2.1.3",
 ]
 
 [[package]]
@@ -8772,7 +8788,7 @@ dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
  "oxc_data_structures",
- "rustc-hash",
+ "rustc-hash 2.1.3",
 ]
 
 [[package]]
@@ -8871,7 +8887,7 @@ dependencies = [
  "oxc_span",
  "oxc_str",
  "oxc_syntax",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "seq-macro",
 ]
 
@@ -8888,7 +8904,7 @@ dependencies = [
  "oxc_span",
  "oxc_str",
  "phf 0.14.0",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "unicode-id-start",
 ]
 
@@ -10164,7 +10180,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -10186,7 +10202,7 @@ dependencies = [
  "rand 0.10.2",
  "rand_pcg",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -10568,7 +10584,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.17.1",
  "log",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "serde",
  "smallvec",
 ]
@@ -10799,6 +10815,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rnix"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c163bd17372eecdf10d351c34584b7de7c1a33be4e92a32f3fb3f5a7fe3f579b"
+dependencies = [
+ "rowan",
+]
+
+[[package]]
 name = "roaring"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10819,6 +10844,18 @@ dependencies = [
  "num-rational",
  "symphonia",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rowan"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "rustc-hash 1.1.0",
+ "text-size",
 ]
 
 [[package]]
@@ -10890,6 +10927,12 @@ name = "rustc-demangle"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -11363,7 +11406,7 @@ dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "servo_arc",
  "smallvec",
 ]
@@ -12564,7 +12607,7 @@ dependencies = [
  "rayon",
  "regex",
  "rust-stemmers",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_json",
  "sketches-ddsketch",
@@ -12898,6 +12941,12 @@ dependencies = [
  "ansitok",
  "unicode-width 0.2.2",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "textwrap"
@@ -13867,7 +13916,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 2.1.3",
 ]
 
 [[package]]
@@ -14434,7 +14483,7 @@ dependencies = [
  "indicatif",
  "libc",
  "nix 0.31.3",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustix 1.1.4",
  "thiserror 2.0.18",
  "uucore",
@@ -14501,7 +14550,7 @@ dependencies = [
  "num-traits",
  "os_display",
  "procfs",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustix 1.1.4",
  "thiserror 2.0.18",
  "unic-langid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,7 +280,9 @@ glob = "0.3"
 heck = "0.5"
 hex = "0.4"
 httparse = "1"
-hegeltest = { version = "0.14", default-features = false }
+hegeltest = { version = "0.28.2", default-features = false }
+# Reparse oracle for ix2nix property tests: emitted Nix must parse cleanly.
+rnix = "0.14"
 # The Iceberg corpus lake (issue #752). iceberg 0.9 pins arrow/parquet ^57.1
 # while the workspace parquet pair is on 59; the 57 tree stays isolated inside
 # lake-iceberg (see its Cargo.toml).

--- a/examples/kernel-build/claude/default.ix
+++ b/examples/kernel-build/claude/default.ix
@@ -7,14 +7,20 @@
 // The key is attached through the ix secret store (`ix secret set
 // anthropic_api_key`) and materializes as a file only the proxy user can
 // read; claude.nix resolves the same path from this declaration.
+// The checked shape of the `mkVm` result: asserted at eval (WHNF plus attr
+// names only), so wiring mistakes fail as positioned .ix type errors.
+type Vm = { nixosConfigurations: object };
+
 export default ({ index }) => {
   // The tree to hack on. Edit these three to target another repo, tag, or
   // checkout path; everything else (ownership handoff, the agent's cwd docs)
-  // follows the dest through `config.services.git-clone`.
-  const repoUrl = "https://github.com/torvalds/linux";
-  const repoRef = "v6.16";
-  const srcDir = "/src/linux";
-  return index.lib.mkVm({
+  // follows the dest through `config.services.git-clone`. The annotations
+  // are checked when the VM evaluates: `srcDir` must be an absolute path,
+  // and a typo'd non-string ref fails here rather than deep in kbuild.
+  const repoUrl: nonEmptyStr = "https://github.com/torvalds/linux";
+  const repoRef: nonEmptyStr = "v6.16";
+  const srcDir: path = "/src/linux";
+  const vm: Vm = index.lib.mkVm({
     name: "kernel-build",
     deployment: {
       secrets: {
@@ -45,4 +51,5 @@ export default ({ index }) => {
       import("./claude.nix"),
     ],
   });
+  return vm;
 };

--- a/packages/agent/skills/property-testing/SKILL.md
+++ b/packages/agent/skills/property-testing/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: property-testing
+description: "Property-based testing with hegel (Antithesis's Hypothesis-based library): which properties to reach for, generator patterns, shrinking, replay, CI determinism. Use when adding property tests, fuzzing a parser/converter/codec, or a test needs generated rather than example inputs."
+---
+
+## Property testing with hegel
+
+Repo-owned Rust crates use `hegeltest` (workspace dev-dependency; lib name
+`hegel`). It is Antithesis's Hypothesis-based property-testing library:
+pure-Rust engine, `#[hegel::test]` under plain `cargo test`, automatic
+shrinking to a minimal counterexample, and a failure database (`.hegel/`,
+gitignored) that replays the last counterexample first on the next run.
+Reference suites: `packages/nix/ix2nix/tests/properties.rs`,
+`packages/minecraft/nbt/tests/property.rs`.
+
+## Which properties earn their keep
+
+In rough order of value per line:
+
+1. **Never panics**: feed `gs::text()` (or arbitrary bytes) to any parser,
+   decoder, or converter; assert it returns `Ok`/`Err` rather than
+   panicking. Cheapest test, catches the most.
+2. **Round trip**: serialize then reparse (or encode/decode) and compare.
+   For a transpiler the analogue is: generated well-formed source converts,
+   and the output parses cleanly under an independent parser (ix2nix uses
+   `rnix` as its oracle).
+3. **Determinism / idempotence**: same input twice gives identical output;
+   `f(f(x)) == f(x)` where claimed.
+4. **Model-based**: compare against an obviously-correct implementation
+   (BTreeMap vs your map; a slow interpreter vs your fast path).
+
+## Generator patterns
+
+- Recursive structures: `gs::deferred::<T>()` + `handle = node.generator()`
+  + `node.set(hegel::one_of!(...))`; bound growth with `.max_size(n)` on
+  `gs::vecs`, or the tree can explode.
+- `gs::sampled_from` takes a slice (`&[..][..]`), not an array.
+- Keep generated programs *well-formed by construction* (fixed distinct
+  binder names, deduplicated object keys) and let values carry the
+  randomness; otherwise the property tests your generator, not the code.
+  Two real generator traps from ix2nix: `${...}` interpolation only exists
+  inside backtick templates, and `=> {}` is a block, not an object literal.
+- A composite generator is a function returning `impl Generator<T>` built
+  from `.map` over `hegel::tuples!(...)`; `#[hegel::composite]` exists for
+  the draw-style equivalent.
+
+## Budget, replay, CI
+
+- Default is 100 test cases; override with `#[hegel::test(test_cases = N)]`.
+  Keep CI at the default; run big budgets ad hoc.
+- Runs are randomized per invocation, so CI is a rolling fuzzer: a red main
+  property test means hegel found a real counterexample that was always
+  legal input. Fix forward; never re-run to green. The failure database
+  gives local replay, but CI sandboxes start fresh, so copy the printed
+  `let source = ...` shrunk case into a regression `#[test]` alongside the
+  fix (see `bool_and_boolean_both_lower` in ix2nix).
+- The engine and macros come from crates.io (`hegeltest`,
+  `default-features = false`); no Python, no network at test time, so tests
+  run unchanged inside nix sandboxes.
+
+## Antithesis
+
+Hegel is Antithesis's PBT family (hegel.dev): the same tests can later run
+under the Antithesis platform for guided exploration, and the `antithesis`
+feature wires assertions into its SDK. Do not enable that feature for
+ordinary CI; it is for workloads launched via the antithesis-* skills.

--- a/packages/minecraft/nbt/Cargo.toml
+++ b/packages/minecraft/nbt/Cargo.toml
@@ -17,7 +17,7 @@ serde_json.workspace = true
 # Property-based testing via Hegel. Pinned to the `native` feature so cargo
 # test runs without the Python hegel-core server (the default backend). The
 # native backend is functionally complete; only performance differs.
-hegeltest = { workspace = true, default-features = false, features = ["native"] }
+hegeltest = { workspace = true, default-features = false }
 
 # cargo-machete can't see hegeltest because it's only reached through the
 # `#[hegel::test]` proc-macro under `tests/`. Listing it here keeps the

--- a/packages/nix/ix2nix/Cargo.toml
+++ b/packages/nix/ix2nix/Cargo.toml
@@ -15,6 +15,10 @@ oxc_diagnostics.workspace = true
 oxc_parser.workspace = true
 oxc_span.workspace = true
 
+[dev-dependencies]
+hegeltest = { workspace = true, default-features = false }
+rnix.workspace = true
+
 [[bin]]
 name = "ix2nix"
 path = "src/main.rs"

--- a/packages/nix/ix2nix/src/ty.rs
+++ b/packages/nix/ix2nix/src/ty.rs
@@ -47,7 +47,8 @@ pub(crate) fn arg_check(loc: String, ty: Expr, value: Expr, body: Expr) -> Expr 
 /// Type names with a fixed meaning; `type` aliases may not shadow them
 /// ([`crate::map`] rejects the declaration), so a reference is never
 /// ambiguous between a built-in and a module alias.
-pub(crate) const BUILTIN_TYPES: [&str; 13] = [
+pub(crate) const BUILTIN_TYPES: [&str; 14] = [
+    "bool",
     "int",
     "float",
     "u8",
@@ -240,6 +241,10 @@ impl Mapper<'_> {
         // `path` / `nonEmptyStr` come from nixpkgs `lib.types`. TypeScript's
         // bare `number` stays banned.
         match name {
+            // TypeScript's keyword is `boolean`; Nix's name is `bool`. The
+            // keyword arrives as TSBooleanKeyword, this arm catches the Nix
+            // spelling, and both lower to the same checker.
+            "bool" => Ok(runtime("bool")),
             "int" => Ok(runtime("int")),
             "float" => Ok(runtime("float")),
             "u8" => Ok(runtime("u8")),
@@ -261,6 +266,34 @@ impl Mapper<'_> {
                      Record<string, T>, plus this module's `type` aliases"
                 ),
             )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Every `__ixTy.<field>` the converter can emit must be defined by the
+    /// runtime, or a typed module fails at eval with `attribute missing`
+    /// instead of a type error. Scans this crate's two emitting sources for
+    /// string literals passed to the `runtime` spelling helper, plus the two
+    /// entry points, and checks each name is bound in `ix-ty.nix`.
+    #[test]
+    fn every_emitted_runtime_field_exists_in_ix_ty_nix() {
+        let sources = [include_str!("ty.rs"), include_str!("map.rs")];
+        let runtime_nix = include_str!("../ix-ty.nix");
+        let mut fields = vec!["arg".to_owned(), "ret".to_owned()];
+        for source in sources {
+            for (index, _) in source.match_indices("runtime(\"") {
+                let rest = &source[index + 9..];
+                let end = rest.find('\"').expect("string literal closes");
+                fields.push(rest[..end].to_owned());
+            }
+        }
+        for field in fields {
+            assert!(
+                runtime_nix.contains(&format!("{field} =")),
+                "__ixTy.{field} is emitted but not defined in ix-ty.nix"
+            );
         }
     }
 }

--- a/packages/nix/ix2nix/tests/convert.rs
+++ b/packages/nix/ix2nix/tests/convert.rs
@@ -73,6 +73,16 @@ fn number_is_rejected_naming_int_and_float() {
 }
 
 #[test]
+fn bool_and_boolean_both_lower() {
+    // Found by the hegel reparse property: `bool` is a plain type reference
+    // in TS (the keyword is `boolean`), so it needs its own builtin arm.
+    for spelling in ["bool", "boolean"] {
+        let out = nix(&format!("export default (x: {spelling}) => x;\n"));
+        assert!(out.contains("__ixTy.bool"), "{spelling}: {out}");
+    }
+}
+
+#[test]
 fn lib_types_refinements_lower_to_runtime_checkers() {
     let out = nix("export default (p: port, d: path, s: nonEmptyStr, u: u32) => p;\n");
     for checker in ["__ixTy.port", "__ixTy.path", "__ixTy.nonEmptyStr", "__ixTy.u32"] {

--- a/packages/nix/ix2nix/tests/properties.rs
+++ b/packages/nix/ix2nix/tests/properties.rs
@@ -1,0 +1,193 @@
+//! Property tests over the converter (hegel, Hypothesis-based).
+//!
+//! Three claims, each over generated input rather than examples:
+//! robustness (arbitrary text never panics the converter), determinism
+//! (same source, same bytes out), and the round-trip that matters for a
+//! transpiler: every well-formed `.ix` program the generator can spell
+//! converts, and the emitted Nix reparses cleanly under an independent
+//! parser (rnix). The generator favors small programs; hegel shrinks any
+//! counterexample toward the minimal one.
+
+use hegel::TestCase;
+use hegel::generators::{self as gs, Generator};
+use ix2nix::convert;
+
+// --- structured program generator -----------------------------------------
+
+/// Identifiers kept distinct from type names so shadowing rules never make
+/// a generated program ill-formed by accident.
+fn ident() -> impl Generator<String> {
+    gs::sampled_from(&["a", "b", "c", "d0", "veryLongName"][..]).map(str::to_owned)
+}
+
+fn type_name() -> impl Generator<String> {
+    gs::sampled_from(
+        &[
+        "string",
+        "bool",
+        "int",
+        "float",
+        "u8",
+        "u16",
+        "u32",
+        "i8",
+        "i16",
+        "i32",
+        "port",
+        "path",
+        "nonEmptyStr",
+        "drv",
+        "any",
+        "unknown",
+        "object",
+        ][..],
+    )
+    .map(str::to_owned)
+}
+
+/// A type expression from the supported surface: builtins, arrays,
+/// `Record<string, T>`, `T | null`, literal unions, inline object types.
+fn ty() -> impl Generator<String> {
+    let node = gs::deferred::<String>();
+    let handle = node.generator();
+
+    let literal_union = gs::vecs(gs::sampled_from(&["\"tcp\"", "\"udp\"", "1", "3"][..]))
+        .min_size(1)
+        .max_size(3)
+        .map(|lits| lits.join(" | "));
+    let array = node.generator().map(|t| format!("({t})[]"));
+    let record = node.generator().map(|t| format!("Record<string, {t}>"));
+    let nullable = node.generator().map(|t| format!("({t}) | null"));
+    let object = gs::vecs(hegel::tuples!(ident(), gs::booleans(), node.generator()))
+        .max_size(3)
+        .map(|fields| {
+            let mut out = String::from("{ ");
+            let mut seen: Vec<String> = Vec::new();
+            for (name, optional, t) in fields {
+                if seen.contains(&name) {
+                    continue; // duplicate keys are ill-formed on purpose
+                }
+                let marker = if optional { "?" } else { "" };
+                out.push_str(&format!("{name}{marker}: {t}; "));
+                seen.push(name);
+            }
+            out.push('}');
+            out
+        });
+
+    node.set(hegel::one_of!(
+        type_name(),
+        literal_union,
+        array,
+        record,
+        nullable,
+        object
+    ));
+    handle
+}
+
+/// An expression tree from the mapped `.ix` surface.
+fn expr() -> impl Generator<String> {
+    let node = gs::deferred::<String>();
+    let handle = node.generator();
+
+    let leaf = hegel::one_of!(
+        gs::integers::<i32>().map(|n| n.to_string()),
+        gs::sampled_from(
+            // The last two exercise the renderer's escaping: a real template
+            // interpolation, and a plain string containing literal `${`.
+            &["true", "false", "null", "\"s\"", "`t ${a} x`", "\"has \\${ curly\""][..],
+        )
+        .map(str::to_owned),
+        ident()
+    );
+    let array = gs::vecs(node.generator())
+        .max_size(3)
+        .map(|items| format!("[{}]", items.join(", ")));
+    let object = gs::vecs(hegel::tuples!(ident(), node.generator()))
+        .max_size(3)
+        .map(|props| {
+            let mut out = String::from("{ ");
+            let mut seen: Vec<String> = Vec::new();
+            for (key, value) in props {
+                if seen.contains(&key) {
+                    continue;
+                }
+                out.push_str(&format!("{key}: {value}, "));
+                seen.push(key);
+            }
+            out.push('}');
+            out
+        });
+    let arrow = hegel::tuples!(ident(), gs::optional(ty()), node.generator()).map(
+        |(param, annotation, body)| {
+            let annotation = annotation.map_or(String::new(), |t| format!(": {t}"));
+            // Parenthesized body: a bare `=> {...}` parses as a block, not an
+            // object literal.
+            format!("(({param}{annotation}) => ({body}))")
+        },
+    );
+    let call = hegel::tuples!(ident(), node.generator()).map(|(f, a)| format!("{f}({a})"));
+    let binary = hegel::tuples!(node.generator(), gs::sampled_from(&["+", "==", "&&"][..]), node.generator())
+        .map(|(l, op, r)| format!("({l} {op} {r})"));
+    let ternary = hegel::tuples!(node.generator(), node.generator(), node.generator())
+        .map(|(c, t, e)| format!("({c} ? {t} : {e})"));
+    let member = hegel::tuples!(ident(), ident()).map(|(base, field)| format!("{base}.{field}"));
+    let cast = hegel::tuples!(node.generator(), ty()).map(|(e, t)| format!("({e} as ({t}))"));
+
+    node.set(hegel::one_of!(
+        leaf, array, object, arrow, call, binary, ternary, member, cast
+    ));
+    handle
+}
+
+/// A whole module: optional type alias, a few consts (possibly annotated),
+/// one `export default`.
+fn program() -> impl Generator<String> {
+    hegel::tuples!(
+        gs::booleans(),
+        gs::vecs(hegel::tuples!(gs::optional(ty()), expr())).max_size(3),
+        expr()
+    )
+    .map(|(with_alias, consts, default)| {
+        let mut out = String::new();
+        if with_alias {
+            out.push_str("type T0 = { host: string; port?: port };\n");
+        }
+        // Fixed distinct names keep generated `const`s well-formed; values
+        // and annotations carry the randomness.
+        for (index, (annotation, value)) in consts.into_iter().enumerate() {
+            let annotation = annotation.map_or(String::new(), |t| format!(": {t}"));
+            out.push_str(&format!("const k{index}{annotation} = {value};\n"));
+        }
+        out.push_str(&format!("export default {default};\n"));
+        out
+    })
+}
+
+// --- properties ------------------------------------------------------------
+
+#[hegel::test]
+fn convert_never_panics_on_arbitrary_text(tc: TestCase) {
+    let source: String = tc.draw(gs::text());
+    let _ = convert(&source); // Ok or a positioned Err; a panic fails the test
+}
+
+#[hegel::test]
+fn convert_is_deterministic(tc: TestCase) {
+    let source = tc.draw(program());
+    assert_eq!(convert(&source), convert(&source));
+}
+
+#[hegel::test]
+fn well_formed_programs_convert_and_emitted_nix_reparses(tc: TestCase) {
+    let source = tc.draw(program());
+    let nix = convert(&source)
+        .unwrap_or_else(|error| panic!("generated program failed to convert: {error}\n{source}"));
+    let parse = rnix::Root::parse(&nix);
+    assert!(
+        parse.errors().is_empty(),
+        "emitted Nix does not reparse: {:?}\n--- source\n{source}\n--- emitted\n{nix}",
+        parse.errors()
+    );
+}


### PR DESCRIPTION
Closes #4114.

- **hegeltest 0.14 -> 0.28.2** (latest; Antithesis's Hypothesis-based PBT library). The `native` feature no longer exists, so the nbt manifest drops it; nbt's property tests pass unchanged on the new engine.
- **Three properties over ix2nix** (`tests/properties.rs`): arbitrary text never panics the converter; conversion is byte-deterministic; generated well-formed `.ix` programs (recursive expr/type generators, deferred + one_of! per house pattern) convert, and the emitted Nix reparses cleanly under `rnix` as an independent oracle.
- **The reparse property found a real merged bug on its first run**: `bool` is a type *reference* in TS (`boolean` is the keyword), so `(x: bool)` failed with "unknown type" while the docs advertise `bool`. Both spellings now lower to the bool checker; the shrunk counterexample is a named regression test.
- **Drift guard**: unit test asserting every `__ixTy.<field>` the converter can emit is defined in `ix-ty.nix`.
- **New `property-testing` skill** (packages/agent/skills): when to reach for hegel, property ranking (never-panics, round-trip, determinism, model-based), generator patterns and the two JS generator traps hit while writing these, CI replay discipline, Antithesis relationship.
- **Typed kernel example**: `kernel-build/claude` uses `nonEmptyStr`/`path` const annotations and a `Vm` return shape; verified evaluating through the checks with a stub `mkVm`.

Verified: 79 cargo tests green across 5 consecutive full runs (properties re-randomize per run), nbt tests green on 0.28.2, `nix build .#ix2nix` green with the new lock, 27 lint stages green.

(PR by an AI agent via Claude Code, Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `bool` type support and property tests to ix2nix
> - Adds `bool` as a built-in type in [ty.rs](https://github.com/indexable-inc/index/pull/4117/files#diff-e15ff6046ccfb2bcaa4e794f318db4257b827fbe1ec85fb96b108f9f96281ce6), lowering it to `__ixTy.bool` alongside the existing `boolean` keyword; `bool` is now reserved and cannot be shadowed by a type alias.
> - Adds a property test suite in [properties.rs](https://github.com/indexable-inc/index/pull/4117/files#diff-c0f514fdc841a28b874edeb2ffe1acf42a0a5cc637aa350621726acac7ce033e) using `hegel` and `rnix`, covering three properties: the converter never panics on arbitrary input, output is deterministic, and well-formed programs produce valid reparseable Nix.
> - Adds a new [SKILL.md](https://github.com/indexable-inc/index/pull/4117/files#diff-c7ecf05b0d537bbc17d3da853da801b3716939991889d413d95e8e711168fb3a) documenting property-testing conventions with `hegel`.
> - Updates the [kernel-build example](https://github.com/indexable-inc/index/pull/4117/files#diff-52e71920603f715bb4659ce1906df7887f6730689b32a839b77c06d6f2e65156) with type annotations and a `Vm` type alias to demonstrate eval-time type checking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79cf24f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->