### PR TITLE
nix fork: auto-clear killed-build CA orphans

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -305,17 +305,17 @@
     "nix-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1784837596,
-        "narHash": "sha256-QwZSAD4QCICe3xHytt1QHz194IBHFP4z4PrG1idhv4Y=",
+        "lastModified": 1784838900,
+        "narHash": "sha256-9occ4hKwbbw5W3sjyoBaZI7GvAarfwzblfWUXwKseBo=",
         "owner": "indexable-inc",
         "repo": "nix",
-        "rev": "0bcdf91ce72e21241359c72a2aa17d55178801b3",
+        "rev": "403b19c5a120dcb57f293790fb1ec470d0d1392c",
         "type": "github"
       },
       "original": {
         "owner": "indexable-inc",
         "repo": "nix",
-        "rev": "0bcdf91ce72e21241359c72a2aa17d55178801b3",
+        "rev": "403b19c5a120dcb57f293790fb1ec470d0d1392c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -154,13 +154,12 @@
     # marks it `autoUpdate = false`): jj-rebase indexable-inc/nix only when we
     # intend to move the daemon version too, then repin here.
     nix-src = {
-      # Megamerge 6191434e (45 patches on 2c6d06e9387c) plus the
-      # first-transfer lost-wakeup fix (indexable-inc/nix#2): libcurl 8.21.0
-      # drains the wakeup eventfd on entering curl_multi_poll, so the first
-      # transfer of every nix process slept the worker's whole 10s idle poll
-      # before starting -- every cold in-guest `nix run` paid +10s on the
-      # flake-registry fetch (index#4122).
-      url = "github:indexable-inc/nix/0bcdf91ce72e21241359c72a2aa17d55178801b3";
+      # Megamerge 403b19c5 (47 patches on 2c6d06e9387c): the 45-patch series
+      # plus the first-transfer lost-wakeup fix (indexable-inc/nix#2, folded
+      # into the patch DAG; index#4122) and the killed-build orphan recovery
+      # (invalid CA scratch-output leftovers are cleared under the build
+      # locks instead of wedging every rebuild of the drv; index#4112).
+      url = "github:indexable-inc/nix/403b19c5a120dcb57f293790fb1ec470d0d1392c";
       flake = false;
     };
 

--- a/packages/ix2nix/src/error.rs
+++ b/packages/ix2nix/src/error.rs
@@ -15,15 +15,24 @@ pub struct Error {
     line_text: String,
 }
 
+/// A 1-based source position. Named (rather than a bare tuple) to satisfy the
+/// workspace's `clippy::anonymous_tuple_return_type`.
+pub(crate) struct LineCol {
+    /// 1-based line number.
+    pub(crate) line: usize,
+    /// 1-based column (in characters) within that line.
+    pub(crate) column: usize,
+}
+
 /// 1-based line and column (in characters) of byte `offset` in `source`.
 /// Shared by diagnostics and the `__ixTy` check locations the mapper emits,
 /// so both spell positions identically.
-pub(crate) fn line_col(offset: usize, source: &str) -> (usize, usize) {
+pub(crate) fn line_col(offset: usize, source: &str) -> LineCol {
     let offset = offset.min(source.len());
     let line_start = source[..offset].rfind('\n').map_or(0, |i| i + 1);
     let line = source[..line_start].matches('\n').count() + 1;
     let column = source[line_start..offset].chars().count() + 1;
-    (line, column)
+    LineCol { line, column }
 }
 
 impl Error {
@@ -34,7 +43,7 @@ impl Error {
         let line_end = source[offset..]
             .find('\n')
             .map_or(source.len(), |i| offset + i);
-        let (line, column) = line_col(offset, source);
+        let LineCol { line, column } = line_col(offset, source);
         let line_start = source[..offset].rfind('\n').map_or(0, |i| i + 1);
 
         Self {

--- a/packages/ix2nix/src/ty.rs
+++ b/packages/ix2nix/src/ty.rs
@@ -10,7 +10,7 @@
 use oxc_ast::ast;
 use oxc_span::{GetSpan as _, Span};
 
-use crate::error::{Error, line_col};
+use crate::error::{Error, LineCol, line_col};
 use crate::map::Mapper;
 use crate::nix::{Attr, Expr, StrPart};
 
@@ -82,7 +82,7 @@ impl Mapper<'_> {
     /// `"<line>:<col> <what>"`: the source location a failed check reports.
     /// The runtime prefixes the module path, which only the importer knows.
     pub(crate) fn check_loc(&self, span: Span, what: &str) -> String {
-        let (line, column) = line_col(span.start as usize, self.source);
+        let LineCol { line, column } = line_col(span.start as usize, self.source);
         format!("{line}:{column} {what}")
     }
 

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -1452,8 +1452,10 @@ fn append_link_arg_reader(script: &mut String, quoted_run_ref: &str, file: &str)
 
 // A killed content-addressed build on a store without a build sandbox (the
 // darwin default) can leave its resolved output path behind in /nix/store as an
-// invalid directory owned by the `_nixbld` user that ran it. Nix does not remove
-// that orphan before a later rebuild of the same drv, so a fresh builder (a
+// invalid directory owned by the `_nixbld` user that ran it. Before fork rev
+// 403b19c5 nix did not remove that orphan before a later rebuild of the same
+// drv (the daemon now clears it itself under the build locks, #4112), so a
+// fresh builder (a
 // different `_nixbld` uid) hits the pre-existing dir at `$out` and the artifact
 // `cp` below fails with a bare `cp: ... Permission denied` one phase after rustc
 // succeeded, which reads like a linker/OOM failure (#2247). Detect the orphan
@@ -1461,9 +1463,11 @@ fn append_link_arg_reader(script: &mut String, quoted_run_ref: &str, file: &str)
 // sealed store path is always root-owned and never pre-exists for a fresh build,
 // so an existing non-writable `$out` here is unambiguously a killed-build
 // leftover; we only detect and report it, never delete a store path from a
-// builder. A nix builder puts GNU coreutils `stat` first on PATH even on
-// darwin, so query the owner with GNU `-c '%U'` first; BSD `stat -f '%Su'` is
-// only the fallback (GNU stat would misparse `-f` as `--file-system`).
+// builder. This precheck firing on a store whose daemon carries the #4112 fix
+// means something new is wrong. A nix builder puts GNU coreutils `stat` first
+// on PATH even on darwin, so query the owner with GNU `-c '%U'` first; BSD
+// `stat -f '%Su'` is only the fallback (GNU stat would misparse `-f` as
+// `--file-system`).
 const ORPHAN_OUTPUT_PRECHECK: &str = "\
 if [ -e \"$out\" ] && [ ! -w \"$out\" ]; then
   echo >&2 \"error: refusing to install over a pre-existing, non-writable output path:\"


### PR DESCRIPTION
Fixes #4112.

A content-addressed build killed after its builder created `$out` leaves that path behind as an invalid, `_nixbld`-owned orphan (non-sandboxed stores, the darwin default, write directly at the deterministic floating-CA scratch path). Nix never cleared it, so every later rebuild of the same drv died one phase after rustc with `cp: ... Permission denied` -- #2247 added a diagnostic with the manual recipe (`nix-store --check-validity`, then `sudo rm -rf`); today's repro found 57 such orphans blocking trivial crate rebuilds on an ix guest.

This bump makes the recovery automatic in the fork daemon:

- **Fork patch** `fix(libstore): clear invalid orphan scratch outputs before rebuilding` (indexable-inc/nix@37514fa32c50, child of the floating-CA GC-race patch). In the scratch output setup, a pre-existing on-disk path at a floating-CA scratch location that is **not** a valid (registered) store path is cleared with one log line (`clearing invalid orphan '<path>' left by a killed build of '<drv>'`) before the build. The check runs under the derivation's output locks, and a fallback scratch path is by construction never a registered path, so valid paths are never touched -- exactly the safety condition the #2247 diagnostic encoded.
- **Regression test** `tests/functional/ca/killed-build-orphan.sh`: plants a non-writable unregistered directory at the recorded scratch path (asserting `check-validity` is nonzero first) and requires the rebuild to clear it, log the line, and succeed with untainted output. Verified to fail on the previous fork rev and pass with the patch; full `ca` suite green.
- **Pin**: `nix-src` -> `403b19c5a120dcb57f293790fb1ec470d0d1392c` (`ix megamerge: 47 patches on 2c6d06e9387c`, pin ref `refs/pins/2026-07-23-403b19c5a120` pushed alongside the bookmark). This megamerge folds in the first-transfer lost-wakeup fix main pins since #4123 (indexable-inc/nix#2, rebased onto its true DAG dependency, the filetransfer half-close/stall patch), so nothing regresses: tree = main's pinned tree + the orphan patch, byte-for-byte.
- `nix-cargo-unit`'s `ORPHAN_OUTPUT_PRECHECK` comment now notes the precheck is a tripwire for stores whose daemon predates the fix (script text unchanged, so no unit hashes move).
- `ix2nix`: `line_col` returns a named `LineCol` struct -- the nix-src bump forces a cache-miss rebuild of the `ix2nix-clippy` gate, which surfaced the latent `clippy::anonymous_tuple_return_type` deny.

Validated locally: `nix build .#nix-ix` succeeds at the new rev (`2.34.7+ix.g403b19c5a120`), `nix build .#ix2nix` green, fork functional test passes (and fails without the libstore patch), `nix fmt` clean.

**Consumers still needing bumps**: downstream consumers pick the fix up only after their own lock bump -- ix needs `nix flake update index nix-src` (its lock pins `nix-src` transitively), after which ix guests get the fixed daemon via the base image rebuild.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update nix fork pin to auto-clear killed-build CA orphans
> - Updates the nix fork pin in [flake.nix](https://github.com/indexable-inc/index/pull/4118/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) from `0bcdf91c` to `403b19c5`, picking up daemon behavior that auto-clears content-addressed orphans left by killed builds.
> - Updates comments in [render.rs](https://github.com/indexable-inc/index/pull/4118/files#diff-da81bb79268fbaf52a96664faa4d392b9b83a48a4b3b54bb1c3a2a5f2f50f26a) to reference the new fork rev and the orphan-precheck behavior (#4112).
> - Introduces a `LineCol` struct in [error.rs](https://github.com/indexable-inc/index/pull/4118/files#diff-4a1fb0c4ada4b7c5cbeec54e0c45c3d26405bddc512861540b2f26ee5961e510) to replace the raw tuple returned by `line_col`, with corresponding updates in [ty.rs](https://github.com/indexable-inc/index/pull/4118/files#diff-ce1ab1000499a3f04d1f67dddea41b821cba34db199b844f7167d4159c869d16).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49ac464.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->