### PR TITLE
prompt: subagents form a star; problems route to the parent

### DIFF
--- a/packages/agent/prompt/rules.nix
+++ b/packages/agent/prompt/rules.nix
@@ -435,6 +435,28 @@
     };
   }
   {
+    subagentTopology = {
+      topics = ["tooling"];
+      text = ''
+        Prefer delegating to subagents over doing everything inline. The
+        topology is a star: the spawner is the hub, subagents are leaves.
+        A leaf that hits a problem outside its charter (a different bug,
+        a design flaw, a blocking dependency) does not fix it and does
+        not spawn its own coordinator; it sends the problem to its parent
+        (SendMessage when available, otherwise its final report), and the
+        parent decides: fix, file, or dispatch another subagent. Subagents
+        never coordinate with each other directly; cross-agent traffic
+        goes through the parent.
+      '';
+      reason = ''
+        Requested 2026-07-23: the spawner is the one context holding the
+        whole picture, so cross-cutting problems route through it. States
+        topology and escalation only; delegation mechanics stay in
+        backgroundSubagents and subagentToolSubset.
+      '';
+    };
+  }
+  {
     wallTime = {
       topics = ["workflow" "agency"];
       text = ''


### PR DESCRIPTION
Adds one house-prompt rule, `subagentTopology` (topics: `tooling`), to `packages/agent/prompt/rules.nix`, placed with the other subagent rules:

> Prefer delegating to subagents over doing everything inline. The topology is a star: the spawner is the hub, subagents are leaves. A leaf that hits a problem outside its charter (a different bug, a design flaw, a blocking dependency) does not fix it and does not spawn its own coordinator; it sends the problem to its parent (SendMessage when available, otherwise its final report), and the parent decides: fix, file, or dispatch another subagent. Subagents never coordinate with each other directly; cross-agent traffic goes through the parent.

Andrew's intent (2026-07-23): delegate freely, but keep the spawner as the one context holding the whole picture. States topology and escalation only; delegation mechanics stay in `backgroundSubagents` and `subagentToolSubset`.

Validated: `nix run .#lint` green (13/13), `nix fmt` clean, rendered prompt rereads with the new rule in place; the `eval` check (provider-prompts assertions) is running locally.

(sent by an AI agent via Claude Code, Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add star topology rule to agent prompt for subagent coordination
> Adds a `subagentTopology` rule to [rules.nix](https://github.com/indexable-inc/index/pull/4120/files#diff-438311cd2350f776fff4331d71f04955c1d9d1d210df9c1a62e2980e444ffae5) instructing subagents to treat the spawner as the hub, delegate tasks outward, and escalate cross-cutting or out-of-charter problems to the parent rather than fixing them directly or coordinating peer-to-peer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad2b988.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->