### PR TITLE
platform: re-enable modprobe wiring so guests can load kernel modules

### DIFF
--- a/lib/image/platform.nix
+++ b/lib/image/platform.nix
@@ -580,6 +580,31 @@ in {
     boot = {
       isContainer = true;
 
+      # `isContainer` makes nixpkgs' container-config.nix turn the modprobe
+      # machinery off ("containers don't have a kernel"), but ix guests DO
+      # have one: the host direct-kernel-boots linux-ix and injects that
+      # kernel's full module tree at /lib/modules/<kver> in every rootfs.
+      # Without this re-enable the guest has no module loader at all:
+      # /proc/sys/kernel/modprobe keeps the kernel's compiled-in default
+      # /sbin/modprobe (which does not exist here), so request_module()
+      # fails and every =m kernel feature is dead -- nftables.service dies
+      # with "Unable to initialize Netlink socket: Protocol not supported"
+      # on every boot and every switch exits 4 (ix#8408). Re-enabling the
+      # upstream module (nixos/modules/system/boot/modprobe.nix) puts
+      # pkgs.kmod on PATH and points the sysctl at its modprobe from an
+      # activation snippet, which runs at boot AND during a switch, so the
+      # fix reaches an already-booted VM through a plain `ix apply`.
+      #
+      # Version skew is safe: nixpkgs kmod probes
+      # /run/{booted,current}-system/kernel-modules first but only takes a
+      # prefix whose <uname -r> subdir exists. ix toplevels never ship the
+      # kernel-modules link (boot.kernel.enable = false under isContainer),
+      # and a user toplevel carrying modules for some other kernel fails
+      # the <uname -r> probe, so resolution always lands on the injected
+      # /lib/modules tree of the RUNNING kernel.
+      # astlog-ignore: no-mkforce container-config.nix sets this unconditionally for isContainer; ix#8408
+      modprobeConfig.enable = lib.mkForce true;
+
       # /tmp on tmpfs (RAM-backed). The default on-disk /tmp grows
       # without bound on long-running VMs, and ix VMs have plenty of RAM
       # to spare for ephemeral working space (see AGENTS.md "VM

--- a/packages/site/src/lib/updates/guest-modprobe-wiring.svx
+++ b/packages/site/src/lib/updates/guest-modprobe-wiring.svx
@@ -1,0 +1,35 @@
+---
+id: guest-modprobe-wiring
+postedAt: "2026-07-23"
+title: kernel module autoloading works in guests, nftables firewall starts green
+links:
+  - label: "ix#8408"
+    href: https://github.com/indexable-inc/ix/issues/8408
+tags:
+  - platform
+  - images
+---
+
+Every ix guest boots the host-provided linux-ix kernel and gets that
+kernel's full module tree injected at `/lib/modules/<kver>`, but until now
+no image shipped a module loader: images set `boot.isContainer = true`, and
+nixpkgs' container-config.nix responds by disabling the whole modprobe
+machinery on the theory that containers have no kernel. The result was that
+`/proc/sys/kernel/modprobe` still pointed at the kernel's compiled-in
+default `/sbin/modprobe` (which does not exist in the guest), so
+`request_module()` always failed and every `=m` kernel feature was dead.
+Concretely, `nftables.service` failed on every boot with "Unable to
+initialize Netlink socket: Protocol not supported" -- the in-guest firewall
+the platform declares was never actually enforcing -- and every
+`switch-to-configuration` exited 4 on it.
+
+The platform profile now re-enables the upstream modprobe module
+(`boot.modprobeConfig.enable`), which puts `kmod` (`modprobe`, `lsmod`,
+`modinfo`, ...) on the system PATH and points
+`/proc/sys/kernel/modprobe` at kmod's modprobe from an activation
+snippet. Activation runs at boot and during a switch, so already-running
+VMs pick the fix up through a plain `ix apply` with the new index pin --
+no base-image rebuild needed for switched VMs. Module resolution follows
+the running kernel: nixpkgs kmod only takes a candidate directory whose
+`uname -r` subtree exists, so even a user toplevel carrying modules for a
+different kernel resolves against the injected `/lib/modules` tree.


### PR DESCRIPTION
Fixes indexable-inc/ix#8408.

## Root cause

Every ix guest boots the host-provided linux-ix kernel, and the host injects that kernel's full module tree at `/lib/modules/<kver>` in every rootfs (ix `crates/control/image/rootfs-patch`). The tree was never the problem — the loader wiring was. `lib/image/platform.nix` sets `boot.isContainer = true`, and nixpkgs `container-config.nix` responds with `boot.modprobeConfig.enable = false` ("containers don't have a kernel"), which turns off the upstream `nixos/modules/system/boot/modprobe.nix`. Result: no `kmod` on the system PATH and `/proc/sys/kernel/modprobe` left at the kernel's compiled-in default `/sbin/modprobe`, which does not exist in the guest. `request_module()` always failed, so every `=m` kernel feature was dead: `nftables.service` died with `Unable to initialize Netlink socket: Protocol not supported` on every boot, and every `switch-to-configuration` exited 4 on it — the platform-declared in-guest firewall was never actually enforcing.

## Fix (the seam)

Re-enable the upstream module: `boot.modprobeConfig.enable = lib.mkForce true` in the shared platform profile (`lib/image/platform.nix`). mkForce is required because container-config.nix's `false` is an unconditional assignment, not a default (astlog-ignore'd like the neighboring `binsh`/`usrbinenv` overrides). This ships `pkgs.kmod` in the system PATH and points `/proc/sys/kernel/modprobe` at kmod's modprobe from the standard activation snippet. No kernel options move to built-in; no firewall workaround.

`systemd-modules-load` is deliberately untouched: the `boot.kernelModules` → `modules-load.d` wiring stays behind `boot.kernel.enable` (still off), and nothing platform-side needs a static module list — the autoload sysctl is the load-bearing piece.

## Version skew

User toplevels may carry a modules tree for a different kernel than the booted one. nixpkgs kmod (module-dir.patch) probes `/run/booted-system/kernel-modules/lib/modules` and `/run/current-system/kernel-modules/lib/modules` first, but only takes a prefix whose `$(uname -r)` subdirectory exists, falling through to `/lib/modules` otherwise. index toplevels never ship the `kernel-modules` link at all (`boot.kernel.enable = false` under isContainer), and a user toplevel with modules for some other kernel fails the `$(uname -r)` probe. Resolution therefore always lands on the injected `/lib/modules/$(uname -r)` tree of the RUNNING kernel; a toplevel tree is only ever used if it matches the running kernel version exactly, in which case it is equivalent.

## Rollout

- **User switches get the fix from the index pin alone**: the modprobe activation snippet runs during `switch-to-configuration`, so a plain `ix apply` sets the sysctl live on an already-booted VM. A unit-changing switch then starts nftables green (verified below). A no-op re-apply does not restart a unit that already failed at boot — that failed state clears on the first real switch or once the base boots fixed.
- **Boot-time green needs the ix/base image rebuild** from the new index pin: reboots and fresh VMs boot the published base toplevel, whose stage-2 `/init` runs the activation script (sysctl set) before systemd starts nftables.

## Evidence (live VM ix-apply-demo / 019f8f98, 2026-07-23)

Before: `/proc/sys/kernel/modprobe` = `/sbin/modprobe` (nonexistent), no modprobe on PATH, `nftables.service` failed every boot/switch, demo config carried a `networking.nftables.enable = mkForce false` workaround just to switch at all.

After removing that workaround and switching with this branch as the index pin:

- `/proc/sys/kernel/modprobe` → `/nix/store/n2vv...-kmod-31/bin/modprobe`; `command -v modprobe` → `/run/current-system/sw/bin/modprobe`
- `modprobe nf_tables` → OK
- Kernel-initiated autoload round trip: `ip link add dummy-8408 type dummy` loads `dummy.ko` via the sysctl'd modprobe
- `nftables.service` **active**, `table inet nixos-fw` ruleset loaded; a follow-up firewall-touching switch (`allowedTCPPorts = [8085]`) restarts it green and the ruleset carries the port
- `nix build .#packages.x86_64-linux.base.toplevel` from this branch: `sw/bin/modprobe` present, `activate` contains the modprobe snippet, and `/init` (stage 2) runs `activate` before systemd — the boot-path mechanism

(sent by an AI agent via Claude Code, Fable 5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-enable modprobe wiring so guests can load kernel modules
> Sets `boot.modprobeConfig.enable = lib.mkForce true` in [platform.nix](https://github.com/indexable-inc/index/pull/4121/files#diff-4e9f8a1975e02453aa569916bd7b0c3a25baa581602e105115a45921f41bf7d7) to override the default behavior that disables modprobe when `isContainer = true`, ensuring the modprobe configuration remains active in guest environments. Also adds a new update post in [guest-modprobe-wiring.svx](https://github.com/indexable-inc/index/pull/4121/files#diff-177168562b035d20211dffe553e9405ed30f754da173bea120fbc66aa45d5d05) describing this change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4295f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->