### PR TITLE
nix: repin nix-src for the first-transfer lost-wakeup fix (+10s cold nix run)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -305,17 +305,17 @@
     "nix-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1784736067,
-        "narHash": "sha256-Rff/kbSi1frC8R97isYroC1kO0AGZIr0w81TNicy3go=",
+        "lastModified": 1784837596,
+        "narHash": "sha256-QwZSAD4QCICe3xHytt1QHz194IBHFP4z4PrG1idhv4Y=",
         "owner": "indexable-inc",
         "repo": "nix",
-        "rev": "6191434e432e91510e3b02e192e3f451a5f8f22a",
+        "rev": "0bcdf91ce72e21241359c72a2aa17d55178801b3",
         "type": "github"
       },
       "original": {
         "owner": "indexable-inc",
         "repo": "nix",
-        "rev": "6191434e432e91510e3b02e192e3f451a5f8f22a",
+        "rev": "0bcdf91ce72e21241359c72a2aa17d55178801b3",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -154,7 +154,13 @@
     # marks it `autoUpdate = false`): jj-rebase indexable-inc/nix only when we
     # intend to move the daemon version too, then repin here.
     nix-src = {
-      url = "github:indexable-inc/nix/6191434e432e91510e3b02e192e3f451a5f8f22a";
+      # Megamerge 6191434e (45 patches on 2c6d06e9387c) plus the
+      # first-transfer lost-wakeup fix (indexable-inc/nix#2): libcurl 8.21.0
+      # drains the wakeup eventfd on entering curl_multi_poll, so the first
+      # transfer of every nix process slept the worker's whole 10s idle poll
+      # before starting -- every cold in-guest `nix run` paid +10s on the
+      # flake-registry fetch (index#4122).
+      url = "github:indexable-inc/nix/0bcdf91ce72e21241359c72a2aa17d55178801b3";
       flake = false;
     };
 


### PR DESCRIPTION
Fixes #4122 (the prod cold `nix run` +11s regression, hello KPI p50 6s -> 16.5s since 2026-07-23 08:07Z).

Repins `nix-src` to the currently-deployed megamerge `6191434e` **plus one fix commit** (indexable-inc/nix#2):

- libcurl 8.21.0 drains the wakeup eventfd on entering `curl_multi_poll`, losing any `curl_multi_wakeup()` issued while the worker is outside the poll.
- The first transfer of every nix process is enqueued (with its wakeup) before the worker thread has ever polled, so it deterministically sleeps the worker's full 10s idle timeout before starting. strace from a prod guest: `poll([{fd=10, events=POLLIN}], 1, 10000) = 0 (Timeout) <10.010139>`.
- Fix: the worker re-checks the incoming/unpause/quit state under the lock after computing its sleep and refuses to sleep past actionable work; embargoed retries cap the sleep at their due time. Regression gtest included (fresh FileTransfer, file:// download, 5s bound).

Evidence: A/B with pristine caches on dev-compute-1 — vanilla 2.34.7 (curl 8.20.0) 0.15s vs every fork build (curl 8.21.0) ~10.1s for cold `nix flake metadata nixpkgs`. Full trace in #4122.

Companion (independent) mitigation PR: stop guest images fetching the global flake registry at all, so the cold path stays hermetic regardless of curl behavior.

Draft until: patched nix built + A/B re-run on dev-compute-1, and an in-guest E2E on a throwaway VM confirms cold `nix run nixpkgs#hello` back to ~6s. Results will be posted here.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Repin `nix-src` to commit with first-transfer lost-wakeup fix
> Updates [flake.nix](https://github.com/indexable-inc/index/pull/4123/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) to point `nix-src` at commit `0bcdf91` (from `6191434`), picking up a fix for a lost-wakeup bug on first transfer. Behavioral Change: cold `nix run` invocations will be ~10s slower due to the new revision.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f034d62.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->