### PR TITLE
image: bake the global flake registry so cold guests never download it

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -120,6 +120,22 @@
         "type": "github"
       }
     },
+    "flake-registry-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782548455,
+        "narHash": "sha256-Jjp/ZivVqZCLptwlSuwU8n0a8b8PXJqabxpSG7KRNuI=",
+        "owner": "NixOS",
+        "repo": "flake-registry",
+        "rev": "10bd3d9e8eefb4725e346eddd3a505aa0aacf01b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-registry",
+        "type": "github"
+      }
+    },
     "ghostty-src": {
       "flake": false,
       "locked": {
@@ -554,6 +570,7 @@
         "drgn-src": "drgn-src",
         "examples": "examples",
         "fff-src": "fff-src",
+        "flake-registry-src": "flake-registry-src",
         "ghostty-src": "ghostty-src",
         "git-src": "git-src",
         "hermes-agent": "hermes-agent",

--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,19 @@
       flake = false;
     };
 
+    # The global flake registry, baked into guest images so an in-guest
+    # `nix run <id>#...` on any registry alias resolves without nix first
+    # downloading https://channels.nixos.org/flake-registry.json on the cold
+    # path (that download was the first HTTP transfer of every cold in-guest
+    # nix process, and paired with the libcurl 8.21 lost-wakeup it cost each
+    # cold `nix run` +10s; index#4122). This repo is the source that channel
+    # URL is published from. Branch-floating: the scheduled flake update
+    # advances it; aliases churn rarely, so staleness is harmless.
+    flake-registry-src = {
+      url = "github:NixOS/flake-registry";
+      flake = false;
+    };
+
     # jj megamerge fork of rust-lang/rust-clippy with the restriction lints
     # tuned for LLM-assisted codebases (lib/fork-packages.nix). Pinned BY
     # REV, not a floating branch: clippy-driver links rustc_private and must match
@@ -353,6 +366,7 @@
     sdk-prebuilt-rust-overlay,
     home-manager,
     home-manager-src,
+    flake-registry-src,
     hermes-agent,
     btop-src,
     nushell-src,
@@ -431,6 +445,7 @@
         sdk-prebuilt-rust-overlay
         home-manager
         home-manager-src
+        flake-registry-src
         hermes-agent
         btop-src
         nushell-src

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -8,6 +8,11 @@
   sdk-prebuilt-rust-overlay,
   home-manager,
   home-manager-src,
+  # The global flake registry source (github:NixOS/flake-registry), baked
+  # into guest images so in-guest nix never downloads it on the cold path
+  # (index#4122). Defaulted `null` so a bare `import ./lib` (no flake) still
+  # evaluates; `lib/image` omits the nix.conf pin when it is absent.
+  flake-registry-src ? null,
   hermes-agent,
   btop-src,
   nushell-src,
@@ -804,6 +809,7 @@
         moduleList
         writeNushellApplication
         packageSetFor
+        flake-registry-src
         ;
     })
     evalImageConfig

--- a/lib/image/default.nix
+++ b/lib/image/default.nix
@@ -14,6 +14,12 @@
   # `nix.registry.index` module below). `null` when `lib` is imported without a
   # flake; the pin is then omitted.
   self ? null,
+  # The global flake registry source (github:NixOS/flake-registry), baked so
+  # in-guest nix resolves registry aliases without downloading
+  # https://channels.nixos.org/flake-registry.json on the cold path (see the
+  # `nix.settings.flake-registry` module below). `null` when `lib` is imported
+  # without a flake; the nix.conf pin is then omitted.
+  flake-registry-src ? null,
 }: let
   # The `nix.registry.index.to` construction, shared with the
   # `image-registry-pin` check (tests/default.nix). See its doc comment.
@@ -149,6 +155,25 @@
           # path-locked submodule seam (index#3981) — see ./registry-pin.nix;
           # the `image-registry-pin` check holds both shapes.
           nix.registry.index.to = registryPin self;
+        }
+        ++ lib.optional (flake-registry-src != null) {
+          # Bake the GLOBAL flake registry too, and point nix.conf's
+          # `flake-registry` at the store copy. Resolving any indirect
+          # flakeref (`nix run nixpkgs#hello` included, even though nixpkgs
+          # is pinned in the system registry above) makes nix construct the
+          # global registry, which by default downloads
+          # https://channels.nixos.org/flake-registry.json -- the FIRST HTTP
+          # transfer of every cold in-guest nix process. That download sat
+          # on the cold path of every `nix run` in a fresh VM, and combined
+          # with the libcurl 8.21 first-transfer lost-wakeup it cost each
+          # cold run +10s (nix_run_hello KPI p50 5.9s -> 16.5s, index#4122).
+          # channels.nixos.org publishes exactly this repo's
+          # flake-registry.json, so behavior is identical for every alias;
+          # the interpolation carries the store-path context, rooting the
+          # file into the image closure. Registry aliases churn rarely, and
+          # the branch-floating input advances under the scheduled flake
+          # update, so staleness is bounded and harmless.
+          nix.settings.flake-registry = "${flake-registry-src}/flake-registry.json";
         }
         ++ [
           ./platform.nix


### PR DESCRIPTION
Companion mitigation for #4122 (cold in-guest `nix run` +11s). Independent of the nix fix in #4123 / indexable-inc/nix#2, and worth having regardless: it removes the last network round trip from the cold `nix run nixpkgs#hello` path.

**What.** Every cold guest nix process downloads `https://channels.nixos.org/flake-registry.json` the first time it resolves an indirect flakeref - even `nixpkgs`, which the image already pins in the system registry. This PR bakes `github:NixOS/flake-registry` (the exact source that URL publishes) into the image closure and sets `nix.settings.flake-registry` to the store copy.

**Behavior.** Identical alias resolution (same file), zero network, zero cold-path stall even on a curl/nix combination with the lost-wakeup bug. Registry aliases churn rarely; the branch-floating input advances under the scheduled flake update.

**Plumbing.** Mirrors the existing `self`/`nixpkgs` registry-pin pattern in `lib/image/default.nix`; `flake-registry-src` is defaulted `null` so bare `import ./lib` consumers (and downstream ix until it passes the input) evaluate unchanged and simply omit the nix.conf pin.

**Measured.** In a fresh prod VM, cold `nix flake metadata nixpkgs` with the global registry off the network path: 0.15s (vs 10.7s live today). Full incident analysis in #4122.

Draft until an in-guest E2E on a rebuilt image confirms the cold hello leg; results will be posted here.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bake the global Nix flake registry into images so cold guests never download it
> - Adds a new non-flake input `flake-registry-src` (pinned to `github:NixOS/flake-registry`) in [flake.nix](https://github.com/indexable-inc/index/pull/4124/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) and threads it through to image configuration.
> - When `flake-registry-src` is provided, sets `nix.settings.flake-registry` to the in-store `flake-registry.json` via a conditional NixOS module in [lib/image/default.nix](https://github.com/indexable-inc/index/pull/4124/files#diff-3883253618b080892e770f4ceb96188ed814f4f588df529f7a82d338874c14bd), so guests never fetch it at runtime.
> - The parameter defaults to `null` at every layer, so builds that omit it are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca21a1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->