### PR TITLE
cache-push: publish the wasm converter workspace's eval-time IFD roots

### DIFF
--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -1298,23 +1298,25 @@
     in
       lib.mergeAttrsList (map rootsForTarget crossTargets)
   );
-  # A cross package whose build rides a distinct `cargoUnit.buildWorkspace`
-  # instead of the shared `crossWorkspace` (codex: its codex-rs is a second
-  # workspace) exposes that workspace's unit-graph IFD artifacts via
-  # `passthru.workspaceIfdRoots`. `crossIfdRoots` only covers the shared
-  # workspace, so harvest these too -- otherwise a Mac consumer substituting the
-  # cross output re-vendors/re-renders that graph at eval and hits the #1890
-  # trap on x86_64-linux drvs it cannot build. Generic over `crossPackages`, so
-  # a future second-workspace cross package joins with no hand-kept list.
-  crossPackageIfdRoots = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux (
+  # A package whose build rides a distinct `cargoUnit.buildWorkspace` instead
+  # of the shared `crossWorkspace` (codex's codex-rs; ix2nix-wasm's
+  # wasm32-unknown-unknown graph) exposes that workspace's unit-graph IFD
+  # artifacts via `passthru.workspaceIfdRoots`. `crossIfdRoots` only covers
+  # the shared workspace, so harvest these too -- otherwise a consumer
+  # substituting the package output re-vendors/re-renders that graph at eval
+  # and hits the #1890 trap on drvs it cannot build (Darwin for codex;
+  # every scaffolded `ix init` eval for the wasm converter, #4127). Generic
+  # over the whole `packageSet` (crossPackages included), so any package
+  # exposing the passthru joins with no hand-kept list.
+  workspacePackageIfdRoots = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux (
     lib.concatMapAttrs (
       name: pkg:
         lib.mapAttrs' (
-          rootName: drv: lib.nameValuePair "cross-ifd-${name}-${rootName}" drv
+          rootName: drv: lib.nameValuePair "workspace-ifd-${name}-${rootName}" drv
         )
         (pkg.passthru.workspaceIfdRoots or {})
     )
-    crossPackages
+    packageSet
   );
   darwinPackageAliases = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux (
     lib.genAttrs (lib.attrNames darwinTargetsBySystem) (
@@ -1836,8 +1838,10 @@ in {
   #      forces at eval when it substitutes a Darwin cross output. These are
   #      build-time deps of the cross packages, so they are absent from those
   #      packages' runtime closures; adding them as roots is the fix for #1687.
-  #      `crossPackageIfdRoots` extends this to cross packages that ride a second
-  #      `buildWorkspace` (codex's codex-rs), whose own unit graph `crossIfdRoots`
+  #      `workspacePackageIfdRoots` extends this to any package that rides a
+  #      second `buildWorkspace` (codex's codex-rs; ix2nix-wasm's wasm32
+  #      graph, which every scaffolded `ix init` eval forces through
+  #      `lib.importIxWasm`, #4127), whose own unit graph `crossIfdRoots`
   #      -- keyed off the shared `crossWorkspace` -- does not see.
   #   4. On Darwin hosts, the native lane's eval-time IFD outputs
   #      (`nativeIfdRoots`): the same three unit-graph artifacts as (3) but for
@@ -1881,7 +1885,7 @@ in {
     # lane sees the cross drvs and its system filter drops them.
     if pkgs.stdenv.hostPlatform.isDarwin
     then imagesAsClosures // nativeIfdRoots
-    else imagesAsClosures // exampleNodeToplevels // crossIfdRoots // crossPackageIfdRoots;
+    else imagesAsClosures // exampleNodeToplevels // crossIfdRoots // workspacePackageIfdRoots;
 
   # The policy manifest is safe to `nix eval --json`: derivations live in the
   # separate securityRootPaths output and must be realized before their terminal

--- a/packages/ix2nix/wasm/default.nix
+++ b/packages/ix2nix/wasm/default.nix
@@ -132,5 +132,16 @@ in
       (old.passthru or {})
       // {
         tests = {inherit e2e;};
+        # This wasm32 graph is its own `buildWorkspace`, invisible to
+        # per-system.nix's shared-workspace `crossIfdRoots`. Every scaffolded
+        # `ix init` eval forces these at eval time through
+        # `lib.importIxWasm` (the `import unitsNix` behind the converter
+        # drv), so cache-push publishes them as explicit roots via the
+        # `workspacePackageIfdRoots` harvest -- otherwise each fresh project
+        # re-vendors and re-renders the graph before its first substitution
+        # (#4127; same #1890 class as codex's second workspace).
+        workspaceIfdRoots = {
+          inherit (workspace) unitsNix unitGraphJson vendorDir;
+        };
       };
   })


### PR DESCRIPTION
Fixes #4127.

## The audit

`packages.x86_64-linux.ix2nix-wasm` itself is **already** in the warm set: it is a `flake = true` registry entry, so it flows `repoFlakePackages` -> `packageSet` -> `cachePushRoots` (`lib/per-system.nix`), and `.github/workflows/cache-push.yml` (the authoritative pipeline for index packages on cache.ix.dev) pushes it on every merge to main. No missing list entry there — the output is absent from cache.ix.dev because **no cache-push run has completed since the flattening merged**: last success was run 29989731602 (07:56Z, pre-#4119 rev `3518235`); everything since has been superseded-cancelled or is starved waiting for a self-hosted runner (dispatcher assigned nothing between ~20:14Z and this PR).

What the scaffold eval path *does* additionally need — and what was never covered — is the wasm workspace's eval-time IFD closure. `ix2nix-wasm` rides its own `wasm32-unknown-unknown` `buildWorkspace`, so its `cargo-units.nix`, `cargo-unit-graph.json`, and `cargo-vendor-dir` sit outside every runtime closure and outside `crossIfdRoots` (shared workspace only). Every scaffolded `ix init` project forces exactly these three drvs at first eval through `lib.importIxWasm` (the `import unitsNix` behind the converter drv), so even with the converter output cached, a fresh project re-vendors and re-renders the graph before its first substitution — the #1890 class, for every scaffold user.

## The change

One seam, generalized, no parallel mechanism:

- `lib/per-system.nix`: the `passthru.workspaceIfdRoots` harvest (previously `crossPackageIfdRoots`, scanning only `crossPackages`) becomes `workspacePackageIfdRoots`, scanning the whole `packageSet`. Any package riding a second `buildWorkspace` joins with no hand-kept list; codex's existing exposure is picked up unchanged (attr names move from `cross-ifd-codex-*` to `workspace-ifd-codex-*`; nothing consumes these names, the pushed store paths are identical).
- `packages/ix2nix/wasm/default.nix`: exposes `passthru.workspaceIfdRoots = { inherit (workspace) unitsNix unitGraphJson vendorDir; }`, the same shape codex uses.

The darwin lane keeps its existing `isLinux` guard: extending the hosted-mac lane's realise cost is a deliberate tradeoff for a separate change if dev macs need it.

## Validation (local)

- `nix run .#lint` exits 0.
- `nix eval .#packages.x86_64-linux.ix2nix-wasm.passthru.workspaceIfdRoots --apply 'rs: builtins.mapAttrs (_: d: d.drvPath) rs'` returns the three wasm-graph drvs (`cargo-units.nix`, `cargo-unit-graph.json`, `cargo-vendor-dir`).
- `nix eval .#cachePushRoots.x86_64-linux` attrNames filtered to `workspace-ifd-*`: evidence in a follow-up comment (eval in flight).
- CI's check gate builds `.#cachePushRoots.x86_64-linux`, so the new roots are realised before merge.

## Unblocking current users

After merge, the cache-push run for the merge commit publishes the current converter output; acceptance is `nix path-info --store https://cache.ix.dev <ix2nix-wasm out path resolved from main>` succeeding, which I will verify and record on #4127 before closing.

(sent by an AI agent via Claude Code, Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish wasm converter workspace eval-time IFD roots in `cache-push`
> - Adds `passthru.workspaceIfdRoots` to the [wasm converter package](https://github.com/indexable-inc/index/pull/4129/files#diff-b9d4494cf22a9133943b33c5bf8b97f0e7aabe57e64d3a4edaa1ad8726f05c9e), exposing `unitsNix`, `unitGraphJson`, and `vendorDir` from the wasm32 `buildWorkspace` unit graph.
> - Expands the IFD root harvest in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/4129/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) from `crossPackages` to the full `packageSet`, renaming the attr binding from `crossPackageIfdRoots` to `workspacePackageIfdRoots` and the key prefix from `cross-ifd-` to `workspace-ifd-`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed7ef90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->