### PR TITLE
curl: vendor multi-wakeup regression fix

### DIFF
--- a/lib/overlay.nix
+++ b/lib/overlay.nix
@@ -21,6 +21,30 @@
 # `final.<attrName>`), so later overlays compose.
 # astlog-ignore: keep-overrides-composable
 let
+  # curl 8.21.0 started consuming the public curl_multi_wakeup() eventfd from
+  # curl_multi_perform(). That loses a wakeup for callers which perform before
+  # polling (notably Nix's file-transfer worker, which can then sleep for its
+  # full 10-second idle timeout). Upstream fixed the regression by giving the
+  # threaded resolver a separate internal wakeup pair:
+  # https://github.com/curl/curl/issues/22272
+  #
+  # Keep the patch here until nixpkgs ships a curl release containing
+  # 009fd378e8f01c97ebe67a14a41a06d56430f3df. The version assertion makes a
+  # nixpkgs curl bump fail visibly instead of silently carrying a stale patch.
+  curl = assert lib.assertMsg (prev.curl.version == "8.21.0")
+  "remove the curl wakeup patch: expected nixpkgs curl 8.21.0, got ${prev.curl.version}";
+    prev.curl.overrideAttrs (old: {
+      patches =
+        (old.patches or [])
+        ++ [
+          (prev.fetchurl {
+            name = "curl-8.21.0-fix-multi-wakeup.patch";
+            url = "https://github.com/curl/curl/commit/009fd378e8f01c97ebe67a14a41a06d56430f3df.patch";
+            hash = "sha256-RMFcifj9jDaWY5jNBGqQc2NUoXb3+mHR/1ubrYjpHvc=";
+          })
+        ];
+    });
+
   # Read the target system from `prev`, not `final`: this overlay's attribute
   # *names* are computed by filtering the registry's `overlay` entries by
   # system (see `overlayEntriesFor`), so forcing the system through `final`
@@ -73,6 +97,8 @@ in
     entry: lib.nameValuePair entry.overlay.attrName (buildOverlayPackage entry)
   )
   // {
+    inherit curl;
+
     # Default Temurin JRE for repo-owned package sets. The major lives in
     # `lib/languages/jvm-defaults.nix`, shared with `ix.languages.{java,scala}`
     # and exported NixOS modules.


### PR DESCRIPTION
## What changed

- Override nixpkgs curl 8.21.0 in the repository overlay with curl upstream commit `009fd378e8f01c97ebe67a14a41a06d56430f3df`.
- Pin the patch download with a SHA-256 hash.
- Assert that the underlying nixpkgs curl remains 8.21.0 so a future curl bump fails visibly and prompts removal of the temporary override.

## Why

curl 8.21.0 consumes the public `curl_multi_wakeup()` eventfd from `curl_multi_perform()`. Callers that perform before polling can consequently lose the wakeup; Nix's file-transfer worker may then sleep for its full 10-second idle timeout.

curl/curl#22272 tracks the regression. The accepted upstream solution separates threaded-resolver notifications onto an internal wakeup pair, preserving the public multi-wakeup contract. This vendors that fix until nixpkgs ships a curl release containing it.

## Impact

Repository package sets receive the corrected libcurl behavior without waiting for the next nixpkgs curl update. The override remains versioned as 8.21.0 for package and vulnerability metadata.

## Validation

- Built the patched curl derivation through the repository overlay on `aarch64-darwin`.
- `alejandra --check lib/overlay.nix`
- `git diff --check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Patch curl 8.21.0 to fix multi-wakeup regression
> Adds an upstream patch (commit `009fd378`) to the `curl` package via [lib/overlay.nix](https://github.com/indexable-inc/index/pull/4130/files#diff-65204771292c901d3da5be0a98b4162f557dc034fc1f1b58400a6d136b0525cd) to fix a multi-wakeup regression in 8.21.0. An assertion hard-fails evaluation if `prev.curl.version` is not exactly `8.21.0`, ensuring the patch is removed when the version is updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2cf3af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->