### PR TITLE
prompt: code reads top down through composed, named parts

### DIFF
--- a/packages/agent-prompt/rules.nix
+++ b/packages/agent-prompt/rules.nix
@@ -709,6 +709,24 @@
     };
   }
   {
+    readTopDown = {
+      topics = ["architecture"];
+      text = ''
+        Compose code so it reads without comments: a reader starts at the
+        top-level abstraction and descends, each level a sentence of
+        well-named parts. Structure carries what the code does. Needing a
+        comment to say what a block does means extract the block and name
+        it.
+      '';
+      reason = ''
+        Requested 2026-07-23: `style` covers naming and why-only comments,
+        commentDensityRewrite the rewrite when explanation runs long; the
+        reading path itself, top down through composition, was unstated as
+        the standard for legibility.
+      '';
+    };
+  }
+  {
     commentDensityRewrite = {
       topics = ["architecture" "agency"];
       text = ''


### PR DESCRIPTION
Adds one house-prompt rule, `readTopDown` (topics: `architecture`), to `packages/agent-prompt/rules.nix`, placed next to `commentDensityRewrite`:

> Compose code so it reads without comments: a reader starts at the top-level abstraction and descends, each level a sentence of well-named parts. Structure carries what the code does. Needing a comment to say what a block does means extract the block and name it.

Andrew's intent (2026-07-23): the standard for legible code is the top-down reading path, not comment quality. `style` already owns naming and why-only comments, `commentDensityRewrite` the rewrite when explanation runs long; this states only the remaining delta, so it lands as a new rule rather than an amendment.

Validated: `nix run .#lint` green (13/13), `nix fmt` clean, all four prompt renders (Claude/Codex, system/context) rereads with the new rule in place; the `eval` check (provider-prompts assertions) is running locally.

(sent by an AI agent via Claude Code, Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `readTopDown` architecture rule to agent prompt rules
> Adds a new `readTopDown` entry to [rules.nix](https://github.com/indexable-inc/index/pull/4131/files#diff-fb8b82842eff4bff819034bd48dd338df6f0439b6a742fe1c41fae6b8c0f7ff8) under the `architecture` topic. The rule advises composing code to read top-down through well-named parts, and to extract or navigate blocks by naming rather than commenting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 896d9e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->