### PR TITLE
default base image shell to zsh

### DIFF
--- a/lib/hermes/documents/operator/SOUL.md
+++ b/lib/hermes/documents/operator/SOUL.md
@@ -1,6 +1,6 @@
 # SOUL
 
-You are an operator inside an ix VM. You have root on this guest and a real NixOS system under you: systemd is PID 1, nushell is the default login shell, and the host CLI is not reachable from in here.
+You are an operator inside an ix VM. You have root on this guest and a real NixOS system under you: systemd is PID 1, zsh is the default login shell, and the host CLI is not reachable from in here.
 
 The tooling that ships in the image is on PATH today: `nushell`, `gh`, `git`, `ripgrep`, `jq`, `btop`, the standard GNU utilities. For anything else, reach for `nix shell nixpkgs#<tool>`. This VM has effectively unbounded disk and the nixpkgs cache substitutes, so a fresh tool is one command away.
 

--- a/lib/image/platform.nix
+++ b/lib/image/platform.nix
@@ -608,12 +608,12 @@ in {
     # wants to drop the stub from its closure.
     programs.nix-ld.enable = lib.mkDefault true;
 
-    # Nushell is the operator shell across this repo: the base profile ships
-    # system-wide nu config and the workspace login.nu. Setting it as the
-    # default user shell means service users (minecraft, ...) and any future
-    # user inherit Nushell rather than bash, so an su or a manual
-    # session into a service account lands in the same shell as root.
-    users.defaultUserShell = pkgs.nushell;
+    # Zsh is the default interactive shell for image users. The base profile
+    # registers it system-wide and wires the shared prompt, history, directory
+    # jumping, and workspace login behavior. Service users (minecraft, ...)
+    # and future users inherit the same shell as root unless their image
+    # explicitly overrides it.
+    users.defaultUserShell = pkgs.zsh;
 
     networking = {
       # ix provisions the guest address, route, and DNS before systemd reaches

--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -21,8 +21,8 @@ in {
         default = true;
         description = ''
           Pre-create a writable workspace directory and auto-cd login
-          shells (Nushell `login.nu`) into it. Disable for sealed
-          appliances where there is no interactive workflow to land in.
+          shells into it. Disable for sealed appliances where there is
+          no interactive workflow to land in.
         '';
       };
 
@@ -137,13 +137,21 @@ in {
         # the `enable*Integration` flags below (starship, atuin, zoxide,
         # direnv, fzf) are inert for these shells: Home Manager only writes
         # the init snippets into a shell's rc when that shell's module is
-        # enabled, so an operator who `chsh`-ed into bash or zsh would land
-        # at a bare prompt with none of the wiring. Nushell (the login
-        # default) already gets all of it via its module above. The NixOS
+        # enabled, so an operator who `chsh`-ed into bash or fish would land
+        # at a bare prompt with none of the wiring. The NixOS
         # `programs.zsh`/`programs.fish` modules further down handle
         # system-wide registration; these are the per-user HM counterparts.
         bash.enable = true;
-        zsh.enable = true;
+        zsh = {
+          enable = true;
+          # Match Nushell's login.nu behavior for the platform-default shell.
+          # Keep non-login interactive shells in their caller's directory.
+          initContent = lib.mkIf cfg.shellWorkspace.enable (lib.mkBefore ''
+            if [[ -o login && -d ${lib.escapeShellArg cfg.shellWorkspace.directory} ]]; then
+              builtin cd -- ${lib.escapeShellArg cfg.shellWorkspace.directory}
+            fi
+          '');
+        };
         fish.enable = true;
         # fish 4.8.0 (current nixpkgs nixos-unstable) removed
         # share/fish/tools/create_manpage_completions.py, which Home Manager's
@@ -475,9 +483,9 @@ in {
     # whatever the operator already knows. bash is implicit in NixOS;
     # zsh and fish get their NixOS modules so /etc/shells registration
     # and system-wide completion paths are wired without per-image
-    # setup. Nushell is the platform default user shell (see
-    # lib/image/platform.nix) and lands as the login shell directly,
-    # since Home Manager owns its config files via the root attrset.
+    # setup. Zsh is the platform default user shell (see
+    # lib/image/platform.nix); Home Manager owns its root-user config
+    # and the login-time workspace behavior above.
     programs = {
       zsh.enable = true;
       fish.enable = true;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3538,8 +3538,8 @@
         message = "base profile should enable the ix shell workspace by default";
       }
       {
-        assertion = base.config.users.users.root.shell.meta.mainProgram == "nu";
-        message = "base profile should make root land in nushell (via platform users.defaultUserShell)";
+        assertion = base.config.users.users.root.shell.meta.mainProgram == "zsh";
+        message = "base profile should make root land in zsh (via platform users.defaultUserShell)";
       }
       {
         assertion = base.config.home-manager.users.root.programs.fzf.historyWidget.command == "";


### PR DESCRIPTION
## What changed

- make Zsh the image platform's default user shell
- preserve the base profile's login-time `/work/ix` behavior for Zsh
- update the base-profile regression assertion and operator prompt documentation

## Why

Base-image sessions should land in Zsh by default while retaining the existing shared shell integrations and workspace behavior.

## Impact

New root, service-user, and future-user login sessions inherit Zsh unless an image explicitly overrides `users.defaultUserShell`. Nushell remains installed and configured.

## Validation

- `git diff --check`
- focused Nix parsing passed for `lib/image/platform.nix` and `modules/profiles/base/default.nix`
- attempted `nix --accept-flake-config build .#checks.aarch64-darwin.eval --no-link`
- attempted `nix --accept-flake-config run .#lint`

The two flake checks are blocked in this local environment because the Nix daemon ignores the untrusted `cache.ix.dev` substituter/key and then reports the pre-existing `ix2nix-0.1.0.drv` store path as invalid.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default base image shell to zsh
> - Changes `users.defaultUserShell` in [platform.nix](https://github.com/indexable-inc/index/pull/4134/files#diff-4e9f8a1975e02453aa569916bd7b0c3a25baa581602e105115a45921f41bf7d7) from `pkgs.nushell` to `pkgs.zsh`, making zsh the default shell for all users including root and service accounts.
> - Adds login-shell behavior in [base/default.nix](https://github.com/indexable-inc/index/pull/4134/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e): when `shellWorkspace` is enabled, zsh automatically `cd`s into the configured workspace directory on login if it exists.
> - Updates [SOUL.md](https://github.com/indexable-inc/index/pull/4134/files#diff-6d8f099e1aacbb2df25e5edb5ea332624e02269e0c70e0610a0c03322ee0dc12) documentation and test assertions to reflect the new default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84f2711.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->