### PR TITLE
rust: remove nondeterministic nextest JUnit output

### DIFF
--- a/lib/rust/cargo-unit.nix
+++ b/lib/rust/cargo-unit.nix
@@ -674,8 +674,6 @@
       [profile.default]
       retries = 0
       slow-timeout = { period = "${rawArgs.nextestPerTestTimeout or "120s"}", terminate-after = 1 }
-      [profile.default.junit]
-      path = "junit.xml"
     '';
     nextestNonInteractiveEnv = {
       # #1597: Nix builders can attach cargo-nextest to a pseudo-terminal
@@ -756,9 +754,6 @@
           ${nextestFilterForTestPolicy packagePolicy}
 
         mkdir -p "$out"
-        if [ -f "$workspace_root/target/nextest/default/junit.xml" ]; then
-          cp "$workspace_root/target/nextest/default/junit.xml" "$out/junit.xml"
-        fi
         echo "ran ${targetName} test target" > "$out/result"
       '';
     nextestByTarget = lib.mapAttrs mkNextestForTarget (units.tests or {});

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -6266,6 +6266,8 @@
     test -d ${
       cargoUnitWorkspace.targetSets.test.tests.cargo_unit_hello.cases."tests::package_test_env_and_path_are_available"
     }
+    test -f ${cargoUnitWorkspace.nextestByTarget.cargo_unit_hello}/result
+    test ! -e ${cargoUnitWorkspace.nextestByTarget.cargo_unit_hello}/junit.xml
     test -d ${(builtins.head (builtins.attrValues cargoUnitWorkspace.doctests)).all}
     test -d ${(builtins.head (builtins.attrValues (builtins.head (builtins.attrValues cargoUnitWorkspace.doctests)).cases))}
     test -s ${cargoUnitWorkspace.testPlan}/packages/cargo-unit-hello/test-binaries


### PR DESCRIPTION
## What changed

- stop configuring cargo-nextest to emit `junit.xml` for per-target cargo-unit checks
- stop copying the volatile JUnit report into the Nix output
- add a regression asserting the deterministic `result` marker remains and `junit.xml` does not

## Why

The JUnit report embeds run-specific UUIDs, timestamps, durations, and test ordering. Multiple CI dispatchers can therefore produce different NAR hashes for the same input-addressed store path. The shared Attic cache keeps the first variant, while later cache-push readback proofs detect a manifest mismatch and retain those publication roots indefinitely.

Removing the unused report makes future nextest check outputs deterministic while preserving pass/fail behavior through cargo-nextest's exit status.

## Impact

Future cargo-unit nextest derivations no longer place JUnit reports in their Nix outputs, preventing this known source of cross-host cache collisions. Existing queued collision entries still require separate operational cleanup.

## Validation

- `nix-instantiate --parse lib/rust/cargo-unit.nix`
- `alejandra --check lib/rust/cargo-unit.nix`
- `git diff --check`

The full `checks.aarch64-darwin.eval` build could not run with the local stock/Determinate evaluator because this repository's test surface requires its indexable Nix fork and CA-derivation feature; evaluation stopped with `experimental Nix feature 'ca-derivations' is disabled`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove JUnit XML output from nextest builds
> Removes the `[profile.default.junit]` section from the embedded `nextest.toml` in [cargo-unit.nix](https://github.com/indexable-inc/index/pull/4135/files#diff-82054df1a7d1648a5be88265641a7ae5d3b9e4ec4cdea72c518359ea4ae3f804), so nextest no longer writes `junit.xml`. The `nextestByTarget` derivation now only writes the `result` file to `$out`. A test in [tests/default.nix](https://github.com/indexable-inc/index/pull/4135/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) asserts that `result` exists and `junit.xml` is absent in the output. Behavioral Change: `nextestByTarget` outputs no longer contain `junit.xml`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 574dff4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->