### PR TITLE
prompt: never write zingers, triads, or superlatives

### DIFF
--- a/packages/agent-prompt/rules.nix
+++ b/packages/agent-prompt/rules.nix
@@ -60,6 +60,25 @@
     };
   }
   {
+    noZingers = {
+      topics = ["writing"];
+      text = ''
+        Never write a zinger: a sentence built to land as a punchline gets
+        flattened into a plain claim. Never write a rhetorical triad; three
+        parallel items ("fast, simple, and correct") lose one or gain a
+        fourth. A superlative ("best", "blazing", "massive") is replaced by
+        the measurement that would earn it, or cut. This covers everything
+        you write: replies, commit messages, PR bodies, docs, site updates.
+      '';
+      reason = ''
+        Requested 2026-07-23: prose sets the register and calibratedClaims
+        handles absolutes, yet punch-up devices kept appearing in agent
+        prose. Lands as its own rule since style governs code as well as
+        prose; the shape follows noEmDashes, one register ban stated once.
+      '';
+    };
+  }
+  {
     promptSource = {
       text = ''
         These rules live at `packages/agent-prompt/rules.nix` in the index


### PR DESCRIPTION
Adds one house-prompt rule, `noZingers` (topics: `writing`), to `packages/agent-prompt/rules.nix`, placed after `prose` and `style`:

> Never write a zinger: a sentence built to land as a punchline gets flattened into a plain claim. Never write a rhetorical triad; three parallel items ("fast, simple, and correct") lose one or gain a fourth. A superlative ("best", "blazing", "massive") is replaced by the measurement that would earn it, or cut. This covers everything you write: replies, commit messages, PR bodies, docs, site updates.

Andrew's intent (2026-07-23): the register rules already demand plain words and exact claims, and `calibratedClaims` handles absolutes; the banned devices themselves were unstated. This states only that delta, as its own rule in the `noEmDashes` pattern rather than a `style` amendment, since `style` governs code as much as prose.

Validated: `nix run .#lint` green (13/13), `nix fmt` clean, all four prompt renders (Claude/Codex, system/context) reread with the rule in place.

(sent by an AI agent via Claude Code, Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `noZingers` rule to agent prompt to prohibit zingers, triads, and superlatives
> Adds a new `noZingers` rule to [rules.nix](https://github.com/indexable-inc/index/pull/4137/files#diff-fb8b82842eff4bff819034bd48dd338df6f0439b6a742fe1c41fae6b8c0f7ff8) that instructs the agent to avoid zingers, rhetorical triads, and superlatives in all written output. The rule is tagged under the `writing` topic and is grouped alongside existing style rules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2dd98cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->