### PR TITLE
fix(image): add local bin to login path

### DIFF
--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -78,6 +78,11 @@ in {
     # kitty, alacritty, wezterm, foot, ...), not the terminal binaries.
     environment.enableAllTerminfo = true;
 
+    # Native CLI installers use the XDG-standard per-user binary directory.
+    # Make those binaries available on the next login without asking every
+    # image user to edit a shell-specific startup file.
+    environment.localBinInPath = true;
+
     # Cubic halves cwnd on any loss, so a residential last-mile at
     # 30 ms and a couple percent loss caps a single TCP flow far
     # below the path's real capacity. BBR models bottleneck bandwidth

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3542,6 +3542,10 @@
         message = "base profile should make root land in zsh (via platform users.defaultUserShell)";
       }
       {
+        assertion = base.config.environment.localBinInPath;
+        message = "base profile should put each user's ~/.local/bin on the login PATH";
+      }
+      {
         assertion = base.config.home-manager.users.root.programs.fzf.historyWidget.command == "";
         message = "base profile should leave Ctrl-R history search to Atuin";
       }


### PR DESCRIPTION
## What changed

- Enable NixOS `environment.localBinInPath` in the auto-enabled base image profile.
- Assert the login-path policy in the base profile eval tests.

## Why

Native CLI installers write binaries to `~/.local/bin`, but the base image omitted that directory from login `PATH`. Installed tools therefore remained unavailable and emitted setup warnings until each user edited shell configuration manually. New login sessions now include the per-user binary directory for every image user.

## Validation

- `alejandra --check modules/profiles/base/default.nix`
- `nix-instantiate --parse modules/profiles/base/default.nix`
- `git diff --check`
- Full eval attempted, but the local Nix store blocked evaluation before this assertion with `…-ix2nix-0.1.0.drv is not valid`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `~/.local/bin` to login PATH in the base profile
> Enables `environment.localBinInPath` in [modules/profiles/base/default.nix](https://github.com/indexable-inc/index/pull/4138/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e) so that each user's `~/.local/bin` is included on `PATH` at login. A corresponding test assertion is added in [tests/default.nix](https://github.com/indexable-inc/index/pull/4138/files#diff-1cc580de297308d93d82f7b72446ae4b98832a8aae3378e9e134102519a0e33a) to verify the option is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72cb2a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->