### PR TITLE
ci-budget: make validation-budget kills loud

### DIFF
--- a/.github/actions/ci-budget/test_ci_budget.py
+++ b/.github/actions/ci-budget/test_ci_budget.py
@@ -668,7 +668,7 @@ class RenderingTests(unittest.TestCase):
         )
         comment = ci_budget.render_comment(result)
         assert comment.startswith(ci_budget.COMMENT_MARKER)
-        assert "start within 5 minutes" in comment
+        assert "start within 120 minutes" in comment
         assert "120 seconds for setup" in comment
         assert "300 seconds for validation" in comment
         assert "10 seconds for cleanup" in comment

--- a/.github/actions/ci-budget/test_ci_policy.py
+++ b/.github/actions/ci-budget/test_ci_policy.py
@@ -43,7 +43,7 @@ def policy_error(path: Path) -> RuntimeError:
 
 class PolicyTests(unittest.TestCase):
     def test_shared_phase_clocks_and_worker_envelopes(self) -> None:
-        assert queue_start_minutes() == 5
+        assert queue_start_minutes() == 120
         assert validation_seconds(big_change=False) == 300
         assert validation_seconds(big_change=True) == 10_800
         assert worker_timeout_minutes(big_change=False) == 8
@@ -142,7 +142,7 @@ class PolicyTests(unittest.TestCase):
 
         assert not decision.managed_workflow
         assert decision.classification.big_change
-        assert decision.queue_start_seconds == 300
+        assert decision.queue_start_seconds == 7200
         assert decision.setup_allowance_seconds == 120
         assert decision.validation_seconds == 10_800
         assert decision.termination_grace_seconds == 10

--- a/.github/actions/ci-budget/worker/action.yml
+++ b/.github/actions/ci-budget/worker/action.yml
@@ -29,9 +29,15 @@ inputs:
 
 outputs:
   lint_result:
-    description: Optional lint phase result emitted by the budgeted script
+    description: >-
+      Optional lint phase result emitted by the budgeted script, or
+      budget-exceeded when the validation clock killed the script before it
+      published one
   nix_result:
-    description: Optional Nix phase result emitted by the budgeted script
+    description: >-
+      Optional Nix phase result emitted by the budgeted script, or
+      budget-exceeded when the validation clock killed the script before it
+      published one
 
 runs:
   using: node24

--- a/.github/actions/ci-budget/worker/worker.mjs
+++ b/.github/actions/ci-budget/worker/worker.mjs
@@ -350,9 +350,14 @@ export function recordBudgetVerdicts({
     if (entry) published.add(entry[1]);
   }
   const missing = outputs.filter((name) => !published.has(name));
+  if (missing.length === 0) return missing;
+  // Guard against a killed script whose last write lacked a newline; a bare
+  // append would corrupt that entry instead of starting a fresh one.
+  const content = readFileSync(githubOutputPath, "utf8");
+  const separator = content === "" || content.endsWith("\n") ? "" : "\n";
   appendFileSync(
     githubOutputPath,
-    missing.map((name) => `${name}=budget-exceeded\n`).join(""),
+    separator + missing.map((name) => `${name}=budget-exceeded\n`).join(""),
   );
   return missing;
 }
@@ -388,6 +393,11 @@ function groupExists(pid) {
     return true;
   } catch (error) {
     if (error?.code === "ESRCH") return false;
+    // Darwin can report EPERM instead of ESRCH while the group's members are
+    // zombies being reaped; we always probe a group this process spawned, so
+    // permission genuinely denied is impossible and EPERM means "gone".
+    // Observed as a rare local test flake in the teardown loop.
+    if (error?.code === "EPERM") return false;
     throw error;
   }
 }

--- a/.github/actions/ci-budget/worker/worker.mjs
+++ b/.github/actions/ci-budget/worker/worker.mjs
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 import { constants as osConstants } from "node:os";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -80,9 +80,14 @@ export function loadPolicy(
   ) {
     throw new Error(`CI budget policy keys must be ${expected.join(", ")}`);
   }
-  return Object.fromEntries(
-    numeric.map((name) => [name, parsePositiveInteger(parsed[name], name)]),
-  );
+  return {
+    // The label is part of the budget-exceeded remedy text: a killed run must
+    // name the exact label that buys the extended tier (index#4139).
+    big_change_label: parsed.big_change_label,
+    ...Object.fromEntries(
+      numeric.map((name) => [name, parsePositiveInteger(parsed[name], name)]),
+    ),
+  };
 }
 
 function repositoryPath(repository) {
@@ -299,6 +304,84 @@ export function validationSeconds({ bigChange, policy }) {
   return policy.routine_validation_seconds;
 }
 
+export function budgetExceededMessage({
+  allowedSeconds,
+  bigChange,
+  elapsedSeconds,
+  policy,
+}) {
+  // allowedSeconds comes from the clock that actually fired, not re-derived
+  // from the policy, so the reported number can never drift from the kill.
+  const budgetName = bigChange
+    ? "extended_validation_seconds"
+    : "routine_validation_seconds";
+  const remedy = bigChange
+    ? "the run already held the extended budget; split the change or revisit " +
+      "the ci-budget policy catalog"
+    : `add the ${policy.big_change_label} label for the ` +
+      `extended_validation_seconds=${policy.extended_validation_seconds}s budget`;
+  return (
+    `validation budget ${budgetName}=${allowedSeconds}s exceeded after ` +
+    `${elapsedSeconds}s; terminating the gate's process group. ` +
+    `To get more time, ${remedy}.`
+  );
+}
+
+// The outputs declared in the worker's action.yml. The budgeted script
+// publishes them to GITHUB_OUTPUT itself, normally as its last act, so a
+// budget kill leaves every hosted mirror job reading a blank result with no
+// cause attached (index#4139).
+export const mirroredOutputs = ["lint_result", "nix_result"];
+
+/// Append a `budget-exceeded` verdict for every mirrored output the killed
+/// script never published, and return the names written. Results the script
+/// already published stay untouched: a phase that finished inside the budget
+/// reported honestly and only the still-blank phases died by policy.
+export function recordBudgetVerdicts({
+  githubOutputPath,
+  outputs = mirroredOutputs,
+}) {
+  if (!githubOutputPath) return [];
+  const published = new Set();
+  for (const line of readFileSync(githubOutputPath, "utf8").split("\n")) {
+    // GITHUB_OUTPUT entries start `name=value` or `name<<DELIMITER`:
+    // https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-output-parameter
+    const entry = /^([^=<\s]+)(=|<<)/.exec(line);
+    if (entry) published.add(entry[1]);
+  }
+  const missing = outputs.filter((name) => !published.has(name));
+  appendFileSync(
+    githubOutputPath,
+    missing.map((name) => `${name}=budget-exceeded\n`).join(""),
+  );
+  return missing;
+}
+
+/// Make a policy kill loud in every place a human looks first: the job log,
+/// the run's annotations, and the mirror jobs' results. Diagnosing one silent
+/// 300s kill took two full CI runs plus a host-journal dig (index#4139).
+export function reportBudgetExceeded({
+  allowedSeconds,
+  bigChange,
+  elapsedSeconds,
+  githubOutputPath = process.env.GITHUB_OUTPUT,
+  policy,
+}) {
+  const message = budgetExceededMessage({
+    allowedSeconds,
+    bigChange,
+    elapsedSeconds,
+    policy,
+  });
+  // Plain line as well as the annotation: whoever tails the raw job log sees
+  // output stop mid-build, and this names the killer inline at that spot.
+  console.log(`ci-budget: ${message}`);
+  console.error(`::error title=CI worker budget exceeded::${message}`);
+  for (const name of recordBudgetVerdicts({ githubOutputPath })) {
+    console.log(`ci-budget: published ${name}=budget-exceeded for the mirror jobs`);
+  }
+}
+
 function groupExists(pid) {
   try {
     process.kill(-pid, 0);
@@ -348,6 +431,7 @@ function signalExitCode(signal) {
 
 export async function runBudgetedScript({
   graceSeconds,
+  onBudgetExceeded,
   scriptArguments = [],
   scriptPath,
   validationSeconds: allowedSeconds,
@@ -361,6 +445,7 @@ export async function runBudgetedScript({
     throw new Error("script must stay inside GITHUB_WORKSPACE");
   }
 
+  const scriptStartedAt = Date.now();
   const child = spawn("bash", [absoluteScript, ...scriptArguments], {
     cwd: workspace,
     detached: true,
@@ -399,6 +484,19 @@ export async function runBudgetedScript({
   try {
     result = await Promise.race([childDone, timedOut, externalSignal]);
     clearTimeout(timeout);
+    if (result.kind === "timeout" && onBudgetExceeded !== undefined) {
+      // Report before any kill signal: the group's own streams die with it,
+      // so nothing after this point can explain the kill from the inside.
+      // Best-effort by design; a reporting bug must not leave the group alive.
+      try {
+        onBudgetExceeded({
+          allowedSeconds,
+          elapsedSeconds: Math.round((Date.now() - scriptStartedAt) / 1000),
+        });
+      } catch (error) {
+        console.error(`::error title=ci-budget-worker::budget report failed: ${error.message}`);
+      }
+    }
     await terminateGroup(child.pid, graceSeconds * 1000);
     if (result.kind !== "child") {
       await Promise.race([childDone.catch(() => undefined), delay(1000)]);
@@ -473,6 +571,8 @@ export async function main() {
   const allowedSeconds = validationSeconds({ bigChange, policy });
   return runBudgetedScript({
     graceSeconds: policy.termination_grace_seconds,
+    onBudgetExceeded: (expiry) =>
+      reportBudgetExceeded({ ...expiry, bigChange, policy }),
     scriptArguments: parseArguments(input("arguments") || "[]"),
     scriptPath,
     validationSeconds: allowedSeconds,

--- a/.github/actions/ci-budget/worker/worker.test.mjs
+++ b/.github/actions/ci-budget/worker/worker.test.mjs
@@ -105,7 +105,7 @@ function response(jobs) {
 test("policy exposes independent queue, setup, validation, and cleanup clocks", () => {
   const policy = loadPolicy();
   assert.equal(policy.big_change_label, "ci/big-change");
-  assert.equal(policy.queue_start_seconds, 300);
+  assert.equal(policy.queue_start_seconds, 7200);
   assert.equal(policy.setup_allowance_seconds, 120);
   assert.equal(policy.routine_validation_seconds, 300);
   assert.equal(policy.extended_validation_seconds, 10_800);
@@ -274,13 +274,18 @@ test("worker identity fails closed on missing and duplicate runner matches", asy
 
 test("queue admission accepts the boundary and rejects one millisecond late", () => {
   const policy = loadPolicy();
+  // Created 10:00:00 plus the 7200s admission budget puts the boundary at
+  // exactly 12:00:00 (#3549 widened it from 300s).
   assert.doesNotThrow(() =>
-    assertQueueAdmission({ job: workerJob(), policy }),
+    assertQueueAdmission({
+      job: workerJob({ startedAt: "2026-07-15T12:00:00Z" }),
+      policy,
+    }),
   );
   assert.throws(
     () =>
       assertQueueAdmission({
-        job: workerJob({ startedAt: "2026-07-15T10:05:00.001Z" }),
+        job: workerJob({ startedAt: "2026-07-15T12:00:00.001Z" }),
         policy,
       }),
     DeadlineExceeded,
@@ -289,23 +294,24 @@ test("queue admission accepts the boundary and rejects one millisecond late", ()
 
 test("queue admission failure reports the wait, the budget, and saturation", () => {
   const policy = loadPolicy();
-  // ix#7625: a PR worker created at 13:17:16Z started 33 minutes later while
-  // stacked deploy runs held every dispatcher slot. The failure must read as
-  // pool saturation with the actual wait, not as a bare timestamp comparison.
+  // ix#7625: a PR worker started long after creation while stacked deploy
+  // runs held every dispatcher slot. The failure must read as pool
+  // saturation with the actual wait, not as a bare timestamp comparison.
+  // (The wait here overruns even the 7200s budget #3549 widened to.)
   assert.throws(
     () =>
       assertQueueAdmission({
         job: workerJob({
           createdAt: "2026-07-17T13:17:16Z",
-          startedAt: "2026-07-17T13:50:23Z",
+          startedAt: "2026-07-17T15:37:16Z",
         }),
         policy,
       }),
     (error) => {
       assert.ok(error instanceof DeadlineExceeded);
-      assert.match(error.message, /waited 1987s for a runner slot/);
-      assert.match(error.message, /300s queue admission budget/);
-      assert.match(error.message, /deadline 2026-07-17T13:22:16\.000Z/);
+      assert.match(error.message, /waited 8400s for a runner slot/);
+      assert.match(error.message, /7200s queue admission budget/);
+      assert.match(error.message, /deadline 2026-07-17T15:17:16\.000Z/);
       assert.match(error.message, /dispatcher\s+slot stayed busy/);
       assert.match(error.message, /ix#7625/);
       return true;
@@ -371,7 +377,7 @@ test("late sibling fails even when another worker started on time", async () => 
           runnerName: "runner-timely",
           startedAt: "2026-07-15T10:00:30Z",
         }),
-        workerJob({ startedAt: "2026-07-15T10:05:01Z" }),
+        workerJob({ startedAt: "2026-07-15T12:00:01Z" }),
       ]),
     repository: "indexable-inc/ix",
     runAttempt: 2,

--- a/.github/actions/ci-budget/worker/worker.test.mjs
+++ b/.github/actions/ci-budget/worker/worker.test.mjs
@@ -451,6 +451,16 @@ test("budget verdicts fill only the outputs the script never published", async (
       await readFile(output, "utf8"),
       "lint_result<<GHDELIM\npartial\nGHDELIM\nnix_result=budget-exceeded\n",
     );
+    // A killed script's last write may lack its newline; the backfill must
+    // start a fresh line instead of corrupting that entry.
+    await writeFile(output, "lint_result=succ");
+    assert.deepEqual(recordBudgetVerdicts({ githubOutputPath: output }), [
+      "nix_result",
+    ]);
+    assert.equal(
+      await readFile(output, "utf8"),
+      "lint_result=succ\nnix_result=budget-exceeded\n",
+    );
     // No GITHUB_OUTPUT (running outside Actions) publishes nothing.
     assert.deepEqual(recordBudgetVerdicts({ githubOutputPath: "" }), []);
   } finally {

--- a/.github/actions/ci-budget/worker/worker.test.mjs
+++ b/.github/actions/ci-budget/worker/worker.test.mjs
@@ -12,10 +12,13 @@ import {
   DeadlineExceeded,
   assertQueueAdmission,
   assertSetupAllowance,
+  budgetExceededMessage,
   currentWorkerJob,
   loadPolicy,
   parseArguments,
   queuedRunCount,
+  recordBudgetVerdicts,
+  reportBudgetExceeded,
   runBudgetedScript,
   validationSeconds,
 } from "./worker.mjs";
@@ -101,6 +104,7 @@ function response(jobs) {
 
 test("policy exposes independent queue, setup, validation, and cleanup clocks", () => {
   const policy = loadPolicy();
+  assert.equal(policy.big_change_label, "ci/big-change");
   assert.equal(policy.queue_start_seconds, 300);
   assert.equal(policy.setup_allowance_seconds, 120);
   assert.equal(policy.routine_validation_seconds, 300);
@@ -405,6 +409,49 @@ test("validation starts with the complete tier allowance after setup", () => {
   assert.equal(validationSeconds({ bigChange: true, policy }), 10_800);
 });
 
+test("budget kill message names the clock, the elapsed time, and the remedy", () => {
+  const policy = loadPolicy();
+  const routine = budgetExceededMessage({
+    allowedSeconds: 300,
+    bigChange: false,
+    elapsedSeconds: 301,
+    policy,
+  });
+  assert.match(routine, /routine_validation_seconds=300s exceeded after 301s/);
+  assert.match(routine, /add the ci\/big-change label/);
+  assert.match(routine, /extended_validation_seconds=10800s budget/);
+
+  const extended = budgetExceededMessage({
+    allowedSeconds: 10_800,
+    bigChange: true,
+    elapsedSeconds: 10_930,
+    policy,
+  });
+  assert.match(extended, /extended_validation_seconds=10800s exceeded after 10930s/);
+  assert.match(extended, /already held the extended budget/);
+});
+
+test("budget verdicts fill only the outputs the script never published", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "ci-budget-worker-verdicts-"));
+  try {
+    const output = join(directory, "github-output");
+    // Heredoc form: the delimiter line must count as a published output.
+    await writeFile(output, "lint_result<<GHDELIM\npartial\nGHDELIM\n");
+
+    assert.deepEqual(recordBudgetVerdicts({ githubOutputPath: output }), [
+      "nix_result",
+    ]);
+    assert.equal(
+      await readFile(output, "utf8"),
+      "lint_result<<GHDELIM\npartial\nGHDELIM\nnix_result=budget-exceeded\n",
+    );
+    // No GITHUB_OUTPUT (running outside Actions) publishes nothing.
+    assert.deepEqual(recordBudgetVerdicts({ githubOutputPath: "" }), []);
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
 test("script arguments cross the JSON boundary as distinct values", async () => {
   const directory = await mkdtemp(join(tmpdir(), "ci-budget-worker-arguments-"));
   try {
@@ -443,6 +490,64 @@ test("timeout kills a TERM-resistant descendant after its leader exits", async (
     });
     assert.equal(status, 124);
     await assertProcessGone(Number(await waitForFile(fixture.descendant)));
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+test("timeout announces the budget kill and backfills mirror verdicts", async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "ci-budget-worker-report-"));
+  try {
+    const script = join(directory, "gate.sh");
+    const output = join(directory, "github-output");
+    // Publish one honest phase result, then outlive the clock, like
+    // run-ci-phases.sh does when the Nix phase overruns after lint finished.
+    await writeFile(
+      script,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "printf 'lint_result=success\\n' >>github-output",
+        "sleep 60",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(output, "");
+
+    const logged = [];
+    t.mock.method(console, "log", (line) => logged.push(line));
+    const annotated = [];
+    t.mock.method(console, "error", (line) => annotated.push(line));
+
+    const policy = loadPolicy();
+    const status = await runBudgetedScript({
+      graceSeconds: 0.05,
+      // Wired exactly as main() wires it, with the budget shrunk to test size.
+      onBudgetExceeded: (expiry) =>
+        reportBudgetExceeded({
+          ...expiry,
+          bigChange: false,
+          githubOutputPath: output,
+          policy,
+        }),
+      scriptPath: "gate.sh",
+      validationSeconds: 0.5,
+      workspace: directory,
+    });
+
+    assert.equal(status, 124);
+    const logText = logged.join("\n");
+    assert.match(logText, /routine_validation_seconds=0\.5s exceeded after \d+s/);
+    assert.match(logText, /published nix_result=budget-exceeded/);
+    assert.match(
+      annotated.join("\n"),
+      /^::error title=CI worker budget exceeded::validation budget routine_validation_seconds=0\.5s .* add the ci\/big-change label for the extended_validation_seconds=10800s budget\.$/m,
+    );
+    // The honest lint verdict survives; only the killed phase reads as policy.
+    assert.equal(
+      await readFile(output, "utf8"),
+      "lint_result=success\nnix_result=budget-exceeded\n",
+    );
   } finally {
     await rm(directory, { force: true, recursive: true });
   }

--- a/packages/site/src/lib/updates/ci-budget-loud-kills.svx
+++ b/packages/site/src/lib/updates/ci-budget-loud-kills.svx
@@ -1,0 +1,25 @@
+---
+id: ci-budget-loud-kills
+postedAt: 2026-07-23T00:00:00-07:00
+title: "CI budget kills now announce themselves in the log, the annotations, and the mirror results"
+tags: [ci]
+links:
+  - label: "#4139: silent kill at routine_validation_seconds"
+    href: https://github.com/indexable-inc/index/issues/4139
+---
+
+When the ci-budget worker's validation clock expired, it killed the gate's
+process group and said nothing: no annotation, no log line, and the hosted
+mirror jobs read blank results. Diagnosing one such kill took two full CI
+runs plus a host-journal dig (#4139), and the same signature hit several
+other PRs the same day.
+
+The worker now reports before it signals. The job log and a `::error`
+annotation both carry one line naming the clock that fired, the elapsed
+time, and the remedy (`add the ci/big-change label for the
+extended_validation_seconds=10800s budget`), and any mirrored output the
+script never published is backfilled as `budget-exceeded`, so the `lint`
+and `build` mirror jobs report the actual cause instead of `missing`.
+Phase results the script published before the kill are kept as-is. Budget
+semantics are unchanged: same clocks, same TERM/KILL contract, same exit
+code 124.


### PR DESCRIPTION
## What changed

When the worker's validation clock expires, it now reports before the first kill signal:

- one plain line in the job log naming the budget, elapsed time, and remedy
- a `::error` annotation with the same text:

```
::error title=CI worker budget exceeded::validation budget routine_validation_seconds=300s exceeded after 301s; terminating the gate's process group. To get more time, add the ci/big-change label for the extended_validation_seconds=10800s budget.
```

- any mirrored output (`lint_result`, `nix_result`) the killed script never published is backfilled as `budget-exceeded`, so the hosted mirror jobs report the cause instead of `missing`. Results the script published before the kill are kept.

Budget semantics are unchanged: same clocks, same TERM/KILL contract, same exit code 124.

Two adjacent fixes ride along in their own commits:

- the worker and classifier test suites were silently red on main since #3549 widened `queue_start_seconds` to 7200 without updating expectations (4 mjs + 3 python failures); this PR's paths trigger `ci-budget-check.yml`, so the expectations are caught up to make that gate honest again
- the process-group liveness probe now treats `EPERM` as a vanished group (Darwin reports it for zombie groups mid-reap; it flaked the teardown tests)

## Why

A `routine_validation_seconds` kill left no annotation, no log line, and blank mirror results; diagnosing one took two full CI runs plus a host-journal dig on hil-compute-3 (ix#8468 attempts 1-3), and the same signature cost the index#4108/#4110/#4111/#4116 family.

## Validation

- `node --test .github/actions/ci-budget/worker/worker.test.mjs` — 18/18, five consecutive clean runs
- `python3 -m unittest discover -s .github/actions/ci-budget -p 'test_*.py'` — 52/52
- `nix run .#lint` — clean

Fixes #4139

(sent by an AI agent via Claude Code, Fable 5)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make CI validation-budget kills emit error annotations and backfill missing outputs
> - When a validation timeout occurs, `reportBudgetExceeded` logs a message, emits a GitHub Actions error annotation, and writes `budget-exceeded` to any mirrored outputs (`lint_result`, `nix_result`) that were not already published.
> - `budgetExceededMessage` composes a human-readable message naming the exceeded budget type, allowed vs. elapsed time, and the remedy (add the big-change label or split/revisit policy).
> - `loadPolicy` now returns `big_change_label` alongside numeric fields so the kill message can reference it.
> - The queue admission window is widened from 5 minutes to 120 minutes, reflected in updated tests and expected values.
> - Behavioral Change: jobs that previously timed out silently now surface an error annotation and set downstream result outputs to `budget-exceeded` instead of leaving them unset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac409d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->