### PR TITLE
profiles/base: merge environment.* keys, un-redden main lint

### DIFF
--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -76,12 +76,13 @@ in {
     # `'xterm-ghostty': unknown terminal type.` because the guest only ships
     # ncurses' built-in set. Pulls only the small `terminfo` outputs (ghostty,
     # kitty, alacritty, wezterm, foot, ...), not the terminal binaries.
-    environment.enableAllTerminfo = true;
-
-    # Native CLI installers use the XDG-standard per-user binary directory.
-    # Make those binaries available on the next login without asking every
-    # image user to edit a shell-specific startup file.
-    environment.localBinInPath = true;
+    environment = {
+      enableAllTerminfo = true;
+      # Native CLI installers use the XDG-standard per-user binary directory.
+      # Make those binaries available on the next login without asking every
+      # image user to edit a shell-specific startup file.
+      localBinInPath = true;
+    };
 
     # Cubic halves cwnd on any loss, so a residential last-mile at
     # 30 ms and a couple percent loss caps a single TCP flow far


### PR DESCRIPTION
statix W20 fired on main after 72cb2a8e added a third top-level `environment.*` key in the base profile; `nix run .#lint` was red for everyone. This folds `enableAllTerminfo` and `localBinInPath` into one attrset, values unchanged. Verified: lint 13/13 on this branch. Closes #4145. (sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Merge `environment` attribute keys in base profile to fix lint warning
> Consolidates two separate `environment.enableAllTerminfo` and `environment.localBinInPath` assignments into a single `environment` attrset in [default.nix](https://github.com/indexable-inc/index/pull/4146/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e). No logic or values change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a290427.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->