### PR TITLE
kernel: single-source the kbuild tool list

### DIFF
--- a/examples/kernel-build/toolchain.ix
+++ b/examples/kernel-build/toolchain.ix
@@ -1,40 +1,37 @@
 // The interactive kernel build environment: everything `make defconfig &&
 // make -j$(nproc)` needs, wired for a plain VM shell rather than a nix-shell.
 //
-// Tool selection mirrors `lib/kernel/kbuild-unit.nix`'s `kbuildInputs` (the
-// repo's CI-grade kernel builder), plus the compiler and binutils that stdenv
-// provides implicitly there.
+// The tool set is `kbuildInputs` from `lib/kernel/kbuild-unit.nix` (the
+// repo's CI-grade kernel builder), plus what stdenv provides implicitly in
+// a derivation (compiler, binutils, make, pkg-config) and git.
 
-export default ({ lib, pkgs, ...rest }) => {
+export default ({ ix, lib, pkgs, ...rest }) => {
   // Libraries kbuild's host tools link against: objtool wants libelf + zlib,
   // extract-cert wants openssl, menuconfig wants ncurses. In a derivation
   // stdenv's cc-wrapper injects their search paths; in an interactive shell
   // nothing does, so the `environment.variables` below carry the dev outputs
   // through gcc's standard CPATH/LIBRARY_PATH lookup instead.
   const hostToolLibs = [pkgs.elfutils, pkgs.ncurses, pkgs.openssl, pkgs.zlib];
+  // The CI kernel builder's own tool list (bison, flex, bc, perl, python3,
+  // pahole, kmod, cpio, ...), so an interactive shell and a kbuild-unit
+  // derivation can never drift apart.
+  const kbuildInputs = ix.kernelUnitFor(pkgs).kbuildInputs;
   return {
     environment: {
       systemPackages: [
+        ...kbuildInputs,
+        // stdenv provides these implicitly inside a derivation; a VM shell
+        // gets nothing implicitly. kbuild execs ld/objcopy/nm/ar directly
+        // (LD=, OBJCOPY=, ...), not through the gcc driver, so the wrapped
+        // compiler's baked-in bintools path does not cover binutils.
         pkgs.gcc,
+        pkgs.binutils,
+        pkgs.gnumake,
+        // scripts/kconfig probes ncurses through HOSTPKG_CONFIG.
+        pkgs["pkg-config"],
         // setlocalversion shells out to git when the tree has .git, and the
         // agent's whole edit loop lives in a git checkout.
         pkgs.git,
-        // kbuild execs ld/objcopy/nm/ar directly (LD=, OBJCOPY=, ...), not
-        // through the gcc driver, so the wrapped compiler's baked-in bintools
-        // path does not cover it.
-        pkgs.binutils,
-        pkgs.gnumake,
-        pkgs.flex,
-        pkgs.bison,
-        pkgs.bc,
-        pkgs.perl,
-        pkgs.python3,
-        // scripts/kconfig probes ncurses through HOSTPKG_CONFIG.
-        pkgs["pkg-config"],
-        // BTF generation when a config sets CONFIG_DEBUG_INFO_BTF=y.
-        pkgs.pahole,
-        pkgs.kmod,
-        pkgs.cpio,
         ...hostToolLibs,
       ],
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -704,6 +704,7 @@
       gitDefaults
       goUnit
       hermes
+      kernelUnitFor
       languages
       kdl
       lists

--- a/lib/kernel/kbuild-unit.nix
+++ b/lib/kernel/kbuild-unit.nix
@@ -834,5 +834,5 @@ only to make the plan's inputs body-independent.
         else tree;
     };
 in {
-  inherit buildKernel;
+  inherit buildKernel kbuildInputs;
 }


### PR DESCRIPTION
Third act of #4128's cleanup: `examples/kernel-build/toolchain.ix` hand-mirrored the CI kernel builder's tool list (its comment admitted it). Now `lib/kernel/kbuild-unit.nix` exports `kbuildInputs`, `kernelUnitFor` joins the `specialArgs.ix` bundle, and the example consumes `ix.kernelUnitFor(pkgs).kbuildInputs` — the interactive shell and the kbuild-unit derivations can no longer drift apart. The example keeps only what stdenv provides implicitly in derivations (gcc, binutils, make, pkg-config) plus git and the interactive host-tool libs.

Verified on top of current main: `nix run .#lint` 13/13; `nix eval .#legacyPackages.aarch64-darwin.kernel-build-up.drvPath` instantiates the VM end to end.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Single-source the kernel build tool list from `kbuildInputs`
> - Exports `kbuildInputs` from [lib/kernel/kbuild-unit.nix](https://github.com/indexable-inc/index/pull/4149/files#diff-894edbcee0d2e832bb188198d9520c9019d57088c5a061e3b3a327a243c1d7ad) and re-exports it via [lib/default.nix](https://github.com/indexable-inc/index/pull/4149/files#diff-84f980eccc1d3f99c10f8b0e6c5c5fc2af2069517533c4c4d73264a190e85188) so consumers can reference the canonical tool list.
> - Updates [examples/kernel-build/toolchain.ix](https://github.com/indexable-inc/index/pull/4149/files#diff-abd807cbe4e41b48e600e5dc27c0486dd43ac64f1ddf6e47c10e409d61915f4a) to populate `environment.systemPackages` from `ix.kernelUnitFor(pkgs).kbuildInputs` instead of a hardcoded list of tools (flex, bison, bc, perl, python3, pahole, kmod, cpio).
> - Behavioral Change: the toolchain component now requires an `ix` argument providing `kernelUnitFor` at runtime; the installed tool set is driven by `kbuildInputs` rather than a fixed enumeration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f409b9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->