### PR TITLE
lint: keep nested .claude/worktrees checkouts out of the walkers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,12 @@ __pycache__/
 .claude/settings.local.json
 CLAUDE.local.md
 
+# Agent isolation worktrees: `git worktree add` checkouts of OTHER commits.
+# fd/rg prune nested git repos on their own, but statix builds its ignore
+# set from this file plus statix.toml only, so without this line lint walks
+# a sibling agent's stale tree and reds this checkout (#4147).
+/.claude/worktrees/
+
 # Skills are built into the `skills` flake package (one dir per skills/<name>).
 # The Claude wrapper exports that prebuilt store path to the SessionStart hook,
 # which copies it here for Claude Code and Codex. Preview with

--- a/lib/per-system.nix
+++ b/lib/per-system.nix
@@ -142,7 +142,7 @@
           | where {|line| $line != "" and not ($line | str starts-with "#") }
         )
         let scripts = (
-          fd --hidden --type file --exclude .git --exclude .claude/worktrees
+          fd --hidden --type file --exclude .git
             --extension sh --extension bash --extension nu
           | lines
         )
@@ -240,7 +240,7 @@
           --extension toml --extension json --extension yaml --extension yml
           --extension kdl --extension ini --extension conf --extension cfg --extension xml
           --extension properties --extension editorconfig --extension sobelow-conf
-          --exclude .git --exclude .claude/worktrees
+          --exclude .git
           | lines
         )
         let denied = ($candidates | where {|path| not ($allowed | any {|pattern| $path =~ $pattern})})


### PR DESCRIPTION
Closes #4147.

`nix run .#lint` walked the agent isolation worktrees under `.claude/worktrees/`, so a sibling agent's stale checkout turned the owner's lint red — reproduced today with statix repeated-keys findings under `./.claude/worktrees/agent-*/users/andrewgazelka/profiles/workstation.nix` while the repo's own tree was clean.

Stage audit: statix is the only walker that descends there. Its hand-rolled walker builds its ignore set from exactly two sources — the root `.gitignore` and `statix.toml` — and walks everything else, hidden or not. The fd/rg-based stages honor gitignore (and were quiet on machines where `lib/util/git-defaults.nix` installs the global `**/.claude/worktrees/` ignore), and deadnix and clone-detect skip hidden directories by default.

Fix at the shared enumeration seam: one tracked line in the root `.gitignore` (`/.claude/worktrees/`, next to the existing `.worktrees/` entry), which every enumerator in the pipeline honors on every clone, with a comment explaining the statix constraint. The per-stage `--exclude .claude/worktrees` flags in the shell-fence and filenames stages duplicated the same fact and are removed.

Verified: with a fake nested worktree at `.claude/worktrees/x` (a `.git` file plus a statix-triggering `bad.nix`), `nix run --extra-experimental-features wasm-builtin --option eval-cache false .#lint` runs all 13 stages green (statix alone exits 1 without the gitignore line, 0 with it), and the same run is green on the repo itself.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude `.claude/worktrees` from lint walkers via `.gitignore`
> Adds `/.claude/worktrees/` to [.gitignore](https://github.com/indexable-inc/index/pull/4150/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) so that nested worktree checkouts created by Claude are ignored by git and file walkers. The explicit `--exclude .claude/worktrees` flags are removed from the `fd` invocations in [lib/per-system.nix](https://github.com/indexable-inc/index/pull/4150/files#diff-9879a1f03396eb758ff538e44a00fb409b99bc0bbfac4656755b05716d036683) since `.gitignore` now handles exclusion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ba1e79.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->