### PR TITLE
determinism: reproducible rebuilds for libghostty-vt, build-script outputs, site, tui-ex (ix#8465)

### DIFF
--- a/lib/build/libghostty-vt.nix
+++ b/lib/build/libghostty-vt.nix
@@ -119,8 +119,29 @@ in
       ''}
     '';
 
+    # An explicit -Dtarget (never `native`) keeps the artifact byte-identical
+    # across build hosts: zig resolves a native target by probing the RUNNING
+    # kernel and glibc (std.zig.system.resolveTargetQuery) and embeds those
+    # versions in compiler_rt.o's `.data.rel.ro.builtin.target`, so a fleet
+    # kernel upgrade flips the narHash of every rebuild and cache publish
+    # proofs can never converge (indexable-inc/ix#8465: 7.0.11 vs 7.1.3
+    # workers). An explicit triple selects zig's fixed default OS/glibc
+    # version range instead.
+    zigTargetTriple =
+      {
+        x86_64-linux = "x86_64-linux-gnu";
+        aarch64-linux = "aarch64-linux-gnu";
+        x86_64-darwin = "x86_64-macos-none";
+        aarch64-darwin = "aarch64-macos-none";
+      }
+      .${
+        stdenv.hostPlatform.system
+      }
+      or (throw "libghostty-vt: no zig target triple mapped for ${stdenv.hostPlatform.system}");
+
     zigInstallArgs = ''
       -Demit-lib-vt=true \
+      -Dtarget=${zigTargetTriple} \
       -Dcpu=baseline \
       -Doptimize=ReleaseFast \
       -fsys=zlib --search-prefix ${pkgs.zlib}'';

--- a/packages/nix-cargo-unit/src/render.rs
+++ b/packages/nix-cargo-unit/src/render.rs
@@ -1684,11 +1684,20 @@ fn render_build_script_run_phase(
     // Cargo nests OUT_DIR several levels deep
     // (`target/<profile>/build/<pkg>-<hash>/out`), so a build script can write
     // relative to its ancestors. The `v8`/`rusty_v8` crate takes a download
-    // lock at `OUT_DIR/../../v8.fslock`; a bare `mktemp -d` gives a path shallow
-    // enough that its grandparent is `/`, so that write hits PermissionDenied.
-    // Nest two levels under the temp dir so `OUT_DIR/../..` lands back inside
-    // the (writable) mktemp dir.
-    script.push_str("build_script_out_dir=$(mktemp -d)/build/out\n");
+    // lock at `OUT_DIR/../../v8.fslock`; a path only one level deep would put
+    // that grandparent at `/`, so that write hits PermissionDenied. Nest two
+    // levels under the build dir so `OUT_DIR/../..` stays writable.
+    //
+    // The path must also be FIXED, never `mktemp -d`: build scripts bake
+    // OUT_DIR into binary artifacts (rustc feature probes embed the probe
+    // source path in their `.rmeta`; cc-compiled objects carry it in debug
+    // strings), and the post-run rewrite to `$out/out-dir` below only touches
+    // text files. A random component in OUT_DIR therefore made those bytes
+    // differ on every rebuild, and the same input-addressed store path
+    // published from two workers failed the cache narHash readback proof
+    // forever (indexable-inc/ix#8465). `$NIX_BUILD_TOP` is constant (`/build`)
+    // inside the sandbox.
+    script.push_str("build_script_out_dir=$NIX_BUILD_TOP/cargo-unit-build-script-run/build/out\n");
     script.push_str("mkdir -p \"$build_script_out_dir\"\n");
     script.push_str("build_script_env=()\n");
     script.push_str("export OUT_DIR=$build_script_out_dir\n");

--- a/packages/site/svelte.config.js
+++ b/packages/site/svelte.config.js
@@ -24,6 +24,14 @@ const config = {
     // app in the ix repo. Override with BASE_PATH for a prefixed deployment.
     paths: {
       base: process.env.BASE_PATH ?? ''
+    },
+    // SvelteKit's default version.name is Date.now(); that stamp lands in the
+    // client bundle, so every rebuild changed a chunk's content hash and
+    // filename and the Nix output never reproduced (indexable-inc/ix#8465).
+    // Nothing here polls /_app/version.json for live update detection, so a
+    // fixed name only removes the nondeterminism.
+    version: {
+      name: 'static'
     }
   }
 };

--- a/packages/tui/ex/default.nix
+++ b/packages/tui/ex/default.nix
@@ -65,6 +65,11 @@ let
       runHook preInstall
       mkdir -p "$out/lib"
       cp -RL _build/prod/lib/tui_ex "$out/lib/tui_ex"
+      # Mix's compile manifests (.mix/compile.elixir etc.) carry build-time
+      # mtimes, so shipping them makes every rebuild's narHash differ and the
+      # cache publish proof never converges (indexable-inc/ix#8465). Nothing
+      # reads them at runtime: :code.priv_dir wants only ebin/ and priv/.
+      rm -rf "$out/lib/tui_ex/.mix"
       runHook postInstall
     '';
 


### PR DESCRIPTION
Rebuild-determinism fixes for the narHash-divergence set harvested in indexable-inc/ix#8465 (fleet cache publish proofs fail permanently when the same drv rebuilds differently across workers). Harvest and per-offender byte diffs: https://github.com/indexable-inc/ix/issues/8465#issuecomment-5064762447

## What changed

- `lib/build/libghostty-vt.nix`: pass an explicit `-Dtarget` (per-platform triple) next to the existing `-Dcpu=baseline`. Zig resolves a `native` target by probing the running kernel and glibc and embeds those versions in `compiler_rt.o`'s `.data.rel.ro.builtin.target`; the fleet kernel upgrade to 7.1.3 left a 7.0.11-stamped NAR in the cache that no current worker can reproduce, so the publish proof for every closure containing libghostty-vt (dbus-1, etc, activate, system-units, every nixos-system-*) retried forever. Verified with `zig build-obj --show-builtin`: native reports the host kernel as os version min/max, explicit `x86_64-linux-gnu` reports the fixed 5.10...6.x default.
- `packages/nix-cargo-unit/src/render.rs`: build-script runs get a fixed OUT_DIR (`$NIX_BUILD_TOP/cargo-unit-build-script-run/build/out`) instead of `$(mktemp -d)/build/out`. Build scripts bake OUT_DIR into binary artifacts (eyre's probe `.rmeta`, cc-compiled objects) and the capture step's `substituteInPlace` rewrite skips binaries, so the random component diverged the captured `*-build-script-output-*` NAR on every rebuild (eyre, libfuzzer-sys on the ix fleet). The two-level nesting the v8 crate needs (`OUT_DIR/../..` writable) is preserved.
- `packages/site/svelte.config.js`: pin `kit.version.name`. The SvelteKit default is `Date.now()`; the stamp lands in the client bundle, renames every content-hashed chunk, and made `ix-site` diverge on rebuild (the divergent fleet NAR's `_app/version.json` is a millisecond epoch; post-fix it is `{"version":"static"}`). Nothing in this static site polls `/_app/version.json`.
- `packages/tui/ex/default.nix`: drop `.mix/` (mtime-bearing Mix compile manifests) from the shipped `tui_ex` app; runtime wants only `ebin/` and `priv/`.

## Validation

- `nix run .#lint` green; `cargo check -p nix-cargo-unit` green.
- `nix build .#libghostty-vt` green on aarch64-darwin.
- `nix build .#site` green on x86_64-linux (hil-compute-1 store); `nix build --rebuild` reproduces it byte-identically (Nix's determinism check passes; before the fix the live fleet pair differed).
- x86_64-linux libghostty-vt build + `--rebuild` proof is queued behind the toolchain (zig/LLVM for the current nixpkgs pin is mid-build by fleet CI on the same hosts); will confirm on this PR before merge.

The dominant divergent family (369 of 382 paths, `cargo-unit-nextest-*` junit.xml) was already fixed by #4135; ix picks all of this up in one index pin bump.

Refs indexable-inc/ix#8465

(sent by an AI agent via Claude Code, Fable 5)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix non-deterministic build outputs for libghostty-vt, build scripts, site, and tui-ex
> - Passes an explicit `-Dtarget` Zig triple in [libghostty-vt.nix](https://github.com/indexable-inc/index/pull/4152/files#diff-b7fb92f2cb27bd4449e20e4354714f07661f87d536349f0905c1b76fec8cbd0a) instead of relying on Zig's native target resolution, covering four supported platforms.
> - Replaces `mktemp`-based `OUT_DIR` creation in [render.rs](https://github.com/indexable-inc/index/pull/4152/files#diff-da81bb79268fbaf52a96664faa4d392b9b83a48a4b3b54bb1c3a2a5f2f50f26a) with a fixed path under `$NIX_BUILD_TOP`, making build script outputs deterministic.
> - Sets `kit.version.name` to `'static'` in [svelte.config.js](https://github.com/indexable-inc/index/pull/4152/files#diff-8ed9bf89ee197b1e1e366425229801c5fb7c2cb758205e54ec4f5902bc89e99a) so the SvelteKit client bundle no longer embeds a timestamp-derived version string.
> - Removes the `.mix` directory from the `tui-ex` Nix package output in [default.nix](https://github.com/indexable-inc/index/pull/4152/files#diff-04c24ebc2932c951a76b4a67e05febbeecb5ca195d4fa7f036b2c0d697f6908e) to eliminate non-deterministic Mix manifests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 27379b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->