### PR TITLE
profiles/base: ship the consensus user baseline in every VM

### DIFF
--- a/lib/dev/base/default.nix
+++ b/lib/dev/base/default.nix
@@ -1,6 +1,7 @@
-# Default ix environment base: agent CLIs plus a normal build toolchain.
+# Default ix environment base: agent CLIs plus the dev-only build extras.
 # The auto-enabled base profile supplies version control, editors, the nushell
-# workspace wrapper, debuggers, tracing tools, and archive utilities.
+# workspace wrapper, debuggers, tracing tools, archive utilities, the default
+# language runtimes (python3, node, uv), and the C toolchain (gcc, make).
 {
   ix,
   pkgs,
@@ -15,17 +16,13 @@
       # surface; `chromium` is the actual browser it drives.
       agent-browser
       chromium
-      # Build toolchain. Most ecosystems lean on cmake / make / ninja and
-      # pkg-config; rustup keeps the toolchain pinnable per-project.
+      # Build-system layer above the base profile's cc + make: cmake /
+      # ninja / pkg-config for the ecosystems that generate their builds;
+      # rustup keeps the Rust toolchain pinnable per-project.
       cmake
-      gcc
-      gnumake
       ninja
       pkg-config
       rustup
-      # Default language runtimes that show up across most dev sessions.
-      nodejs
-      python3
       ;
   };
 }

--- a/modules/profiles/base/default.nix
+++ b/modules/profiles/base/default.nix
@@ -1,8 +1,12 @@
 # Base runtime profile.
 #
-# Auto-enabled by `lib/image/oci-layer.nix`. Ships cross-cutting CLI that should
-# be available on every VM for debugging and introspection. Image-specific
-# runtime dependencies still belong in the image or service that needs them.
+# Auto-enabled by `lib/image/oci-layer.nix`. The bar: the first ten minutes of
+# a person or agent in a fresh VM must just work. That means the consensus
+# baseline every competitor's default sandbox ships (VCS, downloaders,
+# archivers, a Python and Node runtime, a C toolchain) plus the cross-cutting
+# debugging and introspection CLI. Image-specific runtime dependencies still
+# belong in the image or service that needs them; sealed appliances disable
+# the profile to drop the interactive stack.
 {
   config,
   ix,
@@ -492,9 +496,65 @@ in {
     # setup. Zsh is the platform default user shell (see
     # lib/image/platform.nix); Home Manager owns its root-user config
     # and the login-time workspace behavior above.
-    programs = {
-      zsh.enable = true;
-      fish.enable = true;
+    # Every command-not-found points at the escape hatch: with cache.ix.dev
+    # warm, `nix run nixpkgs#<tool>` materializes most tools in about a
+    # second, but nothing surfaces that to someone staring at a bare
+    # "command not found". One hint line per shell; no auto-run (executing
+    # an unreviewed store path on a typo is not a default anyone wants).
+    programs = let
+      hint = tool: "hint: 'nix run nixpkgs#${tool}' runs it without installing (warm cache, about a second); 'nix shell nixpkgs#${tool}' puts it on PATH.";
+    in {
+      zsh = {
+        enable = true;
+        interactiveShellInit = ''
+          command_not_found_handler() {
+            print -u2 "zsh: command not found: $1"
+            print -u2 "${hint "$1"}"
+            return 127
+          }
+        '';
+      };
+      fish = {
+        enable = true;
+        interactiveShellInit = ''
+          function fish_command_not_found
+            echo "fish: Unknown command: $argv[1]" >&2
+            echo "${hint "$argv[1]"}" >&2
+          end
+        '';
+      };
+      bash.interactiveShellInit = ''
+        command_not_found_handle() {
+          echo "bash: $1: command not found" >&2
+          echo "${hint "$1"}" >&2
+          return 127
+        }
+      '';
+
+      # nixpkgs' channel-DB command-not-found defines these same three
+      # handler functions when enabled; its default is only false here
+      # because a flake-pinned nixpkgs tarball lacks programs.sqlite.
+      # Pin it off so the handlers above stay the single owner instead
+      # of colliding by module-include order.
+      command-not-found.enable = false;
+
+      # git for every user, not just root: the curated per-user config
+      # (delta, mergiraf, aliases) stays in Home Manager above, but the
+      # binary itself must not depend on whose profile is on PATH --
+      # DynamicUser services and any future non-root user get git too.
+      # The system gitconfig also carries a fallback identity so the
+      # first `git commit` in a fresh VM never dies with "unable to
+      # auto-detect email address"; system scope is git's lowest
+      # precedence, so any real identity (global or repo-local) wins.
+      git = {
+        enable = true;
+        config = {
+          user = {
+            name = "ix";
+            email = "root@ix.local";
+          };
+        };
+      };
 
       # Neovim is wired through the NixOS module because the wrapper
       # bakes the curated config into the binary itself, so XDG never
@@ -598,6 +658,10 @@ in {
           bat
           bpftrace
           btop
+          # dig/nslookup for DNS debugging; `host` alone (shipped via
+          # NixOS defaults) answers "does it resolve" but not "from which
+          # server, with which record details".
+          dnsutils
           # Stack unwinder and ELF/DWARF inspector. `eu-stack` resolves
           # stripped binaries against separate debuginfo, `eu-readelf`
           # gives a saner view of section/note contents than `readelf`,
@@ -607,7 +671,14 @@ in {
           eza
           fd
           file
+          # C toolchain: `pip install` of any package with a native
+          # extension, node-gyp, and every "./configure && make" README
+          # assume cc + make exist. 5 of 7 competitor default images ship
+          # one; a VM that can't build a C extension fails the first
+          # real Python or Node session.
+          gcc
           gdb
+          gnumake
           # gnutar, gzip, and zstd ride along so any VM switched once stays
           # switchable: the `ix apply` source upload streams a tarball through
           # `tar -x -I zstd` inside the guest, and these binaries are not
@@ -634,11 +705,24 @@ in {
           nh
           nix-output-monitor
           nix-tree
+          # Default language runtimes. python3 and node are the two
+          # interpreters "run this script" instructions assume exist
+          # (both ship in 5 of 7 competitor default sandboxes); uv is
+          # the package/venv path for Python that doesn't fight the
+          # read-only store the way bare pip does.
+          nodejs
+          python3
+          uv
+          # TLS/cert debugging (s_client, x509) plus the digest/keygen
+          # one-liners every deploy doc reaches for.
+          openssl
           # Walks DWARF/BTF type info to pretty-print kernel and userspace
           # structs out of core dumps, /proc/kcore, or VM RAM memfds. The
           # canonical tool for "I have raw memory and I need to know what
           # struct lives at this offset", which gdb/lldb both fumble.
           pahole
+          # killall/pstree muscle memory from every other Unix box.
+          psmisc
           # drgn complements pahole: pahole answers "what is the layout of
           # struct foo?", drgn lets you start from a typed root and walk
           # the live value graph in Python (dereference pointers, follow
@@ -648,16 +732,35 @@ in {
           drgn
           pv
           ripgrep
+          # The `sqlite3` CLI: half of local app state (browsers, package
+          # managers, our own atuin history) is a SQLite file, and
+          # inspecting one without the CLI means writing a script.
+          sqlite
           strace
           tcpdump
+          # zellij (below) is the curated multiplexer, but tmux is the
+          # one operators and agent recipes actually type; both are tiny.
+          tmux
+          tree
           # Complements ripgrep with what it lacks: boolean queries
           # (-%), fuzzy match (-Z), and searching inside archives and
           # compressed files (-z).
           ugrep
+          # Half the internet distributes .zip; gnutar/zstd cover the
+          # rest of the archive formats but reject zip, which turns a
+          # plain `curl -LO <github archive>` into a dead end.
+          unzip
+          # wget rides along for the copy-paste commands that assume it;
+          # curl comes from NixOS' core packages.
+          wget
+          # Hex dump/reverse for quick binary pokes without pulling
+          # a full vim install (nvim's wrapper does not expose xxd).
+          xxd
           # Pane and tab multiplexer for one session. Connection survival
           # across SSH drops is handled by ix itself (AGENTS.md "VM
           # assumptions"), so zellij is shipped for splits, not reattach.
           zellij
+          zip
           zstd
           ;
       })

--- a/packages/site/src/lib/updates/base-image-user-baseline.svx
+++ b/packages/site/src/lib/updates/base-image-user-baseline.svx
@@ -1,0 +1,28 @@
+---
+id: base-image-user-baseline
+postedAt: 2026-07-24T18:55:00-07:00
+title: "Every VM now ships the tools people actually reach for first"
+tags: [interesting, images, base-profile]
+links:
+  - label: PR 4156
+    href: https://github.com/indexable-inc/index/pull/4156
+---
+
+A fresh `ix/base` VM could walk a kernel struct out of a core dump but
+could not run `python3 -c 'print(1)'` or extract a `.zip`. The base
+profile was written for debugging appliances; `ix run`'s default image
+is where people and agents actually land.
+
+Every VM now carries the consensus baseline of the sandbox market
+(surveyed across E2B, Daytona, Modal, Codespaces, Vercel, and
+Cloudflare defaults): `git` on the system PATH for every user, not
+just root's profile, plus `python3`, `node`, `uv`, `gcc`, `make`,
+`unzip`, `zip`, `wget`, `dig`, `sqlite3`, `openssl`, `tree`, `tmux`,
+and friends.
+
+Two paper cuts went with it. The first `git commit` no longer dies on
+identity auto-detection: `/etc/gitconfig` carries a lowest-precedence
+fallback identity that any real `git config` wins over. And a missing
+command in bash, zsh, or fish now prints the escape hatch instead of a
+bare error: `nix run nixpkgs#<tool>` resolves from the warm
+`cache.ix.dev` in about a second, which was true before but invisible.


### PR DESCRIPTION
## Why

`ix/base` is the default `ix run` target - the product's face for "give me a Linux box" - but the base profile was debugger-shaped. Dogfooding a fresh prod VM: you could trace a kernel struct out of a core dump, but `python3`, `unzip`, `wget`, `gcc`, `make` were all missing, a downloaded `.zip` was a hard dead end, the first `git commit` died on identity auto-detection, git existed only in root's home-manager profile, and `command not found` gave zero guidance despite `nix run nixpkgs#<tool>` resolving from cache.ix.dev in ~1s.

A sourced survey of seven competitor default sandboxes (E2B, Daytona, Modal, Codespaces universal/base, Vercel Sandbox, Cloudflare Sandbox SDK) gives the consensus baseline: git, unzip, a runtime-usable install path everywhere; python/node/C-toolchain/wget in ~5 of 7. The market splits between Modal (ships nothing) and Daytona/Codespaces (1.3-3.6 GiB images); nix cross-tenant dedup lets us take the unclaimed middle: small, complete, composable.

## What

- **git on the system PATH** via NixOS `programs.git` (curated per-user config stays in HM; DynamicUser services and non-root users get the binary too). `/etc/gitconfig` carries a lowest-precedence fallback identity (`ix <root@ix.local>`) so the first commit works; any global/repo-local identity wins.
- **Runtimes + toolchain in base:** `python3`, `nodejs`, `uv`, `gcc`, `gnumake` - moved down from `lib/dev/base`, which slims to dev-only extras (cmake, ninja, pkg-config, rustup, agent tooling).
- **Archives/downloads:** `unzip`, `zip`, `wget`.
- **Everyday CLI:** `dnsutils`, `sqlite`, `openssl`, `tree`, `psmisc`, `xxd`, `tmux`.
- **command-not-found hint** in bash/zsh/fish pointing at `nix run nixpkgs#<tool>` / `nix shell`; no auto-run. nixpkgs' channel-DB handler pinned off so ownership is single.
- Base profile header rewritten around the actual bar: the first ten minutes of a person or agent in a fresh VM must just work.

## Testing

- statix, deadnix, alejandra clean on the changed files (full `.#lint` needs the wasm-builtin nix; deferring to CI)
- Closure-size and boot-time delta: to be measured on the CI-built image before merge (base boots in 1.2s today)
- Will re-run the fresh-VM dogfood battery (tool presence, zip roundtrip, git clone+commit, cnf hint) once an image with this profile is bootable

Not in scope, ix-side follow-ups to file: exec-context env (`TERM=dumb`, empty `LANG`/`EDITOR`, cwd `/`), guest hostname should be the VM name instead of `nixos`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ship a standard user baseline of tools and shell hints to every VM base profile
> - Moves common CLI tools (gcc, gnumake, nodejs, python3, uv, sqlite, tmux, openssl, wget, and others) from the dev profile into [`modules/profiles/base/default.nix`](https://github.com/indexable-inc/index/pull/4156/files#diff-f41fc9d5d8fd7fc213d6f7fee2689b23cc1b16849c245dce044804a3431e2d8e) so every VM gets them by default.
> - Adds a custom `command_not_found` handler for bash, zsh, and fish that prints a `nix run nixpkgs#<tool>` hint and returns 127 instead of using the default nixpkgs handler.
> - Disables `programs.command-not-found` to prevent it from overriding the custom shell handlers.
> - Adds system-wide git config with a fallback identity (`ix` / `root@ix.local`) used when no user- or repo-level identity is set.
> - Removes gcc, gnumake, nodejs, and python3 from [`lib/dev/base/default.nix`](https://github.com/indexable-inc/index/pull/4156/files#diff-bf830af170d1bdac01e798a2c46801c24271ecb78d8164afaa6f82eb930a5a29) since they are now provided by the base profile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46c5bfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->