### PR TITLE
claude-code: sync alwaysOnReview knob reference

### DIFF
--- a/packages/agent/home-manager/claude-code.nix
+++ b/packages/agent/home-manager/claude-code.nix
@@ -88,6 +88,7 @@
   #   pluginDirs = [ ];  option pluginDirs; --plugin-dir=<dir> flags: namespaced plugin bundles (the house plugin rides this layer)
   #   primaryCheckouts = <"/home/*/index", "/home/*/ix">;  option primaryCheckouts; globs the PreToolUse worktree guard denies edits under
   #   personalStartupContext = false;  option personalStartupContext; Andrew-only startup context hooks
+  #   alwaysOnReview = false;  arms the PostToolUse edit logger and Stop review gate
   #   extraSessionStart = [ ];  option extraSessionStart; SessionStart commands ({ package, exeName, args, timeout }) whose stdout becomes session context (index#3849)
   #   repoPackages = { };  plumbing: sibling repo packages threaded by lib/packages.nix, not a config knob
   #   mcpServers = <ix.mcp default pair: index + exa>;  option defaultMcpServers; baked --mcp-config layer (CLI layers merge, additions only)


### PR DESCRIPTION
## Summary

- add `alwaysOnReview = false` to the drift-checked Claude Code wrapper knob reference
- restore evaluation of `requiredGateRoots.x86_64-linux.claude-code-knob-reference`

## Root cause

The wrapper added the defaulted `alwaysOnReview` argument without adding the corresponding row to the committed Home Manager reference table. The knob-reference assertion therefore reported it as missing and failed the required CI gate.

## Impact

The reference now accurately documents every accepted defaulted wrapper knob, allowing the required gate and its mirrored closure gate to proceed.

## Validation

- compared the wrapper's 19 accepted defaulted arguments against the reference table with no diff
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add comment documenting `alwaysOnReview` knob in claude-code config
> Adds a documentation comment in [claude-code.nix](https://github.com/indexable-inc/index/pull/4158/files#diff-b941f4c92dd8de3d70290f80abe17e83e8710287c6a7430cad3d5f1c81cdbdab) describing the `alwaysOnReview` option as arming the PostToolUse edit logger and Stop review gate. No executable code is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e56b338.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->