### PR TITLE
Remove session_set_name and topic_set from the Elixir MCP kernel

### DIFF
--- a/packages/mcp-ex/README.md
+++ b/packages/mcp-ex/README.md
@@ -52,7 +52,7 @@ are the discovery surface, generated live from module docs.
 
 ## Tools
 
-The MCP surface is exactly three tools; everything else the Python server
+The MCP surface is exactly one tool; everything else the Python server
 exposed as tools is an in-language callable, pre-aliased in every cell like
 `Jobs` (the server instructions delivered at MCP initialize teach the same
 list):
@@ -60,7 +60,6 @@ list):
 | tool | what it does |
 |---|---|
 | `exec` | run a cell; budget-then-background |
-| `session_set_name` / `topic_set` | label this session's runs in the action log |
 
 | in-cell callable | what it does |
 |---|---|
@@ -81,8 +80,8 @@ path that used to justify out-of-band tools needs none.
 
 Every `tools/call` lands in a local SQLite action log
 (`~/.local/state/ix-mcp-ex/actions.db`): a `sessions` row per server
-instance (created lazily on first use), a `topics` row per `topic_set` call
-(a timeline -- repeated names make new rows), and an `actions` row per call
+instance (created lazily on first use), a `topics` row per topic (a
+timeline -- repeated names make new rows), and an `actions` row per call
 referencing both.
 
 ## Why we left Python

--- a/packages/mcp-ex/default.nix
+++ b/packages/mcp-ex/default.nix
@@ -182,10 +182,9 @@
     }
     ''
       set +e
-      printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+      printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
         '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}' \
         '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
-        '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"session_set_name","arguments":{"name":"smoke"}}}' \
         '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"exec","arguments":{"intent":"utf8 wire roundtrip","budget":60,"code":"\"snow ☃\""}}}' \
         '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"exec","arguments":{"intent":"binary output rides as escapes","budget":60,"code":"IO.puts(<<255, 97>> <> \"bin-marker\")"}}}' \
         '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"exec","arguments":{"intent":"connection survives binary output","budget":60,"code":"\"alive-after-binary\""}}}' \
@@ -220,14 +219,6 @@
         *'"name":"exec"'*) ;;
         *)
           echo "tools/list did not advertise exec" >&2
-          printf '%s\n' "$out_lines" >&2
-          exit 1
-          ;;
-      esac
-      case "$out_lines" in
-        *'session named: smoke'*) ;;
-        *)
-          echo "tools/call session_set_name did not answer" >&2
           printf '%s\n' "$out_lines" >&2
           exit 1
           ;;

--- a/packages/mcp-ex/lib/ix_mcp/action_log.ex
+++ b/packages/mcp-ex/lib/ix_mcp/action_log.ex
@@ -2,8 +2,8 @@ defmodule IxMcp.ActionLog do
   @moduledoc """
   Append-only SQLite record of every MCP action (#3512), normalized (#3532):
   a `sessions` row per server instance (created lazily on first use, so a
-  connection that never acts leaves no row), a `topics` row per `topic_set`
-  call (a timeline -- repeating a name makes a new row), and an `actions` row
+  connection that never acts leaves no row), a `topics` row per topic (a
+  timeline -- repeating a name makes a new row), and an `actions` row
   per `tools/call` referencing both. This module owns all SQLite access; the
   current session/topic ids live in `IxMcp.Session`. Pure logging for future
   reference; nothing on the hot path reads it.

--- a/packages/mcp-ex/lib/ix_mcp/mcp/server.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/server.ex
@@ -108,8 +108,7 @@ defmodule IxMcp.MCP.Server do
     """
     An MCP server whose REPL is Elixir: `exec` runs cells on one shared,
     persistent workspace (bindings survive across calls), each cell in its
-    own supervised BEAM process. Name the session before acting; set a topic
-    per work phase.
+    own supervised BEAM process.
 
     #{Tools.surface_guide()}
     """

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -1,7 +1,7 @@
 defmodule IxMcp.MCP.Tools do
   @moduledoc """
-  The MCP tool surface: exactly `exec`, `session_set_name`, and `topic_set`.
-  Everything that used to be a separate tool (read, trace, restart, PR
+  The MCP tool surface: exactly `exec`. Everything that used to be a
+  separate tool (read, trace, restart, PR
   watching, TUI driving) is an in-language callable aliased into every cell
   (#3532); `surface_guide/0` is the one text that teaches it, shared between
   the `exec` description and the server instructions. Every tool returns
@@ -224,26 +224,6 @@ defmodule IxMcp.MCP.Tools do
           },
           "required" => ["code", "intent"]
         }
-      },
-      %{
-        "name" => "session_set_name",
-        "description" =>
-          "Name this connection's session. Call before acting tools; the name labels every run this server records.",
-        "inputSchema" => %{
-          "type" => "object",
-          "properties" => %{"name" => %{"type" => "string", "minLength" => 3, "maxLength" => 80}},
-          "required" => ["name"]
-        }
-      },
-      %{
-        "name" => "topic_set",
-        "description" =>
-          "Start a new topic. Runs fold under the topic inside the session; change it when work moves to a new phase (each call starts a fresh topic, even under a repeated name).",
-        "inputSchema" => %{
-          "type" => "object",
-          "properties" => %{"topic" => %{"type" => "string", "minLength" => 3, "maxLength" => 80}},
-          "required" => ["topic"]
-        }
       }
     ]
   end
@@ -280,21 +260,6 @@ defmodule IxMcp.MCP.Tools do
     if action_id, do: IxMcp.ActionLog.finish_action(action_id, "failed", true, 0)
     {:error, "exec requires string `code`"}
   end
-
-  def call("session_set_name", %{"name" => name}, _action_id) when is_binary(name) do
-    :ok = IxMcp.Session.set_name(name)
-    {:ok, "session named: #{name}"}
-  end
-
-  def call("session_set_name", _args, _action_id),
-    do: {:error, "session_set_name requires string `name`"}
-
-  def call("topic_set", %{"topic" => topic}, _action_id) when is_binary(topic) do
-    :ok = IxMcp.Session.set_topic(topic)
-    {:ok, "topic set: #{topic}"}
-  end
-
-  def call("topic_set", _args, _action_id), do: {:error, "topic_set requires string `topic`"}
 
   def call(other, _args, _action_id), do: {:error, "unknown tool: #{other}"}
 

--- a/packages/mcp-ex/test/action_log_test.exs
+++ b/packages/mcp-ex/test/action_log_test.exs
@@ -224,7 +224,7 @@ defmodule IxMcp.ActionLogTest do
     end
   end
 
-  test "one server instance is one session; topic_set is a timeline, not a dictionary" do
+  test "one server instance is one session; a topic is a timeline, not a dictionary" do
     # Prime the lazy session row so the count below is stable regardless of
     # which test in this suite touched the global log first.
     %{session_id: session_id} = IxMcp.Session.ids()

--- a/packages/mcp-ex/test/ix_mcp/mcp_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/mcp_test.exs
@@ -21,12 +21,11 @@ defmodule IxMcp.MCPTest do
     assert response["result"]["instructions"] =~ "Read.file"
   end
 
-  test "the tool surface is exactly exec, session_set_name, and topic_set" do
+  test "the tool surface is exactly exec" do
     response = Server.handle(request("tools/list", %{}))
     tools = response["result"]["tools"]
 
-    assert tools |> Enum.map(& &1["name"]) |> Enum.sort() ==
-             ["exec", "session_set_name", "topic_set"]
+    assert tools |> Enum.map(& &1["name"]) == ["exec"]
 
     exec = Enum.find(tools, &(&1["name"] == "exec"))
     assert exec["inputSchema"]["required"] == ["code", "intent"]
@@ -48,18 +47,6 @@ defmodule IxMcp.MCPTest do
     assert text =~ ~s("status":"done")
     assert text =~ "hi"
     assert text =~ "=> 4"
-  end
-
-  test "session_set_name and topic_set round-trip" do
-    Server.handle(
-      request("tools/call", %{"name" => "session_set_name", "arguments" => %{"name" => "abc"}})
-    )
-
-    Server.handle(
-      request("tools/call", %{"name" => "topic_set", "arguments" => %{"topic" => "xyz"}})
-    )
-
-    assert IxMcp.Session.get() == %{name: "abc", topic: "xyz"}
   end
 
   test "unknown method returns a JSON-RPC error, notifications return nil" do


### PR DESCRIPTION
Removes the `session_set_name` and `topic_set` MCP tools from the Elixir kernel (`mcp-ex`).

## Why
They asked every agent to name its session and set a topic before doing real work. That step no longer earns its cost: it is an up-front round-trip that takes agent time, and agents are better served getting straight to editing documents. The labels were only ever consumed by the action-log dashboard grouping, which still works with unnamed sessions.

## Scope
Elixir kernel (`mcp-ex`) only, tools + instruction only:
- `mcp/tools.ex`: drop the two tool definitions and their `call/3` clauses.
- `mcp/server.ex`: drop the "name the session before acting; set a topic" instruction line.
- `default.nix`: drop the `session_set_name` step and assertion from the wire smoke test.
- `README.md`, `action_log.ex` moduledoc, tests: reword.

The sessions/topics SQLite layer (`IxMcp.Session`, `IxMcp.ActionLog`) stays intact and tested. The Python `ix-mcp` (`packages/mcp`) is untouched.

## Validation
- `mcp-ex.tests.elixir`: 182 tests, 0 failures.
- `mcp-ex.tests.smoke`: passes.

(authored by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `session_set_name` and `topic_set` tools from the Elixir MCP kernel
> - Removes the `session_set_name` and `topic_set` entries from [`IxMcp.MCP.Tools`](https://github.com/indexable-inc/index/pull/4159/files#diff-c1967b7edcd9f2a8628cd2ebf989cfe1e0daf0af2416367f04b4e816c897e776); `tools/list` now returns only `exec`.
> - Calls to `session_set_name` or `topic_set` via `tools/call` now return `unknown tool: <name>` instead of updating session/topic state.
> - Updates the smoke test in [`default.nix`](https://github.com/indexable-inc/index/pull/4159/files#diff-563967e170d403f754f28e98f423edbb153588ae9111be797d344a115cd85850) and the MCP integration tests to reflect the single-tool surface.
> - Behavioral Change: any MCP client calling `session_set_name` or `topic_set` will receive an error response rather than a successful update.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 823ef54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->