### PR TITLE
mcp-ex: Jobs.await no longer parks forever when a job is hard-killed

### DIFF
--- a/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
@@ -191,11 +191,24 @@ defmodule IxMcp.Jobs.Job do
       {:finished, summary} ->
         {:ok, summary}
 
-      :subscribed ->
+      {:subscribed, id} ->
+        ref = Process.monitor(server)
+
         receive do
-          {:ix_job_finished, _id, summary} -> {:ok, summary}
+          {:ix_job_finished, _id, summary} ->
+            Process.demonitor(ref, [:flush])
+            {:ok, summary}
+
+          {:DOWN, ^ref, :process, _pid, _reason} ->
+            # The control process died without reporting a terminal
+            # transition -- a hard kill finish/1 cannot run through. The
+            # reaper drives the ledger terminal from outside (#3839); read
+            # that durable record instead of parking here forever, which is
+            # what an :infinity await did when its job was killed.
+            {:ok, killed_summary(id)}
         after
           remaining_ms(timeout_ms, started_mono) ->
+            Process.demonitor(ref, [:flush])
             give_up(server)
         end
 
@@ -235,6 +248,23 @@ defmodule IxMcp.Jobs.Job do
       {:ix_job_finished, _id, summary} -> {:ok, summary}
     after
       0 -> :timeout
+    end
+  end
+
+  # After a control process dies unreported its terminal state lives only in
+  # the ledger, written by the reaper off the same :DOWN this await saw. The
+  # two monitors race, so the read can arrive before the write; poll the
+  # durable summary briefly until it goes terminal (bounded, never a hang).
+  @killed_read_tries 100
+  @killed_read_ms 50
+  defp killed_summary(id, tries \\ @killed_read_tries) do
+    summary = IxMcp.Jobs.get(id)
+
+    if summary.status != :running or tries <= 0 do
+      summary
+    else
+      Process.sleep(@killed_read_ms)
+      killed_summary(id, tries - 1)
     end
   end
 
@@ -426,7 +456,7 @@ defmodule IxMcp.Jobs.Job do
   def handle_call(:cancel, _from, state), do: {:reply, {:error, :finished}, state}
 
   def handle_call({:subscribe, pid}, _from, %{status: :running} = state) do
-    {:reply, :subscribed, %{state | subscribers: [pid | state.subscribers]}}
+    {:reply, {:subscribed, state.id}, %{state | subscribers: [pid | state.subscribers]}}
   end
 
   def handle_call({:subscribe, _pid}, _from, state) do

--- a/packages/mcp-ex/test/ix_mcp/chaos_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/chaos_test.exs
@@ -92,4 +92,21 @@ defmodule IxMcp.ChaosTest do
     assert summary.status == :done
     assert summary.result == ":rises"
   end
+
+  test "await returns the killed terminal instead of parking when a control process is hard-killed" do
+    {job, _} = Jobs.run("Process.sleep(:infinity)", budget: 0.05, intent: "await-on-kill")
+    assert job.running
+    {:ok, pid} = Jobs.lookup(job.id)
+
+    # Await from a separate process so the old :infinity park fails as a Task
+    # timeout here instead of wedging the whole suite.
+    task = Task.async(fn -> Jobs.await(job.id, :infinity) end)
+    # Let the await subscribe and park before the kill, so this exercises the
+    # subscribed-then-killed window rather than the already-gone lookup path.
+    Process.sleep(100)
+    Process.exit(pid, :kill)
+
+    summary = Task.await(task, 10_000)
+    assert summary.status == :killed
+  end
 end


### PR DESCRIPTION
Fixes the one residual in the job-durability cluster (ENG-9605/9151/9437/8879): an `:infinity` `Jobs.await` hung when the awaited job's control process was hard-killed.

## Why
`await` subscribed to the job's control GenServer and waited only for `{:ix_job_finished, ...}`, which `finish/1` sends. A hard `Process.exit(pid, :kill)` cannot run `finish/1`, so the message never arrives and an `:infinity` await parks forever. The reaper already writes the `:killed` terminal to the durable ledger off the same `:DOWN` (#3839).

## Fix
`await` now also monitors the control process. On its `:DOWN` it reads the reaper-written terminal from the ledger via `Jobs.get/1` instead of parking. Bounded (~5s) because the reaper's write and this read both fire off the same death and can race.

## Test
New chaos test hard-kills a running job's control process and asserts `Jobs.await(id, :infinity)` returns a `:killed` summary. It runs the await inside a `Task` so the old infinite-park regression fails as a `Task.await` timeout rather than wedging the suite.

`mix test`: 183 tests, 0 failures.

(authored by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Jobs.await` to return when a job's control process is hard-killed
> - `Jobs.await` now monitors the job server process and handles a `:DOWN` message by returning `{:ok, killed_summary}` instead of parking indefinitely.
> - A new private `killed_summary` helper polls the durable job ledger via `IxMcp.Jobs.get/1` until the status is no longer `:running` or retries are exhausted.
> - `handle_call({:subscribe, pid})` now returns `{:subscribed, id}` instead of `:subscribed` so the caller has the job ID for monitoring purposes.
> - A chaos test in [chaos_test.exs](https://github.com/indexable-inc/index/pull/4161/files#diff-9d3f8d4b63448a18ffa864e8f364da797e984cad2491e654b2bcb7533b4ae2c0) verifies that awaiting a job killed with `:kill` resolves with status `:killed`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ce3bcd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->