### PR TITLE
ci: allow repository token for submodule updates

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -70,6 +70,9 @@ on:
       submodule-app-private-key:
         description: "Private key for submodule-app-client-id."
         required: false
+      submodule-read-token:
+        description: "Existing repository-managed token used to fetch private submodules when no dedicated GitHub App installation covers them."
+        required: false
       slack-bot-token:
         description: "Slack bot token (chat:write) for escalation posts; empty escalates through the tracking issue only."
         required: false
@@ -203,7 +206,7 @@ jobs:
         env:
           DIRECT_PUSH: ${{ inputs.direct-push }}
           GH_TOKEN: ${{ steps.direct-app-token.outputs.token || steps.pr-app-token.outputs.token || github.token }}
-          SUBMODULE_READ_TOKEN: ${{ steps.submodule-app-token.outputs.token }}
+          SUBMODULE_READ_TOKEN: ${{ secrets.submodule-read-token || steps.submodule-app-token.outputs.token }}
           SUBMODULE_PATHS: ${{ inputs.submodule-paths }}
           TRIGGER_USER: ${{ steps.trigger.outputs.user }}
         run: |


### PR DESCRIPTION
## Summary
- allow callers of the reusable flake updater to provide an existing repository-managed submodule read token
- retain the GitHub App token path as the default fallback

## Validation
- `git diff --check`
- `actionlint .github/workflows/update-flake-lock.yml`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow caller-provided repository token for submodule updates in CI workflow
> Adds an optional `submodule-read-token` secret to the [update-flake-lock.yml](.github/workflows/update-flake-lock.yml) reusable workflow. When provided by the caller, the 'Bump submodules' step uses it as `SUBMODULE_READ_TOKEN`; otherwise it falls back to the existing app token from `steps.submodule-app-token`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c6abb2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->