### PR TITLE
ci: separate submodule fetch and push auth

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -222,9 +222,17 @@ jobs:
             # remote without putting a fake credential in process output.
             git remote set-url origin "$UPDATE_REMOTE_URL"
           else
-            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
             clone_token="${SUBMODULE_READ_TOKEN:-${GH_TOKEN}}"
             git config --global url."https://x-access-token:${clone_token}@github.com/".insteadOf "https://github.com/"
+            # Keep the fetch URL credential-free so relative submodule URLs
+            # such as ../nox.git resolve to https://github.com/... and receive
+            # clone_token through the rewrite above. Embedding GH_TOKEN in the
+            # fetch URL makes Git carry that ix-only token into the resolved
+            # Nox URL before insteadOf matching, so the private clone fails.
+            git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+            # Pushes still use the narrowly scoped write App token. A URL with
+            # userinfo does not match the credential-free insteadOf prefix.
+            git remote set-url --push origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           fi
 
           build_candidate() {


### PR DESCRIPTION
## Summary
- keep the updater fetch URL credential-free so relative private-submodule URLs receive the read-token rewrite
- configure the ruleset-bypassing App credential only as the push URL

## Root cause
Embedding the ix-only write token in `origin` made Git resolve `../nox.git` to a URL already containing that token. It therefore never matched the Nox read-token rewrite and cloned anonymously/with the wrong installation.

## Validation
- `submodule-sync-test: PASS`
- `git diff --check`
- production E2E reproduced the pre-fix resolution behavior

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Separate submodule fetch and push auth in update-flake-lock workflow
> Previously, the `update-flake-lock` workflow set a single origin URL embedding `GH_TOKEN` for all git operations. This splits fetch and push authentication: the fetch URL is credential-free so the existing `insteadOf` rewrite injects `clone_token`, while a dedicated push URL (set via `git remote set-url --push`) embeds `GH_TOKEN` for authenticated pushes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a12ae1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->