### PR TITLE
mcp-ex: name the cell that took over a shared binding

### DIFF
--- a/packages/mcp-ex/README.md
+++ b/packages/mcp-ex/README.md
@@ -50,6 +50,42 @@ Bindings, aliases, and modules you define persist: you are building a session,
 not running one-shot snippets. `Api.api("tail")` and `Api.help(Jobs, :tail)`
 are the discovery surface, generated live from module docs.
 
+### A workspace is shared by more agents than you think
+
+One kernel is one MCP connection, and a Claude Code subagent runs on its
+parent's connection. So the parent's cells and every subagent's cells write to
+one binding map, and common names collide: a parent holding `body` as an HTML
+string had it replaced by a subagent's `body`, a list of a file's lines, and
+the parent's next `<>` raised `not a bitstring` (#3967).
+
+Nothing in the MCP protocol says who is calling (a `tools/call` carries only a
+per-call `claudecode/toolUseId`), so the kernel cannot partition bindings by
+agent. What it does instead is refuse to let a takeover be silent. Every write
+records its cell's job, intent, value shape and time, and a cell writing over
+another cell's variable is reported to both sides:
+
+```
+-- warning: shared binding: `body` was bound just now by job 7c5c9b57
+   (intent: "agent A: render the dashboard body") as a 35-byte binary; this
+   cell rebinds it as an 18-element list.
+```
+
+and then, to the cell that goes on to use it, before it uses it:
+
+```
+-- warning: shared binding: `body` changed type under this workspace: job
+   3fab397b (intent: "agent B: read a nix file into lines") rebound it just
+   now from a 35-byte binary to an 18-element list, over the value job
+   7c5c9b57 (intent: "agent A: render the dashboard body") bound just now.
+```
+
+A same-typed takeover is a `note` on the writing side only; nothing downstream
+is about to raise over it. `Ix.bindings()` lists every name with the cell that
+bound it, which is the fast answer to "whose value is this?". Modules get the
+same treatment: they are global to the BEAM whichever cell defines them, so a
+redefinition now names the cell that had it, next to the compiler's own
+`redefining module Page`.
+
 ## Tools
 
 The MCP surface is exactly one tool; everything else the Python server

--- a/packages/mcp-ex/lib/ix_mcp/checkpoint.ex
+++ b/packages/mcp-ex/lib/ix_mcp/checkpoint.ex
@@ -40,6 +40,28 @@ defmodule IxMcp.Checkpoint do
     end
   end
 
+  @doc """
+  Provenance rides its own row (#3967): who bound each variable and each
+  module, so `Ix.restart()` comes back still able to say whose value a
+  binding is. Kept apart from the binding row so the shape the disk
+  checkpoint reads and writes stays exactly what it always was.
+  """
+  @spec store_provenance(map()) :: :ok
+  def store_provenance(provenance) do
+    :ets.insert(@table, {:provenance, provenance})
+    :ok
+  end
+
+  @spec fetch_provenance() :: %{owners: map(), contested: map(), modules: map()}
+  def fetch_provenance do
+    empty = %{owners: %{}, contested: %{}, modules: %{}}
+
+    case :ets.lookup(@table, :provenance) do
+      [{:provenance, provenance}] -> Map.merge(empty, provenance)
+      [] -> empty
+    end
+  end
+
   @spec clear() :: :ok
   def clear do
     :ets.delete(@table, :workspace)

--- a/packages/mcp-ex/lib/ix_mcp/checkpoint.ex
+++ b/packages/mcp-ex/lib/ix_mcp/checkpoint.ex
@@ -65,6 +65,7 @@ defmodule IxMcp.Checkpoint do
   @spec clear() :: :ok
   def clear do
     :ets.delete(@table, :workspace)
+    :ets.delete(@table, :provenance)
     :ok
   end
 

--- a/packages/mcp-ex/lib/ix_mcp/evaluator.ex
+++ b/packages/mcp-ex/lib/ix_mcp/evaluator.ex
@@ -1,31 +1,79 @@
 defmodule IxMcp.Evaluator do
   @moduledoc """
   Evaluates one cell in the calling process, the way Livebook's
-  `Livebook.Runtime.Evaluator` does it: parse to AST, then
-  `Code.eval_quoted_with_env/4` with `:prune_binding` against a snapshot of
-  the workspace context. Output goes to whatever group leader the caller
-  installed (each job installs its own `IxMcp.Evaluator.IOProxy`).
+  `Livebook.Runtime.Evaluator` does it: `scan/1` parses to AST, then
+  `eval_quoted/3` runs it through `Code.eval_quoted_with_env/4` with
+  `:prune_binding` against a snapshot of the workspace context. Output goes
+  to whatever group leader the caller installed (each job installs its own
+  `IxMcp.Evaluator.IOProxy`).
 
-  The parse step is the per-cell gate: code that does not parse is rejected
-  with a compiler diagnostic and never evaluated. Compile-time warnings are
-  collected via `Code.with_diagnostics/2` and returned alongside the result.
+  `scan/1` is the per-cell gate: code that does not parse is rejected with a
+  compiler diagnostic and never evaluated. It is also where the names a cell
+  mentions are read off the AST, which is what lets the shared workspace warn
+  a cell about somebody else's write before the cell runs on it (#3967).
+  Compile-time warnings are collected via `Code.with_diagnostics/2` and
+  returned alongside the result.
   """
 
   @type ok :: {:ok, term(), Code.binding(), Macro.Env.t(), [String.t()]}
-  @type failure :: {:parse_error, String.t()} | {:runtime_error, String.t(), [String.t()]}
+  @type failure :: {:runtime_error, String.t(), [String.t()]}
 
-  @spec eval(String.t(), Code.binding(), Macro.Env.t()) :: ok() | failure()
-  def eval(code, binding, env) when is_binary(code) do
-    case Code.string_to_quoted(code, file: env.file, columns: true, emit_warnings: false) do
-      {:ok, quoted} ->
-        eval_quoted(quoted, binding, env)
+  @typedoc "The names a cell mentions, read off its AST before it runs."
+  @type refs :: %{vars: [atom()], modules: [module()]}
 
-      {:error, {meta, message, token}} ->
-        {:parse_error, format_parse_error(meta, message, token)}
+  @doc """
+  Parse a cell and read off what it mentions: the variables it names and the
+  modules it declares. The caller runs the resulting AST with
+  `eval_quoted/3`; splitting parse from eval is what lets the workspace warn
+  a cell about a variable another cell changed under it *before* the cell
+  uses it, since a cell that raises never reaches the merge (#3967).
+  """
+  @spec scan(String.t()) :: {:ok, Macro.t(), refs()} | {:parse_error, String.t()}
+  def scan(code) when is_binary(code) do
+    case Code.string_to_quoted(code, file: "cell", columns: true, emit_warnings: false) do
+      {:ok, quoted} -> {:ok, quoted, %{vars: variables(quoted), modules: modules(quoted)}}
+      {:error, {meta, message, token}} -> {:parse_error, format_parse_error(meta, message, token)}
     end
   end
 
-  defp eval_quoted(quoted, binding, env) do
+  # A variable node is `{name, meta, context}` with an atom context; a call
+  # carries its arguments there instead, and an alias carries a list. `_`
+  # prefixed names are deliberately throwaway and never worth reporting.
+  defp variables(quoted) do
+    {_quoted, names} =
+      Macro.prewalk(quoted, MapSet.new(), fn
+        {name, _meta, context} = node, names when is_atom(name) and is_atom(context) ->
+          {node, if(reportable_var?(name), do: MapSet.put(names, name), else: names)}
+
+        node, names ->
+          {node, names}
+      end)
+
+    Enum.sort(names)
+  end
+
+  @pseudo_vars [:__MODULE__, :__DIR__, :__ENV__, :__CALLER__, :__STACKTRACE__, :__block__]
+
+  defp reportable_var?(name) do
+    name not in @pseudo_vars and not String.starts_with?(Atom.to_string(name), "_")
+  end
+
+  defp modules(quoted) do
+    {_quoted, declared} =
+      Macro.prewalk(quoted, [], fn
+        {:defmodule, _meta, [{:__aliases__, _alias_meta, parts} | _rest]} = node, declared ->
+          {node, [Module.concat(parts) | declared]}
+
+        node, declared ->
+          {node, declared}
+      end)
+
+    Enum.reverse(declared)
+  end
+
+  @doc "Evaluate an already-parsed cell against a workspace snapshot."
+  @spec eval_quoted(Macro.t(), Code.binding(), Macro.Env.t()) :: ok() | failure()
+  def eval_quoted(quoted, binding, env) do
     {result, diagnostics} =
       Code.with_diagnostics(fn ->
         try do

--- a/packages/mcp-ex/lib/ix_mcp/evaluator.ex
+++ b/packages/mcp-ex/lib/ix_mcp/evaluator.ex
@@ -22,53 +22,114 @@ defmodule IxMcp.Evaluator do
   @type refs :: %{vars: [atom()], modules: [module()]}
 
   @doc """
-  Parse a cell and read off what it mentions: the variables it names and the
-  modules it declares. The caller runs the resulting AST with
+  Parse a cell and read off what it mentions: the workspace variables it
+  reads and the modules it declares. The caller runs the resulting AST with
   `eval_quoted/3`; splitting parse from eval is what lets the workspace warn
   a cell about a variable another cell changed under it *before* the cell
   uses it, since a cell that raises never reaches the merge (#3967).
   """
   @spec scan(String.t()) :: {:ok, Macro.t(), refs()} | {:parse_error, String.t()}
   def scan(code) when is_binary(code) do
+    # `file:` matches what `IxMcp.Workspace` puts in the eval env, which is
+    # what error positions are reported against.
     case Code.string_to_quoted(code, file: "cell", columns: true, emit_warnings: false) do
-      {:ok, quoted} -> {:ok, quoted, %{vars: variables(quoted), modules: modules(quoted)}}
+      {:ok, quoted} -> {:ok, quoted, read_refs(quoted)}
       {:error, {meta, message, token}} -> {:parse_error, format_parse_error(meta, message, token)}
     end
   end
 
-  # A variable node is `{name, meta, context}` with an atom context; a call
-  # carries its arguments there instead, and an alias carries a list. `_`
-  # prefixed names are deliberately throwaway and never worth reporting.
-  defp variables(quoted) do
-    {_quoted, names} =
-      Macro.prewalk(quoted, MapSet.new(), fn
+  # One walk, three questions: which names does the cell mention, which of
+  # those does it introduce itself, and which modules does it declare. A name
+  # the cell introduces in a clause head is that clause's own variable and
+  # says nothing about the workspace's, so `fn body -> body end` must not
+  # count as reading the workspace's `body`. An `=` is deliberately not a
+  # binder here: `body = String.trim(body)` genuinely reads the old value.
+  defp read_refs(quoted) do
+    {_quoted, acc} =
+      Macro.prewalk(quoted, %{vars: MapSet.new(), bound: MapSet.new(), modules: []}, &visit/2)
+
+    %{
+      vars: acc.vars |> MapSet.difference(acc.bound) |> Enum.sort(),
+      modules: Enum.reverse(acc.modules)
+    }
+  end
+
+  # A `defmodule`/`def` body is its own scope and cannot see cell variables at
+  # all, and a `quote` block is code that may never run; neither tells us
+  # anything about what this cell reads, so both are walked for nothing but
+  # the module names `defmodule` claims.
+  defp visit({:quote, _meta, _args} = node, acc), do: {skip(node), acc}
+
+  defp visit({:defmodule, _meta, [alias_node | rest]} = node, acc) do
+    acc =
+      case declared_module(alias_node) do
+        nil -> acc
+        module -> %{acc | modules: [module | acc.modules]}
+      end
+
+    # Walk the body for nested defmodules only; nothing in it reads the cell.
+    {_walked, inner} =
+      Macro.prewalk(rest, %{acc | vars: MapSet.new(), bound: MapSet.new()}, &visit/2)
+
+    {skip(node), %{acc | modules: inner.modules}}
+  end
+
+  defp visit({def_kind, _meta, _args} = node, acc) when def_kind in [:def, :defp, :defmacro],
+    do: {skip(node), acc}
+
+  # `fn`, `case`, `with`, `for`, `try` and friends all reach the compiler as
+  # `->` clauses; a `<-` generator binds the same way.
+  defp visit({:->, _meta, [head, _body]} = node, acc),
+    do: {node, %{acc | bound: MapSet.union(acc.bound, pattern_vars(head))}}
+
+  defp visit({:<-, _meta, [pattern, _source]} = node, acc),
+    do: {node, %{acc | bound: MapSet.union(acc.bound, pattern_vars(pattern))}}
+
+  # A pin reads the outer value even inside a pattern, so it is a mention
+  # that no clause head can take away.
+  defp visit({:^, _meta, [{name, _var_meta, context}]} = node, acc)
+       when is_atom(name) and is_atom(context) do
+    {node, %{acc | bound: MapSet.delete(acc.bound, name), vars: MapSet.put(acc.vars, name)}}
+  end
+
+  defp visit({name, _meta, context} = node, acc) when is_atom(name) and is_atom(context) do
+    {node, if(mentionable?(name), do: %{acc | vars: MapSet.put(acc.vars, name)}, else: acc)}
+  end
+
+  defp visit(node, acc), do: {node, acc}
+
+  # Replacing a node with an atom is how a prewalk declines to descend.
+  defp skip(_node), do: :__skipped__
+
+  # `defmodule __MODULE__.Inner` and `defmodule unquote(name)` name a module
+  # the AST cannot resolve; there is nothing to claim and `Module.concat/1`
+  # would raise on the attempt.
+  defp declared_module({:__aliases__, _meta, parts}) do
+    if Enum.all?(parts, &is_atom/1), do: Module.concat(parts)
+  end
+
+  defp declared_module(_other), do: nil
+
+  defp pattern_vars(pattern) do
+    {_pattern, names} =
+      Macro.prewalk(pattern, MapSet.new(), fn
+        {:^, _meta, _args} = node, names ->
+          {skip(node), names}
+
         {name, _meta, context} = node, names when is_atom(name) and is_atom(context) ->
-          {node, if(reportable_var?(name), do: MapSet.put(names, name), else: names)}
+          {node, if(mentionable?(name), do: MapSet.put(names, name), else: names)}
 
         node, names ->
           {node, names}
       end)
 
-    Enum.sort(names)
+    names
   end
 
   @pseudo_vars [:__MODULE__, :__DIR__, :__ENV__, :__CALLER__, :__STACKTRACE__, :__block__]
 
-  defp reportable_var?(name) do
+  defp mentionable?(name) do
     name not in @pseudo_vars and not String.starts_with?(Atom.to_string(name), "_")
-  end
-
-  defp modules(quoted) do
-    {_quoted, declared} =
-      Macro.prewalk(quoted, [], fn
-        {:defmodule, _meta, [{:__aliases__, _alias_meta, parts} | _rest]} = node, declared ->
-          {node, [Module.concat(parts) | declared]}
-
-        node, declared ->
-          {node, declared}
-      end)
-
-    Enum.reverse(declared)
   end
 
   @doc "Evaluate an already-parsed cell against a workspace snapshot."

--- a/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
@@ -395,6 +395,7 @@ defmodule IxMcp.Jobs.Job do
     job = self()
     code = state.code
     id = state.id
+    writer = writer(state)
 
     {eval_pid, eval_ref} =
       spawn_monitor(fn ->
@@ -405,18 +406,7 @@ defmodule IxMcp.Jobs.Job do
         Process.put(:ix_job_id, id)
         {binding, env} = Workspace.snapshot()
 
-        outcome =
-          case Evaluator.eval(code, binding, env) do
-            {:ok, value, binding, env, diags} ->
-              Workspace.merge(binding, env)
-              {:done, value, diags}
-
-            {:parse_error, message} ->
-              {:failed, "parse error: " <> message, []}
-
-            {:runtime_error, formatted, diags} ->
-              {:failed, formatted, diags}
-          end
+        outcome = evaluate(code, binding, env, writer)
 
         send(job, {:eval_finished, self(), outcome})
       end)
@@ -426,6 +416,42 @@ defmodule IxMcp.Jobs.Job do
 
     {:noreply,
      %{state | io_proxy: io_proxy, eval_pid: eval_pid, eval_ref: eval_ref, flush_scheduled: true}}
+  end
+
+  # Who this cell is, for the shared workspace's provenance (#3967): one
+  # kernel is one session but not one agent, so the job id is the finest
+  # writer identity there is, and its intent is what makes it recognizable
+  # to the agent reading the warning.
+  defp writer(state) do
+    %{
+      job: state.id,
+      intent: state.intent,
+      session_id: state.session_id,
+      session: state.session
+    }
+  end
+
+  # The workspace speaks twice: once before the cell runs, about variables
+  # another cell changed under it and modules it is about to take over, and
+  # once after, about the variables this cell took from somebody else. The
+  # first has to come before evaluation, because the cell holding a clobbered
+  # value is usually the cell that raises, and a raising cell never merges.
+  defp evaluate(code, binding, env, writer) do
+    case Evaluator.scan(code) do
+      {:ok, quoted, refs} ->
+        before = Workspace.check_cell(refs, writer)
+
+        case Evaluator.eval_quoted(quoted, binding, env) do
+          {:ok, value, binding, env, diags} ->
+            {:done, value, before ++ diags ++ Workspace.merge(binding, env, writer)}
+
+          {:runtime_error, formatted, diags} ->
+            {:failed, formatted, before ++ diags}
+        end
+
+      {:parse_error, message} ->
+        {:failed, "parse error: " <> message, []}
+    end
   end
 
   @impl true

--- a/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
+++ b/packages/mcp-ex/lib/ix_mcp/jobs/job.ex
@@ -404,9 +404,8 @@ defmodule IxMcp.Jobs.Job do
         # a quiet wrapper through this, #3934). Process dictionary, not a
         # closure: the id must be readable from inside the running cell.
         Process.put(:ix_job_id, id)
-        {binding, env} = Workspace.snapshot()
 
-        outcome = evaluate(code, binding, env, writer)
+        outcome = evaluate(code, writer)
 
         send(job, {:eval_finished, self(), outcome})
       end)
@@ -436,14 +435,17 @@ defmodule IxMcp.Jobs.Job do
   # once after, about the variables this cell took from somebody else. The
   # first has to come before evaluation, because the cell holding a clobbered
   # value is usually the cell that raises, and a raising cell never merges.
-  defp evaluate(code, binding, env, writer) do
+  defp evaluate(code, writer) do
     case Evaluator.scan(code) do
       {:ok, quoted, refs} ->
-        before = Workspace.check_cell(refs, writer)
+        # One visit to the workspace, so the warnings describe exactly the
+        # values this cell was handed rather than whatever a concurrent cell
+        # merged between the snapshot and the question.
+        {binding, env, before} = Workspace.begin_cell(refs, writer)
 
         case Evaluator.eval_quoted(quoted, binding, env) do
           {:ok, value, binding, env, diags} ->
-            {:done, value, before ++ diags ++ Workspace.merge(binding, env, writer)}
+            {:done, value, before ++ diags ++ Workspace.merge(binding, env, refs, writer)}
 
           {:runtime_error, formatted, diags} ->
             {:failed, formatted, before ++ diags}

--- a/packages/mcp-ex/lib/ix_mcp/kernel.ex
+++ b/packages/mcp-ex/lib/ix_mcp/kernel.ex
@@ -15,10 +15,21 @@ defmodule IxMcp.Kernel do
     Blast radius: this server's jobs, nothing else. When called from a cell,
     that cell's own job is spared so the restart runs to completion and the
     report comes back.
+  * `bindings/0` -- every bound name with the cell that bound it. One
+    kernel's workspace is shared by every agent riding its connection, so
+    "who bound this?" is a real question (#3967).
   """
 
   alias IxMcp.Jobs
   alias IxMcp.Jobs.Job
+
+  @doc """
+  Every bound name with its owner: the job that wrote it, that job's intent,
+  the value's shape, and when. The answer to a variable holding somebody
+  else's work.
+  """
+  @spec bindings() :: [map()]
+  def bindings, do: IxMcp.Workspace.owners()
 
   @doc "Human-readable stack report for all running jobs and core server processes."
   @spec trace() :: String.t()

--- a/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
+++ b/packages/mcp-ex/lib/ix_mcp/mcp/tools.ex
@@ -48,6 +48,12 @@ defmodule IxMcp.MCP.Tools do
                                             default cd: to the kernel's launch dir
                                             (never the movable OS cwd, #3902), so
                                             pass cd: or -C to work elsewhere
+      Ix.bindings()                         every bound name with the cell that bound it:
+                                            job, intent, value shape, time. This kernel's
+                                            bindings are shared by every agent riding its
+                                            connection -- a session and its subagents
+                                            alike -- so a cell taking over another cell's
+                                            variable is reported to both sides (#3967)
       Ix.trace()                            stack dump of every running job's processes,
                                             taken from outside with Process.info/2
       Ix.restart()                          cancel running jobs (sparing the calling

--- a/packages/mcp-ex/lib/ix_mcp/workspace.ex
+++ b/packages/mcp-ex/lib/ix_mcp/workspace.ex
@@ -6,6 +6,17 @@ defmodule IxMcp.Workspace do
   the race concurrent Python cells already had on the shared namespace, minus
   the ability to freeze each other.
 
+  One kernel instance is one MCP connection is one session row, but not one
+  agent: a Claude Code subagent runs on its parent's connection, so the
+  parent and every subagent it fans out share this binding map (#3967). No
+  caller identity reaches the kernel (a `tools/call` carries only a per-call
+  `claudecode/toolUseId`), so bindings cannot be partitioned by agent. What
+  the kernel can do is say who wrote what: every write records its cell's
+  job, intent and value type, and a write over another cell's variable is
+  reported to both sides. The clobbering cell is told what it replaced; a
+  later cell that mentions a variable whose type another cell changed is
+  told before it uses it, which is where the silent corruption used to land.
+
   Every merge is checkpointed into `IxMcp.Checkpoint` (an ETS table owned by a
   different process), so killing or restarting this server -- the analog of a
   kernel restart -- loses nothing: `init/1` restores the last checkpoint.
@@ -22,6 +33,28 @@ defmodule IxMcp.Workspace do
              "alias IxMcp.Serve; " <>
              "alias IxMcp.Requests"
 
+  @typedoc "Who is writing: the cell's job, its intent, and its session row."
+  @type writer :: %{
+          job: String.t() | nil,
+          intent: String.t() | nil,
+          session_id: integer() | nil,
+          session: String.t() | nil
+        }
+
+  @typedoc "What a recorded write knows about itself."
+  @type owner :: %{
+          job: String.t() | nil,
+          intent: String.t() | nil,
+          session_id: integer() | nil,
+          session: String.t() | nil,
+          at: DateTime.t(),
+          tag: atom(),
+          shape: String.t()
+        }
+
+  @typedoc "What a cell mentions, read off its AST before it runs."
+  @type refs :: %{vars: [atom()], modules: [module()]}
+
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
@@ -33,10 +66,28 @@ defmodule IxMcp.Workspace do
     GenServer.call(__MODULE__, :snapshot)
   end
 
-  @doc "Merge a finished cell's resulting context back into the shared state."
-  @spec merge(Code.binding(), Macro.Env.t()) :: :ok
-  def merge(binding, env) do
-    GenServer.call(__MODULE__, {:merge, binding, env})
+  @doc """
+  What the cell about to run should be told, and the module claims it makes.
+
+  Called with the names the cell's source mentions, before it evaluates, so
+  the warning lands above the failure rather than after it: a cell that
+  crashes never merges, and the read side of a clobber is exactly the cell
+  that crashes. Returns diagnostic lines, and records this cell as the
+  definer of the modules it declares.
+  """
+  @spec check_cell(refs(), writer()) :: [String.t()]
+  def check_cell(refs, writer) do
+    GenServer.call(__MODULE__, {:check_cell, refs, writer})
+  end
+
+  @doc """
+  Merge a finished cell's resulting context back into the shared state.
+  Returns a diagnostic line for every variable this cell took over from
+  another cell.
+  """
+  @spec merge(Code.binding(), Macro.Env.t(), writer()) :: [String.t()]
+  def merge(binding, env, writer) do
+    GenServer.call(__MODULE__, {:merge, binding, env, writer})
   end
 
   @doc "Names bound right now (for introspection / api surface)."
@@ -44,6 +95,16 @@ defmodule IxMcp.Workspace do
   def names do
     {binding, _env} = snapshot()
     binding |> Keyword.keys() |> Enum.sort()
+  end
+
+  @doc """
+  Every bound name with the cell that bound it: name, value shape, and the
+  job, intent, session and time of the write. This is how a cell finds out
+  that the `body` it is holding came from somebody else's work.
+  """
+  @spec owners() :: [map()]
+  def owners do
+    GenServer.call(__MODULE__, :owners)
   end
 
   @doc "Drop all bindings and start from the prelude env again."
@@ -54,10 +115,13 @@ defmodule IxMcp.Workspace do
 
   @impl true
   def init(_) do
-    case IxMcp.Checkpoint.fetch() do
-      {:ok, binding, env} -> {:ok, %{binding: binding, env: env}}
-      :empty -> {:ok, fresh()}
-    end
+    state =
+      case IxMcp.Checkpoint.fetch() do
+        {:ok, binding, env} -> %{binding: binding, env: env}
+        :empty -> fresh()
+      end
+
+    {:ok, Map.merge(state, IxMcp.Checkpoint.fetch_provenance())}
   end
 
   @impl true
@@ -65,19 +129,256 @@ defmodule IxMcp.Workspace do
     {:reply, {state.binding, state.env}, state}
   end
 
-  def handle_call({:merge, binding, env}, _from, state) do
+  def handle_call(:owners, _from, state) do
+    rows =
+      state.owners
+      |> Enum.sort_by(fn {name, _owner} -> name end)
+      |> Enum.map(fn {name, owner} ->
+        %{
+          name: name,
+          shape: owner.shape,
+          job: owner.job,
+          intent: owner.intent,
+          session_id: owner.session_id,
+          session: owner.session,
+          at: owner.at
+        }
+      end)
+
+    {:reply, rows, state}
+  end
+
+  def handle_call({:check_cell, refs, writer}, _from, state) do
+    now = DateTime.utc_now()
+
+    var_warnings =
+      Enum.flat_map(Map.get(refs, :vars, []), &contested_warning(state, &1, writer, now))
+
+    {module_warnings, modules} = claim_modules(state, Map.get(refs, :modules, []), writer, now)
+
+    state = %{state | modules: modules}
+    checkpoint_provenance(state)
+    {:reply, var_warnings ++ module_warnings, state}
+  end
+
+  def handle_call({:merge, binding, env, writer}, _from, state) do
+    now = DateTime.utc_now()
+
+    {warnings, owners, contested} =
+      Enum.reduce(binding, {[], state.owners, state.contested}, fn {name, value}, acc ->
+        record_write(state, name, value, writer, now, acc)
+      end)
+
     # Variables the cell bound or rebound win; variables it never touched
     # (pruned from its returned binding) keep their current values.
     merged = Keyword.merge(state.binding, binding)
-    state = %{state | binding: merged, env: env}
+
+    state = %{
+      state
+      | binding: merged,
+        env: env,
+        owners: owners,
+        contested: contested
+    }
+
     IxMcp.Checkpoint.store(state.binding, state.env)
-    {:reply, :ok, state}
+    checkpoint_provenance(state)
+    {:reply, Enum.reverse(warnings), state}
   end
 
   def handle_call(:reset, _from, _state) do
     state = fresh()
     IxMcp.Checkpoint.store(state.binding, state.env)
+    checkpoint_provenance(state)
     {:reply, :ok, state}
+  end
+
+  # A name the cell merely read comes back from `prune_binding` holding the
+  # very term it was given, so an identical value is not a write and must not
+  # take ownership away from the cell that produced it.
+  defp record_write(state, name, value, writer, now, {warnings, owners, contested}) do
+    case Keyword.fetch(state.binding, name) do
+      {:ok, previous} when previous === value ->
+        {warnings, owners, contested}
+
+      previous ->
+        mine = describe(value, writer, now)
+        taken_over = takeover(Map.get(state.owners, name), writer)
+
+        {warnings, contested} =
+          case {previous, taken_over} do
+            {{:ok, was}, %{} = theirs} ->
+              rebind(name, was, theirs, value, mine, warnings, contested)
+
+            _first_binding_or_own_variable ->
+              {warnings, Map.delete(contested, name)}
+          end
+
+        {warnings, Map.put(owners, name, mine), contested}
+    end
+  end
+
+  defp rebind(name, was, theirs, value, mine, warnings, contested) do
+    warning =
+      "#{severity(theirs, mine)}: shared binding: `#{name}` was bound #{ago(theirs.at, mine.at)} " <>
+        "by #{origin(theirs, mine)} as #{shape(was, theirs)}; this cell rebinds it as " <>
+        "#{shape(value, mine)}. #{tail(theirs, mine)}"
+
+    contested =
+      if theirs.tag == mine.tag do
+        Map.delete(contested, name)
+      else
+        Map.put(contested, name, %{was: theirs, now: mine})
+      end
+
+    {[warning | warnings], contested}
+  end
+
+  # The read side of a clobber: reported to any later cell whose source
+  # mentions the name, until somebody binds it again. A type change is the
+  # one that raises (`body` went from a String to a list of lines and the
+  # next cell's `<>` blew up on it, #3967), so it is the one worth stopping
+  # a cell over; a same-typed takeover is reported to the writer only.
+  defp contested_warning(state, name, reader, now) do
+    case Map.fetch(state.contested, name) do
+      {:ok, %{was: was, now: took}} ->
+        [
+          "warning: shared binding: `#{name}` changed type under this workspace: " <>
+            "#{origin(took, reader)} rebound it #{ago(took.at, now)} from #{was.shape} to " <>
+            "#{took.shape}, over the value #{origin(was, reader)} bound #{ago(was.at, now)}. " <>
+            "Check it before using it."
+        ]
+
+      :error ->
+        []
+    end
+  end
+
+  # Modules are global to the BEAM no matter whose cell defines them, so
+  # redefinition stays legal and stays warned about -- the compiler's own
+  # "redefining module Page" says nothing about who had it first.
+  defp claim_modules(state, declared, writer, now) do
+    Enum.reduce(declared, {[], state.modules}, fn module, {warnings, modules} ->
+      mine = %{
+        job: writer.job,
+        intent: writer.intent,
+        session_id: writer.session_id,
+        session: writer.session,
+        at: now,
+        tag: :module,
+        shape: "a module"
+      }
+
+      case takeover(Map.get(modules, module), writer) do
+        %{} = theirs ->
+          warning =
+            "warning: shared module: #{inspect(module)} was defined #{ago(theirs.at, now)} by " <>
+              "#{origin(theirs, mine)}; this cell redefines it for every agent on this kernel, " <>
+              "because modules are global to the BEAM."
+
+          {warnings ++ [warning], Map.put(modules, module, mine)}
+
+        nil ->
+          {warnings, Map.put(modules, module, mine)}
+      end
+    end)
+  end
+
+  # A cell rewriting its own variable is not a collision: the same job means
+  # the same cell, and a cell is the smallest unit any single agent runs.
+  defp takeover(nil, _writer), do: nil
+  defp takeover(%{job: nil}, _writer), do: nil
+  defp takeover(%{job: job} = owner, %{job: mine}) when job != mine, do: owner
+  defp takeover(_owner, _writer), do: nil
+
+  defp severity(theirs, mine) do
+    if theirs.tag == mine.tag, do: "note", else: "warning"
+  end
+
+  # A same-typed takeover is a one-line note over ordinary sequential work as
+  # often as it is a collision, so it stays short; the type change, the one
+  # that has a raise waiting downstream, gets the whole explanation.
+  defp tail(theirs, mine) do
+    if theirs.tag == mine.tag do
+      "`Ix.bindings()` names who bound what."
+    else
+      "One kernel's bindings are shared by every agent on it, a session and " <>
+        "its subagents alike; `Ix.bindings()` names who bound what."
+    end
+  end
+
+  defp origin(owner, reader) do
+    said = if owner.intent, do: " (intent: #{inspect(owner.intent)})", else: ""
+
+    session =
+      if owner.session_id && owner.session_id != Map.get(reader, :session_id) do
+        ", session #{owner.session_id}#{if owner.session, do: " (#{owner.session})", else: ""}"
+      else
+        ""
+      end
+
+    "job #{owner.job}#{said}#{session}"
+  end
+
+  defp describe(value, writer, now) do
+    %{
+      job: writer.job,
+      intent: writer.intent,
+      session_id: writer.session_id,
+      session: writer.session,
+      at: now,
+      tag: tag(value),
+      shape: shape_of(value)
+    }
+  end
+
+  # The recorded shape is what the value looked like when it was written;
+  # `shape/2` prefers it so a warning never re-walks a stale megabyte.
+  defp shape(_value, %{shape: shape}) when is_binary(shape), do: shape
+  defp shape(value, _owner), do: shape_of(value)
+
+  defp tag(value) when is_binary(value), do: :binary
+  defp tag(value) when is_list(value), do: :list
+  defp tag(%module{}), do: module
+  defp tag(value) when is_map(value), do: :map
+  defp tag(value) when is_tuple(value), do: :tuple
+  defp tag(value) when is_integer(value), do: :integer
+  defp tag(value) when is_float(value), do: :float
+  defp tag(value) when is_atom(value), do: :atom
+  defp tag(value) when is_function(value), do: :function
+  defp tag(value) when is_pid(value), do: :pid
+  defp tag(_value), do: :term
+
+  defp shape_of(value) when is_binary(value), do: counted(byte_size(value), "byte binary")
+  defp shape_of(value) when is_list(value), do: counted(length(value), "element list")
+  defp shape_of(%module{}), do: "a #{inspect(module)} struct"
+  defp shape_of(value) when is_map(value), do: counted(map_size(value), "key map")
+  defp shape_of(value) when is_tuple(value), do: counted(tuple_size(value), "element tuple")
+  defp shape_of(value) when is_integer(value), do: "the integer #{value}"
+  defp shape_of(value) when is_float(value), do: "a float"
+  defp shape_of(value) when is_atom(value), do: "the atom #{inspect(value)}"
+  defp shape_of(value) when is_function(value), do: "a function"
+  defp shape_of(_value), do: "a term"
+
+  # "an 18-element list", not "a 18-element list": eight and eighteen are the
+  # only counts whose spoken form opens on a vowel.
+  defp counted(n, noun) do
+    digits = Integer.to_string(n)
+    vowel = String.starts_with?(digits, "8") or n in [11, 18]
+    "#{if vowel, do: "an", else: "a"} #{n}-#{noun}"
+  end
+
+  defp ago(then, now) do
+    case DateTime.diff(now, then) do
+      s when s < 2 -> "just now"
+      s when s < 90 -> "#{s}s ago"
+      s when s < 5400 -> "#{div(s, 60)}m ago"
+      s -> "#{div(s, 3600)}h ago"
+    end
+  end
+
+  defp checkpoint_provenance(state) do
+    IxMcp.Checkpoint.store_provenance(Map.take(state, [:owners, :contested, :modules]))
   end
 
   defp fresh do
@@ -85,7 +386,7 @@ defmodule IxMcp.Workspace do
     # Evaluate the prelude so its aliases live in the env every cell sees;
     # cells can then write `Jobs.tail("ab12", 20)` with no setup.
     {_value, binding, env} = Code.eval_quoted_with_env(quoted_prelude(), [], env)
-    %{binding: binding, env: env}
+    %{binding: binding, env: env, owners: %{}, contested: %{}, modules: %{}}
   end
 
   defp quoted_prelude do

--- a/packages/mcp-ex/lib/ix_mcp/workspace.ex
+++ b/packages/mcp-ex/lib/ix_mcp/workspace.ex
@@ -24,6 +24,8 @@ defmodule IxMcp.Workspace do
 
   use GenServer
 
+  alias IxMcp.Evaluator
+
   # `Kernel` would shadow Elixir's; cells reach trace/restart as `Ix`.
   @prelude "alias IxMcp.Jobs; alias IxMcp.Api; alias IxMcp.Fleet; " <>
              "alias IxMcp.Read; alias IxMcp.Edit; alias IxMcp.PrWatch; alias IxMcp.Tui; " <>
@@ -52,9 +54,6 @@ defmodule IxMcp.Workspace do
           shape: String.t()
         }
 
-  @typedoc "What a cell mentions, read off its AST before it runs."
-  @type refs :: %{vars: [atom()], modules: [module()]}
-
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
@@ -67,27 +66,30 @@ defmodule IxMcp.Workspace do
   end
 
   @doc """
-  What the cell about to run should be told, and the module claims it makes.
+  Open a cell: the {binding, env} it evaluates against, plus what it should
+  be told before it runs.
 
-  Called with the names the cell's source mentions, before it evaluates, so
-  the warning lands above the failure rather than after it: a cell that
-  crashes never merges, and the read side of a clobber is exactly the cell
-  that crashes. Returns diagnostic lines, and records this cell as the
-  definer of the modules it declares.
+  One call, not a snapshot followed by a question, so the warnings describe
+  exactly the values the cell is handed. The warnings come before evaluation
+  because a cell that raises never merges, and the cell holding a clobbered
+  value is usually the cell that raises. Nothing is recorded here; a cell
+  that fails claims nothing.
   """
-  @spec check_cell(refs(), writer()) :: [String.t()]
-  def check_cell(refs, writer) do
-    GenServer.call(__MODULE__, {:check_cell, refs, writer})
+  @spec begin_cell(Evaluator.refs(), writer()) ::
+          {Code.binding(), Macro.Env.t(), [String.t()]}
+  def begin_cell(refs, writer) do
+    GenServer.call(__MODULE__, {:begin_cell, refs, writer})
   end
 
   @doc """
-  Merge a finished cell's resulting context back into the shared state.
-  Returns a diagnostic line for every variable this cell took over from
-  another cell.
+  Merge a finished cell's resulting context back into the shared state, and
+  record it as the owner of the variables it wrote and the modules it
+  declared. Returns a diagnostic line for every variable this cell took over
+  from another cell.
   """
-  @spec merge(Code.binding(), Macro.Env.t(), writer()) :: [String.t()]
-  def merge(binding, env, writer) do
-    GenServer.call(__MODULE__, {:merge, binding, env, writer})
+  @spec merge(Code.binding(), Macro.Env.t(), Evaluator.refs(), writer()) :: [String.t()]
+  def merge(binding, env, refs, writer) do
+    GenServer.call(__MODULE__, {:merge, binding, env, refs, writer})
   end
 
   @doc "Names bound right now (for introspection / api surface)."
@@ -129,44 +131,39 @@ defmodule IxMcp.Workspace do
     {:reply, {state.binding, state.env}, state}
   end
 
+  # Driven off the binding, not off the provenance map: a name restored from
+  # a checkpoint written before this existed has a value and no owner, and
+  # leaving it out would report an empty workspace that is not empty.
   def handle_call(:owners, _from, state) do
     rows =
-      state.owners
-      |> Enum.sort_by(fn {name, _owner} -> name end)
-      |> Enum.map(fn {name, owner} ->
-        %{
-          name: name,
-          shape: owner.shape,
-          job: owner.job,
-          intent: owner.intent,
-          session_id: owner.session_id,
-          session: owner.session,
-          at: owner.at
-        }
-      end)
+      state.binding
+      |> Enum.sort_by(fn {name, _value} -> name end)
+      |> Enum.map(fn {name, value} -> row(name, value, Map.get(state.owners, name)) end)
 
     {:reply, rows, state}
   end
 
-  def handle_call({:check_cell, refs, writer}, _from, state) do
+  def handle_call({:begin_cell, refs, writer}, _from, state) do
     now = DateTime.utc_now()
 
-    var_warnings =
-      Enum.flat_map(Map.get(refs, :vars, []), &contested_warning(state, &1, writer, now))
+    warnings =
+      Enum.flat_map(Map.get(refs, :vars, []), &contested_warning(state, &1, writer, now)) ++
+        Enum.flat_map(Map.get(refs, :modules, []), &module_warning(state, &1, writer, now))
 
-    {module_warnings, modules} = claim_modules(state, Map.get(refs, :modules, []), writer, now)
-
-    state = %{state | modules: modules}
-    checkpoint_provenance(state)
-    {:reply, var_warnings ++ module_warnings, state}
+    {:reply, {state.binding, state.env, warnings}, state}
   end
 
-  def handle_call({:merge, binding, env, writer}, _from, state) do
+  def handle_call({:merge, binding, env, refs, writer}, _from, state) do
     now = DateTime.utc_now()
 
     {warnings, owners, contested} =
       Enum.reduce(binding, {[], state.owners, state.contested}, fn {name, value}, acc ->
         record_write(state, name, value, writer, now, acc)
+      end)
+
+    modules =
+      Enum.reduce(Map.get(refs, :modules, []), state.modules, fn module, modules ->
+        Map.put(modules, module, definition(writer, now))
       end)
 
     # Variables the cell bound or rebound win; variables it never touched
@@ -178,7 +175,8 @@ defmodule IxMcp.Workspace do
       | binding: merged,
         env: env,
         owners: owners,
-        contested: contested
+        contested: contested,
+        modules: modules
     }
 
     IxMcp.Checkpoint.store(state.binding, state.env)
@@ -196,6 +194,8 @@ defmodule IxMcp.Workspace do
   # A name the cell merely read comes back from `prune_binding` holding the
   # very term it was given, so an identical value is not a write and must not
   # take ownership away from the cell that produced it.
+  defp record_write(_state, name, _value, _writer, _now, acc) when not is_atom(name), do: acc
+
   defp record_write(state, name, value, writer, now, {warnings, owners, contested}) do
     case Keyword.fetch(state.binding, name) do
       {:ok, previous} when previous === value ->
@@ -211,7 +211,7 @@ defmodule IxMcp.Workspace do
               rebind(name, was, theirs, value, mine, warnings, contested)
 
             _first_binding_or_own_variable ->
-              {warnings, Map.delete(contested, name)}
+              {warnings, settle(contested, name, mine)}
           end
 
         {warnings, Map.put(owners, name, mine), contested}
@@ -225,13 +225,28 @@ defmodule IxMcp.Workspace do
         "#{shape(value, mine)}. #{tail(theirs, mine)}"
 
     contested =
-      if theirs.tag == mine.tag do
-        Map.delete(contested, name)
-      else
-        Map.put(contested, name, %{was: theirs, now: mine})
+      cond do
+        theirs.tag == mine.tag -> Map.delete(contested, name)
+        restores?(contested, name, mine) -> Map.delete(contested, name)
+        true -> Map.put(contested, name, %{was: theirs, now: mine})
       end
 
     {[warning | warnings], contested}
+  end
+
+  defp restores?(contested, name, mine) do
+    match?({:ok, %{was: %{tag: tag}}} when tag == mine.tag, Map.fetch(contested, name))
+  end
+
+  # A write that puts the name back to the type it was contested away from is
+  # the repair, not a second incident: clearing here is what stops the cell
+  # that fixed `body` from being reported as the cell that broke it.
+  defp settle(contested, name, mine) do
+    case Map.fetch(contested, name) do
+      {:ok, %{was: %{tag: tag}}} when tag == mine.tag -> Map.delete(contested, name)
+      {:ok, _still_contested} -> contested
+      :error -> contested
+    end
   end
 
   # The read side of a clobber: reported to any later cell whose source
@@ -256,32 +271,56 @@ defmodule IxMcp.Workspace do
 
   # Modules are global to the BEAM no matter whose cell defines them, so
   # redefinition stays legal and stays warned about -- the compiler's own
-  # "redefining module Page" says nothing about who had it first.
-  defp claim_modules(state, declared, writer, now) do
-    Enum.reduce(declared, {[], state.modules}, fn module, {warnings, modules} ->
-      mine = %{
-        job: writer.job,
-        intent: writer.intent,
-        session_id: writer.session_id,
-        session: writer.session,
-        at: now,
-        tag: :module,
-        shape: "a module"
-      }
+  # "redefining module Page" says nothing about who had it first. Reported
+  # before the cell runs, recorded only when it succeeds.
+  defp module_warning(state, module, writer, now) do
+    case takeover(Map.get(state.modules, module), writer) do
+      %{} = theirs ->
+        [
+          "warning: shared module: #{inspect(module)} was defined #{ago(theirs.at, now)} by " <>
+            "#{origin(theirs, writer)}; this cell redefines it for every agent on this " <>
+            "kernel, because modules are global to the BEAM."
+        ]
 
-      case takeover(Map.get(modules, module), writer) do
-        %{} = theirs ->
-          warning =
-            "warning: shared module: #{inspect(module)} was defined #{ago(theirs.at, now)} by " <>
-              "#{origin(theirs, mine)}; this cell redefines it for every agent on this kernel, " <>
-              "because modules are global to the BEAM."
+      nil ->
+        []
+    end
+  end
 
-          {warnings ++ [warning], Map.put(modules, module, mine)}
+  defp definition(writer, now) do
+    %{
+      job: writer.job,
+      intent: writer.intent,
+      session_id: writer.session_id,
+      session: writer.session,
+      at: now,
+      tag: :module,
+      shape: "a module"
+    }
+  end
 
-        nil ->
-          {warnings, Map.put(modules, module, mine)}
-      end
-    end)
+  defp row(name, value, nil) do
+    %{
+      name: name,
+      shape: shape_of(value),
+      job: nil,
+      intent: nil,
+      session_id: nil,
+      session: nil,
+      at: nil
+    }
+  end
+
+  defp row(name, _value, owner) do
+    %{
+      name: name,
+      shape: owner.shape,
+      job: owner.job,
+      intent: owner.intent,
+      session_id: owner.session_id,
+      session: owner.session,
+      at: owner.at
+    }
   end
 
   # A cell rewriting its own variable is not a collision: the same job means
@@ -349,16 +388,25 @@ defmodule IxMcp.Workspace do
   defp tag(value) when is_pid(value), do: :pid
   defp tag(_value), do: :term
 
-  defp shape_of(value) when is_binary(value), do: counted(byte_size(value), "byte binary")
-  defp shape_of(value) when is_list(value), do: counted(length(value), "element list")
-  defp shape_of(%module{}), do: "a #{inspect(module)} struct"
-  defp shape_of(value) when is_map(value), do: counted(map_size(value), "key map")
-  defp shape_of(value) when is_tuple(value), do: counted(tuple_size(value), "element tuple")
-  defp shape_of(value) when is_integer(value), do: "the integer #{value}"
-  defp shape_of(value) when is_float(value), do: "a float"
-  defp shape_of(value) when is_atom(value), do: "the atom #{inspect(value)}"
-  defp shape_of(value) when is_function(value), do: "a function"
-  defp shape_of(_value), do: "a term"
+  # Nothing about describing a value may take the workspace down: this runs
+  # inside the GenServer every cell blocks on, and an improper list bound as
+  # iodata (`["a" | "b"]`) is enough to make `length/1` raise (#3967).
+  defp shape_of(value) do
+    describe_shape(value)
+  rescue
+    _any -> "a term"
+  end
+
+  defp describe_shape(value) when is_binary(value), do: counted(byte_size(value), "byte binary")
+  defp describe_shape(value) when is_list(value), do: counted(length(value), "element list")
+  defp describe_shape(%module{}), do: "a #{inspect(module)} struct"
+  defp describe_shape(value) when is_map(value), do: counted(map_size(value), "key map")
+  defp describe_shape(value) when is_tuple(value), do: counted(tuple_size(value), "element tuple")
+  defp describe_shape(value) when is_integer(value), do: "the integer #{value}"
+  defp describe_shape(value) when is_float(value), do: "a float"
+  defp describe_shape(value) when is_atom(value), do: "the atom #{inspect(value)}"
+  defp describe_shape(value) when is_function(value), do: "a function"
+  defp describe_shape(_value), do: "a term"
 
   # "an 18-element list", not "a 18-element list": eight and eighteen are the
   # only counts whose spoken form opens on a vowel.

--- a/packages/mcp-ex/test/ix_mcp/workspace_provenance_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/workspace_provenance_test.exs
@@ -58,7 +58,7 @@ defmodule IxMcp.WorkspaceProvenanceTest do
     {_c, warned} = diagnostics(~s(body = ["settled"]), "A takes it back")
     assert warned =~ "changed type under this workspace"
 
-    {_d, quiet} = diagnostics(~s[length(body)], "A uses it")
+    {_d, quiet} = diagnostics("length(body)", "A uses it")
     refute quiet =~ "changed type under this workspace"
   end
 
@@ -71,7 +71,7 @@ defmodule IxMcp.WorkspaceProvenanceTest do
 
     # Same type means no crash waiting downstream, so the reader is not
     # interrupted; the write side is where the collision is visible.
-    {_c, quiet} = diagnostics(~s[String.length(out)], "A uses out")
+    {_c, quiet} = diagnostics("String.length(out)", "A uses out")
     refute quiet =~ "shared binding"
   end
 
@@ -82,7 +82,7 @@ defmodule IxMcp.WorkspaceProvenanceTest do
 
   test "merely reading a variable does not take it over" do
     {a, _} = diagnostics(~s(shared = "value"), "A binds shared")
-    {_b, quiet} = diagnostics(~s[String.length(shared)], "B reads shared")
+    {_b, quiet} = diagnostics("String.length(shared)", "B reads shared")
     refute quiet =~ "shared binding"
 
     owner = Enum.find(Workspace.owners(), &(&1.name == :shared))
@@ -130,6 +130,92 @@ defmodule IxMcp.WorkspaceProvenanceTest do
       )
 
     refute quiet =~ "shared module"
+  end
+
+  test "a shadowed local is not a read of the shared variable" do
+    {_a, _} = diagnostics(~s(body = "html"), "A binds body")
+    {_b, _} = diagnostics(~s(body = ["lines"]), "B clobbers body")
+
+    # `body` here is the anonymous function's own parameter and cannot reach
+    # the workspace's, so warning about it would be crying wolf.
+    {_c, quiet} = diagnostics("Enum.map([1, 2], fn body -> body + 1 end)", "C shadows body")
+    refute quiet =~ "shared binding"
+
+    {_d, quiet} = diagnostics("case {:ok, 1} do {:ok, body} -> body end", "C matches body")
+    refute quiet =~ "shared binding"
+
+    # Reading it and rebinding it in one expression is a real read.
+    {_e, warned} = diagnostics("body = length(body)", "C reads then rebinds body")
+    assert warned =~ "changed type under this workspace"
+  end
+
+  test "a cell that puts the type back is not reported as the one that broke it" do
+    {_a, _} = diagnostics(~s(body = "html"), "A binds body")
+    {_b, _} = diagnostics(~s(body = ["lines"]), "B clobbers body")
+    {_c, _} = diagnostics(~s(body = "repaired"), "C repairs body")
+
+    {_d, quiet} = diagnostics("String.length(body)", "A uses body again")
+    refute quiet =~ "shared binding"
+  end
+
+  test "a defmodule the AST cannot resolve does not kill the cell" do
+    {summary, _} =
+      diagnostics(
+        "defmodule OuterScan do\n  defmodule __MODULE__.Inner do\n    def hi, do: :ok\n  end\nend",
+        "A defines a nested module"
+      )
+
+    assert summary.status == :done
+    # The module is defined by the cell, so this file cannot call into it.
+    assert function_exported?(OuterScan.Inner, :hi, 0)
+  end
+
+  test "a defmodule inside quote claims nothing" do
+    {_a, _} =
+      diagnostics("q = quote do\n  defmodule QuotedPage do\n  end\nend", "A quotes a module")
+
+    {_b, quiet} =
+      diagnostics("defmodule QuotedPage do\n  def render, do: :ok\nend", "B defines it for real")
+
+    refute quiet =~ "shared module"
+  end
+
+  test "a failed cell claims neither its variables nor its modules" do
+    {failed, _} =
+      diagnostics(
+        ~s(defmodule ClaimedOnFailure do\n  def hi, do: :ok\nend\n\nraise "boom"),
+        "A defines then raises"
+      )
+
+    assert failed.status == :failed
+
+    {_b, quiet} =
+      diagnostics("defmodule ClaimedOnFailure do\n  def hi, do: :no\nend", "B defines it")
+
+    refute quiet =~ "shared module"
+  end
+
+  test "an improper list does not take the workspace down" do
+    workspace = Process.whereis(Workspace)
+    {summary, _} = diagnostics(~s(iodata = ["a" | "b"]), "A binds iodata")
+
+    assert summary.status == :done
+    assert Process.whereis(Workspace) == workspace
+    assert Enum.find(Workspace.owners(), &(&1.name == :iodata)).shape == "a term"
+  end
+
+  test "Ix.bindings reports names that predate the provenance map" do
+    {_a, _} = diagnostics(~s(restored = "value"), "A binds restored")
+    {binding, env} = Workspace.snapshot()
+    IxMcp.Checkpoint.store(binding, env)
+    IxMcp.Checkpoint.store_provenance(%{owners: %{}, contested: %{}, modules: %{}})
+
+    :ok = Supervisor.terminate_child(IxMcp.Supervisor, Workspace)
+    {:ok, _pid} = Supervisor.restart_child(IxMcp.Supervisor, Workspace)
+
+    orphan = Enum.find(IxMcp.Kernel.bindings(), &(&1.name == :restored))
+    assert orphan.job == nil
+    assert orphan.shape == "a 5-byte binary"
   end
 
   test "provenance survives a workspace restart" do

--- a/packages/mcp-ex/test/ix_mcp/workspace_provenance_test.exs
+++ b/packages/mcp-ex/test/ix_mcp/workspace_provenance_test.exs
@@ -1,0 +1,145 @@
+defmodule IxMcp.WorkspaceProvenanceTest do
+  @moduledoc """
+  The shared-workspace collision guard (#3967). One kernel is one MCP
+  connection, and a Claude Code subagent rides its parent's connection, so
+  the parent's cells and the subagent's cells are different jobs on one
+  binding map. These tests drive that exact shape: cell A binds `body` to a
+  string, cell B binds it to a list of lines, cell A uses `body`.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias IxMcp.Jobs
+  alias IxMcp.Workspace
+
+  setup do
+    Workspace.reset()
+    :ok
+  end
+
+  defp diagnostics(code, intent) do
+    {summary, _output} = Jobs.run(code, intent: intent)
+    {summary, Enum.join(summary.diagnostics, "\n")}
+  end
+
+  test "a cell taking over another cell's variable is told what it replaced" do
+    {_a, _quiet} = diagnostics(~s(body = "<html>dashboard</html>"), "agent A: render the body")
+
+    {b, warned} =
+      diagnostics(~s(body = ["line one", "line two"]), "agent B: read a nix file into lines")
+
+    assert b.status == :done
+    assert warned =~ "warning: shared binding: `body` was bound"
+    assert warned =~ ~s(intent: "agent A: render the body")
+    assert warned =~ "as a 22-byte binary"
+    assert warned =~ "rebinds it as a 2-element list"
+  end
+
+  test "the cell that reads the clobbered variable is told before it uses it" do
+    {a, _quiet} = diagnostics(~s(body = "<html>dashboard</html>"), "agent A: render the body")
+    {_b, _warned} = diagnostics(~s(body = ["line one"]), "agent B: read a nix file into lines")
+
+    {victim, warned} = diagnostics(~s(inflight = "<p>x</p>" <> body), "agent A: write the panels")
+
+    # The read side has to be reported by a cell that raises, because that is
+    # the cell the incident actually happened in: `<>` on a list of lines.
+    assert victim.status == :failed
+    assert victim.result =~ "not a bitstring"
+    assert warned =~ "warning: shared binding: `body` changed type under this workspace"
+    assert warned =~ ~s(intent: "agent B: read a nix file into lines")
+    assert warned =~ "from a 22-byte binary to a 1-element list"
+    assert warned =~ ~s(intent: "agent A: render the body")
+    refute warned =~ "job #{a.id} (intent: \"agent A: render the body\") rebound"
+  end
+
+  test "the read-side warning stops once somebody binds the name again" do
+    {_a, _} = diagnostics(~s(body = "html"), "A binds")
+    {_b, _} = diagnostics(~s(body = ["lines"]), "B clobbers")
+    {_c, warned} = diagnostics(~s(body = ["settled"]), "A takes it back")
+    assert warned =~ "changed type under this workspace"
+
+    {_d, quiet} = diagnostics(~s[length(body)], "A uses it")
+    refute quiet =~ "changed type under this workspace"
+  end
+
+  test "a same-typed takeover is reported as a note, not a type-change warning" do
+    {_a, _} = diagnostics(~s(out = "first"), "A binds out")
+    {_b, warned} = diagnostics(~s(out = "second"), "B binds out")
+
+    assert warned =~ "note: shared binding: `out` was bound"
+    assert warned =~ ~s(intent: "A binds out")
+
+    # Same type means no crash waiting downstream, so the reader is not
+    # interrupted; the write side is where the collision is visible.
+    {_c, quiet} = diagnostics(~s[String.length(out)], "A uses out")
+    refute quiet =~ "shared binding"
+  end
+
+  test "a cell rebinding its own variable says nothing" do
+    {_first, quiet} = diagnostics(~s(x = 1; x = x + 1; x), "one cell, two writes")
+    refute quiet =~ "shared binding"
+  end
+
+  test "merely reading a variable does not take it over" do
+    {a, _} = diagnostics(~s(shared = "value"), "A binds shared")
+    {_b, quiet} = diagnostics(~s[String.length(shared)], "B reads shared")
+    refute quiet =~ "shared binding"
+
+    owner = Enum.find(Workspace.owners(), &(&1.name == :shared))
+    assert owner.job == a.id
+    assert owner.intent == "A binds shared"
+  end
+
+  test "Ix.bindings names who bound what" do
+    {a, _} = diagnostics(~s(body = "<html/>"), "A renders")
+    owner = Enum.find(IxMcp.Kernel.bindings(), &(&1.name == :body))
+
+    assert owner.job == a.id
+    assert owner.intent == "A renders"
+    assert owner.shape == "a 7-byte binary"
+  end
+
+  test "redefining another cell's module names the cell that had it" do
+    {a, _} =
+      diagnostics(
+        ~s(defmodule ProvenancePage, do: def render, do: "one"),
+        "A defines ProvenancePage"
+      )
+
+    {b, warned} =
+      diagnostics(
+        ~s(defmodule ProvenancePage, do: def render, do: "two"),
+        "B defines ProvenancePage"
+      )
+
+    assert b.status == :done
+    assert warned =~ "warning: shared module: ProvenancePage was defined"
+    assert warned =~ "by job #{a.id}"
+    assert warned =~ ~s(intent: "A defines ProvenancePage")
+    assert warned =~ "redefines it for every agent on this kernel"
+
+    # The compiler's own notice still fires; ours adds the owner it omits.
+    assert warned =~ "redefining module ProvenancePage"
+  end
+
+  test "a cell redefining its own module says nothing new" do
+    {_a, quiet} =
+      diagnostics(
+        ~s(defmodule OwnPage, do: def render, do: "one"),
+        "A defines OwnPage"
+      )
+
+    refute quiet =~ "shared module"
+  end
+
+  test "provenance survives a workspace restart" do
+    {a, _} = diagnostics(~s(kept = "value"), "A binds kept")
+
+    :ok = Supervisor.terminate_child(IxMcp.Supervisor, Workspace)
+    {:ok, _pid} = Supervisor.restart_child(IxMcp.Supervisor, Workspace)
+
+    owner = Enum.find(Workspace.owners(), &(&1.name == :kept))
+    assert owner.job == a.id
+    assert owner.intent == "A binds kept"
+  end
+end


### PR DESCRIPTION
## What broke

A parent Claude Code session had `body` bound to an HTML string. A subagent,
working a different task at the same time, bound `body` to the lines of
`nix/modules/services/host/ci-dispatcher/ephemeral-upper-tools.nix`. The
parent's next cell did `inflight <> body` and got

```
** (ArgumentError) errors were found at the given arguments:
  * 1st argument: not a bitstring
    :erlang.bit_size(["        set -euo pipefail", "", "        usage() {", ...
```

That is the lucky shape. It raised only because the type happened to be
wrong; a same-typed collision produces a wrong artifact and no error at all.

## What I found before designing anything

Two facts from the running system, both of which move where the fix has to go.

**A subagent is not a separate session.** Claude Code Task subagents run in
the parent's CLI process and use the parent's MCP connection, so they get the
parent's kernel: same OS pid, same `IxMcp.Session` row, same `IxMcp.Workspace`.
Measured directly, parent and subagent:

```
%{os_pid: "11838", session: %{session_id: 1298, topic_id: nil}, binding_count: 0}
```

Since `IxMcp.Session` is one Agent per BEAM and every kernel instance is its
own OS process, two *session rows* can never share a workspace at all. Every
binding collision that is physically possible is intra-session, between an
agent and its own subagents. **Keying bindings on session id, the fix the
issue proposes, would have isolated nothing in this incident.**

**No caller identity reaches the kernel.** I ran a logging MCP server under a
real `claude -p` that called a tool directly and again through a Task
subagent. Both `tools/call` frames carry only:

```json
"_meta": {"claudecode/toolUseId": "toolu_01Pe8...", "progressToken": 2}
```

A fresh id per call and a per-connection counter. Nothing groups calls by
agent, so the kernel has no key to partition a binding map on.

## What I built, and why this and not that

Full per-agent bindings is not "too large to land today", it is not
implementable: the information it needs is not on the wire. So the fix is the
issue's stated fallback, done with real provenance rather than session labels
that would all read the same.

Every write records the cell that made it: job id, intent, value shape,
session, time. A cell writing over another cell's variable is reported to
both sides.

Writer side, the moment the takeover happens:

```
-- warning: shared binding: `body` was bound just now by job 7c5c9b57 (intent: "agent A: render the dashboard body") as a 35-byte binary; this cell rebinds it as an 18-element list. One kernel's bindings are shared by every agent on it, a session and its subagents alike; `Ix.bindings()` names who bound what.
```

Reader side, before the cell that goes on to use it runs:

```
-- warning: shared binding: `body` changed type under this workspace: job 3fab397b (intent: "agent B: read ephemeral-upper-tools.nix into lines") rebound it just now from a 35-byte binary to an 18-element list, over the value job 7c5c9b57 (intent: "agent A: render the dashboard body") bound just now. Check it before using it.
```

The reader-side warning has to come *before* evaluation, which is why
`Evaluator.scan/1` now splits parse from eval: the cell holding a clobbered
value is usually the cell that raises, and a raising cell never reaches the
merge. The warning names the previous cell's `intent`, which the agent wrote
itself, so recognizing your own rebind takes no thought.

A same-typed takeover is a `note` on the writer side only. Nothing downstream
is about to raise over it, so the reader is not interrupted; the write is
still on the record and in `Ix.bindings()`.

Modules get the same treatment. They stay global to the BEAM, which is
correct and unchanged, but the compiler's `redefining module Page` never said
who had it first:

```
-- warning: shared module: Page was defined just now by job 444a97d3 (intent: "agent A: define the Page module"); this cell redefines it for every agent on this kernel, because modules are global to the BEAM.
-- warning: cell:1: redefining module Page (current version defined in memory)
```

`Ix.bindings()` is the new introspection surface: every name with the job,
intent, shape and time of the cell that bound it.

## The two-agent demonstration

`/tmp/eng9967-demo.exs` drives three cells through `IxMcp.MCP.Tools.call/2`
against a private kernel with `IX_MCP_ACTIONS_DB` pointed at a scratch file:
A binds `body` to a string, B binds `body` to a file's lines, A appends to
`body`.

Before, on `origin/main`:

```
--- exec: agent B: read ephemeral-upper-tools.nix into lines
{"job":"a47110cb","status":"done"}
=> ["##", "# Host Database", ...]

--- exec: agent A: write the panels out
{"job":"fc23ad5a","status":"failed"}
** (ArgumentError) errors were found at the given arguments:
  * 1st argument: not a bitstring
    :erlang.bit_size(["##", "# Host Database", ...
```

No warning anywhere. After, same script, same three cells: both warnings
above fire, the crash still happens and now has its cause printed directly
over it.

## What the review round changed

An adversarial pass over the first commit reproduced three crashes on cells
that worked before, all now fixed and each covered by a test watched failing
with its guard removed:

- `defmodule __MODULE__.Inner` is valid Elixir whose alias parts are not all
  atoms. `Module.concat/1` raised on it from outside the evaluator's `try`,
  so the cell died. The scan skips a module name the AST cannot resolve.
- An improper list bound as iodata (`["a" | "b"]`) reached `length/1` inside
  the workspace GenServer, killing the process every other cell blocks on.
  Nothing about describing a value can take the workspace down now.
- The scan counted binder positions as reads, so `fn body -> body + 1 end`
  got the full type-change warning about a variable it cannot reach. Clause
  heads, `<-` generators, `def` bodies and `quote` blocks no longer count;
  `body = length(body)` still does, because it is a read.

Four more: module ownership is recorded on the merge rather than before the
cell runs, so a failing cell and a quoted `defmodule` claim nothing; the
snapshot and the warnings are one server visit, so a warning always describes
the values the cell was handed; `Ix.bindings()` reads the binding rather than
the provenance map, so names restored from an older checkpoint are still
listed; and a cell that puts a contested variable back to its original type
clears the flag instead of being reported as the incident.

One finding was left alone and filed instead: `var!(x, Foo) = 1` produces a
binding keyed `{:x, Foo}` and kills the workspace on `Keyword.merge/2`. That
is pre-existing on main and orthogonal, so it is ENG-9982 rather than scope
creep here.

## Checks

- `mix test`: 206 tests, 0 failures (17 of them new, in
  `test/ix_mcp/workspace_provenance_test.exs`).
- `mix compile` with `--warnings-as-errors`, `mix format --check-formatted`,
  and `mix credo --strict --config-file lib/elixir/credo.exs`: clean.
- Every guard was watched failing. Collapsing writer identity to a constant
  (`job: "one-agent-only"` in `Job.writer/1`) fails 8 of the new tests;
  removing the `takeover/2` discrimination outright does not even compile,
  because Elixir 1.18's type checker proves the collision branch unreachable;
  dropping the `shape_of/1` rescue and the `->` binder clause fails exactly
  the improper-list and shadowed-local tests and nothing else.

## Not done

- Bindings are still one namespace per kernel. They cannot be partitioned
  until an MCP client sends something that identifies the calling agent; the
  provenance map added here is the data a future partition would key on.
- Same-typed collisions warn the writer but never the reader. Warning readers
  on every cross-cell rebind would fire on ordinary sequential work and train
  agents to skip the line, which costs more than it catches.
- `IxMcp.Checkpoint.save_file/1` still writes bindings only; provenance rides
  the in-VM ETS row, so it survives `Ix.restart()` (tested) but not a
  save-to-disk and reload into a new VM.

Refs ENG-9967.

(sent by an AI agent via Claude Code)
