### PR TITLE
hooks: refuse destructive git in a shared checkout that holds others' work

### DIFF
--- a/doc/claude-hooks/overview.md
+++ b/doc/claude-hooks/overview.md
@@ -70,6 +70,62 @@ Matching uses `glob::Pattern` with shell `case`-glob semantics where `*` crosses
 `CLAUDE_CODE_DISABLE_WORKTREE_GUARD`. In claude-code the whole `PreToolUse` block
 is only installed when `primaryCheckouts != []` (`default.nix:257`).
 
+## git-guard (PreToolUse, Bash)
+
+Refuses a destructive git command aimed at a shared primary checkout that
+currently holds uncommitted work. Same protected list as the worktree guard
+above, so it is only installed when `primaryCheckouts != []`. Kill switch:
+`CLAUDE_CODE_DISABLE_GIT_GUARD`.
+
+Why it is a `PreToolUse` hook and not a git hook: git ships no `pre-reset`,
+`pre-checkout`, `pre-clean` or `pre-stash`. `post-checkout` runs after the
+damage, and `reference-transaction` never fires for `git clean` or for a
+`reset --hard` that does not move HEAD. `PreToolUse` is the only seam that sees
+the command before it runs (ENG-9964).
+
+The command string is parsed rather than regex-matched, because the shapes that
+matter are the ones that look indirect:
+
+1. Split into statements on unquoted `;`, newline, `&&`, `||`, `|`, `(`, `)`,
+   tokenizing quote-aware so a quoted path with a space stays one token
+   (`statements`).
+2. Walk the statements in order, tracking `cd`. `cd <primary> && git reset
+   --hard` is judged against the cd target, not the payload `cwd`.
+3. Skip env assignments and wrapper prefixes (`sudo`, `env`, `command`, ...),
+   then require the command word to be `git`.
+4. Walk git's global options, composing every `-C` onto the current directory
+   and stepping over the value-taking options (`-c`, `--git-dir`,
+   `--work-tree`, `--namespace`) so their arguments are not read as the
+   subcommand.
+5. Classify the subcommand with `discards_worktree`, a closed set: `reset
+   --hard|--merge|--keep`, `checkout -f` or its pathspec form, `switch
+   --force|--discard-changes`, `restore` other than `--staged` alone, `clean
+   -f` without `-n`, and any `stash` except `list`, `show` and `create`.
+   Commands git itself refuses against a dirty tree (`merge`, `rebase`,
+   `cherry-pick`) are deliberately absent.
+6. Resolve the target repo. A linked worktree (private git-dir differs from the
+   common dir) is the caller's own and always allowed.
+7. If the toplevel is protected, read `git status --porcelain`. Empty means
+   there is nothing to destroy, so the command proceeds. Otherwise deny, naming
+   the dirty entries, the `git stash create` snapshot that does not touch the
+   tree, and the `worktree add` path under `/tmp/worktree/<org>/<repo>/` derived
+   from the checkout's origin URL.
+
+**This guard does not fail open.** Every other hook here returns silently on any
+error, on the principle that a broken hook is worse than no hook. That trade is
+wrong for the one guard whose failure mode is unrecoverable data loss, so once
+`git-guard` knows the target is a protected checkout it denies when it cannot
+read `git status`, and says why. Before that point (non-Bash tool, unparseable
+payload, no protected list, target not a repo) it still fails open, because
+there is nothing it could be protecting.
+
+Behavioral coverage lives in `packages/claude-code/install-check.nix`: a real
+primary checkout with uncommitted work plus a linked worktree, asserting the
+five destructive shapes deny, the `cd`/`-C`/`sudo`/chained/global-option
+evasions deny, the safe siblings and the recommended rescue commands allow, a
+clean protected checkout allows, the deny message names the dirty files, and the
+kill switch allows silently.
+
 ## prompt-priors (UserPromptSubmit)
 
 Injects score-gated ambient priors from the corpus store, but only after passing

--- a/packages/agent/policy/hooks.nix
+++ b/packages/agent/policy/hooks.nix
@@ -27,6 +27,7 @@
     protectedCheckoutGuard = hookRunnerSubcommand "worktree-guard";
     nixCargoGuard = hookRunnerSubcommand "cargo-guard";
     shellHabitGuard = hookRunnerSubcommand "bash-habits-guard";
+    destructiveGitGuard = hookRunnerSubcommand "git-guard";
     indexedSearchGuard = hookRunnerSubcommand "search-guard";
     promptPriors = hookRunnerSubcommand "prompt-priors";
     subagentCacheLookup = hookRunnerSubcommand "subagent-cache-lookup";
@@ -97,6 +98,16 @@
       {
         matcher = "Bash";
         command = hookCommands.shellHabitGuard;
+      }
+      # git has no pre-reset/pre-checkout/pre-clean/pre-stash hook, so the only
+      # seam that sees `git reset --hard` before it runs is PreToolUse
+      # (ENG-9964). Same protected list as the edit guard above: without one
+      # there is nothing to protect, so it is not installed.
+      {
+        matcher = "Bash";
+        command = hookCommands.destructiveGitGuard;
+        timeout = 10;
+        enable = primaryCheckouts != [];
       }
       {
         matcher = "^Search$";

--- a/packages/claude-code/install-check.nix
+++ b/packages/claude-code/install-check.nix
@@ -476,6 +476,110 @@
     pre_guard search-guard "Search tool denied" deny '{"tool_name":"Search"}'
     pre_guard search-guard "WebSearch not denied" allow '{"tool_name":"WebSearch"}'
 
+    # Behavioral net for git-guard (ENG-9964). Reuses the primary/worktree pair
+    # built above, now with real uncommitted work in each: git has no
+    # pre-reset/pre-clean/pre-stash hook, so PreToolUse is the only seam, and
+    # the guard has to parse the command itself. These checks pin that parse.
+    echo dirty > "$primary/tracked.txt"
+    ${lib.getExe git} -C "$primary" add tracked.txt
+    ${lib.getExe git} -C "$primary" -c user.email=ci@ix -c user.name=ci \
+      commit -q -m tracked
+    echo "another session's work" >> "$primary/tracked.txt"
+    echo untracked > "$primary/scratch.txt"
+    echo "my own work" >> "$wt/tracked.txt"
+
+    git_payload() {
+      ${lib.getExe jq} -nc --arg c "$1" --arg k "$2" \
+        '{tool_name:"Bash",cwd:$c,tool_input:{command:$k}}'
+    }
+    git_guard() {
+      local desc="$1" expect="$2" got verdict
+      got="$(git_payload "$3" "$4" \
+        | CLAUDE_CODE_PRIMARY_CHECKOUTS="$primary" IX_GIT=${lib.getExe git} \
+          ${hookRunner}/bin/claude-hooks git-guard)"
+      case "$got" in
+      ''') verdict=allow ;;
+      *'"permissionDecision":"deny"'*) verdict=deny ;;
+      *) verdict="unparsed: $got" ;;
+      esac
+      if [ "$verdict" != "$expect" ]; then
+        printf 'git-guard check failed (%s): expected %s, got %s\n' \
+          "$desc" "$expect" "$verdict" >&2
+        exit 1
+      fi
+    }
+
+    # The five destructive shapes ENG-9964 names, in a dirty primary checkout.
+    git_guard "reset --hard in primary"     deny "$primary" "git reset --hard HEAD~1"
+    git_guard "checkout -- . in primary"    deny "$primary" "git checkout -- ."
+    git_guard "clean -fd in primary"        deny "$primary" "git clean -fd"
+    git_guard "stash in primary"            deny "$primary" "git stash"
+    git_guard "restore . in primary"        deny "$primary" "git restore ."
+    # Evasions that must not work: cd into the checkout, -C into it, a wrapper
+    # command in front, a global option before the subcommand, and a
+    # destructive call buried later in a chain.
+    git_guard "cd evasion"                  deny /tmp "cd $primary && git reset --hard"
+    git_guard "-C evasion"                  deny /tmp "git -C $primary clean -fdx"
+    git_guard "sudo prefix"                 deny "$primary" "sudo git reset --hard"
+    git_guard "buried in a chain"           deny "$primary" "make build && echo ok; git checkout -f main"
+    git_guard "-c option before subcommand" deny "$primary" "git -c core.pager=cat reset --hard"
+    # A linked worktree is the caller's own; their dirt is theirs to discard.
+    git_guard "reset --hard in worktree"    allow "$wt" "git reset --hard HEAD~1"
+    git_guard "clean -fd in worktree"       allow "$wt" "git clean -fd"
+    # Non-destructive git in the primary checkout stays usable, or the guard
+    # becomes noise and gets switched off.
+    git_guard "status in primary"           allow "$primary" "git status"
+    git_guard "commit in primary"           allow "$primary" "git commit -am wip"
+    git_guard "reset --soft in primary"     allow "$primary" "git reset --soft HEAD~1"
+    git_guard "checkout -b in primary"      allow "$primary" "git checkout -b feature"
+    git_guard "clean -nd (dry run)"         allow "$primary" "git clean -nd"
+    git_guard "stash list"                  allow "$primary" "git stash list"
+    # The rescue command the deny message tells the caller to run must itself
+    # survive the guard, or the advice is a dead end.
+    git_guard "stash create"                allow "$primary" "git stash create"
+    git_guard "restore --staged"            allow "$primary" "git restore --staged ."
+    # A literal mention inside a quoted string is not a command.
+    git_guard "quoted mention"              allow "$primary" "echo 'git reset --hard'"
+    git_guard "outside any protected repo"  allow /tmp "git reset --hard"
+    if [ -n "$(printf '%s' "{\"tool_name\":\"Edit\",\"cwd\":\"$primary\"}" \
+      | CLAUDE_CODE_PRIMARY_CHECKOUTS="$primary" ${hookRunner}/bin/claude-hooks git-guard)" ]; then
+      printf 'git-guard check failed: non-Bash tool must allow silently\n' >&2
+      exit 1
+    fi
+
+    # A clean protected checkout has nothing to lose, so the guard must get out
+    # of the way. This is the allow that proves it reads real repository state
+    # rather than pattern-matching the command string.
+    clean="$checktop/repos/clean"
+    ${lib.getExe git} init -q "$clean"
+    ${lib.getExe git} -C "$clean" -c user.email=ci@ix -c user.name=ci \
+      commit -q --allow-empty -m init
+    if [ -n "$(git_payload "$clean" "git reset --hard" \
+      | CLAUDE_CODE_PRIMARY_CHECKOUTS="$clean" IX_GIT=${lib.getExe git} \
+        ${hookRunner}/bin/claude-hooks git-guard)" ]; then
+      printf 'git-guard check failed: clean checkout has nothing to destroy\n' >&2
+      exit 1
+    fi
+
+    # The deny has to name what would be lost and where to go instead, or the
+    # caller cannot act on it. Assert the message, not just the decision.
+    msg="$(git_payload "$primary" "git reset --hard" \
+      | CLAUDE_CODE_PRIMARY_CHECKOUTS="$primary" IX_GIT=${lib.getExe git} \
+        ${hookRunner}/bin/claude-hooks git-guard)"
+    for want in tracked.txt scratch.txt "worktree add" "stash create" ENG-9964; do
+      case "$msg" in
+      *"$want"*) : ;;
+      *) printf 'git-guard message missing %s:\n%s\n' "$want" "$msg" >&2; exit 1 ;;
+      esac
+    done
+
+    if [ -n "$(git_payload "$primary" "git reset --hard" \
+      | CLAUDE_CODE_DISABLE_GIT_GUARD=1 CLAUDE_CODE_PRIMARY_CHECKOUTS="$primary" \
+        IX_GIT=${lib.getExe git} ${hookRunner}/bin/claude-hooks git-guard)" ]; then
+      printf 'git-guard check failed: kill switch must allow silently\n' >&2
+      exit 1
+    fi
+
     # Review pair: log-edit records an edited path, the Stop gate then blocks once
     # (JSON decision:block) and consumes the marker; a stop_hook_active re-entry
     # allows silently (the loop guard).

--- a/packages/claude-hooks/src/guards.rs
+++ b/packages/claude-hooks/src/guards.rs
@@ -195,9 +195,475 @@ pub fn search_guard() {
     );
 }
 
+// --- git-guard ---
+
+/// Statement prefixes that wrap another command; skipped when looking for the
+/// command word so `sudo git reset --hard` is still seen as git.
+const CMD_PREFIXES: &[&str] = &[
+    "env", "sudo", "command", "nice", "time", "stdbuf", "nohup", "doas",
+];
+
+/// Git global options that consume the following token as their value, so the
+/// subcommand scan does not mistake that value for the subcommand.
+const GIT_VALUE_OPTS: &[&str] = &["-C", "-c", "--git-dir", "--work-tree", "--namespace"];
+
+/// One shell statement: its tokens, quote-aware and with quotes removed.
+type Statement = Vec<String>;
+
+/// Split a command line into statements on the unquoted operators that begin a
+/// new command word (`;`, newline, `&&`, `||`, `|`, `(`, `)`), tokenizing each
+/// on unquoted whitespace and dropping the quote characters.
+///
+/// Hand-rolled rather than regex-split because the paths this guard resolves
+/// are frequently quoted (`git -C "/Users/a b/ix" reset --hard`), and the
+/// quote-stripping trick `bash_habits_guard` uses would eat them.
+fn statements(cmd: &str) -> Vec<Statement> {
+    let (mut out, mut stmt, mut tok) = (Vec::new(), Statement::new(), String::new());
+    let (mut quoted, mut single, mut double) = (false, false, false);
+    let mut chars = cmd.chars().peekable();
+    let flush_tok = |tok: &mut String, stmt: &mut Statement, quoted: &mut bool| {
+        if !tok.is_empty() || *quoted {
+            stmt.push(std::mem::take(tok));
+        }
+        *quoted = false;
+    };
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' if !single => {
+                if let Some(n) = chars.next() {
+                    tok.push(n);
+                }
+            }
+            '\'' if !double => {
+                single = !single;
+                quoted = true;
+            }
+            '"' if !single => {
+                double = !double;
+                quoted = true;
+            }
+            _ if single || double => tok.push(c),
+            ';' | '\n' | '(' | ')' => {
+                flush_tok(&mut tok, &mut stmt, &mut quoted);
+                if !stmt.is_empty() {
+                    out.push(std::mem::take(&mut stmt));
+                }
+            }
+            '&' | '|' => {
+                if chars.peek() == Some(&c) {
+                    chars.next();
+                }
+                flush_tok(&mut tok, &mut stmt, &mut quoted);
+                if !stmt.is_empty() {
+                    out.push(std::mem::take(&mut stmt));
+                }
+            }
+            c if c.is_whitespace() => flush_tok(&mut tok, &mut stmt, &mut quoted),
+            _ => tok.push(c),
+        }
+    }
+    flush_tok(&mut tok, &mut stmt, &mut quoted);
+    if !stmt.is_empty() {
+        out.push(stmt);
+    }
+    out
+}
+
+/// True when any token is the long flag `long`, or a bundled short flag group
+/// (`-fd`, `-xfd`) containing `short`. Scanning stops at `--`, after which
+/// everything is a pathspec.
+fn has_flag(args: &[String], short: char, long: &str) -> bool {
+    args.iter()
+        .take_while(|a| a.as_str() != "--")
+        .any(|a| {
+            a == long
+                || (a.starts_with('-')
+                    && !a.starts_with("--")
+                    && a.len() > 1
+                    && a[1..].chars().all(char::is_alphanumeric)
+                    && a[1..].contains(short))
+        })
+}
+
+/// Classify a git subcommand as one that can discard uncommitted work, naming
+/// what it does. `None` means "cannot lose working-tree state".
+///
+/// A closed, enumerated set. Commands that already refuse to run against a
+/// dirty tree (`merge`, `rebase`, `cherry-pick`) are deliberately absent: git
+/// itself is the guard there, and denying them would be noise.
+fn discards_worktree(sub: &str, args: &[String]) -> Option<&'static str> {
+    let flag = |s: char, l: &str| has_flag(args, s, l);
+    match sub {
+        // --hard throws the tree away; --merge and --keep discard a subset.
+        "reset" if args.iter().any(|a| ["--hard", "--merge", "--keep"].contains(&a.as_str())) => {
+            Some("overwrites the working tree from a commit, discarding every uncommitted change")
+        }
+        // Branch-switching checkout refuses to clobber; the pathspec form
+        // (`-- <path>`, or a bare `.`) and -f do not.
+        "checkout"
+            if flag('f', "--force")
+                || args.iter().any(|a| a == "--" || a == ".") =>
+        {
+            Some("restores the named paths from the index or a commit, discarding their uncommitted changes")
+        }
+        "switch" if flag('f', "--force") || args.iter().any(|a| a == "--discard-changes") => {
+            Some("switches branches discarding local changes")
+        }
+        // `restore --staged` alone only rewrites the index; anything else
+        // (default, or an explicit --worktree) rewrites the working tree.
+        "restore"
+            if !args.iter().any(|a| a == "--staged")
+                || args.iter().any(|a| a == "--worktree" || a == "-W") =>
+        {
+            Some("restores paths over the working tree, discarding their uncommitted changes")
+        }
+        // -n/--dry-run is the safe form; without -f git clean refuses anyway.
+        "clean" if flag('f', "--force") && !flag('n', "--dry-run") => {
+            Some("deletes untracked files, which are never recoverable from the object database")
+        }
+        // `stash list|show|create` inspect or snapshot without touching the
+        // tree; every other form moves work out of it or destroys saved work.
+        "stash"
+            if !matches!(
+                args.iter().find(|a| !a.starts_with('-')).map(String::as_str),
+                Some("list" | "show" | "create")
+            ) =>
+        {
+            Some("moves uncommitted work off the working tree (or destroys already-stashed work)")
+        }
+        _ => None,
+    }
+}
+
+/// `org/repo` from a checkout's origin URL, for the `/tmp/worktree/<org>/<repo>`
+/// convention the suggested command spells out. Falls back to the directory
+/// name when origin is missing or unparseable.
+fn origin_slug(git: &str, top: &str) -> String {
+    let url = std::process::Command::new(git)
+        .args(["-C", top, "remote", "get-url", "origin"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_default();
+    regex::Regex::new(r"[:/]([^/:]+)/([^/]+?)(?:\.git)?/?$")
+        .ok()
+        .and_then(|re| re.captures(url.trim()).map(|c| format!("{}/{}", &c[1], &c[2])))
+        .or_else(|| {
+            std::path::Path::new(top)
+                .file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| "repo".to_owned())
+}
+
+/// A parsed `git` invocation: the directory it runs in (payload cwd, composed
+/// with every `-C`), its subcommand, and the arguments after it.
+struct GitCall {
+    dir: std::path::PathBuf,
+    sub: String,
+    args: Vec<String>,
+}
+
+/// Parse the tokens after the `git` command word. `base` is the directory the
+/// statement runs in; each `-C` composes onto it, exactly as git does.
+fn parse_git_call(rest: &[String], base: &std::path::Path) -> Option<GitCall> {
+    let mut dir = base.to_path_buf();
+    let mut i = 0;
+    while let Some(a) = rest.get(i) {
+        if a == "-C" {
+            if let Some(v) = rest.get(i + 1) {
+                dir = resolve(&dir, v);
+            }
+            i += 2;
+        } else if GIT_VALUE_OPTS.contains(&a.as_str()) {
+            i += 2;
+        } else if a.starts_with('-') {
+            i += 1;
+        } else {
+            // `rest.get(i + 1..)` and not `rest[i + 1..]`: a trailing
+            // value-taking option (`git -c`) leaves `i` past the end.
+            return Some(GitCall {
+                dir,
+                sub: a.clone(),
+                args: rest.get(i + 1..).unwrap_or_default().to_vec(),
+            });
+        }
+    }
+    None
+}
+
+/// The refusal text. Names every entry that would be lost, the snapshot that
+/// does not touch the tree, and the worktree to do the work in instead.
+struct Refusal<'a> {
+    git: &'a str,
+    top: &'a str,
+    sub: &'a str,
+    /// What the subcommand does to the working tree, from `discards_worktree`.
+    effect: &'a str,
+    /// `git status --porcelain` lines, one per entry that would be lost.
+    dirty: &'a [String],
+}
+
+fn deny_message(refusal: &Refusal<'_>) -> String {
+    let Refusal {
+        git,
+        top,
+        sub,
+        effect,
+        dirty,
+    } = *refusal;
+    let shown = dirty
+        .iter()
+        .take(10)
+        .map(|line| format!("    {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let more = if dirty.len() > 10 {
+        format!("\n    ... and {} more", dirty.len() - 10)
+    } else {
+        String::new()
+    };
+    let slug = origin_slug(git, top);
+    let count = dirty.len();
+    format!(
+        "Refusing `git {sub}` in {top}.\n\n\
+         That checkout is shared by every agent session on this machine, it currently \
+         holds {count} entries of uncommitted work, and `git {sub}` {effect}. None of it is \
+         staged, so there is no blob in the object database and no way back (ENG-9964: \
+         exactly this command destroyed 7 uncommitted lines belonging to another session, \
+         recovered only because a nix eval had happened to copy the dirty tree into the \
+         store).\n\n\
+         Would be lost:\n{shown}{more}\n\n\
+         Snapshot it first, which does not touch the working tree:\n\
+         \x20   git -C {top} branch rescue/$(date +%Y-%m-%d-%H%M) \"$(git -C {top} stash create)\"\n\n\
+         Then do the work in a worktree of your own, where destructive commands are yours \
+         to run:\n\
+         \x20   git -C {top} worktree add /tmp/worktree/{slug}/<name> -b <branch> origin/main\n\
+         \x20   git -C /tmp/worktree/{slug}/<name> submodule update --init --recursive\n\n\
+         (git-guard hook, ENG-9964)"
+    )
+}
+
+/// Judge one parsed git call. `Some(reason)` means refuse.
+///
+/// This is where the guard stops failing open. Up to the point where the target
+/// is known to be a protected checkout, anything unreadable means "not our
+/// business" and returns `None`. After it, an unreadable `git status` is a
+/// refusal, because the alternative is allowing the one command whose failure
+/// mode is unrecoverable data loss (ENG-9964).
+fn judge(git: &str, protected: &[String], call: &GitCall) -> Option<String> {
+    let effect = discards_worktree(&call.sub, &call.args)?;
+    let sub = &call.sub;
+
+    let Some(top) = crate::git_rev_parse(git, &call.dir, "--show-toplevel") else {
+        // Not a readable repo. Only a textual match on the protected globs is
+        // left to go on; refuse that rather than guess.
+        // A path that is not valid UTF-8 cannot match a UTF-8 glob pattern, so
+        // there is nothing here this guard could be protecting.
+        let dir = call.dir.to_str()?;
+        return crate::matches_protected(dir, protected).then(|| {
+            format!(
+                "Refusing `git {sub}` in {dir}: that path is a protected primary checkout \
+                 but git could not read it, so this guard cannot tell what would be lost. \
+                 Run the command in your own worktree instead. (git-guard hook, ENG-9964)"
+            )
+        });
+    };
+    // A linked worktree is the caller's own; its dirt is theirs to discard.
+    let gd = crate::git_rev_parse(git, &call.dir, "--git-dir")?;
+    let common = crate::git_rev_parse(git, &call.dir, "--git-common-dir")?;
+    if gd != common || !crate::matches_protected(&top, protected) {
+        return None;
+    }
+
+    let status = std::process::Command::new(git)
+        .args(["-C", &top, "status", "--porcelain"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success());
+    let Some(out) = status else {
+        return Some(format!(
+            "Refusing `git {sub}` in {top}: it is a shared primary checkout and `git status` \
+             could not be read, so this guard cannot tell whether another session has \
+             uncommitted work here. Use your own worktree. (git-guard hook, ENG-9964)"
+        ));
+    };
+    let dirty: Vec<String> = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(str::trim_end)
+        .filter(|l| !l.is_empty())
+        .map(str::to_owned)
+        .collect();
+    // Nothing uncommitted means nothing for this command to destroy. Not a
+    // silent no-op: the checkout is genuinely empty of work to lose.
+    if dirty.is_empty() {
+        return None;
+    }
+    Some(deny_message(&Refusal {
+        git,
+        top: &top,
+        sub,
+        effect,
+        dirty: &dirty,
+    }))
+}
+
+/// `PreToolUse(Bash)`: refuse a destructive git command aimed at a shared
+/// primary checkout that currently holds uncommitted work.
+///
+/// Why a hook and not a git hook: git has no `pre-reset`, `pre-checkout`,
+/// `pre-clean` or `pre-stash`, `post-checkout` runs after the damage, and
+/// `reference-transaction` never fires for `git clean` or for a `reset --hard`
+/// that does not move HEAD. `PreToolUse` is the only seam that sees the command
+/// before it runs (ENG-9964).
+pub fn git_guard() {
+    if crate::flag_set("CLAUDE_CODE_DISABLE_GIT_GUARD") {
+        return;
+    }
+    let Some(payload) = payload() else { return };
+    if payload.get("tool_name").and_then(Value::as_str) != Some("Bash") {
+        return;
+    }
+    let protected = crate::primary_checkouts();
+    if protected.is_empty() {
+        return;
+    }
+    let git = std::env::var("IX_GIT").unwrap_or_else(|_| "git".to_owned());
+    let mut cwd = std::path::PathBuf::from(
+        payload
+            .get("cwd")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map_or_else(
+                || std::env::var("PWD").unwrap_or_else(|_| ".".to_owned()),
+                str::to_owned,
+            ),
+    );
+
+    for stmt in statements(&command_of(&payload)) {
+        let mut it = stmt
+            .iter()
+            .skip_while(|w| is_env_assignment(w) || CMD_PREFIXES.contains(&w.as_str()));
+        let Some(head) = it.next() else { continue };
+        let rest: Vec<String> = it.cloned().collect();
+        // Track `cd` across the chain: `cd <primary> && git reset --hard` must
+        // be judged against the cd target, not the payload cwd.
+        if head == "cd" {
+            if let Some(target) = rest.iter().find(|a| !a.starts_with('-')) {
+                cwd = resolve(&cwd, target);
+            }
+            continue;
+        }
+        if head != "git" {
+            continue;
+        }
+        let Some(call) = parse_git_call(&rest, &cwd) else {
+            continue;
+        };
+        if let Some(reason) = judge(&git, &protected, &call) {
+            deny(reason);
+            return;
+        }
+    }
+}
+
+/// Join `arg` onto `base` unless it is already absolute.
+fn resolve(base: &std::path::Path, arg: &str) -> std::path::PathBuf {
+    let p = std::path::Path::new(arg);
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        base.join(p)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{grep_walks_tree, is_recursive_flag};
+    use super::{
+        discards_worktree, grep_walks_tree, has_flag, is_recursive_flag, parse_git_call, statements,
+    };
+
+    fn toks(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    #[test]
+    fn statement_splitting_is_quote_aware() {
+        assert_eq!(
+            statements("cd /a && git reset --hard"),
+            vec![toks(&["cd", "/a"]), toks(&["git", "reset", "--hard"])]
+        );
+        // A quoted path with a space survives as one token.
+        assert_eq!(
+            statements(r#"git -C "/Users/a b/ix" clean -fd"#),
+            vec![toks(&["git", "-C", "/Users/a b/ix", "clean", "-fd"])]
+        );
+        // Pipes, semicolons and newlines all start a new statement.
+        assert_eq!(statements("a | b ; c\nd").len(), 4);
+        // An operator inside quotes is literal text, not a split.
+        assert_eq!(statements("echo 'a && b'"), vec![toks(&["echo", "a && b"])]);
+    }
+
+    #[test]
+    fn bundled_short_flags() {
+        assert!(has_flag(&toks(&["-fd"]), 'f', "--force"));
+        assert!(has_flag(&toks(&["-xfd"]), 'f', "--force"));
+        assert!(has_flag(&toks(&["--force"]), 'f', "--force"));
+        assert!(!has_flag(&toks(&["-d"]), 'f', "--force"));
+        // Scanning stops at `--`: a pathspec named -f is not a flag.
+        assert!(!has_flag(&toks(&["--", "-f"]), 'f', "--force"));
+    }
+
+    #[test]
+    fn git_call_parsing() {
+        let base = std::path::Path::new("/base");
+        let call = |v: &[&str]| parse_git_call(&toks(v), base);
+        // -C composes onto the payload cwd; global options are stepped over.
+        let c = call(&["-C", "/repo", "reset", "--hard"]).expect("parsed");
+        assert_eq!(c.dir, std::path::Path::new("/repo"));
+        assert_eq!(c.sub, "reset");
+        assert_eq!(c.args, toks(&["--hard"]));
+        // A value-taking global option must not be read as the subcommand.
+        let c = call(&["-c", "core.pager=cat", "clean", "-fd"]).expect("parsed");
+        assert_eq!(c.sub, "clean");
+        assert_eq!(c.dir, base);
+        // A relative -C resolves against the payload cwd.
+        assert_eq!(
+            call(&["-C", "sub", "stash"]).expect("parsed").dir,
+            std::path::Path::new("/base/sub")
+        );
+        // Regression: a trailing value-taking option leaves the scan index past
+        // the end of the argument list, which used to panic on `rest[i..]`.
+        assert!(call(&["-c"]).is_none());
+        assert!(call(&["-C"]).is_none());
+        assert!(call(&[]).is_none());
+    }
+
+    #[test]
+    fn destructive_git_classification() {
+        let d = |sub: &str, a: &[&str]| discards_worktree(sub, &toks(a)).is_some();
+        // The five shapes ENG-9964 names.
+        assert!(d("reset", &["--hard", "HEAD~1"]));
+        assert!(d("checkout", &["--", "."]));
+        assert!(d("clean", &["-fd"]));
+        assert!(d("stash", &[]));
+        assert!(d("restore", &["."]));
+        // Safe siblings must not be denied, or the guard becomes noise.
+        assert!(!d("reset", &["--soft", "HEAD~1"]));
+        assert!(!d("reset", &[]));
+        assert!(!d("checkout", &["-b", "feature"]));
+        assert!(!d("checkout", &["main"]));
+        assert!(!d("clean", &["-nd"]));
+        assert!(!d("stash", &["list"]));
+        // `stash create` is the rescue command the deny message recommends; it
+        // writes a commit object without touching the tree.
+        assert!(!d("stash", &["create"]));
+        assert!(!d("restore", &["--staged", "."]));
+        assert!(!d("status", &[]));
+        assert!(!d("commit", &["-am", "x"]));
+    }
 
     #[test]
     fn recursive_flag_detection() {

--- a/packages/claude-hooks/src/main.rs
+++ b/packages/claude-hooks/src/main.rs
@@ -87,6 +87,7 @@ fn main() -> ExitCode {
         Some("wakeup-gate") => wakeup::wakeup_gate(),
         Some("cargo-guard") => guards::cargo_guard(),
         Some("bash-habits-guard") => guards::bash_habits_guard(),
+        Some("git-guard") => guards::git_guard(),
         Some("search-guard") => guards::search_guard(),
         Some("friction-report") => friction::friction_report(),
         Some("subagent-cache-lookup") => subagent_cache::lookup(),
@@ -305,7 +306,7 @@ fn worktree_guard() {
     }
 }
 
-fn git_rev_parse(git: &str, dir: &Path, what: &str) -> Option<String> {
+pub(crate) fn git_rev_parse(git: &str, dir: &Path, what: &str) -> Option<String> {
     let out = Command::new(git)
         .arg("-C")
         .arg(dir)
@@ -326,7 +327,7 @@ fn git_rev_parse(git: &str, dir: &Path, what: &str) -> Option<String> {
 
 /// User override first, else the wrapper-baked default; colon-separated, empties
 /// dropped. Empty list means no guard.
-fn primary_checkouts() -> Vec<String> {
+pub(crate) fn primary_checkouts() -> Vec<String> {
     let raw = std::env::var("CLAUDE_CODE_PRIMARY_CHECKOUTS")
         .or_else(|_| std::env::var("IX_DEFAULT_PRIMARY_CHECKOUTS"))
         .unwrap_or_default();
@@ -338,7 +339,7 @@ fn primary_checkouts() -> Vec<String> {
 
 /// Shell `case`-glob semantics: `*` crosses `/` (glob's default
 /// `require_literal_separator = false`), matching the whole `toplevel`.
-fn matches_protected(toplevel: &str, patterns: &[String]) -> bool {
+pub(crate) fn matches_protected(toplevel: &str, patterns: &[String]) -> bool {
     patterns
         .iter()
         .any(|p| glob::Pattern::new(p).is_ok_and(|pat| pat.matches(toplevel)))

--- a/users/andrewgazelka/profiles/workstation.nix
+++ b/users/andrewgazelka/profiles/workstation.nix
@@ -106,9 +106,18 @@
   # (IX_DEFAULT_PRIMARY_CHECKOUTS session variable, index#3871) both derive
   # from it. The package default is `/home/*/{index,ix}` (Linux fleet); on
   # this Mac the long-lived checkouts live under ~/Projects.
+  #
+  # The ~/.config/nix entries are not decoration: they were missing, and that
+  # is why the edit guard allowed the writes that ENG-9964 then destroyed.
+  # ~/.config/nix/ix is the checkout every session on this Mac actually shares,
+  # and `/Users/*/Projects/*/ix` does not match it, so the guard was live,
+  # configured, and silently protecting nothing.
   primaryCheckouts = [
     "/Users/*/Projects/*/index"
     "/Users/*/Projects/*/ix"
+    "/Users/*/.config/nix"
+    "/Users/*/.config/nix/ix"
+    "/Users/*/.config/nix/ix/index"
   ];
 
   # SessionStart memory digest: the derived replacement for the retired


### PR DESCRIPTION
## What happened

A `git reset --hard HEAD~1` in the shared `~/.config/nix/ix` checkout destroyed three sets of uncommitted changes, one of them 7 lines belonging to another session (ENG-9964). Nothing warned. Recovery was luck: an earlier `nix eval` had copied the dirty tree into the store, and the file had never been staged, so without that accident there was no blob to recover from.

## Two things were wrong, and the first one is the interesting one

**The protected list did not name the checkout.** `worktree-guard` has denied edits to primary checkouts for a while. Its globs on this Mac were `/Users/*/Projects/*/{index,ix}`. The checkout every session actually shares is `/Users/*/.config/nix/ix`, which matches neither. Measured before the change:

```
shipped list  /Users/*/Projects/*/{index,ix}          -> ALLOW  (no output at all: the guard never saw a protected checkout)
new list      + /Users/*/.config/nix{,/ix,/ix/index}  -> DENY
```

The guard was live, configured, and protecting nothing. That is worse than absent, because it reads as handled.

**Nothing covered Bash.** `worktree-guard` matches `Edit|MultiEdit|Write|NotebookEdit`, so `git reset --hard` was never seen.

## Why this is a PreToolUse hook and not a git hook

git ships no `pre-reset`, `pre-checkout`, `pre-clean` or `pre-stash`. `post-checkout` runs after the damage. `reference-transaction` never fires for `git clean`, nor for a `reset --hard` that leaves HEAD where it is. There is no in-git seam. `PreToolUse` on Bash is the only point that sees the command before it runs.

## The mechanism

A `git-guard` subcommand on the `Bash` matcher, installed only when `primaryCheckouts != []`, same protected list as the edit guard.

It parses the command rather than regex-matching it, because the shapes that matter look indirect. It splits statements quote-aware, tracks `cd` across `&&` chains, composes every `-C` onto the current directory, steps over git's value-taking global options (`-c`, `--git-dir`, `--work-tree`, `--namespace`), and skips wrapper prefixes like `sudo`.

The destructive set is closed and enumerated in `discards_worktree`: `reset --hard|--merge|--keep`, `checkout -f` and its pathspec form, `switch --force|--discard-changes`, `restore` other than `--staged` alone, `clean -f` without `-n`, and any `stash` except `list`, `show`, `create`. Commands git already refuses against a dirty tree (`merge`, `rebase`, `cherry-pick`) are deliberately absent; denying them would be noise, and noise is how a guard gets switched off.

It denies only when there is something to lose. A clean protected checkout, or a linked worktree, passes through untouched.

**It does not fail open.** Every other hook in this binary returns silently on any error, on the theory that a broken hook beats a noisy one. That trade is wrong for the one guard whose failure mode is unrecoverable data loss, so once `git-guard` knows the target is a protected checkout it denies when it cannot read `git status`, and says why. Before that point (non-Bash tool, unparseable payload, empty protected list, target not a repo) it still fails open, because there is nothing it could be protecting.

## The hazard, reproduced against a scratch clone

Not against the live checkout. A clone at `/tmp/eng9964-scratch/ix`, carrying the actual 7 lines from the rescue branch plus a second edit:

```
=== the situation ===
 M crates/tools/ixterm/src/lib.rs
 M nix/flake/outputs/homes.nix
 crates/tools/ixterm/src/lib.rs | 1 +
 nix/flake/outputs/homes.nix    | 7 +++++++
 2 files changed, 8 insertions(+)

############ STEP 1: the hazard, with the guard OFF ############
HEAD is now at 3ad8d2cfdf term: stop the docs describing a pane header that is gone
--- git status after the reset ---
--- are the 7 lines still there? ---
0
GONE: the other session's work was destroyed
```

Exit 0, no output, both files gone.

## The same command through the guard

```
permissionDecision: deny

Refusing `git reset` in /Users/andrewgazelka/.config/nix/ix.

That checkout is shared by every agent session on this machine, it currently holds 4 entries
of uncommitted work, and `git reset` overwrites the working tree from a commit, discarding
every uncommitted change. None of it is staged, so there is no blob in the object database and
no way back (ENG-9964: exactly this command destroyed 7 uncommitted lines belonging to another
session, recovered only because a nix eval had happened to copy the dirty tree into the store).

Would be lost:
     M crates/control/orch/node-agent/src/golden/runtime.rs
     M crates/tools/ixterm/src/lib.rs
     M nix/flake/outputs/homes.nix
     M nix/packages/workspace-binaries.json

Snapshot it first, which does not touch the working tree:
    git -C /Users/andrewgazelka/.config/nix/ix branch rescue/$(date +%Y-%m-%d-%H%M) "$(git -C /Users/andrewgazelka/.config/nix/ix stash create)"

Then do the work in a worktree of your own, where destructive commands are yours to run:
    git -C /Users/andrewgazelka/.config/nix/ix worktree add /tmp/worktree/indexable-inc/ix/<name> -b <branch> origin/main
    git -C /tmp/worktree/indexable-inc/ix/<name> submodule update --init --recursive

(git-guard hook, ENG-9964)
```

The `indexable-inc/ix` in the suggested path is derived from the checkout's origin URL, so the message spells out the house `/tmp/worktree/<org>/<repo>/<name>` convention rather than describing it.

## Verdict matrix

```
VERDICT   COMMAND
deny      git reset --hard HEAD~1
deny      git checkout -- .
deny      git checkout .
deny      git clean -fd
deny      git clean -fdx
deny      git stash
deny      git stash pop
deny      git restore .
deny      git checkout -f main
deny      git switch --discard-changes main
deny      sudo git reset --hard
deny      git -c core.pager=cat reset --hard
deny      make && git reset --hard
--- evasions from a DIFFERENT cwd ---
deny      cd /private/tmp/eng9964-scratch/ix && git reset --hard
deny      git -C /private/tmp/eng9964-scratch/ix clean -fdx
deny      cd /etc; cd /private/tmp/eng9964-scratch/ix; git stash
--- must stay allowed (or the guard is noise) ---
allow     git status
allow     git commit -am wip
allow     git reset --soft HEAD~1
allow     git checkout -b feat
allow     git checkout main
allow     git clean -nd
allow     git stash list
allow     git stash create
allow     git restore --staged .
allow     git log --oneline
allow     echo 'git reset --hard'
allow     git rebase main
```

A linked worktree of the protected checkout also allows: its dirt belongs to whoever is working in it.

## Watched the guard fail

`discards_worktree` stubbed so `reset --hard` is no longer classified as destructive, then `nix build .#claude-code`:

```
error: Cannot build '/nix/store/75iyzldxj5xrj90b0hkkwvjlcym29mis-claude-code-2.1.220.drv'.
       > git-guard check failed (reset --hard in primary): expected deny, got allow
rc=1
```

Restored, `rc=0`.

The behavioral net in `packages/claude-code/install-check.nix` builds a real primary checkout with uncommitted work plus a linked worktree and pins all of the above, including that the deny message actually names the dirty files, that the `git stash create` it recommends is itself allowed (otherwise the advice is a dead end), and that the kill switch allows silently.

## What this does not cover

- **ENG-9963 is not fixed by this.** `nix eval` against a dirty shared tree can still abort with `contents have changed`, because this guard says nothing about `nix eval` and cannot: agents legitimately evaluate from the primary checkout constantly, and denying that would be pure friction against a transient error rather than data loss. What the change does is attack the precondition, since the edit guard now actually covers `~/.config/nix/ix` and so the tree accumulates less agent-written dirt. Filed as a remainder for the `nix run` target ENG-9963 asks for.
- **Only `cd` is tracked**, not `pushd`/`popd` or a subshell that changes directory in a way the parser does not model.
- **Non-git writers are untouched.** A formatter run in place, an `rm`, an editor, a script: all still write to the shared checkout. `treefmt --fail-on-change` rewriting another session's work (ENG-9930) is the same shape and is not covered here.
- **The protected list is still a hand-maintained glob list.** A new shared checkout somewhere else is unprotected until someone adds it, which is exactly the failure this PR is fixing an instance of.
- **It does not subsume andrewgazelka/nix#63.** That issue is about `WorktreeCreate` hooks so Agent `isolation: "worktree"` works from a non-repo cwd; this is about refusing destructive commands in a shared checkout. Related but disjoint. Worth noting for that issue: `WorktreeCreate`/`WorktreeRemove` do exist (Claude Code v2.1.50+), but there is no setting that forces a *top-level* interactive session into a worktree, so hooks alone cannot make isolation the default. Deny guards like this one are what make the unsafe path hard.

Refs ENG-9963, ENG-9964.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add git-guard PreToolUse hook to block destructive git commands on dirty primary checkouts
> - Introduces a new `git-guard` subcommand in [guards.rs](https://github.com/indexable-inc/index/pull/4170/files#diff-d0bfb63d4935fba251de7355e394ca046866f81806414827faafe817f5ece6b9) that runs as a PreToolUse hook before Bash tool execution when `primaryCheckouts` is configured.
> - Parses Bash command lines with quote-aware tokenization, tracks `cd`/`-C` directory changes, skips wrapper prefixes (e.g. `sudo`, `env`), and classifies git subcommands (`reset --hard`, `checkout -f`, `clean -f`, `stash drop`, etc.) as destructive.
> - Denies execution when a destructive git command targets a dirty primary checkout; allows linked worktrees, clean trees, dry-run flags, and unprotected paths to pass through.
> - Denial messages include the destructive effect, a list of dirty files, a suggested `stash create` command, and a suggested worktree path derived from the origin URL.
> - A `CLAUDE_CODE_DISABLE_GIT_GUARD` kill switch bypasses enforcement; the hook is disabled entirely when `primaryCheckouts` is empty.
> - Behavioral Change: agents running Bash in repos listed as primary checkouts will have destructive git commands blocked if the worktree is dirty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24f280a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->