### PR TITLE
nix: repin to 3e68babb for the queryMissing use-after-free (ENG-9972, ENG-9975)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -305,17 +305,17 @@
     "nix-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1784838900,
-        "narHash": "sha256-9occ4hKwbbw5W3sjyoBaZI7GvAarfwzblfWUXwKseBo=",
+        "lastModified": 1785057300,
+        "narHash": "sha256-t3N8x55BclgzE0G7HcZ1bUvn4A3V3nkj+vc9tdPbhaM=",
         "owner": "indexable-inc",
         "repo": "nix",
-        "rev": "403b19c5a120dcb57f293790fb1ec470d0d1392c",
+        "rev": "3e68babbd84a3b98eb68e79ff4dcfb40441ff17d",
         "type": "github"
       },
       "original": {
         "owner": "indexable-inc",
         "repo": "nix",
-        "rev": "403b19c5a120dcb57f293790fb1ec470d0d1392c",
+        "rev": "3e68babbd84a3b98eb68e79ff4dcfb40441ff17d",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -167,12 +167,12 @@
     # marks it `autoUpdate = false`): jj-rebase indexable-inc/nix only when we
     # intend to move the daemon version too, then repin here.
     nix-src = {
-      # Megamerge 403b19c5 (47 patches on 2c6d06e9387c): the 45-patch series
-      # plus the first-transfer lost-wakeup fix (indexable-inc/nix#2, folded
-      # into the patch DAG; index#4122) and the killed-build orphan recovery
-      # (invalid CA scratch-output leftovers are cleared under the build
-      # locks instead of wedging every rebuild of the drv; index#4112).
-      url = "github:indexable-inc/nix/403b19c5a120dcb57f293790fb1ec470d0d1392c";
+      # Megamerge 3e68babb (48 patches on 2c6d06e9387c): the 47-patch series
+      # plus the `queryMissing` thread-pool lifetime fix (ENG-9972). Before it,
+      # `Store::queryMissing` destroyed `state_` and its work-item lambdas
+      # while pool workers were still running them, which produced 123 nix core
+      # dumps across the five CI dispatchers in the retained window.
+      url = "github:indexable-inc/nix/3e68babbd84a3b98eb68e79ff4dcfb40441ff17d";
       flake = false;
     };
 

--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -515,6 +515,15 @@
           upstream = "hold";
           reason = "Genuine upstream bug fix (daemon clientPid always missing on Darwin); wants a human review pass before an attempt mark authorizes the PR.";
         };
+        # A real upstream memory-safety bug, and the most upstream-shaped patch
+        # in this series: it makes `queryMissing` do what `processGraph()` in
+        # the same header already does, with the same reasoning. The evidence
+        # is a fleet of core dumps rather than an argument, so it wants a human
+        # to carry the report as well as the diff.
+        "fix(libstore): join queryMissing's thread pool before its frame dies" = {
+          upstream = "hold";
+          reason = "Use-after-free in upstream `Store::queryMissing`: the frame's `Sync<State>` and work-item lambdas are destroyed before `~ThreadPool` joins the workers that reference them, and the enqueue loop sits outside `ThreadPool::process()`'s exception guard. Diagnosed from 117 of 123 core dumps on our CI dispatchers (ENG-9972). Upstream-worthy and standalone; a human submits it with the core-dump evidence, per this fork's aiPrsAllowed = false.";
+        };
         # Fork-local test adaptations: they exist because fork patches changed
         # failure propagation / added features, so they are meaningless upstream.
         "tests/functional: update failure expectations for preserved leaf errors" = {

--- a/lib/fork-packages.nix
+++ b/lib/fork-packages.nix
@@ -845,6 +845,26 @@
           upstream = "hold";
           reason = "Fixes the eval-time network round trips of NixOS/nix#13556 (getDefaultRef never cached effectively) for rev-pinned fetchGit inputs (indexable-inc/index#4028). Upstream-nix candidate; hold: humans submit Nix patches upstream per NixOS/nix#15984.";
         };
+        # A CA build killed after its builder created $out leaves the floating
+        # scratch path behind on non-chroot stores (the darwin default), owned
+        # by a build user and never registered, so the next build fails writing
+        # over it one phase after the compiler succeeded. The known-path
+        # branches already clear stale paths here; this gives the floating case
+        # the same treatment, under the derivation's output locks.
+        "fix(libstore): clear invalid orphan scratch outputs before rebuilding" = {
+          upstream = "hold";
+          reason = "Clears the invalid build-user-owned scratch output a killed floating-CA build leaves behind, which otherwise wedges every rebuild of that derivation with a bare permission-denied error and needed a manual sudo rm to recover (indexable-inc/index#2247, indexable-inc/index#4112). Upstream master has the same gap; hold: humans submit Nix patches upstream per NixOS/nix#15984.";
+        };
+        # libcurl 8.21.0 drains the wakeup eventfd on entry to
+        # curl_multi_poll, so a wakeup raised while the transfer worker sits
+        # outside the poll is lost. Every process's first transfer hits that
+        # window deterministically and then sleeps the whole 10s idle timeout.
+        # The worker now re-checks the queues under the state lock after
+        # computing its sleep rather than trusting the wakeup.
+        "libstore: never sleep the transfer worker past actionable queued work" = {
+          upstream = "hold";
+          reason = "Lost-wakeup regression against libcurl 8.21.0: every cold `nix run` paid a 10s stall on its first transfer once the fleet's nixpkgs carried 8.21.0 (nix_run_hello p50 5.9s to 16.5s; indexable-inc/index#4122). Upstream-general and standalone, the contract change is upstream's to absorb; hold: humans submit Nix patches upstream per NixOS/nix#15984.";
+        };
       };
     }
     {


### PR DESCRIPTION
## Status

Approved and landing. The repin itself was prepared, built and cross-checked by
an earlier pass, which correctly stopped short of merging on one open gate: one
of the six `nix-src` revs main's `flake.lock` has ever pinned (`0bcdf91ce72e`)
had been orphaned by an unrelated force-move on 2026-07-23. That gate is closed.
All six revs are now anchored by a `refs/pins/*` ref, the missing pin was created
additively, and ENG-9996 tracks the CI check so it cannot recur.

CI is red across the org for unrelated reasons, so this merges with admin.
Merging is not deploying: the fix rides the next deploy, which is a separate
decision.

## What it is

Repins `nix-src` from megamerge `403b19c5` (47 patches) to `3e68babb`
(48 patches). The new patch is
`fix(libstore): join queryMissing's thread pool before its frame dies`
(`4a73af72` in `indexable-inc/nix`), and it fixes a use-after-free in upstream
`Store::queryMissing`.

Fork refs, per the megamerge convention:

```
refs/heads/ix-patched              3e68babbd84a3b98eb68e79ff4dcfb40441ff17d   (48 patches)
refs/pins/2026-07-26-3e68babbd84a  3e68babbd84a3b98eb68e79ff4dcfb40441ff17d   (new)
refs/pins/2026-07-23-403b19c5a120  403b19c5a120dcb57f293790fb1ec470d0d1392c   (previous pin, still reachable)
```

The bookmark move and the new pin went in one `--atomic` push with
`--force-with-lease` on the previous tip. The old megamerge is not an ancestor
of the new one (both are octopus merges over the patch DAG heads: 26 parents
before, 27 now), so its pin ref is what keeps it alive. That ref existed before
the push and still does.

## The bug

`Store::queryMissing` (`src/libstore/misc.cc:102`) declares `ThreadPool pool`
first, so it is destroyed last: `~ThreadPool` joins the workers only after
`state_`, `doPath`, `mustBuildDrv`, `checkOutput` and `enqueueDerivedPaths`
are already gone. Every work item captures all of them by reference.

`ThreadPool::process()` guards its own exception path for exactly this reason,
and says so:

> some workers may still be active. They may be referencing the stack frame of
> the caller. So wait for them to finish. (~ThreadPool also does this, but it
> might be destroyed after objects referenced by the work item lambdas.)

But the enqueue loop is outside that guard. Once any worker throws,
`ThreadPool::doWork` records the exception and sets `quit`; the main thread,
still feeding the loop, gets `ThreadPoolShutDown` out of `pool.enqueue()` and
unwinds `queryMissing` directly, destroying `state_` while the other workers
are inside `doPath`.

`processGraph()` in the same header already guards both ways: it creates its
pool last, and wraps its enqueue loop in `catch (ThreadPoolShutDown &) { break; }`.
`queryMissing` is the outlier. The patch gives it the same treatment (a
`Finally` for the join, since the lambdas name `pool` so the declaration cannot
move, plus the same catch).

## Evidence

Every retained nix core dump on the five CI dispatchers was classified by where
the main thread sits:

| host | drain `path-info` cores | main in `~ThreadPool` from `queryMissing.cold` | main in normal `process()` | other |
| -- | -- | -- | -- | -- |
| hil-compute-1 | 35 | 33 | 0 | 2 |
| hil-compute-2 | 34 | 32 | 0 | 2 |
| hil-compute-3 | 23 | 22 | 0 | 1 |
| vin-compute-1 | 18 | 17 | 0 | 1 |
| vin-compute-2 | 13 | 13 | 0 | 0 |
| **total** | **123** | **117 (95%)** | **0** | **6** |

A representative core (hil-compute-1, pid 4172680, 2026-07-26 08:42:35). Main
thread:

```
#0  __lll_lock_wait
#1  __pthread_mutex_lock
#2  nix::ThreadPool::shutdown()
#3  nix::ThreadPool::~ThreadPool()
#4  nix::Store::queryMissing(std::vector<nix::DerivedPath> const&).cold
#5  nix::printMissing(...)
#6  nix::Installable::build2(...)
```

`.cold` is the unwind path, and `~ThreadPool` is the last local destroyed:
`state_` and the lambdas are already gone. Meanwhile, in the same core:

- 1 thread crashing in
  `boost::unordered::detail::foa::table_core<flat_set_types<std::string>,...>::unchecked_rehash`
  from the `doPath` lambda, on the freed `State::done`
- 11 threads blocked in `pthread_mutex_lock` directly inside the `doPath`
  lambda, on the freed `Sync<State>` mutex
- 17 threads blocked in `pthread_mutex_lock` inside
  `LocalStore::isValidPathUncached`, called from `doPath`
- 1 in `sqlite3_step` under `LocalStore::isValidPath_`

That is the use-after-free caught in the act, on 117 separate occasions.

## What this is not

It is **not** the boost flat-container swap (`9f2b6a1b9`), which was the
starting hypothesis. A full audit of every `boost::unordered_flat_*` and
`boost::concurrent_flat_*` at the pinned rev found no reference, pointer,
iterator or `string_view` escaping a lock or a visitor on any code path a
`nix path-info` client reaches. `State::done` is used correctly, entirely
inside `state_.lock()`. The flat container is the victim, not the cause: it
makes the corruption crash loudly rather than silently.

Two shapes worth their own tickets were found in that audit, both off this
path: `dummy-store.cc:168` and `:342` invoke an arbitrary user callback inside
a `boost::concurrent_flat_map::cvisit` visitor, which the container's contract
forbids; `dummy-store.cc:60` takes a raw pointer out of a visitor.

## Why the fleet and not upstream

The pool is sized `fileTransferSettings.httpConnections`, and
`nix/modules/base/nix-settings.nix:123` sets `http-connections = 128` against
upstream's 25. More threads means more of them stranded when the frame dies.
The trigger is visible in the drain journal at the crash minute:

```
Jul 26 08:42:53 hil-compute-1 ix-cache-push-drain[221674]: error: Resource temporarily unavailable
Jul 26 08:42:53 hil-compute-1 ix-cache-push-drain[221710]: error: Resource temporarily unavailable
```

That is `std::thread` construction failing with EAGAIN inside
`ThreadPool::enqueue` while dozens of concurrent drain children each try to
open a 128-thread pool. Those two processes unwound cleanly and printed the
error; the ones whose workers were still busy segfaulted instead.

## Verification, and its limits

Built: `nix build .#nix-ix --override-input nix-src path:/tmp/nix-patched` on
dev-compute-3 produced
`/nix/store/qd85h35zrq9y12z6dl80p85xr2nqr95v-nix-2.34.7+ix.h8bb8f9ed`. The
lock's narHash for the pushed rev
(`sha256-t3N8x55BclgzE0G7HcZ1bUvn4A3V3nkj+vc9tdPbhaM=`) equals the tree that
was compiled, so this PR pins exactly what was built.

Behaviour: `path-info --json --json-format 1 --stdin` over 20000 paths gives
byte-identical output to the current pin (sha256
`80e6765cb22283783342bf3992d58ba2e6d5b291854345d31db940577a5af5a7` both ways).
Clean exit under SIGINT; no behaviour change under thread starvation at
`ulimit -u` 40/60/100.

**Not verified by reproduction.** Three attempts on dev-compute-5 failed to
reproduce the crash: 240 runs interrupted mid-enqueue (all clean, "interrupted
by the user"), 150 runs under `ulimit -u` 40/80/160 (EAGAIN surfaced 115 times,
zero crashes), and 144 runs at 24-way concurrency with a 128-thread pool (zero
crashes). The missing ingredient is store contention: on an idle dev node the
workers finish each item in microseconds and are parked in the pool's wait
loop, not inside `doPath`, when the frame unwinds. So this is a fix for a
mechanism proven from core dumps, not a fix watched turning a red test green.
Whoever merges should expect the drain crash rate on the dispatchers to be the
real test.

## fork-packages.nix

`lib/fork-packages.nix` gains the entry for this patch with `upstream = "hold"`
and a reason, per the convention.

It also closes ENG-9975 in the same breath, since leaving the registry two
short while adding a third entry to it is the wrong shape. Two patches already
in the pinned megamerge had no entry, so they carried no reason of record and
were invisible to `packages/upstream-sync`:

```
740e02831  libstore: never sleep the transfer worker past actionable queued work
37514fa32  fix(libstore): clear invalid orphan scratch outputs before rebuilding
```

Both are upstream-general libstore fixes (a lost-wakeup regression against
libcurl 8.21.0, index#4122; and clearing the invalid floating-CA scratch
orphan a killed build leaves behind, index#4112), so both are `hold` for the
same reason every other nix patch is.

The registry now declares every patch the pin ships, 48 for 48, with nothing
orphaned in the other direction:

```
declared: 48   shipping: 48
missing: []
orphan:  []
```

The audit has to count merge commits. Three of the 48 have more than one
parent (the jj patch DAG), so `git log --no-merges` sees only 45 and invents
three false "declared but not shipped" entries. Enumerate with
`git rev-list <base>..<tip> --format='%H|%s'`.

Nothing enforces this equality yet. ENG-9996 tracks the check that would.

## Follow-on

`nix-src` lives in this repo's `flake.nix`, so the fleet does not see this
until `indexable-inc/ix` moves both its `index` submodule gitlink and its own
separate `nix-src` lock node (still at `403b19c5a120`). That bump follows
immediately after this lands, and has to land after it: `index.url =
"path:./index"` resolves the gitlink through
`git+ssh://github.com/indexable-inc/index.git?ref=main&rev=<gitlink>`, so a
gitlink that is not reachable from `main` fails with
`Cannot find Git revision ... in ref 'main'`.

(sent by an AI agent via Claude Code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Repin Nix to commit `3e68babb` to fix `queryMissing` use-after-free
> - Updates the pinned Nix source in [flake.nix](https://github.com/indexable-inc/index/pull/4171/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) from `403b19c5` to `3e68babb`, which includes a megamerge with several bug fixes.
> - Fixes a use-after-free in `Store::queryMissing` caused by the thread pool outliving its stack frame.
> - Also picks up fixes for invalid orphan scratch outputs being cleared before rebuild and a lost-wakeup regression introduced with libcurl 8.21.0.
> - Adds patch metadata entries in [lib/fork-packages.nix](https://github.com/indexable-inc/index/pull/4171/files#diff-35e5ff5b02c2dcd32c93fd770ad2194f9fcbfc9f35fdcbd56821891b6e7452f4) for all three fixes, marked `upstream = "hold"` pending human submission.
>
> #### 🖇️ Linked Issues
> Addresses [ENG-9972](https://linear.app/indexable/issue/ENG-9972) and [ENG-9975](https://linear.app/indexable/issue/ENG-9975), both related to the `queryMissing` use-after-free bug in Nix.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c87abf3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
