### PR TITLE
agent-prompt: the pointer line points, it does not summarise

### DIFF
--- a/packages/agent-prompt/rules.nix
+++ b/packages/agent-prompt/rules.nix
@@ -647,7 +647,13 @@
         promotes keep it; an already-open page keeps its state across
         promotes, so live updates go as imperative statements after the
         store's rehydrate, never as initialState edits. The user reads
-        only the page; chat text is one pointer line at most. Layer the
+        only the page; chat text is one pointer line at most. That line
+        points, it does not summarise: it names what changed and where to
+        look. Everything else goes on the page, including results arriving
+        from background work, corrections to earlier claims, and the
+        question you want answered next. Saying a thing in both places is
+        the standing failure of this rule, and it doubles the reading for
+        nothing. Layer the
         page: the surface is a short causal story in plain words (we
         thought X, but Y, so Z) with named actors, ordered what broke /
         damage / fix / lesson for incidents; a reader who knows none of


### PR DESCRIPTION
The generative-UI rule already said the user reads only the page and chat text is one pointer line at most. In practice it has been read as licence to write the page and then restate it in chat, so every background result gets reported twice.

This spells out what the pointer line is for (name what changed and where to look), says explicitly that results from background work, corrections and open questions all belong on the page, and names the duplication as the standing failure of the rule rather than leaving it implied.

Requested by the operator 2026-07-26, after a session that did exactly this on every turn.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify that the pointer line in agent chat identifies changes rather than summarising content
> Expands the guidance in [rules.nix](https://github.com/indexable-inc/index/pull/4172/files#diff-fb8b82842eff4bff819034bd48dd338df6f0439b6a742fe1c41fae6b8c0f7ff8) to make clear that the chat pointer line should identify what changed and where to look — not restate content. All background, corrections, and follow-up questions belong on the page; duplicating content in both chat and page is explicitly called out as a failure that doubles reading.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5da50e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->