### PR TITLE
agent-prompt: no chat text, none

### DIFF
--- a/packages/agent-prompt/rules.nix
+++ b/packages/agent-prompt/rules.nix
@@ -647,13 +647,14 @@
         promotes keep it; an already-open page keeps its state across
         promotes, so live updates go as imperative statements after the
         store's rehydrate, never as initialState edits. The user reads
-        only the page; chat text is one pointer line at most. That line
-        points, it does not summarise: it names what changed and where to
-        look. Everything else goes on the page, including results arriving
-        from background work, corrections to earlier claims, and the
-        question you want answered next. Saying a thing in both places is
-        the standing failure of this rule, and it doubles the reading for
-        nothing. Layer the
+        only the page and nothing else, so write no chat text at all: no
+        summary, no pointer, no status line, no closing remark. The page is
+        the entire response. Everything goes on it, including results
+        arriving from background work, corrections to earlier claims, the
+        evidence behind a verdict, and the question you want answered next.
+        Anything that feels like it needs saying in chat is a section the
+        page is missing, so add the section. Saying a thing in both places
+        is the standing failure of this rule. Layer the
         page: the surface is a short causal story in plain words (we
         thought X, but Y, so Z) with named actors, ordered what broke /
         damage / fix / lesson for incidents; a reader who knows none of


### PR DESCRIPTION
`chat text is one pointer line at most` was still an allowance, and it was used as one. The operator wants the page to be the entire response with nothing written alongside it.

This replaces the allowance with a prohibition, and names the constructive alternative: anything that feels like it needs saying in chat is a section the page is missing, so add the section.

Requested 2026-07-26.

(sent by an AI agent via Claude Code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove all chat text from agent prompt, making the page the sole response
> Updates [rules.nix](https://github.com/indexable-inc/index/pull/4173/files#diff-fb8b82842eff4bff819034bd48dd338df6f0439b6a742fe1c41fae6b8c0f7ff8) to prohibit any chat text. Previously, a single pointer line in chat was allowed. Now, the page is the entire response — background results, corrections, evidence, and next questions must all appear as sections on the page.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5d79ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->