### PR TITLE
elixir check: every phase runs, and the failure names all of them

### DIFF
--- a/lib/build/elixir-check.nix
+++ b/lib/build/elixir-check.nix
@@ -18,6 +18,12 @@ reproducible:
      LLM-slop checks), single source of truth.
   4. `mix test` — the package's ExUnit suite.
 
+2, 3 and 4 all run on every build and the failure names every one of them that
+failed, so a formatting slip can no longer stand in front of a failing test
+suite and report itself as the lane's verdict. 1 still ends the build on its
+own — credo and ExUnit have nothing to read without it — but it says in the log
+that the other three did not run.
+
 The result is meant to be attached as `passthru.tests.elixir` on the package
 and wired into `checks` through lib/per-system.nix, exactly as before.
 
@@ -111,20 +117,81 @@ in
         runHook postConfigure
       '';
 
+    # Compile is the one phase that is still allowed to end the build, because
+    # credo and ExUnit both read the beams it produces and neither says
+    # anything useful without them. What it must not do is end the build
+    # quietly: without the message below, a compile failure looks from the tail
+    # of the log exactly like a lane that ran and passed the rest.
     buildPhase = ''
       # shell
       runHook preBuild
-      mix compile ${depsCheckFlag} --warnings-as-errors
+      if mix compile ${depsCheckFlag} --warnings-as-errors; then
+        :
+      else
+        rc=$?
+        echo "elixir check: compile FAILED (exit $rc)" >&2
+        echo "elixir check: format, credo and test did NOT run" >&2
+        exit "$rc"
+      fi
       runHook postBuild
     '';
 
     doCheck = true;
+
+    # Every phase runs, and the report at the end names all of them.
+    #
+    # These three used to be three bare commands under errexit, so the first
+    # non-zero exit ended the derivation and the others never ran -- and
+    # nothing in the output said so. A check that stops at its cheapest step is
+    # reporting on the cheapest step: in test-ide a formatting slip held `mix
+    # format --check-formatted` at exit 1 for a day, and five failing
+    # ClickHouse tests underneath it were invisible until somebody fixed the
+    # formatting for unrelated reasons (ENG-10061). The cost is not the day, it
+    # is that the gate was green-adjacent the whole time and reported a fact
+    # about whitespace.
+    #
+    # Serialising the discovery one build at a time is not the fix either. The
+    # three are independent -- formatting is not a precondition for credo, and
+    # neither is one for ExUnit -- so all three run, each verdict is kept, and
+    # the failure at the end lists every phase that failed rather than the
+    # first.
     checkPhase = ''
       # shell
       runHook preCheck
-      mix format --check-formatted
-      mix credo --strict
-      mix test ${depsCheckFlag}
+
+      elixirCheckFailed=""
+
+      # Records a verdict instead of ending the build. The condition spelling
+      # is load-bearing: errexit is suspended only for a command that IS a
+      # condition, so `if cmd; then rc=0; else rc=$?; fi` survives where
+      # `cmd; rc=$?` would have exited at `cmd`.
+      elixirCheckRun() {
+        local name="$1"
+        shift
+        local rc
+        echo "elixir check: >>> $name"
+        if "$@"; then rc=0; else rc=$?; fi
+        if [ "$rc" -eq 0 ]; then
+          echo "elixir check: <<< $name passed"
+        else
+          echo "elixir check: <<< $name FAILED (exit $rc)"
+          elixirCheckFailed="$elixirCheckFailed $name"
+        fi
+      }
+
+      elixirCheckRun format mix format --check-formatted
+      elixirCheckRun credo mix credo --strict
+      elixirCheckRun test mix test ${depsCheckFlag}
+
+      if [ -n "$elixirCheckFailed" ]; then
+        # Last, because a failing nix build prints the tail of the log and this
+        # is the line that has to survive that truncation.
+        echo "elixir check: FAILED phases:$elixirCheckFailed" >&2
+        echo "elixir check: compile, format, credo and test all ran; each one's output is above" >&2
+        exit 1
+      fi
+
+      echo "elixir check: compile, format, credo and test all passed"
       runHook postCheck
     '';
 


### PR DESCRIPTION
`ix.buildElixirCheck`'s `checkPhase` was three bare commands under errexit:

```sh
mix format --check-formatted
mix credo --strict
mix test
```

So the first non-zero exit ended the derivation and the rest never ran — and nothing in the output said so. A gate that stops at its cheapest step is reporting on the cheapest step.

That is not hypothetical. In `test-ide` a formatting slip held `mix format --check-formatted` at exit 1, and **five failing ClickHouse tests sat behind it invisible** until someone fixed the formatting for unrelated reasons (ENG-10061). The cost was not the day of latency; it was that the lane looked like it was reporting on the suite while it was reporting a fact about whitespace.

Serialising the discovery one build at a time is not the fix either. The three phases are independent — formatting is not a precondition for credo, and neither is one for ExUnit.

## What it does now

All three run, each verdict is kept, and the build fails at the end naming every phase that failed:

```
elixir check: <<< format FAILED (exit 1)
elixir check: <<< credo FAILED (exit 8)
elixir check: <<< test FAILED (exit 2)
elixir check: FAILED phases: format credo test
elixir check: compile, format, credo and test all ran; each one's output is above
```

The summary is last on purpose: a failing `nix build` prints only the tail of the log, and that is the line which has to survive the truncation. On success the lane ends with `elixir check: compile, format, credo and test all passed`, so "it ran" is visible rather than inferred.

`mix compile --warnings-as-errors` stays a hard stop, because credo and ExUnit both read the beams it produces and neither says anything useful without them. What it no longer does is stop *quietly* — it now prints `format, credo and test did NOT run`, so a compile failure cannot be mistaken from the tail of the log for a lane that ran and passed the rest.

The `if cmd; then rc=0; else rc=$?; fi` spelling is load-bearing: errexit is suspended only for a command that *is* a condition, so `cmd; rc=$?` would have exited at `cmd`.

## Watched failing, not assumed

Each demonstrated by building `test-ide`'s `checks.aarch64-darwin.elixir` against this builder via `--override-input`:

| what was broken | what the log said |
| --- | --- |
| an unformatted file **and** a deliberately failing test | `FAILED phases: format credo test`, all three outputs in one log. Before this change that build stopped at format and never mentioned the others. |
| an unused variable in `lib/` | `compile FAILED (exit 1)` then `format, credo and test did NOT run` |
| nothing | `compile, format, credo and test all passed` |

(`credo` appears in the first row because test-ide's pinned index is 587 commits old and current policy flags 14 pre-existing findings there — incidental to this change, but it did make the point for free: the credo failure was only visible *because* format no longer swallowed the build.)

## Consumers verified

Built on aarch64-darwin against this branch:

- `hive.passthru.tests.elixir` — green, `compile, format, credo and test all passed`
- `mcp-ex.passthru.tests.elixir` — green
- `agent-harness-ex.passthru.tests.elixir` — green

**Not built on linux** — no linux builder reachable from this machine. The change is pure bash inside the derivation with no platform-specific behaviour.

ENG-10061

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run all Elixir check phases independently and report all failures together
> - The `checkPhase` in [elixir-check.nix](https://github.com/indexable-inc/index/pull/4174/files#diff-02733623bc5214fd8874160b6f37e55384657b7ebde828e36a40cdd18a20c6f2) now runs `mix format`, `mix credo`, and `mix test` unconditionally via a helper function, accumulating failures and reporting all failed phase names at the end.
> - The `buildPhase` now prints explicit messages on compile failure indicating that format, credo, and test did not run, then exits with the original error code.
> - Behavioral Change: Previously, a failure in any check phase would stop subsequent checks from running; now all three always run and failures are summarized together.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3991bcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->